### PR TITLE
feat: 增加shortlist命令和本地持久化

### DIFF
--- a/docs/superpowers/plans/2026-04-11-p1-wave1.md
+++ b/docs/superpowers/plans/2026-04-11-p1-wave1.md
@@ -1,0 +1,36 @@
+# P1 Wave 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a job-side shortlist so users and agents can persist interesting jobs independently from recruiter-side labels.
+
+**Architecture:** Extend `CacheStore` with a dedicated `shortlist_records` table keyed by `(security_id, job_id)`. Keep the first version simple and explicit: `shortlist add/list/remove` with metadata passed in directly. Do not couple shortlist to remote labels or pipeline transitions yet.
+
+**Tech Stack:** Python 3.10+, Click command groups, SQLite WAL via `CacheStore`, pytest, existing output/render helpers.
+
+---
+
+## Planned File Touches
+
+- Modify: `src/boss_agent_cli/cache/store.py`
+- Create: `src/boss_agent_cli/commands/shortlist.py`
+- Modify: `src/boss_agent_cli/main.py`
+- Modify: `src/boss_agent_cli/commands/schema.py`
+- Modify: `tests/test_cache.py`
+- Create: `tests/test_shortlist.py`
+- Modify: `tests/test_commands.py`
+- Create: `docs/superpowers/plans/2026-04-11-p1-wave1.md`
+
+## Scope
+
+- Local shortlist persistence
+- `boss shortlist add`
+- `boss shortlist list`
+- `boss shortlist remove`
+- Schema/main/test integration
+
+## Out of Scope
+
+- Sync with remote favorites/labels
+- Auto-add from `show` or `detail`
+- Notes, scoring, ranking, or pipeline coupling

--- a/src/boss_agent_cli/cache/store.py
+++ b/src/boss_agent_cli/cache/store.py
@@ -49,6 +49,17 @@ class CacheStore:
 				applied_at REAL NOT NULL,
 				PRIMARY KEY (security_id, job_id)
 			);
+			CREATE TABLE IF NOT EXISTS shortlist_records (
+				security_id TEXT NOT NULL,
+				job_id TEXT NOT NULL,
+				title TEXT NOT NULL,
+				company TEXT NOT NULL,
+				city TEXT NOT NULL,
+				salary TEXT NOT NULL,
+				source TEXT NOT NULL,
+				created_at REAL NOT NULL,
+				PRIMARY KEY (security_id, job_id)
+			);
 		""")
 
 	@staticmethod
@@ -217,6 +228,55 @@ class CacheStore:
 			(security_id, job_id, time.time()),
 		)
 		self._conn.commit()
+
+	def is_shortlisted(self, security_id: str, job_id: str) -> bool:
+		row = self._conn.execute(
+			"SELECT 1 FROM shortlist_records WHERE security_id = ? AND job_id = ?",
+			(security_id, job_id),
+		).fetchone()
+		return row is not None
+
+	def add_shortlist(self, item: dict) -> None:
+		self._conn.execute(
+			"INSERT OR REPLACE INTO shortlist_records (security_id, job_id, title, company, city, salary, source, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+			(
+				item.get("security_id", ""),
+				item.get("job_id", ""),
+				item.get("title", ""),
+				item.get("company", ""),
+				item.get("city", ""),
+				item.get("salary", ""),
+				item.get("source", ""),
+				time.time(),
+			),
+		)
+		self._conn.commit()
+
+	def list_shortlist(self) -> list[dict]:
+		rows = self._conn.execute(
+			"SELECT security_id, job_id, title, company, city, salary, source, created_at FROM shortlist_records ORDER BY created_at DESC"
+		).fetchall()
+		return [
+			{
+				"security_id": row[0],
+				"job_id": row[1],
+				"title": row[2],
+				"company": row[3],
+				"city": row[4],
+				"salary": row[5],
+				"source": row[6],
+				"created_at": row[7],
+			}
+			for row in rows
+		]
+
+	def remove_shortlist(self, security_id: str, job_id: str) -> bool:
+		cursor = self._conn.execute(
+			"DELETE FROM shortlist_records WHERE security_id = ? AND job_id = ?",
+			(security_id, job_id),
+		)
+		self._conn.commit()
+		return cursor.rowcount > 0
 
 	def close(self):
 		self._conn.close()

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -351,6 +351,11 @@ SCHEMA_DATA = {
 				"--lid": {"type": "string", "default": "", "description": "列表项 ID（可选）"},
 			},
 		},
+		"shortlist": {
+			"description": "管理职位候选池（子命令：add/list/remove）",
+			"args": [],
+			"options": {},
+		},
 	},
 	"global_options": {
 		"--data-dir": {

--- a/src/boss_agent_cli/commands/shortlist.py
+++ b/src/boss_agent_cli/commands/shortlist.py
@@ -1,0 +1,87 @@
+import click
+
+from boss_agent_cli.cache.store import CacheStore
+from boss_agent_cli.display import handle_output, render_simple_list
+
+
+@click.group("shortlist")
+def shortlist_group():
+	"""管理职位候选池。"""
+
+
+@shortlist_group.command("add")
+@click.argument("security_id")
+@click.argument("job_id")
+@click.option("--title", default="", help="职位名称")
+@click.option("--company", default="", help="公司名称")
+@click.option("--city", default="", help="城市")
+@click.option("--salary", default="", help="薪资")
+@click.option("--source", default="manual", help="来源，如 search/recommend/show/manual")
+@click.pass_context
+def shortlist_add_cmd(ctx, security_id, job_id, title, company, city, salary, source):
+	with CacheStore(ctx.obj["data_dir"] / "cache" / "boss_agent.db") as cache:
+		cache.add_shortlist(
+			{
+				"security_id": security_id,
+				"job_id": job_id,
+				"title": title,
+				"company": company,
+				"city": city,
+				"salary": salary,
+				"source": source,
+			}
+		)
+	handle_output(
+		ctx,
+		"shortlist",
+		{
+			"action": "add",
+			"security_id": security_id,
+			"job_id": job_id,
+			"title": title,
+			"company": company,
+			"city": city,
+			"salary": salary,
+			"source": source,
+		},
+		hints={"next_actions": ["boss shortlist list", f"boss shortlist remove {security_id} {job_id}"]},
+	)
+
+
+@shortlist_group.command("list")
+@click.pass_context
+def shortlist_list_cmd(ctx):
+	with CacheStore(ctx.obj["data_dir"] / "cache" / "boss_agent.db") as cache:
+		items = cache.list_shortlist()
+	handle_output(
+		ctx,
+		"shortlist",
+		items,
+		render=lambda data: render_simple_list(
+			data,
+			"shortlist",
+			[
+				("title", "title", "bold cyan"),
+				("company", "company", "green"),
+				("city", "city", "yellow"),
+				("salary", "salary", "dim"),
+				("source", "source", "magenta"),
+			],
+		),
+		hints={"next_actions": ["boss detail <security_id> --job-id <job_id>"]},
+	)
+
+
+@shortlist_group.command("remove")
+@click.argument("security_id")
+@click.argument("job_id")
+@click.pass_context
+def shortlist_remove_cmd(ctx, security_id, job_id):
+	with CacheStore(ctx.obj["data_dir"] / "cache" / "boss_agent.db") as cache:
+		removed = cache.remove_shortlist(security_id, job_id)
+	handle_output(
+		ctx,
+		"shortlist",
+		{"action": "remove", "security_id": security_id, "job_id": job_id, "removed": removed},
+		hints={"next_actions": ["boss shortlist list"]},
+	)

--- a/src/boss_agent_cli/main.py
+++ b/src/boss_agent_cli/main.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import click
 
-from boss_agent_cli.commands import schema, login, logout, status, doctor, search, detail, greet, recommend, export, cities, me, chat, chatmsg, mark, exchange, interviews, show, history, watch, pipeline, apply
+from boss_agent_cli.commands import schema, login, logout, status, doctor, search, detail, greet, recommend, export, cities, me, chat, chatmsg, mark, exchange, interviews, show, history, watch, pipeline, apply, shortlist
 from boss_agent_cli.config import load_config
 from boss_agent_cli.hooks import create_hook_bus
 from boss_agent_cli.output import Logger
@@ -62,3 +62,4 @@ cli.add_command(watch.watch_group, "watch")
 cli.add_command(pipeline.pipeline_cmd, "pipeline")
 cli.add_command(pipeline.follow_up_cmd, "follow-up")
 cli.add_command(apply.apply_cmd, "apply")
+cli.add_command(shortlist.shortlist_group, "shortlist")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -94,3 +94,24 @@ def test_apply_record_idempotency(tmp_path):
 	store.record_apply("sec_001", "job_001")
 	assert store.is_applied("sec_001", "job_001") is True
 	assert store.is_applied("sec_001", "job_002") is False
+
+
+def test_shortlist_crud(tmp_path):
+	store = CacheStore(tmp_path / "test.db")
+	item = {
+		"security_id": "sec_001",
+		"job_id": "job_001",
+		"title": "Go 开发",
+		"company": "TestCo",
+		"city": "广州",
+		"salary": "20-30K",
+		"source": "search",
+	}
+	assert store.is_shortlisted("sec_001", "job_001") is False
+	store.add_shortlist(item)
+	assert store.is_shortlisted("sec_001", "job_001") is True
+	items = store.list_shortlist()
+	assert len(items) == 1
+	assert items[0]["title"] == "Go 开发"
+	assert store.remove_shortlist("sec_001", "job_001") is True
+	assert store.is_shortlisted("sec_001", "job_001") is False

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -131,6 +131,7 @@ def test_schema_includes_new_commands():
 	assert "pipeline" in commands
 	assert "follow-up" in commands
 	assert "apply" in commands
+	assert "shortlist" in commands
 	assert len(commands) >= 23
 
 

--- a/tests/test_shortlist.py
+++ b/tests/test_shortlist.py
@@ -1,0 +1,45 @@
+import json
+
+from click.testing import CliRunner
+
+from boss_agent_cli.main import cli
+
+
+def test_shortlist_add_list_remove(tmp_path):
+	runner = CliRunner()
+	result = runner.invoke(
+		cli,
+		[
+			"--data-dir", str(tmp_path),
+			"--json",
+			"shortlist", "add", "sec_001", "job_001",
+			"--title", "Go 开发",
+			"--company", "TestCo",
+			"--city", "广州",
+			"--salary", "20-30K",
+			"--source", "search",
+		],
+	)
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["security_id"] == "sec_001"
+
+	list_result = runner.invoke(cli, ["--data-dir", str(tmp_path), "--json", "shortlist", "list"])
+	assert list_result.exit_code == 0
+	list_parsed = json.loads(list_result.output)
+	assert len(list_parsed["data"]) == 1
+	assert list_parsed["data"][0]["company"] == "TestCo"
+
+	remove_result = runner.invoke(cli, ["--data-dir", str(tmp_path), "--json", "shortlist", "remove", "sec_001", "job_001"])
+	assert remove_result.exit_code == 0
+	remove_parsed = json.loads(remove_result.output)
+	assert remove_parsed["data"]["removed"] is True
+
+
+def test_shortlist_schema_is_exposed():
+	runner = CliRunner()
+	result = runner.invoke(cli, ["schema"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert "shortlist" in parsed["data"]["commands"]


### PR DESCRIPTION
## Summary
- 为 CacheStore 增加 shortlist_records 本地持久化，支持职位侧候选池管理
- 新增 shortlist 命令组（add/list/remove），补齐职位收藏与后续筛选基础能力
- 更新 schema、main 和测试，为后续与 pipeline/match-score 的集成留出稳定接口

## Test Plan
- env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest tests/test_cache.py tests/test_shortlist.py tests/test_commands.py -q
- env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest tests/ -q
- env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run ruff check src tests