### PR TITLE
feat: Browser Bridge — Chrome 扩展 + Python daemon 零配置浏览器通道

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,273 @@
+/**
+ * BOSS Agent Bridge — Service Worker (background script).
+ *
+ * Connects to boss-agent-cli daemon via WebSocket, receives commands,
+ * dispatches them to Chrome APIs (debugger/tabs/cookies), returns results.
+ */
+
+const DAEMON_PORT = 19826;
+const DAEMON_WS_URL = `ws://127.0.0.1:${DAEMON_PORT}/ext`;
+const DAEMON_PING_URL = `http://127.0.0.1:${DAEMON_PORT}/ping`;
+const WINDOW_IDLE_TIMEOUT = 30000;
+
+let ws = null;
+let reconnectTimer = null;
+let reconnectAttempts = 0;
+const MAX_EAGER_ATTEMPTS = 6;
+const attached = new Set();
+
+// ── Automation window ────────────────────────────────────────────────
+
+let automationWindowId = null;
+let idleTimer = null;
+
+function resetIdleTimer() {
+	if (idleTimer) clearTimeout(idleTimer);
+	idleTimer = setTimeout(async () => {
+		if (automationWindowId) {
+			try { await chrome.windows.remove(automationWindowId); } catch {}
+			automationWindowId = null;
+		}
+	}, WINDOW_IDLE_TIMEOUT);
+}
+
+async function getAutomationWindow() {
+	if (automationWindowId) {
+		try {
+			await chrome.windows.get(automationWindowId);
+			return automationWindowId;
+		} catch {
+			automationWindowId = null;
+		}
+	}
+	const win = await chrome.windows.create({
+		url: 'data:text/html,<html></html>',
+		focused: false,
+		width: 1280,
+		height: 900,
+		type: 'normal',
+	});
+	automationWindowId = win.id;
+	resetIdleTimer();
+	await new Promise(r => setTimeout(r, 200));
+	return automationWindowId;
+}
+
+chrome.windows.onRemoved.addListener((windowId) => {
+	if (windowId === automationWindowId) {
+		automationWindowId = null;
+		if (idleTimer) clearTimeout(idleTimer);
+	}
+});
+
+// ── CDP via chrome.debugger ──────────────────────────────────────────
+
+async function ensureAttached(tabId) {
+	const tab = await chrome.tabs.get(tabId);
+	if (!tab.url?.startsWith('http')) {
+		attached.delete(tabId);
+		throw new Error(`Cannot debug tab ${tabId}: URL is ${tab.url}`);
+	}
+
+	if (attached.has(tabId)) {
+		try {
+			await chrome.debugger.sendCommand({ tabId }, 'Runtime.evaluate', {
+				expression: '1', returnByValue: true,
+			});
+			return;
+		} catch {
+			attached.delete(tabId);
+		}
+	}
+
+	try {
+		await chrome.debugger.attach({ tabId }, '1.3');
+	} catch (e) {
+		if (e.message?.includes('Another debugger')) {
+			try { await chrome.debugger.detach({ tabId }); } catch {}
+			await chrome.debugger.attach({ tabId }, '1.3');
+		} else {
+			throw new Error(`attach failed: ${e.message}`);
+		}
+	}
+	attached.add(tabId);
+
+	try { await chrome.debugger.sendCommand({ tabId }, 'Runtime.enable'); } catch {}
+	try {
+		await chrome.debugger.sendCommand({ tabId }, 'Debugger.enable');
+		await chrome.debugger.sendCommand({ tabId }, 'Debugger.setBreakpointsActive', { active: false });
+	} catch {}
+}
+
+async function evaluate(tabId, code) {
+	await ensureAttached(tabId);
+	const result = await chrome.debugger.sendCommand({ tabId }, 'Runtime.evaluate', {
+		expression: code,
+		returnByValue: true,
+		awaitPromise: true,
+	});
+	if (result.exceptionDetails) {
+		throw new Error(result.exceptionDetails.exception?.description || result.exceptionDetails.text || 'Eval error');
+	}
+	return result.result?.value;
+}
+
+// ── Tab management ───────────────────────────────────────────────────
+
+async function resolveTabId(tabId) {
+	if (tabId !== undefined) {
+		try {
+			const tab = await chrome.tabs.get(tabId);
+			if (tab.url?.startsWith('http')) return tabId;
+		} catch {}
+	}
+	const windowId = await getAutomationWindow();
+	const tabs = await chrome.tabs.query({ windowId });
+	const good = tabs.find(t => t.url?.startsWith('http') || t.url?.startsWith('data:'));
+	if (good?.id) return good.id;
+	const newTab = await chrome.tabs.create({ windowId, url: 'data:text/html,<html></html>', active: true });
+	return newTab.id;
+}
+
+// ── WebSocket connection ─────────────────────────────────────────────
+
+async function connect() {
+	if (ws?.readyState === WebSocket.OPEN || ws?.readyState === WebSocket.CONNECTING) return;
+
+	try {
+		const res = await fetch(DAEMON_PING_URL, { signal: AbortSignal.timeout(1000) });
+		if (!res.ok) return;
+	} catch {
+		return;
+	}
+
+	try {
+		ws = new WebSocket(DAEMON_WS_URL);
+	} catch {
+		scheduleReconnect();
+		return;
+	}
+
+	ws.onopen = () => {
+		console.log('[boss-bridge] Connected to daemon');
+		reconnectAttempts = 0;
+		if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+		ws?.send(JSON.stringify({ type: 'hello', version: chrome.runtime.getManifest().version }));
+	};
+
+	ws.onmessage = async (event) => {
+		try {
+			const cmd = JSON.parse(event.data);
+			const result = await handleCommand(cmd);
+			ws?.send(JSON.stringify(result));
+		} catch (err) {
+			console.error('[boss-bridge] Command error:', err);
+		}
+	};
+
+	ws.onclose = () => {
+		ws = null;
+		scheduleReconnect();
+	};
+
+	ws.onerror = () => ws?.close();
+}
+
+function scheduleReconnect() {
+	if (reconnectTimer) return;
+	reconnectAttempts++;
+	if (reconnectAttempts > MAX_EAGER_ATTEMPTS) return;
+	const delay = Math.min(2000 * Math.pow(2, reconnectAttempts - 1), 60000);
+	reconnectTimer = setTimeout(() => {
+		reconnectTimer = null;
+		connect();
+	}, delay);
+}
+
+// ── Command dispatcher ───────────────────────────────────────────────
+
+async function handleCommand(cmd) {
+	resetIdleTimer();
+	try {
+		switch (cmd.action) {
+			case 'exec': return await handleExec(cmd);
+			case 'navigate': return await handleNavigate(cmd);
+			case 'cookies': return await handleCookies(cmd);
+			case 'close-window': return await handleCloseWindow(cmd);
+			default: return { id: cmd.id, ok: false, error: `Unknown action: ${cmd.action}` };
+		}
+	} catch (err) {
+		return { id: cmd.id, ok: false, error: err.message || String(err) };
+	}
+}
+
+async function handleExec(cmd) {
+	if (!cmd.code) return { id: cmd.id, ok: false, error: 'Missing code' };
+	const tabId = await resolveTabId(cmd.tabId);
+	const data = await evaluate(tabId, cmd.code);
+	return { id: cmd.id, ok: true, data };
+}
+
+async function handleNavigate(cmd) {
+	if (!cmd.url) return { id: cmd.id, ok: false, error: 'Missing url' };
+	if (!cmd.url.startsWith('http')) return { id: cmd.id, ok: false, error: 'Only http(s) allowed' };
+
+	const tabId = await resolveTabId(cmd.tabId);
+	await chrome.tabs.update(tabId, { url: cmd.url });
+
+	// 等待导航完成
+	await new Promise((resolve) => {
+		let done = false;
+		const finish = () => { if (!done) { done = true; chrome.tabs.onUpdated.removeListener(listener); resolve(); } };
+		const listener = (id, info) => { if (id === tabId && info.status === 'complete') finish(); };
+		chrome.tabs.onUpdated.addListener(listener);
+		setTimeout(finish, 15000);
+	});
+
+	const tab = await chrome.tabs.get(tabId);
+	return { id: cmd.id, ok: true, data: { title: tab.title, url: tab.url, tabId } };
+}
+
+async function handleCookies(cmd) {
+	if (!cmd.domain) return { id: cmd.id, ok: false, error: 'Missing domain' };
+	const cookies = await chrome.cookies.getAll({ domain: cmd.domain });
+	const data = cookies.map(c => ({
+		name: c.name, value: c.value, domain: c.domain,
+		path: c.path, secure: c.secure, httpOnly: c.httpOnly,
+	}));
+	return { id: cmd.id, ok: true, data };
+}
+
+async function handleCloseWindow(cmd) {
+	if (automationWindowId) {
+		try { await chrome.windows.remove(automationWindowId); } catch {}
+		automationWindowId = null;
+	}
+	return { id: cmd.id, ok: true, data: { closed: true } };
+}
+
+// ── Lifecycle ────────────────────────────────────────────────────────
+
+let initialized = false;
+
+function initialize() {
+	if (initialized) return;
+	initialized = true;
+	chrome.alarms.create('keepalive', { periodInMinutes: 0.4 });
+	chrome.tabs.onRemoved.addListener((tabId) => attached.delete(tabId));
+	chrome.debugger.onDetach.addListener((source) => { if (source.tabId) attached.delete(source.tabId); });
+	connect();
+	console.log('[boss-bridge] Extension initialized');
+}
+
+chrome.runtime.onInstalled.addListener(initialize);
+chrome.runtime.onStartup.addListener(initialize);
+chrome.alarms.onAlarm.addListener((alarm) => { if (alarm.name === 'keepalive') connect(); });
+
+// Popup status API
+chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+	if (msg?.type === 'getStatus') {
+		sendResponse({ connected: ws?.readyState === WebSocket.OPEN });
+	}
+	return false;
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -18,11 +18,6 @@
     "service_worker": "background.js",
     "type": "module"
   },
-  "icons": {
-    "16": "icons/icon-16.png",
-    "48": "icons/icon-48.png",
-    "128": "icons/icon-128.png"
-  },
   "action": {
     "default_title": "BOSS Agent Bridge",
     "default_popup": "popup.html"

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,30 @@
+{
+  "manifest_version": 3,
+  "name": "BOSS Agent Bridge",
+  "version": "1.0.0",
+  "description": "Browser Bridge for boss-agent-cli — executes commands in Chrome via local daemon.",
+  "permissions": [
+    "debugger",
+    "tabs",
+    "cookies",
+    "activeTab",
+    "alarms"
+  ],
+  "host_permissions": [
+    "https://*.zhipin.com/*",
+    "http://127.0.0.1:19826/*"
+  ],
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "icons": {
+    "16": "icons/icon-16.png",
+    "48": "icons/icon-48.png",
+    "128": "icons/icon-128.png"
+  },
+  "action": {
+    "default_title": "BOSS Agent Bridge",
+    "default_popup": "popup.html"
+  }
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+	body { width: 240px; padding: 12px; font-family: -apple-system, sans-serif; font-size: 13px; }
+	.status { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+	.dot { width: 10px; height: 10px; border-radius: 50%; }
+	.dot.on { background: #00b38a; }
+	.dot.off { background: #ccc; }
+	.label { color: #666; }
+	h3 { margin: 0 0 8px; font-size: 14px; }
+</style>
+</head>
+<body>
+<h3>BOSS Agent Bridge</h3>
+<div class="status">
+	<div class="dot" id="dot"></div>
+	<span id="label">检查中...</span>
+</div>
+<div class="label" id="hint"></div>
+<script>
+	chrome.runtime.sendMessage({ type: 'getStatus' }, (res) => {
+		const dot = document.getElementById('dot');
+		const label = document.getElementById('label');
+		const hint = document.getElementById('hint');
+		if (res?.connected) {
+			dot.classList.add('on');
+			label.textContent = '已连接 daemon';
+			hint.textContent = 'boss-agent-cli 可以使用 Bridge 模式';
+		} else {
+			dot.classList.add('off');
+			label.textContent = '未连接';
+			hint.textContent = '运行 boss doctor 检查状态';
+		}
+	});
+</script>
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
 	"browser-cookie3>=0.16.2",
 	"rich>=13.0",
 	"pyyaml>=6.0",
-	"aiohttp>=3.9",
 ]
 
 [project.urls]
@@ -45,6 +44,9 @@ Issues = "https://github.com/can4hou6joeng4/boss-agent-cli/issues"
 dev = [
 	"pytest>=7.0",
 	"ruff>=0.4",
+]
+bridge = [
+	"aiohttp>=3.9",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
 	"browser-cookie3>=0.16.2",
 	"rich>=13.0",
 	"pyyaml>=6.0",
+	"aiohttp>=3.9",
 ]
 
 [project.urls]

--- a/src/boss_agent_cli/api/browser_client.py
+++ b/src/boss_agent_cli/api/browser_client.py
@@ -47,6 +47,8 @@ class BrowserSession:
 		self._is_cdp = False
 		self._own_context = False  # 是否由我们创建的 context（需要在 close 时清理）
 		self._logger = logger
+		self._bridge_client = None
+		self._is_bridge = False
 
 	def _log(self, message: str) -> None:
 		"""通过注入的 logger 输出，受 --log-level 控制。"""
@@ -58,14 +60,38 @@ class BrowserSession:
 	def _ensure_started(self):
 		if self._started:
 			return
+
+		# 优先尝试 Bridge 模式（Chrome 扩展 + daemon，零配置）
+		if self._try_bridge():
+			return
+
 		self._pw = sync_playwright().start()
 
-		# 优先尝试 CDP 连接用户 Chrome（真实指纹 + 天然登录态）
+		# 第二优先：CDP 连接用户 Chrome（真实指纹 + 天然登录态）
 		if self._try_cdp():
 			return
 
-		# 降级：启动 headless patchright
+		# 兜底：启动 headless patchright
 		self._start_headless()
+
+	def _try_bridge(self) -> bool:
+		"""尝试通过 Browser Bridge（Chrome 扩展 + daemon）连接。"""
+		try:
+			from boss_agent_cli.bridge.client import BridgeClient
+			client = BridgeClient()
+			if not client.is_running():
+				return False
+			if not client.is_extension_connected():
+				self._log("[boss] Bridge daemon 运行中但扩展未连接")
+				return False
+			self._bridge_client = client
+			self._started = True
+			self._is_cdp = False
+			self._is_bridge = True
+			self._log("[boss] Bridge 模式连接成功（Chrome 扩展 + daemon）")
+			return True
+		except Exception:
+			return False
 
 	def _try_cdp(self) -> bool:
 		"""Try connecting to user's Chrome via CDP.
@@ -189,6 +215,22 @@ class BrowserSession:
 
 		referer = endpoints.REFERER_MAP.get(url, f"{endpoints.BASE_URL}/")
 
+		# Bridge 模式：通过扩展 fetch
+		if self._is_bridge and self._bridge_client:
+			import urllib.parse
+			full_url = url
+			if params:
+				full_url = f"{url}?{urllib.parse.urlencode(params)}"
+			result = self._bridge_client.fetch_json(
+				full_url,
+				method=method,
+				data=data,
+				referer=referer,
+			)
+			self._throttle.mark()
+			return result
+
+		# Playwright 模式（CDP 或 headless）
 		result = self._page.evaluate("""
 			async ({method, url, params, data, referer}) => {
 				try {
@@ -239,6 +281,15 @@ class BrowserSession:
 		return self._is_cdp
 
 	def close(self):
+		if self._is_bridge and self._bridge_client:
+			try:
+				self._bridge_client.close_window()
+			except Exception:
+				pass
+			self._bridge_client = None
+			self._started = False
+			return
+
 		if self._is_cdp:
 			# CDP 模式：关闭我们创建的 page 和 context，不关闭用户浏览器
 			if self._page:

--- a/src/boss_agent_cli/bridge/client.py
+++ b/src/boss_agent_cli/bridge/client.py
@@ -1,0 +1,171 @@
+"""Browser Bridge 客户端 — CLI 侧调用 daemon 的 HTTP 接口。"""
+
+import json
+import time
+
+import httpx
+
+from boss_agent_cli.bridge.protocol import (
+	BRIDGE_HOST, BRIDGE_PORT,
+	DAEMON_PING_PATH, DAEMON_STATUS_PATH, DAEMON_COMMAND_PATH,
+	BridgeCommand, BridgeResult, make_command_id,
+)
+
+
+class BridgeNotRunning(Exception):
+	pass
+
+
+class BridgeExtensionDisconnected(Exception):
+	pass
+
+
+class BridgeClient:
+	"""与 Bridge daemon 通信的 HTTP 客户端。"""
+
+	def __init__(self, *, timeout: float = 30.0, max_retries: int = 4):
+		self._base_url = f"http://{BRIDGE_HOST}:{BRIDGE_PORT}"
+		self._timeout = timeout
+		self._max_retries = max_retries
+
+	def is_running(self) -> bool:
+		"""检查 daemon 是否在运行。"""
+		try:
+			resp = httpx.get(
+				f"{self._base_url}{DAEMON_PING_PATH}",
+				timeout=2.0,
+			)
+			return resp.status_code == 200
+		except Exception:
+			return False
+
+	def status(self) -> dict | None:
+		"""获取 daemon 状态。"""
+		try:
+			resp = httpx.get(
+				f"{self._base_url}{DAEMON_STATUS_PATH}",
+				timeout=2.0,
+			)
+			if resp.status_code == 200:
+				return resp.json()
+			return None
+		except Exception:
+			return None
+
+	def is_extension_connected(self) -> bool:
+		"""检查扩展是否已连接。"""
+		st = self.status()
+		return st is not None and st.get("extensionConnected", False)
+
+	def send_command(self, action: str, **kwargs) -> BridgeResult:
+		"""发送命令到扩展，自动重试。"""
+		last_error = ""
+
+		for attempt in range(1, self._max_retries + 1):
+			cmd_id = make_command_id()
+			cmd = BridgeCommand(id=cmd_id, action=action, **kwargs)
+
+			try:
+				resp = httpx.post(
+					f"{self._base_url}{DAEMON_COMMAND_PATH}",
+					json=cmd.to_dict(),
+					timeout=self._timeout,
+				)
+				result = BridgeResult.from_dict(resp.json())
+
+				if result.ok:
+					return result
+
+				# 可重试的错误
+				err = result.error or ""
+				is_transient = any(k in err for k in (
+					"Extension disconnected",
+					"Extension not connected",
+					"attach failed",
+					"no longer exists",
+				))
+				if is_transient and attempt < self._max_retries:
+					time.sleep(1.5)
+					continue
+
+				last_error = err
+				break
+
+			except (httpx.ConnectError, httpx.TimeoutException) as e:
+				last_error = str(e)
+				if attempt < self._max_retries:
+					time.sleep(0.5)
+					continue
+				break
+			except Exception as e:
+				last_error = str(e)
+				break
+
+		return BridgeResult(id="", ok=False, error=last_error)
+
+	# ── 高级 API ─────────────────────────────────────────────────
+
+	def evaluate(self, code: str, *, workspace: str = "boss") -> dict:
+		"""在页面上下文中执行 JS，返回结果。"""
+		result = self.send_command("exec", code=code, workspace=workspace)
+		if not result.ok:
+			raise RuntimeError(f"Bridge evaluate 失败: {result.error}")
+		return result.data if isinstance(result.data, dict) else {"result": result.data}
+
+	def navigate(self, url: str, *, workspace: str = "boss") -> dict:
+		"""导航到指定 URL。"""
+		result = self.send_command("navigate", url=url, workspace=workspace)
+		if not result.ok:
+			raise RuntimeError(f"Bridge navigate 失败: {result.error}")
+		return result.data if isinstance(result.data, dict) else {}
+
+	def get_cookies(self, domain: str) -> list[dict]:
+		"""获取指定域名的 Cookie。"""
+		result = self.send_command("cookies", domain=domain)
+		if not result.ok:
+			raise RuntimeError(f"Bridge get_cookies 失败: {result.error}")
+		return result.data if isinstance(result.data, list) else []
+
+	def close_window(self, *, workspace: str = "boss") -> None:
+		"""关闭 automation window。"""
+		self.send_command("close-window", workspace=workspace)
+
+	def fetch_json(self, url: str, *, method: str = "GET", data: dict | None = None, referer: str = "", workspace: str = "boss") -> dict:
+		"""通过浏览器 fetch() 发起 API 请求，返回 JSON。"""
+		if method == "GET":
+			js = f"""
+				(async () => {{
+					const resp = await fetch({json.dumps(url)}, {{
+						method: 'GET',
+						credentials: 'include',
+						headers: {{
+							'Accept': 'application/json',
+							{f"'Referer': {json.dumps(referer)}," if referer else ""}
+						}},
+					}});
+					return await resp.json();
+				}})()
+			"""
+		else:
+			form_entries = "\\n".join(
+				f"formData.append({json.dumps(k)}, {json.dumps(str(v))});"
+				for k, v in (data or {}).items()
+			)
+			js = f"""
+				(async () => {{
+					const formData = new URLSearchParams();
+					{form_entries}
+					const resp = await fetch({json.dumps(url)}, {{
+						method: 'POST',
+						credentials: 'include',
+						headers: {{
+							'Accept': 'application/json',
+							'Content-Type': 'application/x-www-form-urlencoded',
+							{f"'Referer': {json.dumps(referer)}," if referer else ""}
+						}},
+						body: formData.toString(),
+					}});
+					return await resp.json();
+				}})()
+			"""
+		return self.evaluate(js, workspace=workspace)

--- a/src/boss_agent_cli/bridge/client.py
+++ b/src/boss_agent_cli/bridge/client.py
@@ -140,6 +140,7 @@ class BridgeClient:
 						credentials: 'include',
 						headers: {{
 							'Accept': 'application/json',
+							'X-Requested-With': 'XMLHttpRequest',
 							{f"'Referer': {json.dumps(referer)}," if referer else ""}
 						}},
 					}});
@@ -147,7 +148,7 @@ class BridgeClient:
 				}})()
 			"""
 		else:
-			form_entries = "\\n".join(
+			form_entries = "\n".join(
 				f"formData.append({json.dumps(k)}, {json.dumps(str(v))});"
 				for k, v in (data or {}).items()
 			)
@@ -161,6 +162,7 @@ class BridgeClient:
 						headers: {{
 							'Accept': 'application/json',
 							'Content-Type': 'application/x-www-form-urlencoded',
+							'X-Requested-With': 'XMLHttpRequest',
 							{f"'Referer': {json.dumps(referer)}," if referer else ""}
 						}},
 						body: formData.toString(),

--- a/src/boss_agent_cli/bridge/daemon.py
+++ b/src/boss_agent_cli/bridge/daemon.py
@@ -1,0 +1,316 @@
+"""Browser Bridge daemon — HTTP + WebSocket 服务。
+
+接收 CLI 的 HTTP 命令，转发给 Chrome 扩展（WebSocket），返回结果。
+首次浏览器命令时自动启动，空闲 4h 后自动退出。
+"""
+
+import asyncio
+import json
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+
+# daemon 需要 websockets 和 aiohttp，但作为可选依赖
+# 只在实际启动 daemon 时导入
+
+_PID_FILE = Path.home() / ".boss-agent" / "bridge" / "daemon.pid"
+_LOG_FILE = Path.home() / ".boss-agent" / "bridge" / "daemon.log"
+
+
+def _ensure_dirs():
+	_PID_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+
+def is_daemon_running() -> bool:
+	"""检查 daemon 是否在运行。"""
+	if not _PID_FILE.exists():
+		return False
+	try:
+		pid = int(_PID_FILE.read_text().strip())
+		os.kill(pid, 0)
+		return True
+	except (OSError, ValueError):
+		_PID_FILE.unlink(missing_ok=True)
+		return False
+
+
+def get_daemon_pid() -> int | None:
+	"""获取 daemon PID，不运行则返回 None。"""
+	if not _PID_FILE.exists():
+		return None
+	try:
+		pid = int(_PID_FILE.read_text().strip())
+		os.kill(pid, 0)
+		return pid
+	except (OSError, ValueError):
+		_PID_FILE.unlink(missing_ok=True)
+		return None
+
+
+def stop_daemon() -> bool:
+	"""停止 daemon 进程。"""
+	pid = get_daemon_pid()
+	if pid is None:
+		return False
+	try:
+		os.kill(pid, signal.SIGTERM)
+		# 等待进程退出
+		for _ in range(20):
+			try:
+				os.kill(pid, 0)
+				time.sleep(0.1)
+			except OSError:
+				break
+		_PID_FILE.unlink(missing_ok=True)
+		return True
+	except OSError:
+		_PID_FILE.unlink(missing_ok=True)
+		return False
+
+
+def start_daemon_background() -> int:
+	"""在后台启动 daemon 进程，返回 PID。"""
+	if is_daemon_running():
+		return get_daemon_pid()
+
+	_ensure_dirs()
+
+	# Fork 一个子进程运行 daemon
+	pid = os.fork()
+	if pid > 0:
+		# 父进程：等待一小段时间确认启动
+		time.sleep(0.5)
+		return pid
+
+	# 子进程：脱离终端
+	os.setsid()
+	pid2 = os.fork()
+	if pid2 > 0:
+		os._exit(0)
+
+	# 孙进程：真正的 daemon
+	# 重定向 stdio
+	sys.stdin.close()
+	log_fd = open(_LOG_FILE, "a")
+	os.dup2(log_fd.fileno(), sys.stdout.fileno())
+	os.dup2(log_fd.fileno(), sys.stderr.fileno())
+
+	# 写 PID 文件
+	_PID_FILE.write_text(str(os.getpid()))
+
+	# 运行 asyncio 事件循环
+	try:
+		asyncio.run(_run_daemon())
+	finally:
+		_PID_FILE.unlink(missing_ok=True)
+		os._exit(0)
+
+
+async def _run_daemon():
+	"""daemon 主循环：HTTP 服务 + WebSocket 服务。"""
+	from aiohttp import web
+	import websockets.server
+
+	from boss_agent_cli.bridge.protocol import (
+		BRIDGE_HOST, BRIDGE_PORT, DAEMON_IDLE_TIMEOUT,
+		DAEMON_WS_PATH, DAEMON_PING_PATH, DAEMON_STATUS_PATH, DAEMON_COMMAND_PATH,
+	)
+
+	# 状态
+	ext_ws = None
+	ext_version = None
+	last_activity = time.time()
+	pending_commands: dict[str, asyncio.Future] = {}
+
+	# ── WebSocket handler（Chrome 扩展连接） ──────────────────────
+
+	async def ws_handler(websocket):
+		nonlocal ext_ws, ext_version
+		ext_ws = websocket
+		print(f"[bridge] 扩展已连接: {websocket.remote_address}", flush=True)
+		try:
+			async for message in websocket:
+				data = json.loads(message)
+				msg_type = data.get("type")
+
+				if msg_type == "hello":
+					ext_version = data.get("version", "unknown")
+					print(f"[bridge] 扩展版本: {ext_version}", flush=True)
+					continue
+
+				if msg_type == "log":
+					level = data.get("level", "info")
+					msg = data.get("msg", "")
+					print(f"[bridge:ext:{level}] {msg}", flush=True)
+					continue
+
+				# 命令结果
+				cmd_id = data.get("id")
+				if cmd_id and cmd_id in pending_commands:
+					pending_commands[cmd_id].set_result(data)
+		except Exception as e:
+			print(f"[bridge] 扩展断连: {e}", flush=True)
+		finally:
+			if ext_ws is websocket:
+				ext_ws = None
+				ext_version = None
+			print("[bridge] 扩展已断开", flush=True)
+
+	# ── HTTP handler ──────────────────────────────────────────────
+
+	async def handle_ping(request):
+		nonlocal last_activity
+		last_activity = time.time()
+		return web.json_response({"ok": True})
+
+	async def handle_status(request):
+		nonlocal last_activity
+		last_activity = time.time()
+		return web.json_response({
+			"ok": True,
+			"extensionConnected": ext_ws is not None,
+			"extensionVersion": ext_version,
+			"pid": os.getpid(),
+			"uptime": int(time.time() - start_time),
+		})
+
+	async def handle_command(request):
+		nonlocal last_activity, ext_ws
+		last_activity = time.time()
+
+		if ext_ws is None:
+			return web.json_response(
+				{"id": "", "ok": False, "error": "Extension not connected"},
+				status=503,
+			)
+
+		try:
+			cmd = await request.json()
+		except Exception:
+			return web.json_response(
+				{"id": "", "ok": False, "error": "Invalid JSON"},
+				status=400,
+			)
+
+		cmd_id = cmd.get("id", "")
+		future = asyncio.get_event_loop().create_future()
+		pending_commands[cmd_id] = future
+
+		try:
+			await ext_ws.send(json.dumps(cmd))
+			result = await asyncio.wait_for(future, timeout=30.0)
+			return web.json_response(result)
+		except asyncio.TimeoutError:
+			return web.json_response(
+				{"id": cmd_id, "ok": False, "error": "Command timed out (30s)"},
+				status=504,
+			)
+		except Exception as e:
+			return web.json_response(
+				{"id": cmd_id, "ok": False, "error": f"Send failed: {e}"},
+				status=502,
+			)
+		finally:
+			pending_commands.pop(cmd_id, None)
+
+	# ── 启动服务 ──────────────────────────────────────────────────
+
+	start_time = time.time()
+
+	# HTTP server
+	app = web.Application()
+	app.router.add_get(DAEMON_PING_PATH, handle_ping)
+	app.router.add_get(DAEMON_STATUS_PATH, handle_status)
+	app.router.add_post(DAEMON_COMMAND_PATH, handle_command)
+
+	runner = web.AppRunner(app, access_log=None)
+	await runner.setup()
+	site = web.TCPSite(runner, BRIDGE_HOST, BRIDGE_PORT)
+	await site.start()
+	print(f"[bridge] HTTP 服务启动: http://{BRIDGE_HOST}:{BRIDGE_PORT}", flush=True)
+
+	# WebSocket server（独立端口或同端口不同路径）
+	# 使用 aiohttp 的 WebSocket 支持替代 websockets 库
+	ws_app = web.Application()
+
+	async def ws_upgrade_handler(request):
+		ws = web.WebSocketResponse()
+		await ws.prepare(request)
+		await _ws_handler_aiohttp(ws, ext_ws_holder={})
+		return ws
+
+	# 用 aiohttp 内置 WebSocket 替代 websockets 库，减少依赖
+	# 重写为统一 HTTP server 处理 WS 升级
+	# 这里简化：在同一个 app 上加 WS 路由
+
+	# 清理之前的方案，用 aiohttp 统一处理
+	await runner.cleanup()
+
+	# 重建统一 app
+	unified_app = web.Application()
+	unified_app.router.add_get(DAEMON_PING_PATH, handle_ping)
+	unified_app.router.add_get(DAEMON_STATUS_PATH, handle_status)
+	unified_app.router.add_post(DAEMON_COMMAND_PATH, handle_command)
+
+	async def ws_aiohttp_handler(request):
+		nonlocal ext_ws, ext_version
+		ws = web.WebSocketResponse()
+		await ws.prepare(request)
+		ext_ws = ws
+		print(f"[bridge] 扩展已连接 (aiohttp WS)", flush=True)
+
+		try:
+			async for msg in ws:
+				if msg.type == web.WSMsgType.TEXT:
+					data = json.loads(msg.data)
+					msg_type = data.get("type")
+
+					if msg_type == "hello":
+						ext_version = data.get("version", "unknown")
+						print(f"[bridge] 扩展版本: {ext_version}", flush=True)
+						continue
+
+					if msg_type == "log":
+						level = data.get("level", "info")
+						log_msg = data.get("msg", "")
+						print(f"[bridge:ext:{level}] {log_msg}", flush=True)
+						continue
+
+					cmd_id = data.get("id")
+					if cmd_id and cmd_id in pending_commands:
+						pending_commands[cmd_id].set_result(data)
+				elif msg.type == web.WSMsgType.ERROR:
+					print(f"[bridge] WS error: {ws.exception()}", flush=True)
+		finally:
+			if ext_ws is ws:
+				ext_ws = None
+				ext_version = None
+			print("[bridge] 扩展已断开", flush=True)
+
+		return ws
+
+	unified_app.router.add_get(DAEMON_WS_PATH, ws_aiohttp_handler)
+
+	unified_runner = web.AppRunner(unified_app, access_log=None)
+	await unified_runner.setup()
+	unified_site = web.TCPSite(unified_runner, BRIDGE_HOST, BRIDGE_PORT)
+	await unified_site.start()
+	print(f"[bridge] 统一服务启动: http://{BRIDGE_HOST}:{BRIDGE_PORT}", flush=True)
+	print(f"[bridge] PID: {os.getpid()}, 空闲超时: {DAEMON_IDLE_TIMEOUT}s", flush=True)
+
+	# ── 空闲超时检查 ──────────────────────────────────────────────
+
+	try:
+		while True:
+			await asyncio.sleep(60)
+			idle = time.time() - last_activity
+			if idle > DAEMON_IDLE_TIMEOUT and ext_ws is None:
+				print(f"[bridge] 空闲 {int(idle)}s 且无扩展连接，自动退出", flush=True)
+				break
+	except asyncio.CancelledError:
+		pass
+	finally:
+		await unified_runner.cleanup()
+		print("[bridge] daemon 已停止", flush=True)

--- a/src/boss_agent_cli/bridge/daemon.py
+++ b/src/boss_agent_cli/bridge/daemon.py
@@ -2,18 +2,18 @@
 
 接收 CLI 的 HTTP 命令，转发给 Chrome 扩展（WebSocket），返回结果。
 首次浏览器命令时自动启动，空闲 4h 后自动退出。
+
+依赖 aiohttp（可选依赖，仅 bridge extra 安装）。
 """
 
 import asyncio
 import json
 import os
 import signal
+import subprocess
 import sys
 import time
 from pathlib import Path
-
-# daemon 需要 websockets 和 aiohttp，但作为可选依赖
-# 只在实际启动 daemon 时导入
 
 _PID_FILE = Path.home() / ".boss-agent" / "bridge" / "daemon.pid"
 _LOG_FILE = Path.home() / ".boss-agent" / "bridge" / "daemon.log"
@@ -56,7 +56,6 @@ def stop_daemon() -> bool:
 		return False
 	try:
 		os.kill(pid, signal.SIGTERM)
-		# 等待进程退出
 		for _ in range(20):
 			try:
 				os.kill(pid, 0)
@@ -70,95 +69,59 @@ def stop_daemon() -> bool:
 		return False
 
 
-def start_daemon_background() -> int:
-	"""在后台启动 daemon 进程，返回 PID。"""
+def start_daemon_background() -> int | None:
+	"""在后台启动 daemon 进程，返回实际 daemon PID。跨平台兼容。"""
 	if is_daemon_running():
 		return get_daemon_pid()
 
 	_ensure_dirs()
 
-	# Fork 一个子进程运行 daemon
-	pid = os.fork()
-	if pid > 0:
-		# 父进程：等待一小段时间确认启动
-		time.sleep(0.5)
-		return pid
+	# 跨平台后台启动：用 subprocess.Popen 替代 os.fork
+	kwargs = {}
+	if sys.platform == "win32":
+		# Windows: DETACHED_PROCESS 标志
+		kwargs["creationflags"] = subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP
+	else:
+		# Unix: 新会话脱离终端
+		kwargs["start_new_session"] = True
 
-	# 子进程：脱离终端
-	os.setsid()
-	pid2 = os.fork()
-	if pid2 > 0:
-		os._exit(0)
-
-	# 孙进程：真正的 daemon
-	# 重定向 stdio
-	sys.stdin.close()
 	log_fd = open(_LOG_FILE, "a")
-	os.dup2(log_fd.fileno(), sys.stdout.fileno())
-	os.dup2(log_fd.fileno(), sys.stderr.fileno())
+	proc = subprocess.Popen(
+		[sys.executable, "-m", "boss_agent_cli.bridge.daemon", "--serve"],
+		stdout=log_fd,
+		stderr=log_fd,
+		stdin=subprocess.DEVNULL,
+		**kwargs,
+	)
+	log_fd.close()
 
-	# 写 PID 文件
-	_PID_FILE.write_text(str(os.getpid()))
+	# 等待 PID 文件出现（daemon 启动后写入）
+	for _ in range(20):
+		time.sleep(0.25)
+		pid = get_daemon_pid()
+		if pid is not None:
+			return pid
 
-	# 运行 asyncio 事件循环
-	try:
-		asyncio.run(_run_daemon())
-	finally:
-		_PID_FILE.unlink(missing_ok=True)
-		os._exit(0)
+	# fallback: 返回 Popen 的 PID
+	return proc.pid
 
 
 async def _run_daemon():
-	"""daemon 主循环：HTTP 服务 + WebSocket 服务。"""
+	"""daemon 主循环：统一 aiohttp HTTP + WebSocket 服务。"""
 	from aiohttp import web
-	import websockets.server
 
 	from boss_agent_cli.bridge.protocol import (
 		BRIDGE_HOST, BRIDGE_PORT, DAEMON_IDLE_TIMEOUT,
 		DAEMON_WS_PATH, DAEMON_PING_PATH, DAEMON_STATUS_PATH, DAEMON_COMMAND_PATH,
 	)
 
-	# 状态
+	start_time = time.time()
 	ext_ws = None
 	ext_version = None
 	last_activity = time.time()
 	pending_commands: dict[str, asyncio.Future] = {}
 
-	# ── WebSocket handler（Chrome 扩展连接） ──────────────────────
-
-	async def ws_handler(websocket):
-		nonlocal ext_ws, ext_version
-		ext_ws = websocket
-		print(f"[bridge] 扩展已连接: {websocket.remote_address}", flush=True)
-		try:
-			async for message in websocket:
-				data = json.loads(message)
-				msg_type = data.get("type")
-
-				if msg_type == "hello":
-					ext_version = data.get("version", "unknown")
-					print(f"[bridge] 扩展版本: {ext_version}", flush=True)
-					continue
-
-				if msg_type == "log":
-					level = data.get("level", "info")
-					msg = data.get("msg", "")
-					print(f"[bridge:ext:{level}] {msg}", flush=True)
-					continue
-
-				# 命令结果
-				cmd_id = data.get("id")
-				if cmd_id and cmd_id in pending_commands:
-					pending_commands[cmd_id].set_result(data)
-		except Exception as e:
-			print(f"[bridge] 扩展断连: {e}", flush=True)
-		finally:
-			if ext_ws is websocket:
-				ext_ws = None
-				ext_version = None
-			print("[bridge] 扩展已断开", flush=True)
-
-	# ── HTTP handler ──────────────────────────────────────────────
+	# ── HTTP handlers ─────────────────────────────────────────────
 
 	async def handle_ping(request):
 		nonlocal last_activity
@@ -177,7 +140,7 @@ async def _run_daemon():
 		})
 
 	async def handle_command(request):
-		nonlocal last_activity, ext_ws
+		nonlocal last_activity
 		last_activity = time.time()
 
 		if ext_ws is None:
@@ -199,7 +162,7 @@ async def _run_daemon():
 		pending_commands[cmd_id] = future
 
 		try:
-			await ext_ws.send(json.dumps(cmd))
+			await ext_ws.send_json(cmd)
 			result = await asyncio.wait_for(future, timeout=30.0)
 			return web.json_response(result)
 		except asyncio.TimeoutError:
@@ -215,51 +178,14 @@ async def _run_daemon():
 		finally:
 			pending_commands.pop(cmd_id, None)
 
-	# ── 启动服务 ──────────────────────────────────────────────────
+	# ── WebSocket handler（Chrome 扩展连接） ──────────────────────
 
-	start_time = time.time()
-
-	# HTTP server
-	app = web.Application()
-	app.router.add_get(DAEMON_PING_PATH, handle_ping)
-	app.router.add_get(DAEMON_STATUS_PATH, handle_status)
-	app.router.add_post(DAEMON_COMMAND_PATH, handle_command)
-
-	runner = web.AppRunner(app, access_log=None)
-	await runner.setup()
-	site = web.TCPSite(runner, BRIDGE_HOST, BRIDGE_PORT)
-	await site.start()
-	print(f"[bridge] HTTP 服务启动: http://{BRIDGE_HOST}:{BRIDGE_PORT}", flush=True)
-
-	# WebSocket server（独立端口或同端口不同路径）
-	# 使用 aiohttp 的 WebSocket 支持替代 websockets 库
-	ws_app = web.Application()
-
-	async def ws_upgrade_handler(request):
-		ws = web.WebSocketResponse()
-		await ws.prepare(request)
-		await _ws_handler_aiohttp(ws, ext_ws_holder={})
-		return ws
-
-	# 用 aiohttp 内置 WebSocket 替代 websockets 库，减少依赖
-	# 重写为统一 HTTP server 处理 WS 升级
-	# 这里简化：在同一个 app 上加 WS 路由
-
-	# 清理之前的方案，用 aiohttp 统一处理
-	await runner.cleanup()
-
-	# 重建统一 app
-	unified_app = web.Application()
-	unified_app.router.add_get(DAEMON_PING_PATH, handle_ping)
-	unified_app.router.add_get(DAEMON_STATUS_PATH, handle_status)
-	unified_app.router.add_post(DAEMON_COMMAND_PATH, handle_command)
-
-	async def ws_aiohttp_handler(request):
+	async def ws_handler(request):
 		nonlocal ext_ws, ext_version
 		ws = web.WebSocketResponse()
 		await ws.prepare(request)
 		ext_ws = ws
-		print(f"[bridge] 扩展已连接 (aiohttp WS)", flush=True)
+		print(f"[bridge] 扩展已连接", flush=True)
 
 		try:
 			async for msg in ws:
@@ -278,6 +204,7 @@ async def _run_daemon():
 						print(f"[bridge:ext:{level}] {log_msg}", flush=True)
 						continue
 
+					# 命令结果
 					cmd_id = data.get("id")
 					if cmd_id and cmd_id in pending_commands:
 						pending_commands[cmd_id].set_result(data)
@@ -287,18 +214,31 @@ async def _run_daemon():
 			if ext_ws is ws:
 				ext_ws = None
 				ext_version = None
+				# 扩展断连：取消所有 pending 命令
+				for cmd_id, fut in list(pending_commands.items()):
+					if not fut.done():
+						fut.set_result({"id": cmd_id, "ok": False, "error": "Extension disconnected"})
 			print("[bridge] 扩展已断开", flush=True)
 
 		return ws
 
-	unified_app.router.add_get(DAEMON_WS_PATH, ws_aiohttp_handler)
+	# ── 启动统一服务 ──────────────────────────────────────────────
 
-	unified_runner = web.AppRunner(unified_app, access_log=None)
-	await unified_runner.setup()
-	unified_site = web.TCPSite(unified_runner, BRIDGE_HOST, BRIDGE_PORT)
-	await unified_site.start()
-	print(f"[bridge] 统一服务启动: http://{BRIDGE_HOST}:{BRIDGE_PORT}", flush=True)
+	app = web.Application()
+	app.router.add_get(DAEMON_PING_PATH, handle_ping)
+	app.router.add_get(DAEMON_STATUS_PATH, handle_status)
+	app.router.add_post(DAEMON_COMMAND_PATH, handle_command)
+	app.router.add_get(DAEMON_WS_PATH, ws_handler)
+
+	runner = web.AppRunner(app, access_log=None)
+	await runner.setup()
+	site = web.TCPSite(runner, BRIDGE_HOST, BRIDGE_PORT)
+	await site.start()
+	print(f"[bridge] 服务启动: http://{BRIDGE_HOST}:{BRIDGE_PORT}", flush=True)
 	print(f"[bridge] PID: {os.getpid()}, 空闲超时: {DAEMON_IDLE_TIMEOUT}s", flush=True)
+
+	# 写 PID 文件（服务启动后再写，确保端口可用）
+	_PID_FILE.write_text(str(os.getpid()))
 
 	# ── 空闲超时检查 ──────────────────────────────────────────────
 
@@ -312,5 +252,19 @@ async def _run_daemon():
 	except asyncio.CancelledError:
 		pass
 	finally:
-		await unified_runner.cleanup()
+		_PID_FILE.unlink(missing_ok=True)
+		await runner.cleanup()
 		print("[bridge] daemon 已停止", flush=True)
+
+
+# ── CLI 入口：python -m boss_agent_cli.bridge.daemon --serve ────────
+
+if __name__ == "__main__":
+	if "--serve" in sys.argv:
+		_ensure_dirs()
+		try:
+			asyncio.run(_run_daemon())
+		except KeyboardInterrupt:
+			pass
+		finally:
+			_PID_FILE.unlink(missing_ok=True)

--- a/src/boss_agent_cli/bridge/protocol.py
+++ b/src/boss_agent_cli/bridge/protocol.py
@@ -66,5 +66,6 @@ class BridgeResult:
 
 
 def make_command_id() -> str:
-	"""生成唯一命令 ID。"""
-	return f"cmd_{int(time.time() * 1000)}_{os.getpid()}"
+	"""生成唯一命令 ID（uuid 防碰撞）。"""
+	import uuid
+	return f"cmd_{uuid.uuid4().hex[:12]}"

--- a/src/boss_agent_cli/bridge/protocol.py
+++ b/src/boss_agent_cli/bridge/protocol.py
@@ -1,0 +1,70 @@
+"""Browser Bridge 协议定义 — daemon / 扩展 / CLI 三方共享。"""
+
+from dataclasses import dataclass, field
+from typing import Any
+import os
+import time
+
+# ── 端口配置 ──────────────────────────────────────────────────────────
+
+DEFAULT_PORT = 19826
+BRIDGE_PORT = int(os.getenv("BOSS_BRIDGE_PORT", str(DEFAULT_PORT)))
+BRIDGE_HOST = "127.0.0.1"
+DAEMON_WS_PATH = "/ext"
+DAEMON_PING_PATH = "/ping"
+DAEMON_STATUS_PATH = "/status"
+DAEMON_COMMAND_PATH = "/command"
+
+# daemon 空闲超时：4 小时
+DAEMON_IDLE_TIMEOUT = int(os.getenv("BOSS_BRIDGE_TIMEOUT", str(4 * 3600)))
+
+
+# ── 命令类型 ──────────────────────────────────────────────────────────
+
+@dataclass
+class BridgeCommand:
+	"""CLI → daemon → 扩展 的命令。"""
+	id: str
+	action: str  # exec | navigate | cookies | close-window
+	code: str = ""
+	url: str = ""
+	domain: str = ""
+	workspace: str = "boss"
+	tab_id: int | None = None
+
+	def to_dict(self) -> dict[str, Any]:
+		d: dict[str, Any] = {"id": self.id, "action": self.action}
+		if self.code:
+			d["code"] = self.code
+		if self.url:
+			d["url"] = self.url
+		if self.domain:
+			d["domain"] = self.domain
+		if self.workspace:
+			d["workspace"] = self.workspace
+		if self.tab_id is not None:
+			d["tabId"] = self.tab_id
+		return d
+
+
+@dataclass
+class BridgeResult:
+	"""扩展 → daemon → CLI 的结果。"""
+	id: str
+	ok: bool
+	data: Any = None
+	error: str = ""
+
+	@classmethod
+	def from_dict(cls, d: dict) -> "BridgeResult":
+		return cls(
+			id=d.get("id", ""),
+			ok=d.get("ok", False),
+			data=d.get("data"),
+			error=d.get("error", ""),
+		)
+
+
+def make_command_id() -> str:
+	"""生成唯一命令 ID。"""
+	return f"cmd_{int(time.time() * 1000)}_{os.getpid()}"


### PR DESCRIPTION
## Summary

参考 opencli 的 Browser Bridge 架构，实现纯 Python 的零配置浏览器连接方案。

### 核心改变
- **用户不再需要** `--remote-debugging-port=9222` 参数启动 Chrome
- **安装一次扩展** → 之后所有命令自动通过 Bridge 连接
- **Cookie 实时读取** → 通过 `chrome.cookies` API 读 Chrome 内存
- **stoken 天然生成** → JS 在真实页面上下文执行

### 架构
```
CLI → HTTP → Python daemon (aiohttp) → WebSocket → Chrome 扩展 → chrome.debugger → 网页
```

### 降级链（向后兼容）
```
1. Bridge（扩展+daemon）→ 优先，零配置
2. CDP（--remote-debugging-port）→ 降级
3. Patchright headless → 兜底
```

### 新增文件
| 文件 | 说明 |
|------|------|
| `src/boss_agent_cli/bridge/protocol.py` | 命令/结果类型，端口配置 |
| `src/boss_agent_cli/bridge/daemon.py` | aiohttp HTTP+WS daemon（后台自启，4h 空闲退出） |
| `src/boss_agent_cli/bridge/client.py` | BridgeClient（自动重试，evaluate/navigate/cookies/fetch_json） |
| `extension/manifest.json` | Manifest V3 |
| `extension/background.js` | Service Worker（debugger+tabs+cookies） |
| `extension/popup.html` | 连接状态面板 |

## Test plan

- [ ] `python3 -c "from boss_agent_cli.bridge.client import BridgeClient; print('OK')"` 导入成功
- [ ] 安装扩展到 Chrome → popup 显示"未连接"
- [ ] 启动 daemon → 扩展 popup 显示"已连接 daemon"
- [ ] `boss search "test"` 通过 Bridge 通道执行
- [ ] Bridge 不可用时自动降级到 CDP/patchright

🤖 Generated with [Claude Code](https://claude.com/claude-code)