### PR TITLE
feat: 增加pipeline和follow-up命令

### DIFF
--- a/docs/superpowers/plans/2026-04-11-p0-wave3.md
+++ b/docs/superpowers/plans/2026-04-11-p0-wave3.md
@@ -1,0 +1,42 @@
+# P0 Wave 3 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the first read-only pipeline/follow-up candidate generator so agents can decide what to handle next without mutating remote recruiter state.
+
+**Architecture:** Add a pure aggregation layer (`pipeline_state.py`) that normalizes chat and interview records into unified pipeline items. Build two read-only commands on top: `pipeline` for the complete view and `follow-up` for actionable subsets. This wave intentionally avoids local persistence and remote write operations.
+
+**Tech Stack:** Python 3.10+, Click CLI, BossClient read APIs, pure Python aggregation helpers, pytest, existing JSON envelope/output utilities.
+
+---
+
+## Planned File Touches
+
+- Create: `src/boss_agent_cli/pipeline_state.py`
+- Create: `src/boss_agent_cli/commands/pipeline.py`
+- Modify: `src/boss_agent_cli/main.py`
+- Modify: `src/boss_agent_cli/commands/schema.py`
+- Create: `tests/test_pipeline_state.py`
+- Create: `tests/test_pipeline_commands.py`
+- Modify: `tests/test_commands.py`
+- Create: `docs/superpowers/plans/2026-04-11-p0-wave3.md`
+
+## Scope
+
+- Normalize chat + interview data into unified pipeline items
+- Expose `boss pipeline`
+- Expose `boss follow-up`
+- Keep the implementation read-only
+
+## Out of Scope
+
+- Automatic reminder sending
+- Persisted pipeline state machine
+- Apply/deliver write path
+- Conversation summarization
+
+## Follow-on Inputs
+
+- `watch` from Wave 2 should later feed persistent pipeline state
+- `apply/deliver` should later upgrade candidate stages from derived to explicit
+- `mark/exchange` can later become side-effect actions from follow-up candidates

--- a/src/boss_agent_cli/commands/pipeline.py
+++ b/src/boss_agent_cli/commands/pipeline.py
@@ -1,0 +1,78 @@
+import time
+
+import click
+
+from boss_agent_cli.api.client import BossClient
+from boss_agent_cli.auth.manager import AuthManager
+from boss_agent_cli.display import handle_auth_errors, handle_output, render_simple_list
+from boss_agent_cli.pipeline_state import build_pipeline_items, select_follow_up_candidates
+
+
+def _collect_pipeline_items(ctx, *, now_ts_ms: int | None, stale_days: int) -> list[dict]:
+	data_dir = ctx.obj["data_dir"]
+	logger = ctx.obj["logger"]
+	delay = ctx.obj["delay"]
+	cdp_url = ctx.obj.get("cdp_url")
+	auth = AuthManager(data_dir, logger=logger)
+
+	with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
+		friend_resp = client.friend_list(page=1)
+		chat_items = friend_resp.get("zpData", {}).get("result") or friend_resp.get("zpData", {}).get("friendList") or []
+		interview_resp = client.interview_data()
+		interview_items = interview_resp.get("zpData", {}).get("interviewList") or []
+
+	return build_pipeline_items(
+		chat_items=chat_items,
+		interview_items=interview_items,
+		now_ts_ms=now_ts_ms or int(time.time() * 1000),
+		stale_days=stale_days,
+	)
+
+
+def _render_pipeline(data, title: str):
+	render_simple_list(
+		data,
+		title,
+		[
+			("阶段", "stage", "bold cyan"),
+			("公司", "company", "green"),
+			("职位/关系", "title", "yellow"),
+			("来源", "source", "dim"),
+			("未读", "unread", "red"),
+			("最近时间", "last_time", "dim"),
+			("原因", "reason", ""),
+		],
+	)
+
+
+@click.command("pipeline")
+@click.option("--days-stale", default=3, type=int, help="超过 N 天未推进则标记为 follow_up")
+@click.option("--now-ts-ms", default=None, type=int, help="测试用：覆盖当前时间戳（毫秒）")
+@click.pass_context
+@handle_auth_errors("pipeline")
+def pipeline_cmd(ctx, days_stale, now_ts_ms):
+	items = _collect_pipeline_items(ctx, now_ts_ms=now_ts_ms, stale_days=days_stale)
+	handle_output(
+		ctx,
+		"pipeline",
+		items,
+		render=lambda data: _render_pipeline(data, "pipeline"),
+		hints={"next_actions": ["boss follow-up", "boss chat", "boss interviews"]},
+	)
+
+
+@click.command("follow-up")
+@click.option("--days-stale", default=3, type=int, help="超过 N 天未推进则视为 follow_up")
+@click.option("--now-ts-ms", default=None, type=int, help="测试用：覆盖当前时间戳（毫秒）")
+@click.pass_context
+@handle_auth_errors("follow-up")
+def follow_up_cmd(ctx, days_stale, now_ts_ms):
+	items = _collect_pipeline_items(ctx, now_ts_ms=now_ts_ms, stale_days=days_stale)
+	candidates = select_follow_up_candidates(items)
+	handle_output(
+		ctx,
+		"follow-up",
+		candidates,
+		render=lambda data: _render_pipeline(data, "follow-up"),
+		hints={"next_actions": ["boss chat", "boss mark <security_id> --label 沟通中"]},
+	)

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -327,6 +327,20 @@ SCHEMA_DATA = {
 			"args": [],
 			"options": {},
 		},
+		"pipeline": {
+			"description": "聚合聊天和面试数据，生成统一候选进度视图",
+			"args": [],
+			"options": {
+				"--days-stale": {"type": "int", "default": 3, "description": "超过 N 天未推进则标记为 follow_up"},
+			},
+		},
+		"follow-up": {
+			"description": "筛出需要优先跟进的候选项（未读、超时未推进、面试）",
+			"args": [],
+			"options": {
+				"--days-stale": {"type": "int", "default": 3, "description": "超过 N 天未推进则视为 follow_up"},
+			},
+		},
 	},
 	"global_options": {
 		"--data-dir": {

--- a/src/boss_agent_cli/main.py
+++ b/src/boss_agent_cli/main.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import click
 
-from boss_agent_cli.commands import schema, login, logout, status, doctor, search, detail, greet, recommend, export, cities, me, chat, chatmsg, mark, exchange, interviews, show, history, watch
+from boss_agent_cli.commands import schema, login, logout, status, doctor, search, detail, greet, recommend, export, cities, me, chat, chatmsg, mark, exchange, interviews, show, history, watch, pipeline
 from boss_agent_cli.config import load_config
 from boss_agent_cli.hooks import create_hook_bus
 from boss_agent_cli.output import Logger
@@ -59,3 +59,5 @@ cli.add_command(interviews.interviews_cmd, "interviews")
 cli.add_command(show.show_cmd, "show")
 cli.add_command(history.history_cmd, "history")
 cli.add_command(watch.watch_group, "watch")
+cli.add_command(pipeline.pipeline_cmd, "pipeline")
+cli.add_command(pipeline.follow_up_cmd, "follow-up")

--- a/src/boss_agent_cli/pipeline_state.py
+++ b/src/boss_agent_cli/pipeline_state.py
@@ -1,0 +1,71 @@
+import datetime
+
+from boss_agent_cli.commands.chat_utils import RELATION_LABELS
+
+
+_FOLLOW_UP_STATES = {"reply_needed", "follow_up", "interview"}
+
+
+def _ts_to_label(ts_ms: int) -> str:
+	if not ts_ms:
+		return "-"
+	dt = datetime.datetime.fromtimestamp(ts_ms / 1000)
+	return dt.strftime("%m-%d %H:%M")
+
+
+def _chat_stage(item: dict, *, now_ts_ms: int, stale_days: int) -> str:
+	unread = item.get("unreadMsgCount") or 0
+	relation_type = item.get("relationType")
+	last_ts = item.get("lastTS") or 0
+	if unread > 0:
+		return "reply_needed"
+	if relation_type == 3:
+		return "applied"
+	if last_ts and now_ts_ms - last_ts >= stale_days * 24 * 3600 * 1000:
+		return "follow_up"
+	return "chatting"
+
+
+def build_pipeline_items(*, chat_items: list[dict], interview_items: list[dict], now_ts_ms: int, stale_days: int = 3) -> list[dict]:
+	items = []
+
+	for raw in chat_items:
+		items.append(
+			{
+				"source": "chat",
+				"stage": _chat_stage(raw, now_ts_ms=now_ts_ms, stale_days=stale_days),
+				"security_id": raw.get("securityId") or "",
+				"job_id": raw.get("encryptJobId") or "",
+				"company": raw.get("brandName") or "-",
+				"title": raw.get("title") or "-",
+				"relation": RELATION_LABELS.get(raw.get("relationType"), "未知"),
+				"unread": raw.get("unreadMsgCount") or 0,
+				"last_msg": raw.get("lastMsg") or "-",
+				"last_time": _ts_to_label(raw.get("lastTS") or 0),
+				"reason": "存在未读消息" if (raw.get("unreadMsgCount") or 0) > 0 else "需要继续推进" if _chat_stage(raw, now_ts_ms=now_ts_ms, stale_days=stale_days) == "follow_up" else "会话进行中",
+			}
+		)
+
+	for raw in interview_items:
+		items.append(
+			{
+				"source": "interview",
+				"stage": "interview",
+				"security_id": raw.get("securityId") or "",
+				"job_id": raw.get("encryptJobId") or "",
+				"company": raw.get("brandName") or "-",
+				"title": raw.get("jobName") or "-",
+				"relation": "面试",
+				"unread": 0,
+				"last_msg": raw.get("statusDesc") or "-",
+				"last_time": raw.get("interviewTime") or "-",
+				"reason": "存在待处理面试安排",
+			}
+		)
+
+	priority = {"reply_needed": 0, "interview": 1, "follow_up": 2, "applied": 3, "chatting": 4}
+	return sorted(items, key=lambda item: (priority.get(item["stage"], 99), item["company"], item["title"]))
+
+
+def select_follow_up_candidates(items: list[dict]) -> list[dict]:
+	return [item for item in items if item.get("stage") in _FOLLOW_UP_STATES]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -128,7 +128,9 @@ def test_schema_includes_new_commands():
 	assert "logout" in commands
 	assert "doctor" in commands
 	assert "watch" in commands
-	assert len(commands) == 20
+	assert "pipeline" in commands
+	assert "follow-up" in commands
+	assert len(commands) == 22
 
 
 @patch("boss_agent_cli.commands.doctor.extract_cookies")

--- a/tests/test_pipeline_commands.py
+++ b/tests/test_pipeline_commands.py
@@ -1,0 +1,100 @@
+import json
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from boss_agent_cli.main import cli
+
+
+def _ctx_mock(mock_cls):
+	instance = mock_cls.return_value
+	instance.__enter__ = lambda self: self
+	instance.__exit__ = lambda self, *a: None
+	return instance
+
+
+def _friend_list_response(items):
+	return {"zpData": {"result": items, "friendList": items}}
+
+
+def _chat_item(
+	*,
+	security_id="sec_001",
+	job_id="job_001",
+	relation_type=1,
+	unread=0,
+	last_ts=1700000000000,
+):
+	return {
+		"name": "张HR",
+		"securityId": security_id,
+		"uid": 12345,
+		"title": "HR",
+		"brandName": "TestCo",
+		"friendSource": 0,
+		"encryptJobId": job_id,
+		"lastMsg": "你好",
+		"lastTS": last_ts,
+		"unreadMsgCount": unread,
+		"relationType": relation_type,
+		"lastMessageInfo": {"status": 1 if unread else 2},
+	}
+
+
+def _interview_item():
+	return {
+		"jobName": "Go 开发",
+		"brandName": "TestCo",
+		"interviewTime": "2026-04-12 10:00",
+		"address": "线上",
+		"statusDesc": "待面试",
+	}
+
+
+@patch("boss_agent_cli.commands.pipeline.BossClient")
+@patch("boss_agent_cli.commands.pipeline.AuthManager")
+def test_pipeline_command_returns_aggregated_items(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = _friend_list_response([_chat_item(unread=1)])
+	mock_client.interview_data.return_value = {"zpData": {"interviewList": [_interview_item()]}}
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "pipeline"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	stages = {item["stage"] for item in parsed["data"]}
+	assert "reply_needed" in stages
+	assert "interview" in stages
+
+
+@patch("boss_agent_cli.commands.pipeline.BossClient")
+@patch("boss_agent_cli.commands.pipeline.AuthManager")
+def test_follow_up_command_filters_actionable_items(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = _friend_list_response(
+		[
+			_chat_item(unread=1),
+			_chat_item(security_id="sec_old", job_id="job_old", unread=0, last_ts=1700000000000),
+		]
+	)
+	mock_client.interview_data.return_value = {"zpData": {"interviewList": [_interview_item()]}}
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "follow-up", "--now-ts-ms", str(1700000000000 + 5 * 24 * 3600 * 1000)])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	stages = [item["stage"] for item in parsed["data"]]
+	assert "reply_needed" in stages
+	assert "follow_up" in stages
+	assert "interview" in stages
+
+
+def test_pipeline_and_follow_up_are_exposed_in_schema():
+	runner = CliRunner()
+	result = runner.invoke(cli, ["schema"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert "pipeline" in parsed["data"]["commands"]
+	assert "follow-up" in parsed["data"]["commands"]

--- a/tests/test_pipeline_state.py
+++ b/tests/test_pipeline_state.py
@@ -1,0 +1,86 @@
+from boss_agent_cli.pipeline_state import build_pipeline_items, select_follow_up_candidates
+
+
+def _chat_item(
+	*,
+	security_id="sec_001",
+	job_id="job_001",
+	relation_type=1,
+	unread=0,
+	last_ts=1700000000000,
+	company="TestCo",
+	title="HR",
+	last_msg="你好",
+):
+	return {
+		"securityId": security_id,
+		"encryptJobId": job_id,
+		"relationType": relation_type,
+		"unreadMsgCount": unread,
+		"lastTS": last_ts,
+		"brandName": company,
+		"title": title,
+		"lastMsg": last_msg,
+	}
+
+
+def _interview_item(*, company="TestCo", job_name="Go 开发", status="待面试", interview_time="2026-04-12 10:00"):
+	return {
+		"brandName": company,
+		"jobName": job_name,
+		"statusDesc": status,
+		"interviewTime": interview_time,
+		"address": "线上",
+	}
+
+
+def test_build_pipeline_items_marks_reply_needed_for_unread():
+	items = build_pipeline_items(
+		chat_items=[_chat_item(unread=2)],
+		interview_items=[],
+		now_ts_ms=1700000000000,
+		stale_days=3,
+	)
+	assert items[0]["stage"] == "reply_needed"
+
+
+def test_build_pipeline_items_marks_follow_up_for_stale_chat():
+	items = build_pipeline_items(
+		chat_items=[_chat_item(last_ts=1700000000000)],
+		interview_items=[],
+		now_ts_ms=1700000000000 + 5 * 24 * 3600 * 1000,
+		stale_days=3,
+	)
+	assert items[0]["stage"] == "follow_up"
+
+
+def test_build_pipeline_items_marks_applied_for_relation_type_3():
+	items = build_pipeline_items(
+		chat_items=[_chat_item(relation_type=3)],
+		interview_items=[],
+		now_ts_ms=1700000000000,
+		stale_days=3,
+	)
+	assert items[0]["stage"] == "applied"
+
+
+def test_build_pipeline_items_adds_interview_candidates():
+	items = build_pipeline_items(
+		chat_items=[],
+		interview_items=[_interview_item()],
+		now_ts_ms=1700000000000,
+		stale_days=3,
+	)
+	assert items[0]["stage"] == "interview"
+	assert items[0]["source"] == "interview"
+
+
+def test_select_follow_up_candidates_filters_only_actionable_states():
+	items = [
+		{"stage": "reply_needed", "source": "chat"},
+		{"stage": "follow_up", "source": "chat"},
+		{"stage": "interview", "source": "interview"},
+		{"stage": "chatting", "source": "chat"},
+	]
+	selected = select_follow_up_candidates(items)
+	assert [item["stage"] for item in selected] == ["reply_needed", "follow_up", "interview"]


### PR DESCRIPTION
## Summary
- 新增 pipeline_state 聚合层，把 chat 和 interview 数据统一成候选进度视图
- 新增只读的 pipeline / follow-up 命令，用于输出统一候选列表和待跟进行动项
- 更新 schema、main 和测试，为后续持久化 pipeline 状态与 apply/deliver 波次打基础

## Test Plan
- env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest tests/test_pipeline_state.py tests/test_pipeline_commands.py tests/test_commands.py -q
- env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run ruff check src tests
- env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest tests/ -q