### PR TITLE
refactor: chat.py 渲染逻辑去重

### DIFF
--- a/src/boss_agent_cli/commands/chat.py
+++ b/src/boss_agent_cli/commands/chat.py
@@ -348,6 +348,107 @@ def _find_previous_snapshot(snapshot_dir: str, today: str) -> str | None:
 # ── L2: 导出渲染 ─────────────────────────────────────────────────
 
 
+def _prepare_render_data(
+	friends: list[dict],
+	from_who: str | None,
+	diff_result: dict,
+) -> dict:
+	"""公共数据准备：分组、统计、diff 标记、渲染顺序。供 MD/HTML 共用。"""
+	now_str = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+
+	# 按 relationType 分组
+	groups: dict[str, list[dict]] = {}
+	for item in friends:
+		key = item.get("initiated_by", "未知")
+		groups.setdefault(key, []).append(item)
+
+	total = len(friends)
+	counts = {k: len(v) for k, v in groups.items()}
+	count_parts = [f"{k} {v}" for k, v in counts.items()]
+
+	me_items = groups.get("我主动", [])
+	me_read = sum(1 for x in me_items if x.get("msg_status") == "已读")
+	me_unread = len(me_items) - me_read
+
+	added_ids = {item.get("security_id") for item in diff_result.get("added", [])}
+
+	# diff 摘要
+	diff_summary = None
+	if not diff_result.get("is_first", True):
+		prev_date = diff_result.get("prev_date", "?")
+		parts = []
+		added_count = len(diff_result.get("added", []))
+		removed_count = len(diff_result.get("removed", []))
+		new_unread_count = len(diff_result.get("new_unread", []))
+		if added_count:
+			parts.append(f"新增 {added_count} 条")
+		if removed_count:
+			parts.append(f"消失 {removed_count} 条")
+		if new_unread_count:
+			parts.append(f"新消息 {new_unread_count} 条")
+		diff_summary = {
+			"prev_date": prev_date,
+			"change": "，".join(parts) if parts else "无变化",
+		}
+
+	# 构建渲染顺序
+	render_order = list(_GROUP_ORDER)
+	for key in groups:
+		if key not in render_order:
+			render_order.append(key)
+
+	# 按顺序生成分组数据 + 全局编号
+	sections = []
+	id_map: list[tuple[str, str, str]] = []
+	global_idx = 0
+
+	for group_key in render_order:
+		group_items = groups.get(group_key)
+		if group_items is None:
+			continue
+		if from_who == "boss" and group_key != "对方主动":
+			continue
+		if from_who == "me" and group_key != "我主动":
+			continue
+
+		subtitle = f"{group_key}（{len(group_items)} 条"
+		if group_key == "我主动":
+			subtitle += f" · 已读 {me_read} / 未读 {me_unread}"
+		subtitle += "）"
+
+		rows = []
+		for item in group_items:
+			global_idx += 1
+			sid = item.get("security_id", "")
+			is_new = sid in added_ids
+			ref = f"S{global_idx}"
+			msg = str(item.get("last_msg") or "-")
+			unread = item.get("unread") or 0
+			rows.append({
+				"ref": ref, "is_new": is_new, "sid": sid,
+				"brand_name": item.get("brand_name") or "-",
+				"name": item.get("name") or "-",
+				"title": item.get("title") or "-",
+				"last_time": item.get("last_time") or "-",
+				"unread": unread,
+				"msg_status": item.get("msg_status") or "-",
+				"last_msg": msg,
+			})
+			id_map.append((ref, sid, f"{item.get('brand_name') or '-'} {item.get('name') or '-'}"))
+
+		sections.append({"subtitle": subtitle, "rows": rows})
+
+	return {
+		"now_str": now_str,
+		"total": total,
+		"count_parts": count_parts,
+		"diff_summary": diff_summary,
+		"sections": sections,
+		"id_map": id_map,
+		"removed": diff_result.get("removed", []),
+	}
+
+
 def _render_export(
 	friends: list[dict],
 	fmt: str,
@@ -390,117 +491,49 @@ def _render_markdown(
 	diff_result: dict,
 ) -> str:
 	"""渲染为分组 Markdown 格式，含摘要和 diff 标记。"""
-	now_str = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
-
-	# 按 relationType 分组
-	groups: dict[str, list[dict]] = {}
-	for item in friends:
-		key = item.get("initiated_by", "未知")
-		groups.setdefault(key, []).append(item)
-
-	# 统计
-	total = len(friends)
-	counts = {k: len(v) for k, v in groups.items()}
-	count_parts = [f"{k} {v}" for k, v in counts.items()]
-
-	# 已读/未读统计（我主动）
-	me_items = groups.get("我主动", [])
-	me_read = sum(1 for x in me_items if x.get("msg_status") == "已读")
-	me_unread = len(me_items) - me_read
-
-	# diff 增量标记集合
-	added_ids = {item.get("security_id") for item in diff_result.get("added", [])}
+	rd = _prepare_render_data(friends, from_who, diff_result)
 
 	lines = [
 		"# BOSS 直聘沟通列表",
 		"",
-		f"> 生成时间：{now_str}  ",
-		f"> 总计：{total} 条（{' / '.join(count_parts)}）",
+		f"> 生成时间：{rd['now_str']}  ",
+		f"> 总计：{rd['total']} 条（{' / '.join(rd['count_parts'])}）",
 	]
 
-	# diff 摘要
-	if not diff_result.get("is_first", True):
-		prev_date = diff_result.get("prev_date", "?")
-		added_count = len(diff_result.get("added", []))
-		removed_count = len(diff_result.get("removed", []))
-		new_unread_count = len(diff_result.get("new_unread", []))
-		diff_parts = []
-		if added_count:
-			diff_parts.append(f"新增 {added_count} 条")
-		if removed_count:
-			diff_parts.append(f"消失 {removed_count} 条")
-		if new_unread_count:
-			diff_parts.append(f"新消息 {new_unread_count} 条")
-		if diff_parts:
-			lines.append(f"> 较上次（{prev_date}）变化：{'，'.join(diff_parts)}")
-		else:
-			lines.append(f"> 较上次（{prev_date}）无变化")
+	if rd["diff_summary"]:
+		ds = rd["diff_summary"]
+		lines.append(f"> 较上次（{ds['prev_date']}）变化：{ds['change']}")
 
 	lines.append("")
 
-	# 全局编号 → security_id 映射表
-	id_map: list[tuple[str, str, str]] = []  # (编号, security_id, 公司+联系人)
-	global_idx = 0
-
-	# 构建渲染顺序：已知分组 + 未知分组
-	render_order = list(_GROUP_ORDER)
-	for key in groups:
-		if key not in render_order:
-			render_order.append(key)
-
-	for group_key in render_order:
-		group_items = groups.get(group_key)
-		if group_items is None:
-			continue
-		# 如果指定了筛选且不匹配，跳过
-		if from_who == "boss" and group_key != "对方主动":
-			continue
-		if from_who == "me" and group_key != "我主动":
-			continue
-
-		# 小标题
-		subtitle = f"{group_key}（{len(group_items)} 条"
-		if group_key == "我主动":
-			subtitle += f" · 已读 {me_read} / 未读 {me_unread}"
-		subtitle += "）"
-		lines.append(f"## {subtitle}")
+	for section in rd["sections"]:
+		lines.append(f"## {section['subtitle']}")
 		lines.append("")
-
-		# 表头
 		lines.append("| # | 公司 | 联系人 | 职称 | 时间 | 未读 | 已读 | 最近消息 |")
 		lines.append("|---|------|--------|------|------|------|------|----------|")
 
-		for idx, item in enumerate(group_items, 1):
-			global_idx += 1
-			sid = item.get("security_id", "")
-			is_new = sid in added_ids
-			prefix = "NEW " if is_new else ""
-			msg = str(item.get("last_msg") or "-")
+		for row in section["rows"]:
+			prefix = "NEW " if row["is_new"] else ""
+			msg = row["last_msg"]
 			if len(msg) > 40:
 				msg = msg[:40] + "…"
-			unread = item.get("unread") or 0
-			unread_str = str(unread) if unread > 0 else ""
-			ref = f"S{global_idx}"
+			unread_str = str(row["unread"]) if row["unread"] > 0 else ""
 			lines.append(
-				f"| {prefix}{ref} | {_escape_md_cell(item.get('brand_name') or '-')} "
-				f"| {_escape_md_cell(item.get('name') or '-')} "
-				f"| {_escape_md_cell(item.get('title') or '-')} "
-				f"| {_escape_md_cell(item.get('last_time') or '-')} | {unread_str} "
-				f"| {_escape_md_cell(item.get('msg_status') or '-')} "
+				f"| {prefix}{row['ref']} | {_escape_md_cell(row['brand_name'])} "
+				f"| {_escape_md_cell(row['name'])} "
+				f"| {_escape_md_cell(row['title'])} "
+				f"| {_escape_md_cell(row['last_time'])} | {unread_str} "
+				f"| {_escape_md_cell(row['msg_status'])} "
 				f"| {_escape_md_cell(msg)} |"
 			)
-			id_map.append((ref, sid, f"{_escape_md_cell(item.get('brand_name') or '-')} {_escape_md_cell(item.get('name') or '-')}"))
-
 		lines.append("")
 
-	# 消失的条目
-	removed = diff_result.get("removed", [])
-	if removed:
+	if rd["removed"]:
 		lines.append("## 已消失（较上次）")
 		lines.append("")
 		lines.append("| 公司 | 联系人 | 上次时间 |")
 		lines.append("|------|--------|----------|")
-		for item in removed:
+		for item in rd["removed"]:
 			lines.append(
 				f"| {_escape_md_cell(item.get('brand_name') or '-')} "
 				f"| {_escape_md_cell(item.get('name') or '-')} "
@@ -508,14 +541,13 @@ def _render_markdown(
 			)
 		lines.append("")
 
-	# security_id 映射表（折叠，避免主表 token 膨胀）
-	if id_map:
+	if rd["id_map"]:
 		lines.append("<details>")
 		lines.append("<summary>security_id 映射表（点击展开）</summary>")
 		lines.append("")
 		lines.append("| 编号 | 公司/联系人 | security_id |")
 		lines.append("|------|------------|-------------|")
-		for ref, sid, label in id_map:
+		for ref, sid, label in rd["id_map"]:
 			lines.append(f"| {ref} | {label} | {sid} |")
 		lines.append("")
 		lines.append("</details>")
@@ -532,93 +564,37 @@ def _render_html(
 ) -> str:
 	"""渲染为 HTML 格式，含分组、diff 标记和 security_id 映射。"""
 	esc = _html.escape
-	now_str = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
-
-	# 按 relationType 分组
-	groups: dict[str, list[dict]] = {}
-	for item in friends:
-		key = item.get("initiated_by", "未知")
-		groups.setdefault(key, []).append(item)
-
-	total = len(friends)
-	counts = {k: len(v) for k, v in groups.items()}
-	count_parts = [f"{k} {v}" for k, v in counts.items()]
-
-	me_items = groups.get("我主动", [])
-	me_read = sum(1 for x in me_items if x.get("msg_status") == "已读")
-	me_unread = len(me_items) - me_read
-
-	added_ids = {item.get("security_id") for item in diff_result.get("added", [])}
+	rd = _prepare_render_data(friends, from_who, diff_result)
 
 	# diff 摘要
 	diff_html = ""
-	if not diff_result.get("is_first", True):
-		prev_date = diff_result.get("prev_date", "?")
-		parts = []
-		added_count = len(diff_result.get("added", []))
-		removed_count = len(diff_result.get("removed", []))
-		new_unread_count = len(diff_result.get("new_unread", []))
-		if added_count:
-			parts.append(f"新增 {added_count} 条")
-		if removed_count:
-			parts.append(f"消失 {removed_count} 条")
-		if new_unread_count:
-			parts.append(f"新消息 {new_unread_count} 条")
-		change = "，".join(parts) if parts else "无变化"
-		diff_html = f"<div class='diff'>较上次（{esc(prev_date)}）变化：{esc(change)}</div>"
+	if rd["diff_summary"]:
+		ds = rd["diff_summary"]
+		diff_html = f"<div class='diff'>较上次（{esc(ds['prev_date'])}）变化：{esc(ds['change'])}</div>"
 
-	# 构建渲染顺序
-	render_order = list(_GROUP_ORDER)
-	for key in groups:
-		if key not in render_order:
-			render_order.append(key)
-
-	sections = []
-	id_map: list[tuple[str, str, str]] = []
-	global_idx = 0
-
-	for group_key in render_order:
-		group_items = groups.get(group_key)
-		if group_items is None:
-			continue
-		if from_who == "boss" and group_key != "对方主动":
-			continue
-		if from_who == "me" and group_key != "我主动":
-			continue
-
-		subtitle = f"{esc(group_key)}（{len(group_items)} 条"
-		if group_key == "我主动":
-			subtitle += f" · 已读 {me_read} / 未读 {me_unread}"
-		subtitle += "）"
-
+	sections_html = []
+	for section in rd["sections"]:
 		rows = []
-		for item in group_items:
-			global_idx += 1
-			sid = item.get("security_id", "")
-			is_new = sid in added_ids
-			ref = f"S{global_idx}"
-			badge = '<span class="badge-new">NEW</span> ' if is_new else ""
-			msg = str(item.get("last_msg") or "-")
+		for row in section["rows"]:
+			badge = '<span class="badge-new">NEW</span> ' if row["is_new"] else ""
+			msg = row["last_msg"]
 			if len(msg) > 60:
 				msg = msg[:60] + "…"
-			unread = item.get("unread") or 0
-			unread_str = f'<span class="unread">{unread}</span>' if unread > 0 else ""
+			unread_str = f'<span class="unread">{row["unread"]}</span>' if row["unread"] > 0 else ""
 			rows.append(
 				f"<tr>"
-				f"<td>{badge}{ref}</td>"
-				f"<td class='company'>{esc(item.get('brand_name') or '-')}</td>"
-				f"<td>{esc(item.get('name') or '-')}</td>"
-				f"<td class='dim'>{esc(item.get('title') or '-')}</td>"
-				f"<td class='dim'>{esc(item.get('last_time') or '-')}</td>"
+				f"<td>{badge}{row['ref']}</td>"
+				f"<td class='company'>{esc(row['brand_name'])}</td>"
+				f"<td>{esc(row['name'])}</td>"
+				f"<td class='dim'>{esc(row['title'])}</td>"
+				f"<td class='dim'>{esc(row['last_time'])}</td>"
 				f"<td>{unread_str}</td>"
-				f"<td class='dim'>{esc(item.get('msg_status') or '-')}</td>"
+				f"<td class='dim'>{esc(row['msg_status'])}</td>"
 				f"<td class='msg'>{esc(msg)}</td>"
 				f"</tr>"
 			)
-			id_map.append((ref, sid, f"{esc(item.get('brand_name') or '-')} {esc(item.get('name') or '-')}"))
-
-		sections.append(f"""
-		<h2>{subtitle}</h2>
+		sections_html.append(f"""
+		<h2>{esc(section['subtitle'])}</h2>
 		<table>
 			<thead><tr>
 				<th>#</th><th>公司</th><th>联系人</th><th>职称</th>
@@ -628,11 +604,10 @@ def _render_html(
 		</table>""")
 
 	# 消失的条目
-	removed = diff_result.get("removed", [])
 	removed_html = ""
-	if removed:
+	if rd["removed"]:
 		rrows = []
-		for item in removed:
+		for item in rd["removed"]:
 			rrows.append(
 				f"<tr>"
 				f"<td>{esc(item.get('brand_name') or '-')}</td>"
@@ -649,8 +624,8 @@ def _render_html(
 
 	# security_id 映射表
 	map_rows = []
-	for ref, sid, label in id_map:
-		map_rows.append(f"<tr><td>{ref}</td><td>{label}</td><td class='sid'>{esc(sid)}</td></tr>")
+	for ref, sid, label in rd["id_map"]:
+		map_rows.append(f"<tr><td>{ref}</td><td>{esc(label)}</td><td class='sid'>{esc(sid)}</td></tr>")
 	map_html = f"""
 	<details>
 		<summary>security_id 映射表（点击展开）</summary>
@@ -663,7 +638,7 @@ def _render_html(
 	return f"""<!DOCTYPE html>
 <html lang="zh-CN"><head><meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>BOSS 直聘沟通列表 · {esc(now_str)}</title>
+<title>BOSS 直聘沟通列表 · {esc(rd['now_str'])}</title>
 <style>
   :root {{ --green: #00b38a; --bg: #f8f9fa; }}
   * {{ margin: 0; padding: 0; box-sizing: border-box; }}
@@ -692,9 +667,9 @@ def _render_html(
   }}
 </style></head><body>
 <h1>BOSS 直聘沟通列表</h1>
-<div class="sub">生成时间：{esc(now_str)} · 总计：{total} 条（{esc(' / '.join(count_parts))}）</div>
+<div class="sub">生成时间：{esc(rd['now_str'])} · 总计：{rd['total']} 条（{esc(' / '.join(rd['count_parts']))}）</div>
 {diff_html}
-{''.join(sections)}
+{''.join(sections_html)}
 {removed_html}
 {map_html}
 </body></html>


### PR DESCRIPTION
## Summary

- 抽取 `_prepare_render_data()` 公共函数，将 `_render_markdown` 和 `_render_html` 共享的分组/统计/diff/编号逻辑统一
- 两个渲染函数从"数据准备+模板输出"简化为"仅模板输出"
- 消除约 60 行重复代码（+147/-172）

## Test plan

- [ ] `uv run pytest tests/ -v -k chat` 全绿（MD/HTML/CSV/JSON 导出测试）
- [ ] 手动验证 `boss chat --export md` 和 `boss chat --export html` 输出一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)