### PR TITLE
fix: P3 低优先级改进（doctor/config/greet/chat）

### DIFF
--- a/src/boss_agent_cli/commands/chat.py
+++ b/src/boss_agent_cli/commands/chat.py
@@ -25,8 +25,11 @@ _GROUP_ORDER = ["对方主动", "我主动", "投递"]
 
 
 def _sanitize_csv_cell(value: str) -> str:
-	"""防止 CSV 公式注入：以 =+@- 开头的值前置单引号。"""
-	if isinstance(value, str) and value and value[0] in ("=", "+", "-", "@"):
+	"""防止 CSV 公式注入：以 =+@- 开头的值前置单引号；过滤 Tab 和回车。"""
+	if not isinstance(value, str):
+		return str(value)
+	value = value.replace("\t", " ").replace("\r", "")
+	if value and value[0] in ("=", "+", "-", "@"):
 		return f"'{value}"
 	return value
 

--- a/src/boss_agent_cli/commands/doctor.py
+++ b/src/boss_agent_cli/commands/doctor.py
@@ -31,8 +31,16 @@ def doctor_cmd(ctx):
 		})
 
 	# 1) CLI dependencies
-	python_ok = True
-	add_check("python", "ok" if python_ok else "error", "Python 运行环境可用")
+	import sys
+	py_version = sys.version_info
+	python_ok = py_version >= (3, 10)
+	py_detail = f"Python {py_version.major}.{py_version.minor}.{py_version.micro}"
+	add_check(
+		"python",
+		"ok" if python_ok else "error",
+		f"{py_detail}" if python_ok else f"{py_detail}（需要 >=3.10）",
+		None if python_ok else "升级 Python 到 3.10+",
+	)
 
 	patchright_bin = shutil.which("patchright")
 	add_check(

--- a/src/boss_agent_cli/commands/greet.py
+++ b/src/boss_agent_cli/commands/greet.py
@@ -214,7 +214,8 @@ def batch_greet_cmd(ctx, query, city, salary, experience, education, industry, s
 						break
 
 					if success and idx < len(candidates) - 1:
-						time.sleep(random.uniform(2.0, 5.0))
+						bg_delay = ctx.obj.get("config", {}).get("batch_greet_delay", [2.0, 5.0])
+						time.sleep(random.uniform(bg_delay[0], bg_delay[1]))
 
 				data = {
 					"greeted": [r for r in results if r["status"] == "success"],

--- a/src/boss_agent_cli/config.py
+++ b/src/boss_agent_cli/config.py
@@ -10,7 +10,7 @@ DEFAULTS = {
 	"log_level": "error",
 	"login_timeout": 120,
 	"cdp_url": None,
-	"export_dir": "~/Documents/files/boss",
+	"export_dir": None,
 }
 
 


### PR DESCRIPTION
## Summary

- **doctor**: Python 检查改为实际版本校验 `>=3.10`，不再永远为 True
- **config**: 默认 `export_dir` 改为 `None`，fallback 到 `data_dir/chat-export`
- **greet**: batch-greet 延迟从 `config.batch_greet_delay` 读取，不再硬编码
- **chat**: CSV 注入防护增加 `\t` `\r` 过滤

## Test plan

- [ ] `uv run boss doctor` 输出 Python 版本号
- [ ] batch-greet 延迟可通过 config.json 配置
- [ ] CSV 导出中含 Tab 的字段被替换为空格

🤖 Generated with [Claude Code](https://claude.com/claude-code)