### PR TITLE
docs: 更新终端演示脚本并同步锁文件版本

### DIFF
--- a/demo.tape
+++ b/demo.tape
@@ -6,44 +6,63 @@ Output demo.gif
 Set Shell "zsh"
 Set FontSize 14
 Set Width 1200
-Set Height 620
+Set Height 700
 Set Theme "Catppuccin Mocha"
 Set Padding 20
-Set TypingSpeed 50ms
+Set TypingSpeed 40ms
 
-# ── 工具介绍 ──────────────────────────────────
+# ══════════════════════════════════════════════════
+# Act 1: 全局概览 — 19 个命令，覆盖完整求职链
+# ══════════════════════════════════════════════════
 Sleep 500ms
+Type "# AI Agent 求职自动化 — boss-agent-cli"
+Enter
+Sleep 1s
 Type "boss --help"
 Sleep 300ms
 Enter
 Sleep 3s
 
-# ── 能力自描述 ────────────────────────────────
-Type "boss schema 2>/dev/null | python3 -m json.tool | head -40"
+Ctrl+L
+Sleep 300ms
+
+# ══════════════════════════════════════════════════
+# Act 2: AI 自描述协议 — Agent 一次调用理解全部能力
+# ══════════════════════════════════════════════════
+Type "# AI 自描述协议：一次调用 → 19 commands + 错误自愈 + JSON 输出"
+Enter
+Sleep 800ms
+Type "boss --json schema 2>/dev/null | python3 demo_showcase.py"
+Sleep 300ms
+Enter
+Sleep 5s
+
+Ctrl+L
+Sleep 300ms
+
+# ══════════════════════════════════════════════════
+# Act 3: 环境诊断 — 一键自检全覆盖
+# ══════════════════════════════════════════════════
+Type "# 一键诊断：Python / 浏览器 / 登录态 / 网络"
+Enter
+Sleep 800ms
+Type "boss doctor"
 Sleep 300ms
 Enter
 Sleep 4s
 
-# ── 环境诊断 ──────────────────────────────────
-Type "boss doctor 2>/dev/null | python3 -m json.tool"
+Ctrl+L
 Sleep 300ms
-Enter
-Sleep 4s
 
-# ── 城市列表 ──────────────────────────────────
-Type "boss cities 2>/dev/null | python3 -m json.tool | head -30"
-Sleep 300ms
+# ══════════════════════════════════════════════════
+# Act 4: 核心功能 — 搜索 + 福利精准筛选
+# ══════════════════════════════════════════════════
+Type "# 搜索 + 福利精准筛选（自动翻页 + 详情匹配，只返回命中结果）"
 Enter
-Sleep 3s
-
-# ── 搜索示例（展示命令格式） ──────────────────
-Type "# 搜索广州 Golang 职位，要求双休+五险一金"
-Sleep 300ms
-Enter
-Sleep 1s
+Sleep 800ms
 Type 'boss search "Golang" --city 广州 --welfare "双休,五险一金"'
 Sleep 500ms
 Enter
-Sleep 4s
+Sleep 8s
 
 Sleep 2s

--- a/demo_showcase.py
+++ b/demo_showcase.py
@@ -1,0 +1,29 @@
+"""Demo helper — compact schema summary for GIF recording."""
+import json
+import sys
+
+
+def main():
+	d = json.load(sys.stdin)["data"]
+	cmds = d["commands"]
+	errs = d["error_codes"]
+
+	print(f"\n  {d['name']} — {d['description']}")
+	print(f"  {len(cmds)} commands | {len(errs)} error codes | JSON protocol\n")
+
+	for name, cmd in cmds.items():
+		desc = cmd["description"]
+		if len(desc) > 42:
+			desc = desc[:42] + "..."
+		print(f"    boss {name:14s} {desc}")
+
+	recoverable = [(k, v) for k, v in errs.items() if v["recoverable"]]
+	print(f"\n  Error Recovery ({len(recoverable)} auto-recoverable):")
+	for code, info in recoverable:
+		print(f"    {code:25s} -> {info['recovery_action']}")
+
+	print("\n  Protocol: stdout=JSON | stderr=logs | exit 0/1\n")
+
+
+if __name__ == "__main__":
+	main()

--- a/uv.lock
+++ b/uv.lock
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "boss-agent-cli"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },


### PR DESCRIPTION
## Summary
- 重写 demo.tape 的演示节奏，改为 help、schema、doctor、welfare search 四幕结构，并修正文案为当前实际的 19 个命令
- 新增 demo_showcase.py，将 schema JSON 压缩成更适合 GIF 展示的摘要输出
- 同步 uv.lock 中 boss-agent-cli 的版本号到 1.2.0，和 pyproject.toml 保持一致

## Test Plan
- env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache PYTHONDONTWRITEBYTECODE=1 uv run boss --json schema | python3 -B demo_showcase.py
- vhs validate demo.tape
- 尝试运行 vhs demo.tape，结果确认本机 vhs 0.11.0 在 randomPort() 处崩溃，demo.gif 本次未更新