### PR TITLE
fix/feat: P0 安全修复 + P1 健壮性改进 + 3 个新命令

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ my-boss-profile.md
 CLAUDE.md
 AGENTS.md
 GEMINI.md
+.ace-tool/

--- a/README.md
+++ b/README.md
@@ -46,25 +46,75 @@ uv run patchright install chromium
 
 </details>
 
+## 登录链路说明
+
+`boss login` 当前采用三级降级：
+
+1. **Cookie 提取**
+   - 优先尝试从本机浏览器提取 `zhipin.com` Cookie
+   - 适合你已经在 Chrome / Edge / Firefox 中登录过 BOSS 直聘的场景
+2. **CDP 登录**
+   - 若检测到带远程调试端口的 Chrome，则复用用户浏览器完成登录
+   - 适合希望保持浏览器真实指纹、减少额外扫码的场景
+3. **patchright 扫码**
+   - 最后兜底，拉起 patchright Chromium 让你扫码登录
+
+推荐工作流：
+
+```bash
+boss doctor
+boss login
+boss status
+```
+
+### CDP 启动示例
+
+macOS:
+
+```bash
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/boss-chrome
+```
+
+Linux:
+
+```bash
+google-chrome --remote-debugging-port=9222 --user-data-dir=/tmp/boss-chrome
+```
+
+然后可执行：
+
+```bash
+boss --cdp-url http://localhost:9222 doctor
+boss --cdp-url http://localhost:9222 login --cdp
+```
+
 ## 快速开始
 
 ```bash
+# 0. 先做环境自检（推荐）
+boss doctor
+
 # 1. 登录（优先免扫码，失败弹出浏览器）
 boss login
 
-# 2. 搜索广州的 Golang 职位，要求双休+五险一金
+# 2. 验证登录态
+boss status
+
+# 3. 搜索广州的 Golang 职位，要求双休+五险一金
 boss search "Golang" --city 广州 --welfare "双休,五险一金"
 
-# 3. 查看职位详情
+# 4. 查看职位详情
 boss detail <security_id>
 
-# 4. 向招聘者打招呼
+# 5. 向招聘者打招呼
 boss greet <security_id> <job_id>
 
-# 5. 获取个性化推荐
+# 6. 获取个性化推荐
 boss recommend
 
-# 6. 导出 50 条搜索结果为 CSV
+# 7. 导出 50 条搜索结果为 CSV
 boss export "Golang" --city 广州 --count 50 -o jobs.csv
 ```
 
@@ -119,6 +169,7 @@ npx skills add can4hou6joeng4/boss-agent-cli
 | 命令 | 说明 |
 |------|------|
 | `boss login` | 登录（Cookie 提取优先，失败扫码） |
+| `boss doctor` | 诊断本地环境、依赖、登录态和网络 |
 | `boss status` | 检查登录态 |
 | `boss me` | 我的信息（用户/简历/期望/投递记录） |
 | `boss search <query>` | 搜索职位（支持 `--welfare` 福利筛选） |
@@ -161,6 +212,51 @@ boss search "Golang" --city 广州 --welfare "双休,五险一金,年终奖"
 4. 每个结果带 `welfare_match` 字段说明匹配来源
 
 支持的福利关键词：`双休` `五险一金` `年终奖` `餐补` `住房补贴` `定期体检` `股票期权` `加班补助` `带薪年假`
+
+## 诊断与排障
+
+优先执行：
+
+```bash
+boss doctor
+```
+
+典型诊断项：
+- `patchright`：CLI 是否已安装
+- `patchright_chromium`：Chromium 内核是否已安装
+- `cookie_extract`：是否能从本地浏览器提取 zhipin Cookie
+- `auth_session`：本地登录态是否存在、是否可解密
+- `auth_token_quality`：当前登录态质量（是否具备 wt2 / stoken）
+- `cdp`：Chrome 远程调试端口是否可连
+- `network`：是否可访问 `https://www.zhipin.com/`
+- `data_dir`：数据目录是否可写
+
+常见修复动作：
+
+```bash
+# 安装浏览器内核
+patchright install chromium
+
+# 清除损坏/旧机器指纹的登录态
+boss logout
+
+# 重新登录
+boss login
+
+# 指定 CDP 地址做诊断
+boss --cdp-url http://localhost:9222 doctor
+```
+
+如果 `doctor` 中 `auth_session` 显示“session 文件但无法解密/已损坏”，通常意味着：
+- 登录态来自旧机器指纹
+- 或 session 文件已损坏
+
+此时执行 `boss logout && boss login` 即可恢复。
+
+如果 `doctor` 中 `auth_token_quality` 显示：
+- `wt2/stoken 均存在`：登录态完整，可优先执行 `boss status`
+- `wt2 存在，但 stoken 缺失`：通常仍能读取部分信息；若接口失败，再执行 `boss login`
+- `wt2 缺失`：说明关键 Cookie 不完整，建议直接 `boss logout && boss login`
 
 ## 错误处理
 

--- a/src/boss_agent_cli/api/boss.yaml
+++ b/src/boss_agent_cli/api/boss.yaml
@@ -73,6 +73,10 @@ endpoints:
     method: GET
     path: "/wapi/zpgeek/history/joblist.json"
     referer: "/web/geek/job"
+  chat_history:
+    method: GET
+    path: "/wapi/zpchat/geek/historyMsg"
+    referer: "/web/geek/chat"
 
 lookups:
   city:

--- a/src/boss_agent_cli/api/boss.yaml
+++ b/src/boss_agent_cli/api/boss.yaml
@@ -77,6 +77,14 @@ endpoints:
     method: GET
     path: "/wapi/zpchat/geek/historyMsg"
     referer: "/web/geek/chat"
+  friend_label_add:
+    method: GET
+    path: "/wapi/zprelation/friend/label/addMark"
+    referer: "/web/geek/chat"
+  friend_label_delete:
+    method: GET
+    path: "/wapi/zprelation/friend/label/deleteMark"
+    referer: "/web/geek/chat"
 
 lookups:
   city:

--- a/src/boss_agent_cli/api/boss.yaml
+++ b/src/boss_agent_cli/api/boss.yaml
@@ -85,6 +85,10 @@ endpoints:
     method: GET
     path: "/wapi/zprelation/friend/label/deleteMark"
     referer: "/web/geek/chat"
+  exchange_request:
+    method: POST
+    path: "/wapi/zpchat/exchange/request"
+    referer: "/web/geek/chat"
 
 lookups:
   city:

--- a/src/boss_agent_cli/api/browser_client.py
+++ b/src/boss_agent_cli/api/browser_client.py
@@ -34,7 +34,7 @@ class BrowserSession:
 	Tries CDP connection to user's Chrome first; falls back to headless patchright.
 	"""
 
-	def __init__(self, cookies: dict, user_agent: str, *, delay: tuple[float, float] = (1.5, 3.0), cdp_url: str | None = None):
+	def __init__(self, cookies: dict, user_agent: str, *, delay: tuple[float, float] = (1.5, 3.0), cdp_url: str | None = None, logger=None):
 		self._throttle = RequestThrottle(delay)
 		self._pw = None
 		self._browser = None
@@ -46,6 +46,14 @@ class BrowserSession:
 		self._cdp_url = cdp_url
 		self._is_cdp = False
 		self._own_context = False  # 是否由我们创建的 context（需要在 close 时清理）
+		self._logger = logger
+
+	def _log(self, message: str) -> None:
+		"""通过注入的 logger 输出，受 --log-level 控制。"""
+		if self._logger:
+			self._logger.info(message)
+		else:
+			print(message, file=sys.stderr)
 
 	def _ensure_started(self):
 		if self._started:
@@ -115,7 +123,7 @@ class BrowserSession:
 				pass  # 即使导航超时，页面 JS 环境已可用
 			self._started = True
 			self._is_cdp = True
-			print(f"[boss] CDP 连接成功 ({url})，使用用户 Chrome（隔离 context）", file=sys.stderr)
+			self._log(f"[boss] CDP 连接成功 ({url})，使用用户 Chrome（隔离 context）")
 			return True
 		except Exception:
 			if self._browser:
@@ -171,7 +179,7 @@ class BrowserSession:
 		self._page.wait_for_load_state("networkidle")
 		self._started = True
 		self._is_cdp = False
-		print("[boss] CDP 不可用（提示：需以 --remote-debugging-port=9222 启动 Chrome），降级到 headless patchright", file=sys.stderr)
+		self._log("[boss] CDP 不可用（提示：需以 --remote-debugging-port=9222 启动 Chrome），降级到 headless patchright")
 
 	# ── Core request via browser fetch() ─────────────────────────────
 

--- a/src/boss_agent_cli/api/client.py
+++ b/src/boss_agent_cli/api/client.py
@@ -225,6 +225,11 @@ class BossClient:
 		params = {"page": page}
 		return self._request("GET", endpoints.JOB_HISTORY_URL, params=params)
 
+	def chat_history(self, gid: str, security_id: str, *, page: int = 1, count: int = 20) -> dict:
+		"""获取与指定好友的聊天消息历史。"""
+		params = {"gid": gid, "securityId": security_id, "page": page, "c": count, "src": 0}
+		return self._request("GET", endpoints.CHAT_HISTORY_URL, params=params)
+
 	# ── Lifecycle ────────────────────────────────────────────────────
 
 	def close(self):

--- a/src/boss_agent_cli/api/client.py
+++ b/src/boss_agent_cli/api/client.py
@@ -236,6 +236,11 @@ class BossClient:
 		params = {"friendId": friend_id, "friendSource": friend_source, "labelId": label_id}
 		return self._request("GET", url, params=params)
 
+	def exchange_contact(self, security_id: str, uid: str, name: str, exchange_type: int = 1) -> dict:
+		"""请求交换联系方式（1=手机, 2=微信）。"""
+		data = {"type": exchange_type, "securityId": security_id, "uniqueId": uid, "name": name}
+		return self._browser_request("POST", endpoints.EXCHANGE_REQUEST_URL, data=data)
+
 	# ── Lifecycle ────────────────────────────────────────────────────
 
 	def close(self):

--- a/src/boss_agent_cli/api/client.py
+++ b/src/boss_agent_cli/api/client.py
@@ -230,6 +230,12 @@ class BossClient:
 		params = {"gid": gid, "securityId": security_id, "page": page, "c": count, "src": 0}
 		return self._request("GET", endpoints.CHAT_HISTORY_URL, params=params)
 
+	def friend_label(self, friend_id: str, label_id: int, friend_source: int = 0, *, remove: bool = False) -> dict:
+		"""添加或移除好友标签。"""
+		url = endpoints.FRIEND_LABEL_DELETE_URL if remove else endpoints.FRIEND_LABEL_ADD_URL
+		params = {"friendId": friend_id, "friendSource": friend_source, "labelId": label_id}
+		return self._request("GET", url, params=params)
+
 	# ── Lifecycle ────────────────────────────────────────────────────
 
 	def close(self):

--- a/src/boss_agent_cli/api/client.py
+++ b/src/boss_agent_cli/api/client.py
@@ -82,49 +82,56 @@ class BossClient:
 
 	# ── httpx request (low-risk ops) ─────────────────────────────────
 
-	def _request(self, method: str, url: str, *, _retry_count: int = 0, **kwargs) -> dict:
-		client = self._get_client()
-		token = self._auth.get_token()
-		stoken = token.get("stoken", "")
+	def _request(self, method: str, url: str, **kwargs) -> dict:
+		"""httpx 请求，循环重试（最多 _MAX_RETRIES 次），替代递归调用。"""
+		for attempt in range(_MAX_RETRIES + 1):
+			client = self._get_client()
+			token = self._auth.get_token()
+			stoken = token.get("stoken", "")
 
-		if method == "GET":
-			params = kwargs.get("params", {})
-			params["__zp_stoken__"] = stoken
-			kwargs["params"] = params
+			if method == "GET":
+				params = kwargs.get("params", {})
+				params["__zp_stoken__"] = stoken
+				kwargs["params"] = params
 
-		self._throttle.wait()
+			self._throttle.wait()
 
-		extra_headers = self._headers_for(url)
-		resp = client.request(method, url, headers=extra_headers, **kwargs)
-		self._throttle.mark()
-		self._merge_cookies(resp)
+			extra_headers = self._headers_for(url)
+			resp = client.request(method, url, headers=extra_headers, **kwargs)
+			self._throttle.mark()
+			self._merge_cookies(resp)
 
-		if resp.status_code == 403 or "安全验证" in resp.text:
-			if _retry_count >= _MAX_RETRIES:
-				raise AuthError("Token 刷新后仍被拒绝，请重新登录")
-			backoff = (2 ** _retry_count) + random.uniform(0.5, 1.5)
-			time.sleep(backoff)
-			self._auth.force_refresh(cdp_url=self._cdp_url)
-			self._client = None
-			return self._request(method, url, _retry_count=_retry_count + 1, **kwargs)
+			# 403 或安全验证 → 刷新 token 重试
+			if resp.status_code == 403 or "安全验证" in resp.text:
+				if attempt >= _MAX_RETRIES:
+					raise AuthError("Token 刷新后仍被拒绝，请重新登录")
+				backoff = (2 ** attempt) + random.uniform(0.5, 1.5)
+				time.sleep(backoff)
+				self._auth.force_refresh(cdp_url=self._cdp_url)
+				self._client = None
+				continue
 
-		resp.raise_for_status()
-		data = resp.json()
-		code = data.get("code")
+			resp.raise_for_status()
+			data = resp.json()
+			code = data.get("code")
 
-		if code == endpoints.CODE_STOKEN_EXPIRED and _retry_count < _MAX_RETRIES:
-			backoff = (2 ** _retry_count) + random.uniform(0.5, 1.5)
-			time.sleep(backoff)
-			self._auth.force_refresh(cdp_url=self._cdp_url)
-			self._client = None
-			return self._request(method, url, _retry_count=_retry_count + 1, **kwargs)
+			# stoken 过期 → 刷新重试
+			if code == endpoints.CODE_STOKEN_EXPIRED and attempt < _MAX_RETRIES:
+				backoff = (2 ** attempt) + random.uniform(0.5, 1.5)
+				time.sleep(backoff)
+				self._auth.force_refresh(cdp_url=self._cdp_url)
+				self._client = None
+				continue
 
-		if code == endpoints.CODE_RATE_LIMITED and _retry_count < _MAX_RETRIES:
-			cooldown = min(60, 10 * (2 ** _retry_count))
-			time.sleep(cooldown)
-			return self._request(method, url, _retry_count=_retry_count + 1, **kwargs)
+			# 频率限制 → 冷却重试
+			if code == endpoints.CODE_RATE_LIMITED and attempt < _MAX_RETRIES:
+				cooldown = min(60, 10 * (2 ** attempt))
+				time.sleep(cooldown)
+				continue
 
-		return data
+			return data
+
+		raise AuthError("请求失败，已达最大重试次数")
 
 	# ── Browser request (high-risk ops) ──────────────────────────────
 

--- a/src/boss_agent_cli/api/client.py
+++ b/src/boss_agent_cli/api/client.py
@@ -66,6 +66,7 @@ class BossClient:
 				user_agent=token.get("user_agent", ""),
 				delay=self._delay,
 				cdp_url=self._cdp_url,
+				logger=getattr(self._auth, '_logger', None),
 			)
 		return self._browser_session
 

--- a/src/boss_agent_cli/api/endpoints.py
+++ b/src/boss_agent_cli/api/endpoints.py
@@ -33,6 +33,8 @@ FRIEND_LIST_URL = _url("friend_list")
 INTERVIEW_DATA_URL = _url("interview_data")
 JOB_HISTORY_URL = _url("job_history")
 CHAT_HISTORY_URL = _url("chat_history")
+FRIEND_LABEL_ADD_URL = _url("friend_label_add")
+FRIEND_LABEL_DELETE_URL = _url("friend_label_delete")
 
 # ── API response codes ──────────────────────────────────────────────
 CODE_SUCCESS = _spec.response_codes.get("success", 0)

--- a/src/boss_agent_cli/api/endpoints.py
+++ b/src/boss_agent_cli/api/endpoints.py
@@ -35,6 +35,7 @@ JOB_HISTORY_URL = _url("job_history")
 CHAT_HISTORY_URL = _url("chat_history")
 FRIEND_LABEL_ADD_URL = _url("friend_label_add")
 FRIEND_LABEL_DELETE_URL = _url("friend_label_delete")
+EXCHANGE_REQUEST_URL = _url("exchange_request")
 
 # ── API response codes ──────────────────────────────────────────────
 CODE_SUCCESS = _spec.response_codes.get("success", 0)

--- a/src/boss_agent_cli/api/endpoints.py
+++ b/src/boss_agent_cli/api/endpoints.py
@@ -32,6 +32,7 @@ DELIVER_LIST_URL = _url("deliver_list")
 FRIEND_LIST_URL = _url("friend_list")
 INTERVIEW_DATA_URL = _url("interview_data")
 JOB_HISTORY_URL = _url("job_history")
+CHAT_HISTORY_URL = _url("chat_history")
 
 # ── API response codes ──────────────────────────────────────────────
 CODE_SUCCESS = _spec.response_codes.get("success", 0)

--- a/src/boss_agent_cli/auth/token_store.py
+++ b/src/boss_agent_cli/auth/token_store.py
@@ -2,13 +2,14 @@ import hashlib
 import json
 import os
 import platform
+import shutil
 import subprocess
 import time
 from base64 import urlsafe_b64encode
 from contextlib import contextmanager
 from pathlib import Path
 
-from cryptography.fernet import Fernet
+from cryptography.fernet import Fernet, InvalidToken
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from cryptography.hazmat.primitives import hashes
 
@@ -24,28 +25,48 @@ class TokenStore:
 		self._lock_path = auth_dir / "refresh.lock"
 
 	def _get_machine_id(self) -> str:
+		# 允许显式覆盖，便于测试 / CI / 沙箱环境稳定运行
+		if override := os.getenv("BOSS_AGENT_MACHINE_ID"):
+			return override
+
 		system = platform.system()
-		if system == "Darwin":
-			result = subprocess.run(
-				["ioreg", "-rd1", "-c", "IOPlatformExpertDevice"],
-				capture_output=True, text=True,
-			)
-			for line in result.stdout.splitlines():
-				if "IOPlatformUUID" in line:
-					return line.split('"')[-2]
-		elif system == "Linux":
-			machine_id = Path("/etc/machine-id")
-			if machine_id.exists():
-				return machine_id.read_text().strip()
-		elif system == "Windows":
-			result = subprocess.run(
-				["reg", "query", r"HKLM\SOFTWARE\Microsoft\Cryptography", "/v", "MachineGuid"],
-				capture_output=True, text=True,
-			)
-			for line in result.stdout.splitlines():
-				if "MachineGuid" in line:
-					return line.split()[-1]
-		return "boss-agent-cli-fallback-id"
+		try:
+			if system == "Darwin":
+				if shutil.which("ioreg"):
+					result = subprocess.run(
+						["ioreg", "-rd1", "-c", "IOPlatformExpertDevice"],
+						capture_output=True,
+						text=True,
+						check=False,
+					)
+					for line in result.stdout.splitlines():
+						if "IOPlatformUUID" in line:
+							return line.split('"')[-2]
+			elif system == "Linux":
+				machine_id = Path("/etc/machine-id")
+				if machine_id.exists():
+					return machine_id.read_text().strip()
+			elif system == "Windows":
+				if shutil.which("reg"):
+					result = subprocess.run(
+						["reg", "query", r"HKLM\SOFTWARE\Microsoft\Cryptography", "/v", "MachineGuid"],
+						capture_output=True,
+						text=True,
+						check=False,
+					)
+					for line in result.stdout.splitlines():
+						if "MachineGuid" in line:
+							return line.split()[-1]
+		except (OSError, ValueError):
+			pass
+
+		# 最终兜底：基于主机名+系统信息稳定生成一个本地 fallback id
+		fingerprint = "|".join([
+			platform.node() or "unknown-node",
+			system or "unknown-system",
+			platform.machine() or "unknown-machine",
+		])
+		return hashlib.sha256(fingerprint.encode()).hexdigest()
 
 	def _get_salt(self) -> bytes:
 		if self._salt_path.exists():
@@ -77,7 +98,10 @@ class TokenStore:
 			return None
 		fernet = Fernet(self._derive_key())
 		encrypted = self._session_path.read_bytes()
-		plaintext = fernet.decrypt(encrypted)
+		try:
+			plaintext = fernet.decrypt(encrypted)
+		except (InvalidToken, ValueError):
+			return None
 		return json.loads(plaintext)
 
 	def clear(self) -> None:
@@ -86,14 +110,22 @@ class TokenStore:
 
 	@contextmanager
 	def refresh_lock(self):
+		"""原子文件锁：使用 O_CREAT|O_EXCL 避免 TOCTOU 竞态条件。"""
 		deadline = time.time() + _LOCK_TIMEOUT
-		while self._lock_path.exists():
-			if time.time() > deadline:
-				self._lock_path.unlink(missing_ok=True)
-				break
-			time.sleep(0.5)
-		self._lock_path.touch()
+		fd = None
+		while True:
+			try:
+				fd = os.open(str(self._lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+				break  # 成功获取锁
+			except FileExistsError:
+				if time.time() > deadline:
+					# 超时：锁可能是残留的，强制释放
+					self._lock_path.unlink(missing_ok=True)
+					continue
+				time.sleep(0.5)
 		try:
+			if fd is not None:
+				os.close(fd)
 			yield
 		finally:
 			self._lock_path.unlink(missing_ok=True)

--- a/src/boss_agent_cli/cache/store.py
+++ b/src/boss_agent_cli/cache/store.py
@@ -93,3 +93,9 @@ class CacheStore:
 
 	def close(self):
 		self._conn.close()
+
+	def __enter__(self):
+		return self
+
+	def __exit__(self, *args):
+		self.close()

--- a/src/boss_agent_cli/commands/chat.py
+++ b/src/boss_agent_cli/commands/chat.py
@@ -229,9 +229,9 @@ def chat_cmd(ctx, page, from_who, days, export_fmt, output_path):
 
 
 def _format_ts(ts_ms: int) -> str:
-	"""将毫秒时间戳格式化为可读日期"""
-	dt = datetime.datetime.fromtimestamp(ts_ms / 1000)
-	now = datetime.datetime.now()
+	"""将毫秒时间戳格式化为可读日期（使用本地时区）"""
+	dt = datetime.datetime.fromtimestamp(ts_ms / 1000, tz=datetime.timezone.utc).astimezone()
+	now = datetime.datetime.now(tz=datetime.timezone.utc).astimezone()
 	if dt.date() == now.date():
 		return dt.strftime("今天 %H:%M")
 	delta = (now.date() - dt.date()).days

--- a/src/boss_agent_cli/commands/chat.py
+++ b/src/boss_agent_cli/commands/chat.py
@@ -68,8 +68,8 @@ def chat_cmd(ctx, page, from_who, days, export_fmt, output_path):
 		return
 
 	try:
-		client = BossClient(auth, delay=delay, cdp_url=cdp_url)
-		resp = client.friend_list(page=page)
+		with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
+			resp = client.friend_list(page=page)
 		zp_data = resp.get("zpData", {})
 		items = zp_data.get("result") or zp_data.get("friendList") or []
 
@@ -134,6 +134,17 @@ def chat_cmd(ctx, page, from_who, days, export_fmt, output_path):
 					export_dir = os.path.join(data_dir, "chat-export")
 				os.makedirs(export_dir, exist_ok=True)
 				output_path = os.path.join(export_dir, f"沟通列表-{today}.{export_fmt}")
+
+			# 路径安全校验：禁止 .. 跳转
+			resolved = os.path.realpath(output_path)
+			if ".." in os.path.relpath(resolved, os.getcwd()):
+				safe_dir = os.path.realpath(export_dir if 'export_dir' in dir() else data_dir)
+				if not resolved.startswith(safe_dir) and not resolved.startswith(os.path.realpath(os.getcwd())):
+					handle_error_output(
+						ctx, "chat", code="INVALID_PARAM",
+						message=f"输出路径不安全: {output_path}",
+					)
+					return
 
 			os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
 			with open(output_path, "w", encoding="utf-8", newline="") as f:

--- a/src/boss_agent_cli/commands/chatmsg.py
+++ b/src/boss_agent_cli/commands/chatmsg.py
@@ -1,0 +1,115 @@
+import datetime
+
+import click
+
+from boss_agent_cli.api.client import BossClient
+from boss_agent_cli.auth.manager import AuthManager, AuthRequired, TokenRefreshFailed
+from boss_agent_cli.display import handle_error_output, handle_output, render_simple_list
+
+_MSG_TYPE_MAP = {
+	1: "文本", 2: "图片", 3: "招呼", 4: "简历", 5: "系统",
+	6: "名片", 7: "语音", 8: "视频", 9: "表情",
+}
+
+
+@click.command("chatmsg")
+@click.argument("security_id")
+@click.option("--page", default=1, help="页码")
+@click.option("--count", default=20, help="每页消息数量")
+@click.pass_context
+def chatmsg_cmd(ctx, security_id, page, count):
+	"""查看与指定好友的聊天消息历史"""
+	data_dir = ctx.obj["data_dir"]
+	logger = ctx.obj["logger"]
+	delay = ctx.obj["delay"]
+	cdp_url = ctx.obj.get("cdp_url")
+	auth = AuthManager(data_dir, logger=logger)
+
+	try:
+		with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
+			# 先从 friend_list 找到对应的 gid
+			friends_resp = client.friend_list(page=1)
+			zp_data = friends_resp.get("zpData", {})
+			items = zp_data.get("result") or zp_data.get("friendList") or []
+
+			gid = None
+			friend_name = None
+			for item in items:
+				if item.get("securityId") == security_id:
+					gid = str(item.get("uid", ""))
+					friend_name = item.get("name") or "-"
+					break
+
+			if not gid:
+				handle_error_output(
+					ctx, "chatmsg",
+					code="JOB_NOT_FOUND",
+					message=f"未在沟通列表中找到 security_id={security_id}，请确认该联系人存在",
+				)
+				return
+
+			resp = client.chat_history(gid, security_id, page=page, count=count)
+			msg_data = resp.get("zpData", {})
+			messages = msg_data.get("messages") or msg_data.get("historyMsgList") or []
+
+			result = []
+			for msg in messages:
+				from_obj = msg.get("from", {})
+				is_self = False
+				from_name = friend_name
+				if isinstance(from_obj, dict):
+					is_self = str(from_obj.get("uid", "")) != gid
+					if not is_self:
+						from_name = from_obj.get("name", friend_name)
+				if is_self:
+					from_name = "我"
+
+				msg_time = ""
+				if ts := msg.get("time"):
+					msg_time = datetime.datetime.fromtimestamp(ts / 1000).strftime("%m-%d %H:%M")
+
+				result.append({
+					"from": from_name,
+					"type": _MSG_TYPE_MAP.get(msg.get("type"), f"其他({msg.get('type')})"),
+					"text": msg.get("text") or msg.get("body", {}).get("text", "") or "",
+					"time": msg_time,
+				})
+
+			def _render(data):
+				render_simple_list(
+					data,
+					f"聊天记录 — {friend_name}",
+					[
+						("发送方", "from", "bold cyan"),
+						("类型", "type", "dim"),
+						("内容", "text", "yellow"),
+						("时间", "time", "dim"),
+					],
+				)
+
+			handle_output(
+				ctx, "chatmsg", result,
+				render=_render,
+				hints={"next_actions": [
+					"boss chat — 返回沟通列表",
+					f"boss detail {security_id} — 查看职位详情",
+				]},
+			)
+	except AuthRequired:
+		handle_error_output(
+			ctx, "chatmsg", code="AUTH_REQUIRED",
+			message="未登录，请先执行 boss login",
+			recoverable=True, recovery_action="boss login",
+		)
+	except TokenRefreshFailed:
+		handle_error_output(
+			ctx, "chatmsg", code="TOKEN_REFRESH_FAILED",
+			message="Token 刷新失败，请重新登录",
+			recoverable=True, recovery_action="boss login",
+		)
+	except Exception as e:
+		handle_error_output(
+			ctx, "chatmsg", code="NETWORK_ERROR",
+			message=f"获取聊天记录失败: {e}",
+			recoverable=True, recovery_action="重试",
+		)

--- a/src/boss_agent_cli/commands/chatmsg.py
+++ b/src/boss_agent_cli/commands/chatmsg.py
@@ -3,8 +3,8 @@ import datetime
 import click
 
 from boss_agent_cli.api.client import BossClient
-from boss_agent_cli.auth.manager import AuthManager, AuthRequired, TokenRefreshFailed
-from boss_agent_cli.display import handle_error_output, handle_output, render_simple_list
+from boss_agent_cli.auth.manager import AuthManager
+from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_simple_list
 
 _MSG_TYPE_MAP = {
 	1: "文本", 2: "图片", 3: "招呼", 4: "简历", 5: "系统",
@@ -17,6 +17,7 @@ _MSG_TYPE_MAP = {
 @click.option("--page", default=1, help="页码")
 @click.option("--count", default=20, help="每页消息数量")
 @click.pass_context
+@handle_auth_errors("chatmsg")
 def chatmsg_cmd(ctx, security_id, page, count):
 	"""查看与指定好友的聊天消息历史"""
 	data_dir = ctx.obj["data_dir"]
@@ -25,91 +26,71 @@ def chatmsg_cmd(ctx, security_id, page, count):
 	cdp_url = ctx.obj.get("cdp_url")
 	auth = AuthManager(data_dir, logger=logger)
 
-	try:
-		with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
-			# 先从 friend_list 找到对应的 gid
-			friends_resp = client.friend_list(page=1)
-			zp_data = friends_resp.get("zpData", {})
-			items = zp_data.get("result") or zp_data.get("friendList") or []
+	with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
+		friends_resp = client.friend_list(page=1)
+		zp_data = friends_resp.get("zpData", {})
+		items = zp_data.get("result") or zp_data.get("friendList") or []
 
-			gid = None
-			friend_name = None
-			for item in items:
-				if item.get("securityId") == security_id:
-					gid = str(item.get("uid", ""))
-					friend_name = item.get("name") or "-"
-					break
+		gid = None
+		friend_name = None
+		for item in items:
+			if item.get("securityId") == security_id:
+				gid = str(item.get("uid", ""))
+				friend_name = item.get("name") or "-"
+				break
 
-			if not gid:
-				handle_error_output(
-					ctx, "chatmsg",
-					code="JOB_NOT_FOUND",
-					message=f"未在沟通列表中找到 security_id={security_id}，请确认该联系人存在",
-				)
-				return
-
-			resp = client.chat_history(gid, security_id, page=page, count=count)
-			msg_data = resp.get("zpData", {})
-			messages = msg_data.get("messages") or msg_data.get("historyMsgList") or []
-
-			result = []
-			for msg in messages:
-				from_obj = msg.get("from", {})
-				is_self = False
-				from_name = friend_name
-				if isinstance(from_obj, dict):
-					is_self = str(from_obj.get("uid", "")) != gid
-					if not is_self:
-						from_name = from_obj.get("name", friend_name)
-				if is_self:
-					from_name = "我"
-
-				msg_time = ""
-				if ts := msg.get("time"):
-					msg_time = datetime.datetime.fromtimestamp(ts / 1000).strftime("%m-%d %H:%M")
-
-				result.append({
-					"from": from_name,
-					"type": _MSG_TYPE_MAP.get(msg.get("type"), f"其他({msg.get('type')})"),
-					"text": msg.get("text") or msg.get("body", {}).get("text", "") or "",
-					"time": msg_time,
-				})
-
-			def _render(data):
-				render_simple_list(
-					data,
-					f"聊天记录 — {friend_name}",
-					[
-						("发送方", "from", "bold cyan"),
-						("类型", "type", "dim"),
-						("内容", "text", "yellow"),
-						("时间", "time", "dim"),
-					],
-				)
-
-			handle_output(
-				ctx, "chatmsg", result,
-				render=_render,
-				hints={"next_actions": [
-					"boss chat — 返回沟通列表",
-					f"boss detail {security_id} — 查看职位详情",
-				]},
+		if not gid:
+			handle_error_output(
+				ctx, "chatmsg",
+				code="JOB_NOT_FOUND",
+				message=f"未在沟通列表中找到 security_id={security_id}，请确认该联系人存在",
 			)
-	except AuthRequired:
-		handle_error_output(
-			ctx, "chatmsg", code="AUTH_REQUIRED",
-			message="未登录，请先执行 boss login",
-			recoverable=True, recovery_action="boss login",
-		)
-	except TokenRefreshFailed:
-		handle_error_output(
-			ctx, "chatmsg", code="TOKEN_REFRESH_FAILED",
-			message="Token 刷新失败，请重新登录",
-			recoverable=True, recovery_action="boss login",
-		)
-	except Exception as e:
-		handle_error_output(
-			ctx, "chatmsg", code="NETWORK_ERROR",
-			message=f"获取聊天记录失败: {e}",
-			recoverable=True, recovery_action="重试",
+			return
+
+		resp = client.chat_history(gid, security_id, page=page, count=count)
+		msg_data = resp.get("zpData", {})
+		messages = msg_data.get("messages") or msg_data.get("historyMsgList") or []
+
+		result = []
+		for msg in messages:
+			from_obj = msg.get("from", {})
+			is_self = False
+			from_name = friend_name
+			if isinstance(from_obj, dict):
+				is_self = str(from_obj.get("uid", "")) != gid
+				if not is_self:
+					from_name = from_obj.get("name", friend_name)
+			if is_self:
+				from_name = "我"
+
+			msg_time = ""
+			if ts := msg.get("time"):
+				msg_time = datetime.datetime.fromtimestamp(ts / 1000).strftime("%m-%d %H:%M")
+
+			result.append({
+				"from": from_name,
+				"type": _MSG_TYPE_MAP.get(msg.get("type"), f"其他({msg.get('type')})"),
+				"text": msg.get("text") or msg.get("body", {}).get("text", "") or "",
+				"time": msg_time,
+			})
+
+		def _render(data):
+			render_simple_list(
+				data,
+				f"聊天记录 — {friend_name}",
+				[
+					("发送方", "from", "bold cyan"),
+					("类型", "type", "dim"),
+					("内容", "text", "yellow"),
+					("时间", "time", "dim"),
+				],
+			)
+
+		handle_output(
+			ctx, "chatmsg", result,
+			render=_render,
+			hints={"next_actions": [
+				"boss chat — 返回沟通列表",
+				f"boss detail {security_id} — 查看职位详情",
+			]},
 		)

--- a/src/boss_agent_cli/commands/doctor.py
+++ b/src/boss_agent_cli/commands/doctor.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import click
+import httpx
+
+from boss_agent_cli.auth.browser import probe_cdp
+from boss_agent_cli.auth.cookie_extract import extract_cookies
+from boss_agent_cli.auth.manager import AuthManager
+from boss_agent_cli.display import handle_output, render_simple_list
+
+
+@click.command("doctor")
+@click.pass_context
+def doctor_cmd(ctx):
+	"""诊断本地运行环境、依赖和登录条件。"""
+	data_dir = ctx.obj["data_dir"]
+	auth = AuthManager(data_dir)
+	cdp_url = ctx.obj.get("cdp_url")
+
+	checks: list[dict] = []
+
+	def add_check(name: str, status: str, detail: str, hint: str = ""):
+		checks.append({
+			"name": name,
+			"status": status,
+			"detail": detail,
+			"hint": hint,
+		})
+
+	# 1) CLI dependencies
+	python_ok = True
+	add_check("python", "ok" if python_ok else "error", "Python 运行环境可用")
+
+	patchright_bin = shutil.which("patchright")
+	add_check(
+		"patchright",
+		"ok" if patchright_bin else "warn",
+		f"{patchright_bin}" if patchright_bin else "未找到 patchright 可执行文件",
+		"运行 uv run patchright install chromium 或确认已正确安装 patchright",
+	)
+
+	patchright_browser_dirs = [
+		Path.home() / ".cache" / "ms-playwright",
+		Path.home() / "Library" / "Caches" / "ms-playwright",
+	]
+	chromium_candidates = []
+	for base in patchright_browser_dirs:
+		if base.exists():
+			chromium_candidates.extend(base.glob("chromium-*"))
+	add_check(
+		"patchright_chromium",
+		"ok" if chromium_candidates else "warn",
+		f"检测到 {len(chromium_candidates)} 个 Chromium 安装" if chromium_candidates else "未检测到 patchright/Playwright Chromium 缓存",
+		"运行 patchright install chromium 安装浏览器内核",
+	)
+
+	chrome_bins = [
+		"google-chrome",
+		"google-chrome-stable",
+		"chromium",
+		"chromium-browser",
+		"chrome",
+		"msedge",
+	]
+	chrome_path = next((shutil.which(name) for name in chrome_bins if shutil.which(name)), None)
+	add_check(
+		"browser",
+		"ok" if chrome_path else "warn",
+		chrome_path or "未在 PATH 中发现 Chrome/Chromium/Edge",
+		"如需 CDP 登录，请先启动支持远程调试端口的浏览器；如仅用 patchright，可忽略此项",
+	)
+
+	# 2) Auth storage
+	auth_dir = data_dir / "auth"
+	session_path = auth_dir / "session.enc"
+	salt_path = auth_dir / "salt"
+	token = auth.check_status()
+	has_token = token is not None
+	if token:
+		cookie_count = len(token.get("cookies", {}))
+		stoken_state = "存在" if token.get("stoken") else "缺失"
+		add_check("auth_session", "ok", f"检测到登录态文件: {session_path}（cookies={cookie_count}, stoken={stoken_state}）")
+	else:
+		status = "warn"
+		detail = "未检测到本地登录态"
+		if session_path.exists():
+			status = "error"
+			detail = f"检测到 session 文件但无法解密/已损坏: {session_path}"
+		add_check("auth_session", status, detail, "运行 boss login 完成登录；如为旧密钥残留，可先 boss logout")
+
+	add_check(
+		"auth_salt",
+		"ok" if salt_path.exists() else "warn",
+		f"salt 文件{'存在' if salt_path.exists() else '不存在'}: {salt_path}",
+		"首次保存登录态后会自动生成，可忽略",
+	)
+
+	if token:
+		cookies = token.get("cookies", {}) or {}
+		has_wt2 = bool(cookies.get("wt2"))
+		has_stoken = bool(token.get("stoken"))
+		if has_wt2 and has_stoken:
+			quality_status = "ok"
+			quality_detail = "登录态完整：wt2/stoken 均存在"
+			quality_hint = "可直接运行 boss status / boss search 验证实际可用性"
+		elif has_wt2 and not has_stoken:
+			quality_status = "warn"
+			quality_detail = "登录态部分可用：wt2 存在，但 stoken 缺失"
+			quality_hint = "通常仍可读信息；若请求失败可先运行 boss status，必要时 boss login 触发重建/刷新"
+		elif not has_wt2 and has_stoken:
+			quality_status = "error"
+			quality_detail = "登录态异常：stoken 存在，但关键 Cookie wt2 缺失"
+			quality_hint = "执行 boss logout && boss login 重建登录态"
+		else:
+			quality_status = "error"
+			quality_detail = "登录态无效：wt2/stoken 均缺失"
+			quality_hint = "执行 boss login 建立有效登录态"
+		add_check("auth_token_quality", quality_status, quality_detail, quality_hint)
+	else:
+		add_check("auth_token_quality", "warn", "未检测到可评估的登录态", "先运行 boss login，再用 boss doctor / boss status 复查")
+
+	# 3) Cookie extraction support
+	cookie_probe = extract_cookies(None)
+	if cookie_probe:
+		cookie_sources = ",".join(sorted(cookie_probe.get("cookies", {}).keys())[:5])
+		add_check(
+			"cookie_extract",
+			"ok",
+			f"可从本地浏览器提取 Cookie（示例键: {cookie_sources or 'n/a'}）",
+		)
+	else:
+		add_check(
+			"cookie_extract",
+			"warn",
+			"未从本地浏览器提取到 zhipin Cookie",
+			"请先在本机浏览器登录 zhipin.com，或使用 boss login 走 CDP/扫码",
+		)
+
+	# 4) CDP availability
+	try:
+		ws_url = probe_cdp(cdp_url)
+		cdp_detail = ws_url or f"CDP 不可用（目标: {cdp_url or 'http://localhost:9222'}）"
+		if ws_url:
+			try:
+				resp = httpx.get(f"{cdp_url or 'http://localhost:9222'}/json/version", timeout=3)
+				meta = resp.json()
+				browser_name = meta.get("Browser") or "unknown-browser"
+				user_agent = meta.get("User-Agent") or "unknown-ua"
+				cdp_detail = f"{browser_name} | {user_agent} | {ws_url}"
+			except Exception:
+				pass
+		add_check(
+			"cdp",
+			"ok" if ws_url else "warn",
+			cdp_detail,
+			"如需复用用户 Chrome，请以远程调试模式启动浏览器",
+		)
+	except Exception as e:
+		add_check("cdp", "error", f"CDP 探测失败: {e}", "检查浏览器和调试端口配置")
+
+	# 5) Network probe
+	try:
+		resp = httpx.get("https://www.zhipin.com/", timeout=5, follow_redirects=True)
+		status = "ok" if resp.status_code < 400 else "warn"
+		add_check("network", status, f"访问 zhipin.com 返回 HTTP {resp.status_code}")
+	except Exception as e:
+		add_check("network", "warn", f"访问 zhipin.com 失败: {e}", "检查网络、代理或风控拦截")
+
+	# 6) Data dir writable
+	try:
+		auth_dir.mkdir(parents=True, exist_ok=True)
+		probe_file = auth_dir / ".doctor-write-test"
+		probe_file.write_text("ok", encoding="utf-8")
+		probe_file.unlink(missing_ok=True)
+		add_check("data_dir", "ok", f"数据目录可写: {data_dir}")
+	except Exception as e:
+		add_check("data_dir", "error", f"数据目录不可写: {e}", "修改 --data-dir 或目录权限")
+
+	status_rank = {"ok": 0, "warn": 1, "error": 2}
+	worst = max((status_rank[item["status"]] for item in checks), default=0)
+	summary = "healthy" if worst == 0 else ("degraded" if worst == 1 else "broken")
+
+	next_actions = []
+	if not has_token:
+		next_actions.append("boss login — 建立登录态")
+	else:
+		auth_quality = next((item for item in checks if item["name"] == "auth_token_quality"), None)
+		if auth_quality and auth_quality["status"] == "warn":
+			next_actions.append("boss status — 验证缺失 stoken 的登录态是否仍可用")
+			next_actions.append("如状态异常，执行 boss login — 重建或刷新登录态")
+		elif auth_quality and auth_quality["status"] == "error":
+			next_actions.append("boss logout && boss login — 重建损坏的登录态")
+		else:
+			next_actions.append("boss status — 验证当前账号是否可用")
+	if not any(item["name"] == "cdp" and item["status"] == "ok" for item in checks):
+		next_actions.append("boss --cdp-url http://localhost:9222 doctor — 检查指定 CDP 地址")
+	if not any(item["name"] == "cookie_extract" and item["status"] == "ok" for item in checks):
+		next_actions.append("先在本机浏览器登录 zhipin.com，再重试 boss login")
+
+	data = {
+		"summary": summary,
+		"data_dir": str(data_dir),
+		"check_count": len(checks),
+		"checks": checks,
+	}
+	hints = {
+		"next_actions": next_actions,
+	}
+	handle_output(
+		ctx,
+		"doctor",
+		data,
+		render=lambda d: render_simple_list(
+			d["checks"],
+			f"doctor: {d['summary']}",
+			[
+				("name", "name", "cyan"),
+				("status", "status", "green"),
+				("detail", "detail", "white"),
+			],
+		),
+		hints=hints,
+	)

--- a/src/boss_agent_cli/commands/exchange.py
+++ b/src/boss_agent_cli/commands/exchange.py
@@ -1,0 +1,78 @@
+import click
+
+from boss_agent_cli.api.client import BossClient
+from boss_agent_cli.auth.manager import AuthManager, AuthRequired, TokenRefreshFailed
+from boss_agent_cli.display import handle_error_output, handle_output, render_message_panel
+
+
+@click.command("exchange")
+@click.argument("security_id")
+@click.option("--type", "exchange_type", default="phone", type=click.Choice(["phone", "wechat"]), help="交换类型：phone=手机号 / wechat=微信")
+@click.pass_context
+def exchange_cmd(ctx, security_id, exchange_type):
+	"""请求交换联系方式（手机号或微信）"""
+	data_dir = ctx.obj["data_dir"]
+	logger = ctx.obj["logger"]
+	delay = ctx.obj["delay"]
+	cdp_url = ctx.obj.get("cdp_url")
+	auth = AuthManager(data_dir, logger=logger)
+
+	type_id = 2 if exchange_type == "wechat" else 1
+	type_label = "微信" if exchange_type == "wechat" else "手机号"
+
+	try:
+		with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
+			# 从 friend_list 找到 uid 和 name
+			friends_resp = client.friend_list(page=1)
+			zp_data = friends_resp.get("zpData", {})
+			items = zp_data.get("result") or zp_data.get("friendList") or []
+
+			uid = None
+			friend_name = None
+			for item in items:
+				if item.get("securityId") == security_id:
+					uid = str(item.get("uid", ""))
+					friend_name = item.get("name") or "-"
+					break
+
+			if not uid:
+				handle_error_output(
+					ctx, "exchange", code="JOB_NOT_FOUND",
+					message=f"未在沟通列表中找到 security_id={security_id}",
+				)
+				return
+
+			client.exchange_contact(security_id, uid, friend_name, exchange_type=type_id)
+
+			data = {
+				"security_id": security_id,
+				"name": friend_name,
+				"type": type_label,
+				"message": f"已向 {friend_name} 发送{type_label}交换请求",
+			}
+			handle_output(
+				ctx, "exchange", data,
+				render=lambda d: render_message_panel(d, title="exchange"),
+				hints={"next_actions": [
+					"boss chat — 返回沟通列表",
+					f"boss chatmsg {security_id} — 查看聊天记录",
+				]},
+			)
+	except AuthRequired:
+		handle_error_output(
+			ctx, "exchange", code="AUTH_REQUIRED",
+			message="未登录，请先执行 boss login",
+			recoverable=True, recovery_action="boss login",
+		)
+	except TokenRefreshFailed:
+		handle_error_output(
+			ctx, "exchange", code="TOKEN_REFRESH_FAILED",
+			message="Token 刷新失败，请重新登录",
+			recoverable=True, recovery_action="boss login",
+		)
+	except Exception as e:
+		handle_error_output(
+			ctx, "exchange", code="NETWORK_ERROR",
+			message=f"交换联系方式失败: {e}",
+			recoverable=True, recovery_action="重试",
+		)

--- a/src/boss_agent_cli/commands/exchange.py
+++ b/src/boss_agent_cli/commands/exchange.py
@@ -1,14 +1,15 @@
 import click
 
 from boss_agent_cli.api.client import BossClient
-from boss_agent_cli.auth.manager import AuthManager, AuthRequired, TokenRefreshFailed
-from boss_agent_cli.display import handle_error_output, handle_output, render_message_panel
+from boss_agent_cli.auth.manager import AuthManager
+from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_message_panel
 
 
 @click.command("exchange")
 @click.argument("security_id")
 @click.option("--type", "exchange_type", default="phone", type=click.Choice(["phone", "wechat"]), help="交换类型：phone=手机号 / wechat=微信")
 @click.pass_context
+@handle_auth_errors("exchange")
 def exchange_cmd(ctx, security_id, exchange_type):
 	"""请求交换联系方式（手机号或微信）"""
 	data_dir = ctx.obj["data_dir"]
@@ -20,59 +21,39 @@ def exchange_cmd(ctx, security_id, exchange_type):
 	type_id = 2 if exchange_type == "wechat" else 1
 	type_label = "微信" if exchange_type == "wechat" else "手机号"
 
-	try:
-		with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
-			# 从 friend_list 找到 uid 和 name
-			friends_resp = client.friend_list(page=1)
-			zp_data = friends_resp.get("zpData", {})
-			items = zp_data.get("result") or zp_data.get("friendList") or []
+	with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
+		friends_resp = client.friend_list(page=1)
+		zp_data = friends_resp.get("zpData", {})
+		items = zp_data.get("result") or zp_data.get("friendList") or []
 
-			uid = None
-			friend_name = None
-			for item in items:
-				if item.get("securityId") == security_id:
-					uid = str(item.get("uid", ""))
-					friend_name = item.get("name") or "-"
-					break
+		uid = None
+		friend_name = None
+		for item in items:
+			if item.get("securityId") == security_id:
+				uid = str(item.get("uid", ""))
+				friend_name = item.get("name") or "-"
+				break
 
-			if not uid:
-				handle_error_output(
-					ctx, "exchange", code="JOB_NOT_FOUND",
-					message=f"未在沟通列表中找到 security_id={security_id}",
-				)
-				return
-
-			client.exchange_contact(security_id, uid, friend_name, exchange_type=type_id)
-
-			data = {
-				"security_id": security_id,
-				"name": friend_name,
-				"type": type_label,
-				"message": f"已向 {friend_name} 发送{type_label}交换请求",
-			}
-			handle_output(
-				ctx, "exchange", data,
-				render=lambda d: render_message_panel(d, title="exchange"),
-				hints={"next_actions": [
-					"boss chat — 返回沟通列表",
-					f"boss chatmsg {security_id} — 查看聊天记录",
-				]},
+		if not uid:
+			handle_error_output(
+				ctx, "exchange", code="JOB_NOT_FOUND",
+				message=f"未在沟通列表中找到 security_id={security_id}",
 			)
-	except AuthRequired:
-		handle_error_output(
-			ctx, "exchange", code="AUTH_REQUIRED",
-			message="未登录，请先执行 boss login",
-			recoverable=True, recovery_action="boss login",
-		)
-	except TokenRefreshFailed:
-		handle_error_output(
-			ctx, "exchange", code="TOKEN_REFRESH_FAILED",
-			message="Token 刷新失败，请重新登录",
-			recoverable=True, recovery_action="boss login",
-		)
-	except Exception as e:
-		handle_error_output(
-			ctx, "exchange", code="NETWORK_ERROR",
-			message=f"交换联系方式失败: {e}",
-			recoverable=True, recovery_action="重试",
+			return
+
+		client.exchange_contact(security_id, uid, friend_name, exchange_type=type_id)
+
+		data = {
+			"security_id": security_id,
+			"name": friend_name,
+			"type": type_label,
+			"message": f"已向 {friend_name} 发送{type_label}交换请求",
+		}
+		handle_output(
+			ctx, "exchange", data,
+			render=lambda d: render_message_panel(d, title="exchange"),
+			hints={"next_actions": [
+				"boss chat — 返回沟通列表",
+				f"boss chatmsg {security_id} — 查看聊天记录",
+			]},
 		)

--- a/src/boss_agent_cli/commands/greet.py
+++ b/src/boss_agent_cli/commands/greet.py
@@ -134,123 +134,116 @@ def batch_greet_cmd(ctx, query, city, salary, experience, education, industry, s
 
 	count = min(count, 10)
 
-	cache = CacheStore(data_dir / "cache" / "boss_agent.db")
-
-	try:
-		auth = AuthManager(data_dir, logger=logger)
-		with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
-			raw = client.search_jobs(
-				query, city=city, salary=salary, experience=experience,
-				education=education, industry=industry, scale=scale,
-				stage=stage, job_type=job_type,
-			)
-			zp_data = raw.get("zpData", {})
-			job_list = zp_data.get("jobList", [])
-
-			candidates = []
-			for raw_item in job_list:
-				item = JobItem.from_api(raw_item)
-				if not cache.is_greeted(item.security_id):
-					candidates.append(item)
-				if len(candidates) >= count:
-					break
-
-			if dry_run:
-				items = [item.to_dict() for item in candidates]
-				cache.close()
-				handle_output(
-					ctx, "batch-greet", {
-						"dry_run": True,
-						"candidates": items,
-						"count": len(items),
-					},
-					render=lambda d: render_batch_operation_summary(d, title="batch-greet"),
+	with CacheStore(data_dir / "cache" / "boss_agent.db") as cache:
+		try:
+			auth = AuthManager(data_dir, logger=logger)
+			with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
+				raw = client.search_jobs(
+					query, city=city, salary=salary, experience=experience,
+					education=education, industry=industry, scale=scale,
+					stage=stage, job_type=job_type,
 				)
-				return
+				zp_data = raw.get("zpData", {})
+				job_list = zp_data.get("jobList", [])
 
-			results = []
-			stopped_reason = None
-
-			for item in candidates:
-				retry_count = 0
-				success = False
-
-				while retry_count <= 1:
-					try:
-						client.greet(item.security_id, item.job_id)
-						cache.record_greet(item.security_id, item.job_id)
-						results.append({
-							"security_id": item.security_id,
-							"job_id": item.job_id,
-							"title": item.title,
-							"company": item.company,
-							"status": "success",
-						})
-						success = True
-						logger.info(f"打招呼成功: {item.title} @ {item.company}")
+				candidates = []
+				for raw_item in job_list:
+					item = JobItem.from_api(raw_item)
+					if not cache.is_greeted(item.security_id):
+						candidates.append(item)
+					if len(candidates) >= count:
 						break
-					except Exception as e:
-						error_msg = str(e)
-						if "RATE_LIMITED" in error_msg or "频率" in error_msg:
-							stopped_reason = "RATE_LIMITED"
-							break
-						if "GREET_LIMIT" in error_msg or "上限" in error_msg:
-							stopped_reason = "GREET_LIMIT"
-							break
-						if retry_count == 0:
-							logger.warning(f"打招呼失败，重试中: {item.title}")
-							retry_count += 1
-							time.sleep(random.uniform(1.0, 2.0))
-						else:
+
+				if dry_run:
+					items = [item.to_dict() for item in candidates]
+					handle_output(
+						ctx, "batch-greet", {
+							"dry_run": True,
+							"candidates": items,
+							"count": len(items),
+						},
+						render=lambda d: render_batch_operation_summary(d, title="batch-greet"),
+					)
+					return
+
+				results = []
+				stopped_reason = None
+
+				for idx, item in enumerate(candidates):
+					retry_count = 0
+					success = False
+
+					while retry_count <= 1:
+						try:
+							client.greet(item.security_id, item.job_id)
+							cache.record_greet(item.security_id, item.job_id)
 							results.append({
 								"security_id": item.security_id,
 								"job_id": item.job_id,
 								"title": item.title,
 								"company": item.company,
-								"status": "failed",
-								"error": error_msg,
+								"status": "success",
 							})
+							success = True
+							logger.info(f"打招呼成功: {item.title} @ {item.company}")
 							break
+						except Exception as e:
+							error_msg = str(e)
+							if "RATE_LIMITED" in error_msg or "频率" in error_msg:
+								stopped_reason = "RATE_LIMITED"
+								break
+							if "GREET_LIMIT" in error_msg or "上限" in error_msg:
+								stopped_reason = "GREET_LIMIT"
+								break
+							if retry_count == 0:
+								logger.warning(f"打招呼失败，重试中: {item.title}")
+								retry_count += 1
+								time.sleep(random.uniform(1.0, 2.0))
+							else:
+								results.append({
+									"security_id": item.security_id,
+									"job_id": item.job_id,
+									"title": item.title,
+									"company": item.company,
+									"status": "failed",
+									"error": error_msg,
+								})
+								break
 
+					if stopped_reason:
+						break
+
+					if success and idx < len(candidates) - 1:
+						time.sleep(random.uniform(2.0, 5.0))
+
+				data = {
+					"greeted": [r for r in results if r["status"] == "success"],
+					"failed": [r for r in results if r["status"] == "failed"],
+					"total_greeted": sum(1 for r in results if r["status"] == "success"),
+					"total_failed": sum(1 for r in results if r["status"] == "failed"),
+				}
 				if stopped_reason:
-					break
+					data["stopped_reason"] = stopped_reason
 
-				if success and item != candidates[-1]:
-					time.sleep(random.uniform(2.0, 5.0))
-
-			cache.close()
-
-			data = {
-				"greeted": [r for r in results if r["status"] == "success"],
-				"failed": [r for r in results if r["status"] == "failed"],
-				"total_greeted": sum(1 for r in results if r["status"] == "success"),
-				"total_failed": sum(1 for r in results if r["status"] == "failed"),
-			}
-			if stopped_reason:
-				data["stopped_reason"] = stopped_reason
-
-			handle_output(
-				ctx, "batch-greet", data,
-				render=lambda d: render_batch_operation_summary(d, title="batch-greet"),
+				handle_output(
+					ctx, "batch-greet", data,
+					render=lambda d: render_batch_operation_summary(d, title="batch-greet"),
+				)
+		except AuthRequired:
+			handle_error_output(
+				ctx, "batch-greet", code="AUTH_REQUIRED",
+				message="未登录，请先执行 boss login",
+				recoverable=True, recovery_action="boss login",
 			)
-	except AuthRequired:
-		cache.close()
-		handle_error_output(
-			ctx, "batch-greet", code="AUTH_REQUIRED",
-			message="未登录，请先执行 boss login",
-			recoverable=True, recovery_action="boss login",
-		)
-	except TokenRefreshFailed:
-		cache.close()
-		handle_error_output(
-			ctx, "batch-greet", code="TOKEN_REFRESH_FAILED",
-			message="Token 刷新失败，请重新登录",
-			recoverable=True, recovery_action="boss login",
-		)
-	except Exception as e:
-		cache.close()
-		handle_error_output(
-			ctx, "batch-greet", code="NETWORK_ERROR",
-			message=f"批量打招呼失败: {e}",
-			recoverable=True, recovery_action="重试",
-		)
+		except TokenRefreshFailed:
+			handle_error_output(
+				ctx, "batch-greet", code="TOKEN_REFRESH_FAILED",
+				message="Token 刷新失败，请重新登录",
+				recoverable=True, recovery_action="boss login",
+			)
+		except Exception as e:
+			handle_error_output(
+				ctx, "batch-greet", code="NETWORK_ERROR",
+				message=f"批量打招呼失败: {e}",
+				recoverable=True, recovery_action="重试",
+			)

--- a/src/boss_agent_cli/commands/greet.py
+++ b/src/boss_agent_cli/commands/greet.py
@@ -33,90 +33,83 @@ def greet_cmd(ctx, security_id, job_id, message):
 	delay = ctx.obj["delay"]
 	cdp_url = ctx.obj.get("cdp_url")
 
-	cache = CacheStore(data_dir / "cache" / "boss_agent.db")
-
-	if cache.is_greeted(security_id):
-		cache.close()
-		handle_error_output(
-			ctx, "greet",
-			code="ALREADY_GREETED",
-			message="已向该招聘者打过招呼",
-			hints={"next_actions": ["boss search <query> — 搜索其他职位"]},
-		)
-		return
-
-	try:
-		auth = AuthManager(data_dir, logger=logger)
-		with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
-			# greet_before hook — allows veto
-			hooks = ctx.obj.get("hooks")
-			if hooks:
-				veto = hooks.greet_before.call({
-					"security_id": security_id,
-					"job_id": job_id,
-					"message": message,
-					"source": "greet",
-				})
-				if veto:
-					cache.close()
-					handle_error_output(
-						ctx, "greet", code="HOOK_BLOCKED",
-						message=f"打招呼被钩子阻止: {veto}",
-						recoverable=True,
-					)
-					return
-
-			result = client.greet(security_id, job_id, message)
-
-			cache.record_greet(security_id, job_id)
-			cache.close()
-
-			# greet_after hook
-			if hooks:
-				hooks.greet_after.call({
-					"security_id": security_id,
-					"job_id": job_id,
-					"success": True,
-					"source": "greet",
-				})
-
-			data = {
-				"security_id": security_id,
-				"job_id": job_id,
-				"message": "打招呼成功",
-			}
-			hints = {
-				"next_actions": [
-					"boss search <query> — 继续搜索其他职位",
-					"boss recommend — 获取个性化推荐",
-				],
-			}
-			handle_output(
-				ctx, "greet", data,
-				render=lambda d: render_message_panel(d, title="greet"),
-				hints=hints,
+	with CacheStore(data_dir / "cache" / "boss_agent.db") as cache:
+		if cache.is_greeted(security_id):
+			handle_error_output(
+				ctx, "greet",
+				code="ALREADY_GREETED",
+				message="已向该招聘者打过招呼",
+				hints={"next_actions": ["boss search <query> — 搜索其他职位"]},
 			)
-	except AuthRequired:
-		cache.close()
-		handle_error_output(
-			ctx, "greet", code="AUTH_REQUIRED",
-			message="未登录，请先执行 boss login",
-			recoverable=True, recovery_action="boss login",
-		)
-	except TokenRefreshFailed:
-		cache.close()
-		handle_error_output(
-			ctx, "greet", code="TOKEN_REFRESH_FAILED",
-			message="Token 刷新失败，请重新登录",
-			recoverable=True, recovery_action="boss login",
-		)
-	except Exception as e:
-		cache.close()
-		handle_error_output(
-			ctx, "greet", code="NETWORK_ERROR",
-			message=f"打招呼失败: {e}",
-			recoverable=True, recovery_action="重试",
-		)
+			return
+
+		try:
+			auth = AuthManager(data_dir, logger=logger)
+			with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
+				# greet_before hook — allows veto
+				hooks = ctx.obj.get("hooks")
+				if hooks:
+					veto = hooks.greet_before.call({
+						"security_id": security_id,
+						"job_id": job_id,
+						"message": message,
+						"source": "greet",
+					})
+					if veto:
+						handle_error_output(
+							ctx, "greet", code="HOOK_BLOCKED",
+							message=f"打招呼被钩子阻止: {veto}",
+							recoverable=True,
+						)
+						return
+
+				result = client.greet(security_id, job_id, message)
+
+				cache.record_greet(security_id, job_id)
+
+				# greet_after hook
+				if hooks:
+					hooks.greet_after.call({
+						"security_id": security_id,
+						"job_id": job_id,
+						"success": True,
+						"source": "greet",
+					})
+
+				data = {
+					"security_id": security_id,
+					"job_id": job_id,
+					"message": "打招呼成功",
+				}
+				hints = {
+					"next_actions": [
+						"boss search <query> — 继续搜索其他职位",
+						"boss recommend — 获取个性化推荐",
+					],
+				}
+				handle_output(
+					ctx, "greet", data,
+					render=lambda d: render_message_panel(d, title="greet"),
+					hints=hints,
+				)
+		except AuthRequired:
+			handle_error_output(
+				ctx, "greet", code="AUTH_REQUIRED",
+				message="未登录，请先执行 boss login",
+				recoverable=True, recovery_action="boss login",
+			)
+		except TokenRefreshFailed:
+			handle_error_output(
+				ctx, "greet", code="TOKEN_REFRESH_FAILED",
+				message="Token 刷新失败，请重新登录",
+				recoverable=True, recovery_action="boss login",
+			)
+		except Exception as e:
+			handle_error_output(
+				ctx, "greet", code="NETWORK_ERROR",
+				message=f"打招呼失败: {e}",
+				recoverable=True, recovery_action="重试",
+			)
 
 
 @click.command("batch-greet")

--- a/src/boss_agent_cli/commands/mark.py
+++ b/src/boss_agent_cli/commands/mark.py
@@ -1,0 +1,103 @@
+import click
+
+from boss_agent_cli.api.client import BossClient
+from boss_agent_cli.auth.manager import AuthManager, AuthRequired, TokenRefreshFailed
+from boss_agent_cli.display import handle_error_output, handle_output, render_message_panel
+
+_LABEL_MAP = {
+	"新招呼": 1, "沟通中": 2, "已约面": 3, "已获取简历": 4,
+	"已交换电话": 5, "已交换微信": 6, "不合适": 7, "牛人发起": 8, "收藏": 11,
+}
+
+_LABEL_NAMES = {v: k for k, v in _LABEL_MAP.items()}
+
+
+def _resolve_label(label_input: str) -> int:
+	"""将标签名称或 ID 解析为数字 ID。"""
+	if label_input in _LABEL_MAP:
+		return _LABEL_MAP[label_input]
+	if label_input.isdigit():
+		return int(label_input)
+	for name, lid in _LABEL_MAP.items():
+		if label_input in name:
+			return lid
+	raise click.BadParameter(
+		f"未知标签: {label_input}。可用: {', '.join(_LABEL_MAP.keys())}"
+	)
+
+
+@click.command("mark")
+@click.argument("security_id")
+@click.option("--label", required=True, help="标签名称（新招呼/沟通中/已约面/已获取简历/已交换电话/已交换微信/不合适/收藏）或 ID")
+@click.option("--remove", is_flag=True, default=False, help="移除标签（默认为添加）")
+@click.pass_context
+def mark_cmd(ctx, security_id, label, remove):
+	"""给联系人添加/移除标签"""
+	data_dir = ctx.obj["data_dir"]
+	logger = ctx.obj["logger"]
+	delay = ctx.obj["delay"]
+	cdp_url = ctx.obj.get("cdp_url")
+	auth = AuthManager(data_dir, logger=logger)
+
+	label_id = _resolve_label(label)
+	label_name = _LABEL_NAMES.get(label_id, str(label_id))
+	action_text = "移除" if remove else "添加"
+
+	try:
+		with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
+			# 从 friend_list 找到 friend_id (uid)
+			friends_resp = client.friend_list(page=1)
+			zp_data = friends_resp.get("zpData", {})
+			items = zp_data.get("result") or zp_data.get("friendList") or []
+
+			friend_id = None
+			friend_source = 0
+			friend_name = None
+			for item in items:
+				if item.get("securityId") == security_id:
+					friend_id = str(item.get("uid", ""))
+					friend_source = item.get("friendSource", 0)
+					friend_name = item.get("name") or "-"
+					break
+
+			if not friend_id:
+				handle_error_output(
+					ctx, "mark", code="JOB_NOT_FOUND",
+					message=f"未在沟通列表中找到 security_id={security_id}",
+				)
+				return
+
+			client.friend_label(friend_id, label_id, friend_source, remove=remove)
+
+			data = {
+				"security_id": security_id,
+				"name": friend_name,
+				"label": label_name,
+				"action": action_text,
+				"message": f"已{action_text}标签「{label_name}」",
+			}
+			handle_output(
+				ctx, "mark", data,
+				render=lambda d: render_message_panel(d, title="mark"),
+				hints={"next_actions": [
+					"boss chat — 返回沟通列表",
+				]},
+			)
+	except AuthRequired:
+		handle_error_output(
+			ctx, "mark", code="AUTH_REQUIRED",
+			message="未登录，请先执行 boss login",
+			recoverable=True, recovery_action="boss login",
+		)
+	except TokenRefreshFailed:
+		handle_error_output(
+			ctx, "mark", code="TOKEN_REFRESH_FAILED",
+			message="Token 刷新失败，请重新登录",
+			recoverable=True, recovery_action="boss login",
+		)
+	except Exception as e:
+		handle_error_output(
+			ctx, "mark", code="NETWORK_ERROR",
+			message=f"标签操作失败: {e}",
+			recoverable=True, recovery_action="重试",
+		)

--- a/src/boss_agent_cli/commands/mark.py
+++ b/src/boss_agent_cli/commands/mark.py
@@ -1,8 +1,8 @@
 import click
 
 from boss_agent_cli.api.client import BossClient
-from boss_agent_cli.auth.manager import AuthManager, AuthRequired, TokenRefreshFailed
-from boss_agent_cli.display import handle_error_output, handle_output, render_message_panel
+from boss_agent_cli.auth.manager import AuthManager
+from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_message_panel
 
 _LABEL_MAP = {
 	"新招呼": 1, "沟通中": 2, "已约面": 3, "已获取简历": 4,
@@ -31,6 +31,7 @@ def _resolve_label(label_input: str) -> int:
 @click.option("--label", required=True, help="标签名称（新招呼/沟通中/已约面/已获取简历/已交换电话/已交换微信/不合适/收藏）或 ID")
 @click.option("--remove", is_flag=True, default=False, help="移除标签（默认为添加）")
 @click.pass_context
+@handle_auth_errors("mark")
 def mark_cmd(ctx, security_id, label, remove):
 	"""给联系人添加/移除标签"""
 	data_dir = ctx.obj["data_dir"]
@@ -43,61 +44,41 @@ def mark_cmd(ctx, security_id, label, remove):
 	label_name = _LABEL_NAMES.get(label_id, str(label_id))
 	action_text = "移除" if remove else "添加"
 
-	try:
-		with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
-			# 从 friend_list 找到 friend_id (uid)
-			friends_resp = client.friend_list(page=1)
-			zp_data = friends_resp.get("zpData", {})
-			items = zp_data.get("result") or zp_data.get("friendList") or []
+	with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
+		friends_resp = client.friend_list(page=1)
+		zp_data = friends_resp.get("zpData", {})
+		items = zp_data.get("result") or zp_data.get("friendList") or []
 
-			friend_id = None
-			friend_source = 0
-			friend_name = None
-			for item in items:
-				if item.get("securityId") == security_id:
-					friend_id = str(item.get("uid", ""))
-					friend_source = item.get("friendSource", 0)
-					friend_name = item.get("name") or "-"
-					break
+		friend_id = None
+		friend_source = 0
+		friend_name = None
+		for item in items:
+			if item.get("securityId") == security_id:
+				friend_id = str(item.get("uid", ""))
+				friend_source = item.get("friendSource", 0)
+				friend_name = item.get("name") or "-"
+				break
 
-			if not friend_id:
-				handle_error_output(
-					ctx, "mark", code="JOB_NOT_FOUND",
-					message=f"未在沟通列表中找到 security_id={security_id}",
-				)
-				return
-
-			client.friend_label(friend_id, label_id, friend_source, remove=remove)
-
-			data = {
-				"security_id": security_id,
-				"name": friend_name,
-				"label": label_name,
-				"action": action_text,
-				"message": f"已{action_text}标签「{label_name}」",
-			}
-			handle_output(
-				ctx, "mark", data,
-				render=lambda d: render_message_panel(d, title="mark"),
-				hints={"next_actions": [
-					"boss chat — 返回沟通列表",
-				]},
+		if not friend_id:
+			handle_error_output(
+				ctx, "mark", code="JOB_NOT_FOUND",
+				message=f"未在沟通列表中找到 security_id={security_id}",
 			)
-	except AuthRequired:
-		handle_error_output(
-			ctx, "mark", code="AUTH_REQUIRED",
-			message="未登录，请先执行 boss login",
-			recoverable=True, recovery_action="boss login",
-		)
-	except TokenRefreshFailed:
-		handle_error_output(
-			ctx, "mark", code="TOKEN_REFRESH_FAILED",
-			message="Token 刷新失败，请重新登录",
-			recoverable=True, recovery_action="boss login",
-		)
-	except Exception as e:
-		handle_error_output(
-			ctx, "mark", code="NETWORK_ERROR",
-			message=f"标签操作失败: {e}",
-			recoverable=True, recovery_action="重试",
+			return
+
+		client.friend_label(friend_id, label_id, friend_source, remove=remove)
+
+		data = {
+			"security_id": security_id,
+			"name": friend_name,
+			"label": label_name,
+			"action": action_text,
+			"message": f"已{action_text}标签「{label_name}」",
+		}
+		handle_output(
+			ctx, "mark", data,
+			render=lambda d: render_message_panel(d, title="mark"),
+			hints={"next_actions": [
+				"boss chat — 返回沟通列表",
+			]},
 		)

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -283,6 +283,16 @@ SCHEMA_DATA = {
 				},
 			},
 		},
+		"chatmsg": {
+			"description": "查看与指定好友的聊天消息历史",
+			"args": [
+				{"name": "security_id", "required": True, "description": "联系人的 security_id（从 chat 命令获取）"},
+			],
+			"options": {
+				"--page": {"type": "int", "default": 1, "description": "页码"},
+				"--count": {"type": "int", "default": 20, "description": "每页消息数量"},
+			},
+		},
 		"interviews": {
 			"description": "查看面试邀请列表",
 			"args": [],

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -27,6 +27,11 @@ SCHEMA_DATA = {
 			"args": [],
 			"options": {},
 		},
+		"doctor": {
+			"description": "诊断本地运行环境、依赖、登录条件和网络连通性",
+			"args": [],
+			"options": {},
+		},
 		"search": {
 			"description": "按关键词和筛选条件搜索职位列表",
 			"args": [

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -293,6 +293,16 @@ SCHEMA_DATA = {
 				"--count": {"type": "int", "default": 20, "description": "每页消息数量"},
 			},
 		},
+		"mark": {
+			"description": "给联系人添加/移除标签（新招呼/沟通中/已约面/不合适/收藏等）",
+			"args": [
+				{"name": "security_id", "required": True, "description": "联系人的 security_id（从 chat 命令获取）"},
+			],
+			"options": {
+				"--label": {"type": "string", "required": True, "description": "标签名称或 ID", "enum": ["新招呼", "沟通中", "已约面", "已获取简历", "已交换电话", "已交换微信", "不合适", "收藏"]},
+				"--remove": {"type": "boolean", "default": False, "description": "移除标签（默认为添加）"},
+			},
+		},
 		"interviews": {
 			"description": "查看面试邀请列表",
 			"args": [],

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -303,6 +303,15 @@ SCHEMA_DATA = {
 				"--remove": {"type": "boolean", "default": False, "description": "移除标签（默认为添加）"},
 			},
 		},
+		"exchange": {
+			"description": "请求交换联系方式（手机号或微信）",
+			"args": [
+				{"name": "security_id", "required": True, "description": "联系人的 security_id（从 chat 命令获取）"},
+			],
+			"options": {
+				"--type": {"type": "string", "default": "phone", "description": "交换类型", "enum": ["phone", "wechat"]},
+			},
+		},
 		"interviews": {
 			"description": "查看面试邀请列表",
 			"args": [],

--- a/src/boss_agent_cli/commands/status.py
+++ b/src/boss_agent_cli/commands/status.py
@@ -26,15 +26,15 @@ def status_cmd(ctx):
 		return
 
 	try:
-		client = BossClient(auth, delay=delay, cdp_url=cdp_url)
-		info = client.user_info()
-		user_name = info.get("zpData", {}).get("name", "未知用户")
-		data = {
-			"logged_in": True,
-			"user_name": user_name,
-			"token_expires_in": None,
-		}
-		handle_output(ctx, "status", data, render=render_status)
+		with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
+			info = client.user_info()
+			user_name = info.get("zpData", {}).get("name", "未知用户")
+			data = {
+				"logged_in": True,
+				"user_name": user_name,
+				"token_expires_in": None,
+			}
+			handle_output(ctx, "status", data, render=render_status)
 	except AuthRequired:
 		handle_error_output(
 			ctx, "status",

--- a/src/boss_agent_cli/display.py
+++ b/src/boss_agent_cli/display.py
@@ -265,3 +265,44 @@ def render_export_summary(data: dict) -> None:
 		console.print(f"[green]exported[/green] {count} jobs to [bold]{path}[/bold] ({fmt})")
 	else:
 		console.print(f"[green]exported[/green] {count} jobs ({fmt})")
+
+
+# ── Auth error decorator ─────────────────────────────────────────────
+
+
+def handle_auth_errors(command_name: str):
+	"""装饰器：统一处理 AuthRequired / TokenRefreshFailed / Exception 三层捕获。
+
+	用法:
+		@handle_auth_errors("search")
+		def _search_impl(ctx, ...):
+			...  # 只写业务逻辑，不需要 try/except
+	"""
+	from functools import wraps
+
+	def decorator(func):
+		@wraps(func)
+		def wrapper(ctx, *args, **kwargs):
+			from boss_agent_cli.auth.manager import AuthRequired, TokenRefreshFailed
+			try:
+				return func(ctx, *args, **kwargs)
+			except AuthRequired:
+				handle_error_output(
+					ctx, command_name, code="AUTH_REQUIRED",
+					message="未登录，请先执行 boss login",
+					recoverable=True, recovery_action="boss login",
+				)
+			except TokenRefreshFailed:
+				handle_error_output(
+					ctx, command_name, code="TOKEN_REFRESH_FAILED",
+					message="Token 刷新失败，请重新登录",
+					recoverable=True, recovery_action="boss login",
+				)
+			except Exception as e:
+				handle_error_output(
+					ctx, command_name, code="NETWORK_ERROR",
+					message=f"{command_name} 失败: {e}",
+					recoverable=True, recovery_action="重试",
+				)
+		return wrapper
+	return decorator

--- a/src/boss_agent_cli/display.py
+++ b/src/boss_agent_cli/display.py
@@ -66,7 +66,7 @@ def handle_error_output(
 		console.print(f"[red]error[/red] [{code}] {message}")
 		if recovery_action:
 			console.print(f"  [dim]recovery: {recovery_action}[/dim]")
-		sys.exit(1)
+		raise SystemExit(1)
 
 
 # ── Table builders ──────────────────────────────────────────────────

--- a/src/boss_agent_cli/main.py
+++ b/src/boss_agent_cli/main.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import click
 
-from boss_agent_cli.commands import schema, login, logout, status, doctor, search, detail, greet, recommend, export, cities, me, chat, chatmsg, mark, interviews, show, history
+from boss_agent_cli.commands import schema, login, logout, status, doctor, search, detail, greet, recommend, export, cities, me, chat, chatmsg, mark, exchange, interviews, show, history
 from boss_agent_cli.config import load_config
 from boss_agent_cli.hooks import create_hook_bus
 from boss_agent_cli.output import Logger
@@ -54,6 +54,7 @@ cli.add_command(me.me_cmd, "me")
 cli.add_command(chat.chat_cmd, "chat")
 cli.add_command(chatmsg.chatmsg_cmd, "chatmsg")
 cli.add_command(mark.mark_cmd, "mark")
+cli.add_command(exchange.exchange_cmd, "exchange")
 cli.add_command(interviews.interviews_cmd, "interviews")
 cli.add_command(show.show_cmd, "show")
 cli.add_command(history.history_cmd, "history")

--- a/src/boss_agent_cli/main.py
+++ b/src/boss_agent_cli/main.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import click
 
-from boss_agent_cli.commands import schema, login, logout, status, search, detail, greet, recommend, export, cities, me, chat, interviews, show, history
+from boss_agent_cli.commands import schema, login, logout, status, doctor, search, detail, greet, recommend, export, cities, me, chat, interviews, show, history
 from boss_agent_cli.config import load_config
 from boss_agent_cli.hooks import create_hook_bus
 from boss_agent_cli.output import Logger
@@ -42,6 +42,7 @@ cli.add_command(schema.schema_cmd, "schema")
 cli.add_command(login.login_cmd, "login")
 cli.add_command(logout.logout_cmd, "logout")
 cli.add_command(status.status_cmd, "status")
+cli.add_command(doctor.doctor_cmd, "doctor")
 cli.add_command(search.search_cmd, "search")
 cli.add_command(detail.detail_cmd, "detail")
 cli.add_command(greet.greet_cmd, "greet")

--- a/src/boss_agent_cli/main.py
+++ b/src/boss_agent_cli/main.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import click
 
-from boss_agent_cli.commands import schema, login, logout, status, doctor, search, detail, greet, recommend, export, cities, me, chat, chatmsg, interviews, show, history
+from boss_agent_cli.commands import schema, login, logout, status, doctor, search, detail, greet, recommend, export, cities, me, chat, chatmsg, mark, interviews, show, history
 from boss_agent_cli.config import load_config
 from boss_agent_cli.hooks import create_hook_bus
 from boss_agent_cli.output import Logger
@@ -53,6 +53,7 @@ cli.add_command(cities.cities_cmd, "cities")
 cli.add_command(me.me_cmd, "me")
 cli.add_command(chat.chat_cmd, "chat")
 cli.add_command(chatmsg.chatmsg_cmd, "chatmsg")
+cli.add_command(mark.mark_cmd, "mark")
 cli.add_command(interviews.interviews_cmd, "interviews")
 cli.add_command(show.show_cmd, "show")
 cli.add_command(history.history_cmd, "history")

--- a/src/boss_agent_cli/main.py
+++ b/src/boss_agent_cli/main.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import click
 
-from boss_agent_cli.commands import schema, login, logout, status, doctor, search, detail, greet, recommend, export, cities, me, chat, interviews, show, history
+from boss_agent_cli.commands import schema, login, logout, status, doctor, search, detail, greet, recommend, export, cities, me, chat, chatmsg, interviews, show, history
 from boss_agent_cli.config import load_config
 from boss_agent_cli.hooks import create_hook_bus
 from boss_agent_cli.output import Logger
@@ -52,6 +52,7 @@ cli.add_command(export.export_cmd, "export")
 cli.add_command(cities.cities_cmd, "cities")
 cli.add_command(me.me_cmd, "me")
 cli.add_command(chat.chat_cmd, "chat")
+cli.add_command(chatmsg.chatmsg_cmd, "chatmsg")
 cli.add_command(interviews.interviews_cmd, "interviews")
 cli.add_command(show.show_cmd, "show")
 cli.add_command(history.history_cmd, "history")

--- a/src/boss_agent_cli/search_filters.py
+++ b/src/boss_agent_cli/search_filters.py
@@ -183,8 +183,8 @@ def match_all_welfare(
 	return results
 
 
-def _fetch_and_check(client, cache, welfare_conditions, raw_item) -> dict | None:
-	"""Single job: fetch detail + welfare match."""
+def _fetch_and_check(client, welfare_conditions, raw_item) -> dict | None:
+	"""Single job: fetch detail + welfare match. 不访问 cache（线程安全）。"""
 	welfare_list = raw_item.get("welfareList", [])
 	try:
 		card_raw = client.job_card(
@@ -198,7 +198,6 @@ def _fetch_and_check(client, cache, welfare_conditions, raw_item) -> dict | None
 	match_results = match_all_welfare(welfare_conditions, welfare_list, desc)
 	if match_results:
 		item = JobItem.from_api(raw_item)
-		item.greeted = cache.is_greeted(item.security_id)
 		d = item.to_dict()
 		d["welfare_match"] = "✅ " + ", ".join(match_results)
 		return d
@@ -206,10 +205,10 @@ def _fetch_and_check(client, cache, welfare_conditions, raw_item) -> dict | None
 
 
 def _check_details_parallel(client, cache, logger, welfare_conditions, items, matched):
-	"""Parallel detail check, append matched to list."""
+	"""Parallel detail check, append matched to list. cache 操作在主线程完成。"""
 	with ThreadPoolExecutor(max_workers=_WELFARE_WORKERS) as pool:
 		futures = {
-			pool.submit(_fetch_and_check, client, cache, welfare_conditions, raw_item): raw_item
+			pool.submit(_fetch_and_check, client, welfare_conditions, raw_item): raw_item
 			for raw_item in items
 		}
 		for future in as_completed(futures):
@@ -219,6 +218,10 @@ def _check_details_parallel(client, cache, logger, welfare_conditions, items, ma
 			try:
 				result = future.result()
 				if result:
+					# is_greeted 在主线程中安全访问 cache
+					sid = result.get("security_id", "")
+					if sid:
+						result["greeted"] = cache.is_greeted(sid)
 					matched.append(result)
 					logger.info(f"  ✅ {company} - {title}（详情匹配）")
 				else:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import patch
 
 from boss_agent_cli.auth.token_store import TokenStore
 
@@ -27,8 +28,29 @@ def test_overwrite(tmp_path):
 	assert loaded["cookies"]["wt2"] == "new"
 
 
+def test_load_invalid_token_returns_none(tmp_path):
+	store = TokenStore(tmp_path)
+	(store._auth_dir / "session.enc").write_bytes(b"not-a-valid-fernet-token")
+	assert store.load() is None
+
+
 def test_file_lock(tmp_path):
 	store = TokenStore(tmp_path)
 	with store.refresh_lock():
 		assert (tmp_path / "refresh.lock").exists()
 	assert not (tmp_path / "refresh.lock").exists()
+
+
+@patch.dict("os.environ", {"BOSS_AGENT_MACHINE_ID": "test-machine-id"})
+def test_machine_id_env_override(tmp_path):
+	store = TokenStore(tmp_path)
+	assert store._get_machine_id() == "test-machine-id"
+
+
+@patch("platform.system", return_value="Darwin")
+@patch("shutil.which", return_value=None)
+def test_machine_id_darwin_without_ioreg_falls_back(mock_which, mock_system, tmp_path):
+	store = TokenStore(tmp_path)
+	machine_id = store._get_machine_id()
+	assert machine_id
+	assert machine_id != "boss-agent-cli-fallback-id"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -124,7 +124,52 @@ def test_schema_includes_new_commands():
 	assert "chat" in commands
 	assert "interviews" in commands
 	assert "logout" in commands
-	assert len(commands) == 15
+	assert "doctor" in commands
+	assert len(commands) == 16
+
+
+@patch("boss_agent_cli.commands.doctor.extract_cookies")
+@patch("boss_agent_cli.commands.doctor.httpx.get")
+@patch("boss_agent_cli.commands.doctor.probe_cdp")
+@patch("boss_agent_cli.commands.doctor.AuthManager")
+def test_doctor_command(mock_auth_cls, mock_probe_cdp, mock_httpx_get, mock_extract_cookies):
+	mock_auth_cls.return_value.check_status.return_value = None
+	mock_probe_cdp.return_value = None
+	mock_extract_cookies.return_value = None
+	mock_httpx_get.return_value = MagicMock(status_code=200)
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["doctor"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["command"] == "doctor"
+	assert parsed["data"]["check_count"] >= 8
+	assert "checks" in parsed["data"]
+	assert any(item["name"] == "network" for item in parsed["data"]["checks"])
+	assert any(item["name"] == "cookie_extract" for item in parsed["data"]["checks"])
+	assert any(item["name"] == "auth_token_quality" for item in parsed["data"]["checks"])
+	assert parsed["hints"]["next_actions"]
+
+
+@patch("boss_agent_cli.commands.doctor.extract_cookies")
+@patch("boss_agent_cli.commands.doctor.httpx.get")
+@patch("boss_agent_cli.commands.doctor.probe_cdp")
+@patch("boss_agent_cli.commands.doctor.AuthManager")
+def test_doctor_with_partial_token_quality_warn(mock_auth_cls, mock_probe_cdp, mock_httpx_get, mock_extract_cookies):
+	mock_auth_cls.return_value.check_status.return_value = {"cookies": {"wt2": "ok"}, "stoken": ""}
+	mock_probe_cdp.return_value = None
+	mock_extract_cookies.return_value = {"cookies": {"wt2": "ok"}}
+	mock_httpx_get.return_value = MagicMock(status_code=200)
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["doctor"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	quality = next(item for item in parsed["data"]["checks"] if item["name"] == "auth_token_quality")
+	assert quality["status"] == "warn"
+	assert "stoken 缺失" in quality["detail"]
+	assert any("boss status" in action for action in parsed["hints"]["next_actions"])
 
 
 @patch("boss_agent_cli.commands.recommend.CacheStore")


### PR DESCRIPTION
## Summary

- **P0 安全修复**: token_store 文件锁竞态(TOCTOU)改为原子 O_CREAT|O_EXCL；chat 导出路径遍历防护；chat BossClient 资源泄漏修复
- **P1 健壮性改进**: CacheStore 添加 context manager；display.py sys.exit 改 SystemExit；client.py 递归重试改循环；greet/batch-greet 资源管理统一
- **3 个新命令**: `boss chatmsg`（聊天消息历史）、`boss mark`（联系人标签管理）、`boss exchange`（交换手机/微信）
- **其他**: doctor 命令、status/schema 增强、测试补齐

### 新增命令

| 命令 | 功能 | 参考来源 |
|------|------|---------|
| `boss chatmsg <security_id>` | 查看与联系人的聊天消息 | opencli boss/chatmsg.ts |
| `boss mark <security_id> --label 沟通中` | 添加/移除标签(9种) | opencli boss/mark.ts |
| `boss exchange <security_id> --type phone` | 请求交换手机/微信 | opencli boss/exchange.ts |

### Commits (6)

1. `fix: P0 安全修复 + P1 健壮性改进` — 原子锁、context manager、路径防护、SystemExit
2. `refactor: P1 健壮性改进` — 递归改循环、batch-greet 资源管理、enumerate 修复
3. `feat: doctor 命令 + status/schema 增强 + 测试补齐`
4. `feat: 新增 boss chatmsg 命令`
5. `feat: 新增 boss mark 命令`
6. `feat: 新增 boss exchange 命令`

## Test plan

- [ ] `uv run pytest tests/ -v` 全绿
- [ ] `uv run boss schema` 输出包含 chatmsg/mark/exchange 三个新命令
- [ ] `uv run boss chatmsg --help` / `boss mark --help` / `boss exchange --help` 显示正确
- [ ] 人工验证文件锁原子性（并发 refresh_lock 不产生竞态）

🤖 Generated with [Claude Code](https://claude.com/claude-code)