### PR TITLE
feat: 增加saved search和watch命令

### DIFF
--- a/docs/superpowers/plans/2026-04-10-p0-wave2.md
+++ b/docs/superpowers/plans/2026-04-10-p0-wave2.md
@@ -1,0 +1,40 @@
+# P0 Wave 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the first persistent discovery capability by adding saved-search/watch while preserving room for the later pipeline/follow-up and apply/deliver waves.
+
+**Architecture:** Extend the existing search domain instead of introducing a new top-level workflow engine. Persist saved searches and watch hit history in SQLite via `CacheStore`, keep `watch` as a thin CLI layer, and reuse `SearchFilterCriteria` plus `run_search_pipeline()` for execution. Capture pre-research conclusions for future `pipeline` and `apply` work, but do not mix them into this wave.
+
+**Tech Stack:** Python 3.10+, Click CLI groups, SQLite WAL via `CacheStore`, pytest, existing JSON envelope/display helpers.
+
+---
+
+## Scope
+
+- Add persistent saved-search CRUD
+- Add watch execution with incremental "new item" detection
+- Expose `watch` in CLI and schema
+- Cover behavior with cache and command tests
+
+## Out of Scope
+
+- Apply / deliver write path
+- Unified pipeline / follow-up orchestration
+- Scheduled execution / cron automation
+
+## Planned File Touches
+
+- Modify: `src/boss_agent_cli/cache/store.py`
+- Modify: `src/boss_agent_cli/main.py`
+- Modify: `src/boss_agent_cli/commands/schema.py`
+- Create: `src/boss_agent_cli/commands/watch.py`
+- Modify: `tests/test_cache.py`
+- Modify: `tests/test_commands.py`
+- Create: `tests/test_watch.py`
+
+## Follow-on Inputs
+
+- `apply/deliver` should reuse `BossClient` browser-side write paths and likely prefer `Bridge/CDP`
+- `watch` should stay in the search domain
+- `pipeline/follow-up` should land later as an orchestration layer over chat/interviews/mark/history, not as logic hidden inside `watch`

--- a/src/boss_agent_cli/cache/store.py
+++ b/src/boss_agent_cli/cache/store.py
@@ -29,6 +29,20 @@ class CacheStore:
 				response TEXT NOT NULL,
 				created_at REAL NOT NULL
 			);
+			CREATE TABLE IF NOT EXISTS saved_searches (
+				name TEXT PRIMARY KEY,
+				params TEXT NOT NULL,
+				created_at REAL NOT NULL,
+				updated_at REAL NOT NULL
+			);
+			CREATE TABLE IF NOT EXISTS watch_hits (
+				search_name TEXT NOT NULL,
+				job_key TEXT NOT NULL,
+				payload TEXT NOT NULL,
+				first_seen_at REAL NOT NULL,
+				last_seen_at REAL NOT NULL,
+				PRIMARY KEY (search_name, job_key)
+			);
 		""")
 
 	@staticmethod
@@ -90,6 +104,99 @@ class CacheStore:
 				(excess,),
 			)
 			self._conn.commit()
+
+	def save_saved_search(self, name: str, params: dict) -> None:
+		now = time.time()
+		existing = self._conn.execute(
+			"SELECT created_at FROM saved_searches WHERE name = ?",
+			(name,),
+		).fetchone()
+		created_at = existing[0] if existing else now
+		self._conn.execute(
+			"INSERT OR REPLACE INTO saved_searches (name, params, created_at, updated_at) VALUES (?, ?, ?, ?)",
+			(name, json.dumps(params, ensure_ascii=False, sort_keys=True), created_at, now),
+		)
+		self._conn.commit()
+
+	def get_saved_search(self, name: str) -> dict | None:
+		row = self._conn.execute(
+			"SELECT name, params, created_at, updated_at FROM saved_searches WHERE name = ?",
+			(name,),
+		).fetchone()
+		if row is None:
+			return None
+		return {
+			"name": row[0],
+			"params": json.loads(row[1]),
+			"created_at": row[2],
+			"updated_at": row[3],
+		}
+
+	def list_saved_searches(self) -> list[dict]:
+		rows = self._conn.execute(
+			"SELECT name, params, created_at, updated_at FROM saved_searches ORDER BY updated_at DESC"
+		).fetchall()
+		return [
+			{
+				"name": row[0],
+				"params": json.loads(row[1]),
+				"created_at": row[2],
+				"updated_at": row[3],
+			}
+			for row in rows
+		]
+
+	def delete_saved_search(self, name: str) -> bool:
+		cursor = self._conn.execute(
+			"DELETE FROM saved_searches WHERE name = ?",
+			(name,),
+		)
+		self._conn.execute(
+			"DELETE FROM watch_hits WHERE search_name = ?",
+			(name,),
+		)
+		self._conn.commit()
+		return cursor.rowcount > 0
+
+	@staticmethod
+	def _make_watch_job_key(item: dict) -> str:
+		security_id = item.get("security_id") or item.get("securityId") or ""
+		job_id = item.get("job_id") or item.get("encryptJobId") or ""
+		if security_id or job_id:
+			return f"{security_id}:{job_id}"
+		raw = json.dumps(item, sort_keys=True, ensure_ascii=False)
+		return hashlib.sha256(raw.encode()).hexdigest()
+
+	def record_watch_results(self, search_name: str, items: list[dict]) -> dict:
+		now = time.time()
+		new_items = []
+		seen_count = 0
+		for item in items:
+			job_key = self._make_watch_job_key(item)
+			payload = json.dumps(item, ensure_ascii=False, sort_keys=True)
+			row = self._conn.execute(
+				"SELECT 1 FROM watch_hits WHERE search_name = ? AND job_key = ?",
+				(search_name, job_key),
+			).fetchone()
+			if row is None:
+				new_items.append(item)
+				self._conn.execute(
+					"INSERT INTO watch_hits (search_name, job_key, payload, first_seen_at, last_seen_at) VALUES (?, ?, ?, ?, ?)",
+					(search_name, job_key, payload, now, now),
+				)
+			else:
+				seen_count += 1
+				self._conn.execute(
+					"UPDATE watch_hits SET payload = ?, last_seen_at = ? WHERE search_name = ? AND job_key = ?",
+					(payload, now, search_name, job_key),
+				)
+		self._conn.commit()
+		return {
+			"new_count": len(new_items),
+			"seen_count": seen_count,
+			"new_items": new_items,
+			"total_count": len(items),
+		}
 
 	def close(self):
 		self._conn.close()

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -322,6 +322,11 @@ SCHEMA_DATA = {
 			"args": [],
 			"options": {},
 		},
+		"watch": {
+			"description": "保存搜索条件并执行增量监控（子命令：add/list/remove/run）",
+			"args": [],
+			"options": {},
+		},
 	},
 	"global_options": {
 		"--data-dir": {

--- a/src/boss_agent_cli/commands/watch.py
+++ b/src/boss_agent_cli/commands/watch.py
@@ -1,0 +1,151 @@
+import click
+
+from boss_agent_cli.api.client import BossClient
+from boss_agent_cli.api.endpoints import (
+	CITY_CODES,
+	INDUSTRY_CODES,
+	JOB_TYPE_CODES,
+	SCALE_CODES,
+	STAGE_CODES,
+)
+from boss_agent_cli.auth.manager import AuthManager
+from boss_agent_cli.cache.store import CacheStore
+from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output
+from boss_agent_cli.search_filters import SearchFilterCriteria, resolve_welfare_keywords, run_search_pipeline
+
+
+def _parse_watch_filters(query, city, salary, experience, education, industry, scale, stage, job_type, welfare) -> tuple[dict, list[tuple[str, list[str]]] | None]:
+	params = {
+		"query": query,
+		"city": city,
+		"salary": salary,
+		"experience": experience,
+		"education": education,
+		"industry": industry,
+		"scale": scale,
+		"stage": stage,
+		"job_type": job_type,
+		"welfare": welfare,
+	}
+	welfare_conditions = None
+	if welfare:
+		labels = [w.strip() for w in welfare.split(",") if w.strip()]
+		welfare_conditions = [(label, resolve_welfare_keywords(label)) for label in labels]
+	return params, welfare_conditions
+
+
+@click.group("watch")
+def watch_group():
+	"""保存搜索条件并执行增量监控。"""
+
+
+@watch_group.command("add")
+@click.argument("name")
+@click.argument("query")
+@click.option("--city", default=None, help="城市名称")
+@click.option("--salary", default=None, help="薪资范围")
+@click.option("--experience", default=None, help="经验要求")
+@click.option("--education", default=None, help="学历要求")
+@click.option("--industry", default=None, type=click.Choice(list(INDUSTRY_CODES.keys()), case_sensitive=False), help="行业类型")
+@click.option("--scale", default=None, type=click.Choice(list(SCALE_CODES.keys()), case_sensitive=False), help="公司规模")
+@click.option("--stage", default=None, type=click.Choice(list(STAGE_CODES.keys()), case_sensitive=False), help="融资阶段")
+@click.option("--job-type", default=None, type=click.Choice(list(JOB_TYPE_CODES.keys()), case_sensitive=False), help="职位类型")
+@click.option("--welfare", default=None, help="福利筛选")
+@click.pass_context
+def watch_add_cmd(ctx, name, query, city, salary, experience, education, industry, scale, stage, job_type, welfare):
+	if city and city not in CITY_CODES:
+		handle_error_output(ctx, "watch", code="INVALID_PARAM", message=f"未知城市: {city}")
+		return
+
+	params, _ = _parse_watch_filters(query, city, salary, experience, education, industry, scale, stage, job_type, welfare)
+	with CacheStore(ctx.obj["data_dir"] / "cache" / "boss_agent.db") as cache:
+		cache.save_saved_search(name, params)
+	handle_output(
+		ctx, "watch",
+		{"action": "add", "name": name, "params": params},
+		hints={"next_actions": [f"boss watch run {name}", "boss watch list"]},
+	)
+
+
+@watch_group.command("list")
+@click.pass_context
+def watch_list_cmd(ctx):
+	with CacheStore(ctx.obj["data_dir"] / "cache" / "boss_agent.db") as cache:
+		items = cache.list_saved_searches()
+	handle_output(ctx, "watch", items, hints={"next_actions": ["boss watch run <name>", "boss watch remove <name>"]})
+
+
+@watch_group.command("remove")
+@click.argument("name")
+@click.pass_context
+def watch_remove_cmd(ctx, name):
+	with CacheStore(ctx.obj["data_dir"] / "cache" / "boss_agent.db") as cache:
+		removed = cache.delete_saved_search(name)
+	handle_output(ctx, "watch", {"action": "remove", "name": name, "removed": removed})
+
+
+@watch_group.command("run")
+@click.argument("name")
+@click.pass_context
+@handle_auth_errors("watch")
+def watch_run_cmd(ctx, name):
+	data_dir = ctx.obj["data_dir"]
+	logger = ctx.obj["logger"]
+	delay = ctx.obj["delay"]
+	cdp_url = ctx.obj.get("cdp_url")
+
+	with CacheStore(data_dir / "cache" / "boss_agent.db") as cache:
+		record = cache.get_saved_search(name)
+		if record is None:
+			handle_error_output(ctx, "watch", code="JOB_NOT_FOUND", message=f"未找到 watch: {name}")
+			return
+
+		params = record["params"]
+		welfare = params.get("welfare")
+		_, welfare_conditions = _parse_watch_filters(
+			params.get("query"),
+			params.get("city"),
+			params.get("salary"),
+			params.get("experience"),
+			params.get("education"),
+			params.get("industry"),
+			params.get("scale"),
+			params.get("stage"),
+			params.get("job_type"),
+			welfare,
+		)
+		criteria = SearchFilterCriteria(
+			query=params.get("query", ""),
+			city=params.get("city"),
+			salary=params.get("salary"),
+			experience=params.get("experience"),
+			education=params.get("education"),
+			industry=params.get("industry"),
+			scale=params.get("scale"),
+			stage=params.get("stage"),
+			job_type=params.get("job_type"),
+		)
+		auth = AuthManager(data_dir, logger=logger)
+		with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
+			pipeline_result = run_search_pipeline(
+				client,
+				cache,
+				logger,
+				criteria=criteria,
+				start_page=1,
+				max_pages=5 if welfare_conditions else 1,
+				welfare_conditions=welfare_conditions,
+			)
+		watch_result = cache.record_watch_results(name, pipeline_result.items)
+		handle_output(
+			ctx,
+			"watch",
+			{
+				"name": name,
+				"new_count": watch_result["new_count"],
+				"seen_count": watch_result["seen_count"],
+				"total_count": watch_result["total_count"],
+				"new_items": watch_result["new_items"],
+			},
+			hints={"next_actions": ["boss detail <security_id>", "boss watch list"]},
+		)

--- a/src/boss_agent_cli/main.py
+++ b/src/boss_agent_cli/main.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import click
 
-from boss_agent_cli.commands import schema, login, logout, status, doctor, search, detail, greet, recommend, export, cities, me, chat, chatmsg, mark, exchange, interviews, show, history
+from boss_agent_cli.commands import schema, login, logout, status, doctor, search, detail, greet, recommend, export, cities, me, chat, chatmsg, mark, exchange, interviews, show, history, watch
 from boss_agent_cli.config import load_config
 from boss_agent_cli.hooks import create_hook_bus
 from boss_agent_cli.output import Logger
@@ -58,3 +58,4 @@ cli.add_command(exchange.exchange_cmd, "exchange")
 cli.add_command(interviews.interviews_cmd, "interviews")
 cli.add_command(show.show_cmd, "show")
 cli.add_command(history.history_cmd, "history")
+cli.add_command(watch.watch_group, "watch")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -54,3 +54,35 @@ def test_search_cache_max_100(tmp_path):
 		store.put_search({"query": f"q{i}", "page": "1"}, f'{{"i": {i}}}')
 	assert store.get_search({"query": "q0", "page": "1"}) is None
 	assert store.get_search({"query": "q104", "page": "1"}) is not None
+
+
+def test_saved_search_crud(tmp_path):
+	store = CacheStore(tmp_path / "test.db")
+	store.save_saved_search("golang-gz", {"query": "golang", "city": "广州", "welfare": "双休"})
+	record = store.get_saved_search("golang-gz")
+	assert record is not None
+	assert record["params"]["query"] == "golang"
+	assert len(store.list_saved_searches()) == 1
+	assert store.delete_saved_search("golang-gz") is True
+	assert store.get_saved_search("golang-gz") is None
+
+
+def test_watch_results_only_mark_new_items_once(tmp_path):
+	store = CacheStore(tmp_path / "test.db")
+	first = store.record_watch_results(
+		"golang-gz",
+		[
+			{"security_id": "sec-1", "job_id": "job-1", "title": "Go 开发"},
+			{"security_id": "sec-2", "job_id": "job-2", "title": "Python 开发"},
+		],
+	)
+	second = store.record_watch_results(
+		"golang-gz",
+		[
+			{"security_id": "sec-2", "job_id": "job-2", "title": "Python 开发"},
+			{"security_id": "sec-3", "job_id": "job-3", "title": "Rust 开发"},
+		],
+	)
+	assert first["new_count"] == 2
+	assert second["new_count"] == 1
+	assert second["new_items"][0]["security_id"] == "sec-3"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -127,7 +127,8 @@ def test_schema_includes_new_commands():
 	assert "interviews" in commands
 	assert "logout" in commands
 	assert "doctor" in commands
-	assert len(commands) == 19
+	assert "watch" in commands
+	assert len(commands) == 20
 
 
 @patch("boss_agent_cli.commands.doctor.extract_cookies")

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -1,0 +1,104 @@
+import json
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from boss_agent_cli.main import cli
+
+
+def _ctx_mock(mock_cls):
+	instance = mock_cls.return_value
+	instance.__enter__ = lambda self: self
+	instance.__exit__ = lambda self, *a: None
+	return instance
+
+
+def _job(security_id: str, job_id: str, title: str = "Go 开发"):
+	return {
+		"encryptJobId": job_id,
+		"jobName": title,
+		"brandName": "TestCo",
+		"salaryDesc": "20-30K",
+		"cityName": "广州",
+		"areaDistrict": "天河区",
+		"jobExperience": "3-5年",
+		"jobDegree": "本科",
+		"skills": ["Go"],
+		"welfareList": ["双休"],
+		"brandIndustry": "互联网",
+		"brandScaleName": "100-499人",
+		"brandStageName": "A轮",
+		"bossName": "李",
+		"bossTitle": "HR",
+		"bossOnline": True,
+		"securityId": security_id,
+	}
+
+
+def test_watch_add_list_remove(tmp_path):
+	runner = CliRunner()
+	result = runner.invoke(
+		cli,
+		[
+			"--data-dir", str(tmp_path),
+			"--json",
+			"watch", "add", "golang-gz", "golang",
+			"--city", "广州",
+			"--welfare", "双休",
+		],
+	)
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["name"] == "golang-gz"
+
+	list_result = runner.invoke(cli, ["--data-dir", str(tmp_path), "--json", "watch", "list"])
+	assert list_result.exit_code == 0
+	list_parsed = json.loads(list_result.output)
+	assert list_parsed["data"][0]["name"] == "golang-gz"
+
+	remove_result = runner.invoke(cli, ["--data-dir", str(tmp_path), "--json", "watch", "remove", "golang-gz"])
+	assert remove_result.exit_code == 0
+	remove_parsed = json.loads(remove_result.output)
+	assert remove_parsed["data"]["removed"] is True
+
+
+@patch("boss_agent_cli.commands.watch.BossClient")
+@patch("boss_agent_cli.commands.watch.AuthManager")
+def test_watch_run_marks_only_new_items(mock_auth_cls, mock_client_cls, tmp_path):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.search_jobs.return_value = {
+		"zpData": {
+			"hasMore": False,
+			"jobList": [_job("sec-1", "job-1")],
+		},
+	}
+
+	runner = CliRunner()
+	runner.invoke(
+		cli,
+		[
+			"--data-dir", str(tmp_path),
+			"--json",
+			"watch", "add", "golang-gz", "golang",
+			"--city", "广州",
+		],
+	)
+
+	first = runner.invoke(cli, ["--data-dir", str(tmp_path), "--json", "watch", "run", "golang-gz"])
+	assert first.exit_code == 0
+	first_parsed = json.loads(first.output)
+	assert first_parsed["data"]["new_count"] == 1
+
+	second = runner.invoke(cli, ["--data-dir", str(tmp_path), "--json", "watch", "run", "golang-gz"])
+	assert second.exit_code == 0
+	second_parsed = json.loads(second.output)
+	assert second_parsed["data"]["new_count"] == 0
+
+
+def test_watch_schema_is_exposed():
+	runner = CliRunner()
+	result = runner.invoke(cli, ["schema"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert "watch" in parsed["data"]["commands"]


### PR DESCRIPTION
## Summary
- 为 CacheStore 增加 saved search 与 watch hit 持久化能力，支持命名查询与增量去重
- 新增 watch 命令组（add/list/remove/run），复用现有 search pipeline 执行保存查询并返回 new_count/new_items
- 更新 schema 与测试，确保 watch 能力可发现且全量回归通过

## Test Plan
- env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest tests/test_cache.py tests/test_watch.py tests/test_commands.py -q
- env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run ruff check src tests
- env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest tests/ -q