### PR TITLE
feat: 增加apply命令和幂等记录

### DIFF
--- a/docs/superpowers/plans/2026-04-11-p0-wave4.md
+++ b/docs/superpowers/plans/2026-04-11-p0-wave4.md
@@ -1,0 +1,43 @@
+# P0 Wave 4 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the smallest honest `apply` command so the CLI can represent an explicit投递/立即沟通 action, with local idempotency protection.
+
+**Architecture:** Reuse the existing high-risk browser write path rather than inventing a new transport. Add a dedicated `apply_records` table for local idempotency, expose `client.apply()` as a separate semantic action, and keep the first command shape intentionally narrow: `apply <security_id> <job_id> [--lid]`.
+
+**Tech Stack:** Python 3.10+, Click CLI, BossClient browser request path, SQLite WAL via CacheStore, pytest, existing JSON envelope/output helpers.
+
+---
+
+## Planned File Touches
+
+- Modify: `src/boss_agent_cli/cache/store.py`
+- Modify: `src/boss_agent_cli/api/client.py`
+- Create: `src/boss_agent_cli/commands/apply.py`
+- Modify: `src/boss_agent_cli/main.py`
+- Modify: `src/boss_agent_cli/commands/schema.py`
+- Create: `tests/test_apply.py`
+- Modify: `tests/test_cache.py`
+- Modify: `tests/test_commands.py`
+- Create: `docs/superpowers/plans/2026-04-11-p0-wave4.md`
+
+## Scope
+
+- Add local apply idempotency tracking
+- Add `client.apply()`
+- Add `boss apply`
+- Expose command in schema
+- Cover behavior with focused tests
+
+## Out of Scope
+
+- Automatic parameter discovery from `detail/show/index`
+- Remote deliver-list reconciliation
+- Batch apply
+- Persistent pipeline state transition after apply
+
+## Follow-on Inputs
+
+- Future wave should enrich apply with `job_id` recovery and verification against `deliver_list`
+- Future wave should connect apply results into persisted pipeline state

--- a/src/boss_agent_cli/api/client.py
+++ b/src/boss_agent_cli/api/client.py
@@ -198,6 +198,16 @@ class BossClient:
 		}
 		return self._browser_request("POST", endpoints.GREET_URL, data=data)
 
+	def apply(self, security_id: str, job_id: str, lid: str = "") -> dict:
+		"""Current minimal apply path - reuses the immediate-chat browser endpoint."""
+		data = {
+			"securityId": security_id,
+			"jobId": job_id,
+		}
+		if lid:
+			data["lid"] = lid
+		return self._browser_request("POST", endpoints.GREET_URL, data=data)
+
 	def job_card(self, security_id: str, lid: str = "") -> dict:
 		params = {"securityId": security_id, "lid": lid}
 		return self._browser_request("GET", endpoints.JOB_CARD_URL, params=params)

--- a/src/boss_agent_cli/cache/store.py
+++ b/src/boss_agent_cli/cache/store.py
@@ -43,6 +43,12 @@ class CacheStore:
 				last_seen_at REAL NOT NULL,
 				PRIMARY KEY (search_name, job_key)
 			);
+			CREATE TABLE IF NOT EXISTS apply_records (
+				security_id TEXT NOT NULL,
+				job_id TEXT NOT NULL,
+				applied_at REAL NOT NULL,
+				PRIMARY KEY (security_id, job_id)
+			);
 		""")
 
 	@staticmethod
@@ -197,6 +203,20 @@ class CacheStore:
 			"new_items": new_items,
 			"total_count": len(items),
 		}
+
+	def is_applied(self, security_id: str, job_id: str) -> bool:
+		row = self._conn.execute(
+			"SELECT 1 FROM apply_records WHERE security_id = ? AND job_id = ?",
+			(security_id, job_id),
+		).fetchone()
+		return row is not None
+
+	def record_apply(self, security_id: str, job_id: str) -> None:
+		self._conn.execute(
+			"INSERT OR REPLACE INTO apply_records (security_id, job_id, applied_at) VALUES (?, ?, ?)",
+			(security_id, job_id, time.time()),
+		)
+		self._conn.commit()
 
 	def close(self):
 		self._conn.close()

--- a/src/boss_agent_cli/commands/apply.py
+++ b/src/boss_agent_cli/commands/apply.py
@@ -1,0 +1,60 @@
+import click
+
+from boss_agent_cli.api.client import BossClient
+from boss_agent_cli.auth.manager import AuthManager
+from boss_agent_cli.cache.store import CacheStore
+from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_message_panel
+
+
+@click.command("apply")
+@click.argument("security_id")
+@click.argument("job_id")
+@click.option("--lid", default="", help="列表项 ID（可选）")
+@click.pass_context
+@handle_auth_errors("apply")
+def apply_cmd(ctx, security_id, job_id, lid):
+	"""发起最小可用投递/立即沟通动作（当前复用立即沟通链路）。"""
+	data_dir = ctx.obj["data_dir"]
+	logger = ctx.obj["logger"]
+	delay = ctx.obj["delay"]
+	cdp_url = ctx.obj.get("cdp_url")
+
+	with CacheStore(data_dir / "cache" / "boss_agent.db") as cache:
+		if cache.is_applied(security_id, job_id):
+			handle_error_output(
+				ctx,
+				"apply",
+				code="ALREADY_APPLIED",
+				message="已对该职位发起过投递/立即沟通",
+				hints={"next_actions": ["boss me --section deliver", "boss chat"]},
+			)
+			return
+
+		auth = AuthManager(data_dir, logger=logger)
+		with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
+			resp = client.apply(security_id, job_id, lid=lid)
+			if resp.get("code") not in (None, 0):
+				handle_error_output(
+					ctx,
+					"apply",
+					code="NETWORK_ERROR",
+					message=resp.get("message") or "投递/立即沟通提交失败",
+					recoverable=True,
+					recovery_action="重试",
+				)
+				return
+			cache.record_apply(security_id, job_id)
+
+	handle_output(
+		ctx,
+		"apply",
+		{
+			"security_id": security_id,
+			"job_id": job_id,
+			"lid": lid,
+			"mode": "immediate_chat_apply",
+			"message": "投递/立即沟通已提交",
+		},
+		render=lambda d: render_message_panel(d, title="apply"),
+		hints={"next_actions": ["boss me --section deliver", "boss chat"]},
+	)

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -341,6 +341,16 @@ SCHEMA_DATA = {
 				"--days-stale": {"type": "int", "default": 3, "description": "超过 N 天未推进则视为 follow_up"},
 			},
 		},
+		"apply": {
+			"description": "发起最小可用投递/立即沟通动作（当前复用立即沟通链路）",
+			"args": [
+				{"name": "security_id", "required": True, "description": "安全 ID"},
+				{"name": "job_id", "required": True, "description": "加密职位 ID"},
+			],
+			"options": {
+				"--lid": {"type": "string", "default": "", "description": "列表项 ID（可选）"},
+			},
+		},
 	},
 	"global_options": {
 		"--data-dir": {
@@ -398,6 +408,11 @@ SCHEMA_DATA = {
 		},
 		"ALREADY_GREETED": {
 			"message": "已向该招聘者打过招呼",
+			"recoverable": False,
+			"recovery_action": None,
+		},
+		"ALREADY_APPLIED": {
+			"message": "已发起过投递/立即沟通",
 			"recoverable": False,
 			"recovery_action": None,
 		},

--- a/src/boss_agent_cli/main.py
+++ b/src/boss_agent_cli/main.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import click
 
-from boss_agent_cli.commands import schema, login, logout, status, doctor, search, detail, greet, recommend, export, cities, me, chat, chatmsg, mark, exchange, interviews, show, history, watch, pipeline
+from boss_agent_cli.commands import schema, login, logout, status, doctor, search, detail, greet, recommend, export, cities, me, chat, chatmsg, mark, exchange, interviews, show, history, watch, pipeline, apply
 from boss_agent_cli.config import load_config
 from boss_agent_cli.hooks import create_hook_bus
 from boss_agent_cli.output import Logger
@@ -61,3 +61,4 @@ cli.add_command(history.history_cmd, "history")
 cli.add_command(watch.watch_group, "watch")
 cli.add_command(pipeline.pipeline_cmd, "pipeline")
 cli.add_command(pipeline.follow_up_cmd, "follow-up")
+cli.add_command(apply.apply_cmd, "apply")

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -1,0 +1,72 @@
+import json
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from boss_agent_cli.main import cli
+
+
+def _ctx_mock(mock_cls):
+	instance = mock_cls.return_value
+	instance.__enter__ = lambda self: self
+	instance.__exit__ = lambda self, *a: None
+	return instance
+
+
+@patch("boss_agent_cli.commands.apply.BossClient")
+@patch("boss_agent_cli.commands.apply.AuthManager")
+@patch("boss_agent_cli.commands.apply.CacheStore")
+def test_apply_success(mock_cache_cls, mock_auth_cls, mock_client_cls):
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.is_applied.return_value = False
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.apply.return_value = {"code": 0, "zpData": {}}
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "apply", "sec_001", "job_001"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["security_id"] == "sec_001"
+	assert parsed["data"]["job_id"] == "job_001"
+	assert parsed["data"]["mode"] == "immediate_chat_apply"
+	mock_cache.record_apply.assert_called_once_with("sec_001", "job_001")
+
+
+@patch("boss_agent_cli.commands.apply.BossClient")
+@patch("boss_agent_cli.commands.apply.AuthManager")
+@patch("boss_agent_cli.commands.apply.CacheStore")
+def test_apply_duplicate_is_blocked(mock_cache_cls, mock_auth_cls, mock_client_cls):
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.is_applied.return_value = True
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["apply", "sec_001", "job_001"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "ALREADY_APPLIED"
+
+
+@patch("boss_agent_cli.commands.apply.BossClient")
+@patch("boss_agent_cli.commands.apply.AuthManager")
+@patch("boss_agent_cli.commands.apply.CacheStore")
+def test_apply_failure_does_not_record_local_state(mock_cache_cls, mock_auth_cls, mock_client_cls):
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.is_applied.return_value = False
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.apply.return_value = {"code": 1, "message": "失败"}
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["apply", "sec_001", "job_001"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "NETWORK_ERROR"
+	mock_cache.record_apply.assert_not_called()
+
+
+def test_apply_is_exposed_in_schema():
+	runner = CliRunner()
+	result = runner.invoke(cli, ["schema"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert "apply" in parsed["data"]["commands"]

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -86,3 +86,11 @@ def test_watch_results_only_mark_new_items_once(tmp_path):
 	assert first["new_count"] == 2
 	assert second["new_count"] == 1
 	assert second["new_items"][0]["security_id"] == "sec-3"
+
+
+def test_apply_record_idempotency(tmp_path):
+	store = CacheStore(tmp_path / "test.db")
+	assert store.is_applied("sec_001", "job_001") is False
+	store.record_apply("sec_001", "job_001")
+	assert store.is_applied("sec_001", "job_001") is True
+	assert store.is_applied("sec_001", "job_002") is False

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -130,7 +130,8 @@ def test_schema_includes_new_commands():
 	assert "watch" in commands
 	assert "pipeline" in commands
 	assert "follow-up" in commands
-	assert len(commands) == 22
+	assert "apply" in commands
+	assert len(commands) >= 23
 
 
 @patch("boss_agent_cli.commands.doctor.extract_cookies")


### PR DESCRIPTION
## Summary
- 新增最小可用的 apply 命令与本地 apply 幂等记录，先把显式投递/立即沟通动作纳入命令面
- 在 BossClient 中增加 apply 语义入口，并明确当前实现复用立即沟通浏览器链路
- 更新 schema、cache 和测试，避免失败请求写入本地已投递状态

## Test Plan
- env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest tests/test_apply.py tests/test_cache.py tests/test_commands.py -q
- /Users/can4hou6joeng4/Documents/code/boss-agent-cli/.worktrees/codex-p0-wave4/.venv/bin/ruff check /Users/can4hou6joeng4/Documents/code/boss-agent-cli/.worktrees/codex-p0-wave4/src /Users/can4hou6joeng4/Documents/code/boss-agent-cli/.worktrees/codex-p0-wave4/tests
- env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest tests/ -q