### PR TITLE
补齐高风险链路测试覆盖并修正搜索分页边界

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 build/
 .pytest_cache/
 .playwright-mcp/
+.worktrees/
 .claude/
 docs/superpowers/
 my-boss-profile.md

--- a/src/boss_agent_cli/search_filters.py
+++ b/src/boss_agent_cli/search_filters.py
@@ -248,6 +248,7 @@ def run_search_pipeline(
 	stats = SearchPipelineStats()
 	matched: list[dict] = []
 	current_page = start_page
+	last_page_scanned = 0
 	has_more = False
 
 	for _ in range(max_pages):
@@ -265,6 +266,7 @@ def run_search_pipeline(
 		)
 		zp_data = raw.get("zpData", {})
 		job_list = zp_data.get("jobList", [])
+		last_page_scanned = current_page
 		stats.pages_scanned += 1
 		stats.jobs_seen += len(job_list)
 
@@ -333,6 +335,6 @@ def run_search_pipeline(
 		items=matched,
 		has_more=has_more,
 		total=len(matched),
-		last_page=current_page,
+		last_page=last_page_scanned,
 		stats=stats,
 	)

--- a/tests/test_api_client_retry.py
+++ b/tests/test_api_client_retry.py
@@ -1,0 +1,164 @@
+from unittest.mock import patch
+
+import pytest
+
+from boss_agent_cli.api import endpoints
+from boss_agent_cli.api.client import AuthError, BossClient
+
+
+class FakeCookieJar:
+	def __init__(self, initial: dict[str, str] | None = None):
+		self._data = dict(initial or {})
+
+	def items(self):
+		return self._data.items()
+
+	def set(self, name: str, value: str):
+		self._data[name] = value
+
+	def get(self, name: str):
+		return self._data.get(name)
+
+
+class FakeResponse:
+	def __init__(self, *, status_code: int = 200, payload: dict | None = None, text: str = "", cookies: dict | None = None):
+		self.status_code = status_code
+		self._payload = payload or {"code": 0}
+		self.text = text
+		self.cookies = FakeCookieJar(cookies)
+
+	def json(self):
+		return self._payload
+
+	def raise_for_status(self):
+		if self.status_code >= 400:
+			raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class FakeHttpxClient:
+	def __init__(self, responses: list[FakeResponse]):
+		self.responses = list(responses)
+		self.calls: list[dict] = []
+		self.cookies = FakeCookieJar()
+
+	def request(self, method: str, url: str, headers: dict | None = None, **kwargs):
+		self.calls.append({"method": method, "url": url, "headers": headers, "kwargs": kwargs})
+		return self.responses.pop(0)
+
+	def close(self):
+		pass
+
+
+class FakeAuthManager:
+	def __init__(self):
+		self.token = {"cookies": {"wt2": "cookie"}, "stoken": "initial-stoken", "user_agent": "agent-ua"}
+		self.refresh_calls: list[str | None] = []
+
+	def get_token(self):
+		return self.token
+
+	def force_refresh(self, cdp_url: str | None = None):
+		self.refresh_calls.append(cdp_url)
+		self.token = {**self.token, "stoken": f"refreshed-{len(self.refresh_calls)}"}
+
+
+def test_request_get_adds_stoken_and_merges_cookies():
+	auth = FakeAuthManager()
+	client = BossClient(auth)
+	http_client = FakeHttpxClient([FakeResponse(payload={"code": 0}, cookies={"bst": "cookie-from-resp"})])
+	client._client = http_client
+	client._throttle.wait = lambda: None
+	client._throttle.mark = lambda: None
+
+	data = client._request("GET", endpoints.USER_INFO_URL, params={"page": 1})
+
+	assert data["code"] == 0
+	assert http_client.calls[0]["kwargs"]["params"]["__zp_stoken__"] == "initial-stoken"
+	assert http_client.cookies.get("bst") == "cookie-from-resp"
+
+
+@patch("boss_agent_cli.api.client.random.uniform", return_value=0)
+@patch("boss_agent_cli.api.client.time.sleep")
+@patch("boss_agent_cli.api.client.httpx.Client")
+def test_request_retries_after_403_and_refreshes_token(mock_http_client_cls, mock_sleep, mock_uniform):
+	auth = FakeAuthManager()
+	first = FakeHttpxClient([FakeResponse(status_code=403, text="forbidden")])
+	second = FakeHttpxClient([FakeResponse(payload={"code": 0, "zpData": {"ok": True}})])
+	mock_http_client_cls.side_effect = [first, second]
+
+	client = BossClient(auth, cdp_url="http://127.0.0.1:9222")
+	client._throttle.wait = lambda: None
+	client._throttle.mark = lambda: None
+
+	data = client._request("GET", endpoints.USER_INFO_URL)
+
+	assert data["zpData"]["ok"] is True
+	assert auth.refresh_calls == ["http://127.0.0.1:9222"]
+	assert mock_sleep.call_args_list[0].args[0] == 1
+	assert second.calls[0]["kwargs"]["params"]["__zp_stoken__"] == "refreshed-1"
+
+
+@patch("boss_agent_cli.api.client.random.uniform", return_value=0)
+@patch("boss_agent_cli.api.client.time.sleep")
+@patch("boss_agent_cli.api.client.httpx.Client")
+def test_request_retries_after_stoken_expired_code(mock_http_client_cls, mock_sleep, mock_uniform):
+	auth = FakeAuthManager()
+	first = FakeHttpxClient([FakeResponse(payload={"code": endpoints.CODE_STOKEN_EXPIRED})])
+	second = FakeHttpxClient([FakeResponse(payload={"code": 0, "zpData": {"ok": True}})])
+	mock_http_client_cls.side_effect = [first, second]
+
+	client = BossClient(auth)
+	client._throttle.wait = lambda: None
+	client._throttle.mark = lambda: None
+
+	data = client._request("GET", endpoints.USER_INFO_URL)
+
+	assert data["zpData"]["ok"] is True
+	assert auth.refresh_calls == [None]
+	assert mock_sleep.call_args_list[0].args[0] == 1
+	assert second.calls[0]["kwargs"]["params"]["__zp_stoken__"] == "refreshed-1"
+
+
+@patch("boss_agent_cli.api.client.time.sleep")
+@patch("boss_agent_cli.api.client.httpx.Client")
+def test_request_retries_after_rate_limited_code(mock_http_client_cls, mock_sleep):
+	auth = FakeAuthManager()
+	client_with_retry = FakeHttpxClient(
+		[
+			FakeResponse(payload={"code": endpoints.CODE_RATE_LIMITED}),
+			FakeResponse(payload={"code": 0, "zpData": {"ok": True}}),
+		],
+	)
+	mock_http_client_cls.return_value = client_with_retry
+
+	client = BossClient(auth)
+	client._throttle.wait = lambda: None
+	client._throttle.mark = lambda: None
+
+	data = client._request("GET", endpoints.USER_INFO_URL)
+
+	assert data["zpData"]["ok"] is True
+	assert auth.refresh_calls == []
+	assert mock_sleep.call_args_list[0].args[0] == 10
+
+
+@patch("boss_agent_cli.api.client.random.uniform", return_value=0)
+@patch("boss_agent_cli.api.client.time.sleep")
+@patch("boss_agent_cli.api.client.httpx.Client")
+def test_request_raises_auth_error_after_max_403_retries(mock_http_client_cls, mock_sleep, mock_uniform):
+	auth = FakeAuthManager()
+	mock_http_client_cls.side_effect = [
+		FakeHttpxClient([FakeResponse(status_code=403, text="forbidden")]),
+		FakeHttpxClient([FakeResponse(status_code=403, text="forbidden")]),
+		FakeHttpxClient([FakeResponse(status_code=403, text="forbidden")]),
+		FakeHttpxClient([FakeResponse(status_code=403, text="forbidden")]),
+	]
+
+	client = BossClient(auth)
+	client._throttle.wait = lambda: None
+	client._throttle.mark = lambda: None
+
+	with pytest.raises(AuthError, match="Token 刷新后仍被拒绝，请重新登录"):
+		client._request("GET", endpoints.USER_INFO_URL)
+
+	assert auth.refresh_calls == [None, None, None]

--- a/tests/test_auth_manager_flow.py
+++ b/tests/test_auth_manager_flow.py
@@ -1,0 +1,134 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from boss_agent_cli.auth.manager import AuthManager, TokenRefreshFailed
+
+
+def _make_store(token: dict | None = None):
+	store = MagicMock()
+	store.load.return_value = token
+	lock = MagicMock()
+	lock.__enter__.return_value = None
+	lock.__exit__.return_value = None
+	store.refresh_lock.return_value = lock
+	return store
+
+
+@patch("boss_agent_cli.auth.manager.TokenStore")
+@patch("boss_agent_cli.auth.manager.login_via_cdp")
+@patch("boss_agent_cli.auth.manager.extract_cookies")
+def test_login_force_cdp_skips_cookie_extraction(mock_extract, mock_login_via_cdp, mock_store_cls, tmp_path):
+	store = _make_store()
+	mock_store_cls.return_value = store
+	mock_login_via_cdp.return_value = {"cookies": {"wt2": "cdp-cookie"}, "stoken": "cdp-token"}
+
+	manager = AuthManager(tmp_path)
+
+	result = manager.login(timeout=45, cdp_url="http://127.0.0.1:9222", force_cdp=True)
+
+	mock_extract.assert_not_called()
+	mock_login_via_cdp.assert_called_once_with(cdp_url="http://127.0.0.1:9222", timeout=45)
+	store.save.assert_called_once_with({"cookies": {"wt2": "cdp-cookie"}, "stoken": "cdp-token"})
+	assert result["_method"] == "CDP 扫码"
+	assert manager._token["stoken"] == "cdp-token"
+
+
+@patch("boss_agent_cli.auth.manager.TokenStore")
+@patch("boss_agent_cli.auth.manager.login_via_browser")
+@patch("boss_agent_cli.auth.manager.login_via_cdp")
+@patch("boss_agent_cli.auth.manager.probe_cdp")
+@patch("boss_agent_cli.auth.manager.extract_cookies")
+def test_login_uses_valid_cookie_without_fallback(
+	mock_extract,
+	mock_probe_cdp,
+	mock_login_via_cdp,
+	mock_login_via_browser,
+	mock_store_cls,
+	tmp_path,
+):
+	store = _make_store()
+	mock_store_cls.return_value = store
+	cookie_token = {"cookies": {"wt2": "cookie-token"}, "stoken": "cookie-stoken"}
+	mock_extract.return_value = cookie_token
+
+	manager = AuthManager(tmp_path)
+
+	with patch.object(manager, "_verify_cookie", return_value=True):
+		result = manager.login()
+
+	mock_probe_cdp.assert_not_called()
+	mock_login_via_cdp.assert_not_called()
+	mock_login_via_browser.assert_not_called()
+	store.save.assert_called_once_with(cookie_token)
+	assert result["_method"] == "Cookie 提取"
+
+
+@patch("boss_agent_cli.auth.manager.TokenStore")
+@patch("boss_agent_cli.auth.manager.login_via_browser")
+@patch("boss_agent_cli.auth.manager.login_via_cdp")
+@patch("boss_agent_cli.auth.manager.probe_cdp")
+@patch("boss_agent_cli.auth.manager.extract_cookies")
+def test_login_falls_back_to_browser_when_cdp_login_fails(
+	mock_extract,
+	mock_probe_cdp,
+	mock_login_via_cdp,
+	mock_login_via_browser,
+	mock_store_cls,
+	tmp_path,
+):
+	store = _make_store()
+	mock_store_cls.return_value = store
+	mock_extract.return_value = {"cookies": {"wt2": "stale-cookie"}, "stoken": "old"}
+	mock_probe_cdp.return_value = True
+	mock_login_via_cdp.side_effect = RuntimeError("cdp failed")
+	mock_login_via_browser.return_value = {"cookies": {"wt2": "browser-cookie"}, "stoken": "browser-token"}
+
+	manager = AuthManager(tmp_path)
+
+	with patch.object(manager, "_verify_cookie", return_value=False):
+		result = manager.login(timeout=30)
+
+	mock_login_via_cdp.assert_called_once_with(cdp_url=None, timeout=30)
+	mock_login_via_browser.assert_called_once_with(timeout=30)
+	store.save.assert_called_once_with({"cookies": {"wt2": "browser-cookie"}, "stoken": "browser-token"})
+	assert result["_method"] == "扫码登录"
+
+
+@patch("boss_agent_cli.auth.manager.TokenStore")
+def test_force_refresh_raises_when_no_token(mock_store_cls, tmp_path):
+	store = _make_store(token=None)
+	mock_store_cls.return_value = store
+	manager = AuthManager(tmp_path)
+
+	with pytest.raises(TokenRefreshFailed, match="无法刷新 Token，请重新登录"):
+		manager.force_refresh()
+
+
+@patch("boss_agent_cli.auth.manager.TokenStore")
+@patch("boss_agent_cli.auth.manager.refresh_stoken")
+@patch("boss_agent_cli.auth.manager.refresh_stoken_via_cdp")
+@patch("boss_agent_cli.auth.manager.probe_cdp")
+def test_force_refresh_prefers_cdp_and_persists_new_stoken(
+	mock_probe_cdp,
+	mock_refresh_cdp,
+	mock_refresh_stoken,
+	mock_store_cls,
+	tmp_path,
+):
+	current = {"cookies": {"wt2": "cookie"}, "stoken": "old-token", "user_agent": "ua"}
+	store = _make_store(token=current.copy())
+	mock_store_cls.return_value = store
+	mock_probe_cdp.return_value = True
+	mock_refresh_cdp.return_value = "new-token"
+
+	manager = AuthManager(tmp_path)
+
+	manager.force_refresh(cdp_url="http://127.0.0.1:9222")
+
+	mock_refresh_stoken.assert_not_called()
+	mock_refresh_cdp.assert_called_once_with("http://127.0.0.1:9222")
+	store.save.assert_called_once()
+	saved_token = store.save.call_args.args[0]
+	assert saved_token["stoken"] == "new-token"
+	assert manager._token["stoken"] == "new-token"

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1,6 +1,6 @@
 """Tests for bridge module — protocol, client, daemon utilities."""
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from boss_agent_cli.bridge.protocol import (
 	BridgeCommand, BridgeResult, make_command_id,

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,7 +1,6 @@
 """Tests for display.py — TTY detection, renderers, auth error decorator."""
 
 import sys
-from io import StringIO
 from unittest.mock import patch, MagicMock
 
 from boss_agent_cli.display import (
@@ -9,7 +8,6 @@ from boss_agent_cli.display import (
 	handle_output,
 	handle_error_output,
 	handle_auth_errors,
-	render_string_grid,
 )
 
 

--- a/tests/test_index_cache.py
+++ b/tests/test_index_cache.py
@@ -1,8 +1,6 @@
 """Tests for index_cache.py — save, load, get by index."""
 
 import json
-import time
-from pathlib import Path
 
 from boss_agent_cli.index_cache import (
 	save_index, try_save_index, get_job_by_index, get_index_info,

--- a/tests/test_search_pipeline.py
+++ b/tests/test_search_pipeline.py
@@ -1,0 +1,204 @@
+from boss_agent_cli.search_filters import SearchFilterCriteria, resolve_welfare_keywords, run_search_pipeline
+
+
+class FakeLogger:
+	def __init__(self):
+		self.messages: list[str] = []
+
+	def info(self, message: str):
+		self.messages.append(message)
+
+
+class FakeCache:
+	def __init__(self, greeted_ids: set[str] | None = None):
+		self.greeted_ids = greeted_ids or set()
+
+	def is_greeted(self, security_id: str) -> bool:
+		return security_id in self.greeted_ids
+
+
+class FakeClient:
+	def __init__(self, pages: list[dict], descriptions: dict[str, str | Exception]):
+		self.pages = list(pages)
+		self.descriptions = descriptions
+		self.search_calls: list[dict] = []
+		self.detail_calls: list[tuple[str, str]] = []
+
+	def search_jobs(self, query: str, **filters):
+		self.search_calls.append({"query": query, "filters": filters})
+		return self.pages.pop(0)
+
+	def job_card(self, security_id: str, lid: str = ""):
+		self.detail_calls.append((security_id, lid))
+		value = self.descriptions[security_id]
+		if isinstance(value, Exception):
+			raise value
+		return {"zpData": {"jobCard": {"postDescription": value}}}
+
+
+def _make_job_raw(*, security_id: str, job_id: str, welfare: list[str] | None = None, lid: str = ""):
+	return {
+		"encryptJobId": job_id,
+		"jobName": f"Job-{job_id}",
+		"brandName": f"Company-{job_id}",
+		"salaryDesc": "20-30K",
+		"cityName": "广州",
+		"areaDistrict": "天河区",
+		"jobExperience": "3-5年",
+		"jobDegree": "本科",
+		"skills": ["Python"],
+		"welfareList": welfare or [],
+		"brandIndustry": "互联网",
+		"brandScaleName": "100-499人",
+		"brandStageName": "A轮",
+		"bossName": "李女士",
+		"bossTitle": "HR",
+		"bossOnline": True,
+		"securityId": security_id,
+		"lid": lid,
+	}
+
+
+def _welfare_conditions():
+	return [("双休", resolve_welfare_keywords("双休"))]
+
+
+def test_pipeline_uses_detail_fallback_and_marks_greeted():
+	client = FakeClient(
+		pages=[{"zpData": {"hasMore": False, "jobList": [_make_job_raw(security_id="sec-1", job_id="job-1")]}}],
+		descriptions={"sec-1": "这里提供双休和五险一金"},
+	)
+	cache = FakeCache({"sec-1"})
+	logger = FakeLogger()
+
+	result = run_search_pipeline(
+		client,
+		cache,
+		logger,
+		criteria=SearchFilterCriteria(query="python"),
+		welfare_conditions=_welfare_conditions(),
+	)
+
+	assert len(result.items) == 1
+	assert result.items[0]["security_id"] == "sec-1"
+	assert result.items[0]["greeted"] is True
+	assert "双休(描述)" in result.items[0]["welfare_match"]
+
+
+def test_pipeline_detail_exception_does_not_abort_other_matches():
+	client = FakeClient(
+		pages=[
+			{
+				"zpData": {
+					"hasMore": False,
+					"jobList": [
+						_make_job_raw(security_id="sec-fail", job_id="job-fail"),
+						_make_job_raw(security_id="sec-ok", job_id="job-ok"),
+					],
+				},
+			},
+		],
+		descriptions={
+			"sec-fail": OSError("network error"),
+			"sec-ok": "岗位描述明确写了双休",
+		},
+	)
+
+	result = run_search_pipeline(
+		client,
+		FakeCache(),
+		FakeLogger(),
+		criteria=SearchFilterCriteria(query="python"),
+		welfare_conditions=_welfare_conditions(),
+	)
+
+	assert [item["security_id"] for item in result.items] == ["sec-ok"]
+
+
+def test_pipeline_skip_greeted_filters_detail_matched_items():
+	client = FakeClient(
+		pages=[{"zpData": {"hasMore": False, "jobList": [_make_job_raw(security_id="sec-1", job_id="job-1")]}}],
+		descriptions={"sec-1": "这里提供双休"},
+	)
+
+	result = run_search_pipeline(
+		client,
+		FakeCache({"sec-1"}),
+		FakeLogger(),
+		criteria=SearchFilterCriteria(query="python"),
+		welfare_conditions=_welfare_conditions(),
+		skip_greeted=True,
+	)
+
+	assert result.items == []
+
+
+def test_pipeline_stops_after_limit_during_welfare_search():
+	client = FakeClient(
+		pages=[
+			{
+				"zpData": {
+					"hasMore": True,
+					"jobList": [
+						_make_job_raw(security_id="sec-1", job_id="job-1", welfare=["双休"]),
+						_make_job_raw(security_id="sec-2", job_id="job-2", welfare=["双休"]),
+					],
+				},
+			},
+			{
+				"zpData": {
+					"hasMore": False,
+					"jobList": [_make_job_raw(security_id="sec-3", job_id="job-3", welfare=["双休"])],
+				},
+			},
+		],
+		descriptions={},
+	)
+
+	result = run_search_pipeline(
+		client,
+		FakeCache(),
+		FakeLogger(),
+		criteria=SearchFilterCriteria(query="python"),
+		welfare_conditions=_welfare_conditions(),
+		limit=1,
+		max_pages=5,
+	)
+
+	assert len(result.items) == 1
+	assert len(client.search_calls) == 1
+	assert result.has_more is True
+
+
+def test_pipeline_respects_max_pages_even_when_has_more():
+	client = FakeClient(
+		pages=[
+			{
+				"zpData": {
+					"hasMore": True,
+					"jobList": [_make_job_raw(security_id="sec-1", job_id="job-1", welfare=["双休"])],
+				},
+			},
+			{
+				"zpData": {
+					"hasMore": True,
+					"jobList": [_make_job_raw(security_id="sec-2", job_id="job-2", welfare=["双休"])],
+				},
+			},
+		],
+		descriptions={},
+	)
+
+	result = run_search_pipeline(
+		client,
+		FakeCache(),
+		FakeLogger(),
+		criteria=SearchFilterCriteria(query="python"),
+		welfare_conditions=_welfare_conditions(),
+		max_pages=1,
+	)
+
+	assert len(client.search_calls) == 1
+	assert len(result.items) == 1
+	assert result.last_page == 1
+	assert result.has_more is True


### PR DESCRIPTION
## Summary
- 为 API 客户端重试、AuthManager 登录/刷新流程、搜索筛选主链路新增高风险场景测试，覆盖 403、stoken 失效、限流、CDP/浏览器回退等行为。
- 修正 run_search_pipeline 的 last_page 记录逻辑，避免在提前停止或受 max_pages 限制时返回越界页码。
- 清理测试目录中的未使用导入告警，并补充 .gitignore 忽略本地 .worktrees/ 目录。

## Test Plan
- uv run pytest tests/test_api_client_retry.py tests/test_auth_manager_flow.py tests/test_search_pipeline.py -v
- uv run pytest tests/test_bridge.py tests/test_display.py tests/test_index_cache.py -v
- uv run pytest tests/ -v
- uv run ruff check src tests