### PR TITLE
feat: 增加匹配分和原因输出

### DIFF
--- a/docs/superpowers/plans/2026-04-11-p1-wave2.md
+++ b/docs/superpowers/plans/2026-04-11-p1-wave2.md
@@ -1,0 +1,35 @@
+# P1 Wave 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add deterministic, explainable match scoring so search and recommendation results can tell users and agents why a job should rank higher.
+
+**Architecture:** Introduce a pure scoring module that evaluates job data against explicit search constraints first, and optionally against `resume_expect` data when available. Keep the feature opt-in via `--with-score` on `search` and `recommend`, and avoid changing default result shape for existing consumers.
+
+**Tech Stack:** Python 3.10+, Click CLI, existing `JobItem` model, search filter helpers, pytest.
+
+---
+
+## Planned File Touches
+
+- Create: `src/boss_agent_cli/match_score.py`
+- Modify: `src/boss_agent_cli/commands/search.py`
+- Modify: `src/boss_agent_cli/commands/recommend.py`
+- Modify: `src/boss_agent_cli/commands/schema.py`
+- Create: `tests/test_match_score.py`
+- Modify: `tests/test_commands.py`
+- Create: `docs/superpowers/plans/2026-04-11-p1-wave2.md`
+
+## Scope
+
+- Add `score_job_item` / `score_job_dict`
+- Add `--with-score` to `search`
+- Add `--with-score` to `recommend`
+- Return `match_score`, `match_reasons`, `mismatch_reasons`
+
+## Out of Scope
+
+- Ranking persistence
+- AI-generated explanations
+- Detail-page scoring UI
+- Scoring effects on default sort order

--- a/src/boss_agent_cli/commands/recommend.py
+++ b/src/boss_agent_cli/commands/recommend.py
@@ -6,13 +6,15 @@ from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.cache.store import CacheStore
 from boss_agent_cli.display import handle_output, render_job_table, handle_auth_errors
 from boss_agent_cli.index_cache import try_save_index
+from boss_agent_cli.match_score import score_job_dict
 
 
 @click.command("recommend")
 @click.option("--page", default=1, type=int, help="页码")
+@click.option("--with-score", is_flag=True, default=False, help="附加匹配分和原因")
 @click.pass_context
 @handle_auth_errors("recommend")
-def recommend_cmd(ctx, page):
+def recommend_cmd(ctx, page, with_score):
 	"""基于简历的个性化职位推荐"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
@@ -22,6 +24,7 @@ def recommend_cmd(ctx, page):
 	auth = AuthManager(data_dir, logger=logger)
 	with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
 		with CacheStore(data_dir / "cache" / "boss_agent.db") as cache:
+			expect_data = client.resume_expect().get("zpData", {}) if with_score else None
 
 			raw = client.recommend_jobs(page=page)
 			zp_data = raw.get("zpData", {})
@@ -31,7 +34,10 @@ def recommend_cmd(ctx, page):
 			for raw_item in job_list:
 				item = JobItem.from_api(raw_item)
 				item.greeted = cache.is_greeted(item.security_id)
-				items.append(item.to_dict())
+				item_dict = item.to_dict()
+				if with_score:
+					item_dict = score_job_dict(item_dict, criteria=None, expect_data=expect_data)
+				items.append(item_dict)
 
 		try_save_index(data_dir, items, source="recommend", logger=logger)
 

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -93,6 +93,11 @@ SCHEMA_DATA = {
 					"default": 1,
 					"description": "页码",
 				},
+				"--with-score": {
+					"type": "bool",
+					"default": False,
+					"description": "附加匹配分和原因",
+				},
 				"--no-cache": {
 					"type": "bool",
 					"default": False,
@@ -199,6 +204,7 @@ SCHEMA_DATA = {
 			"args": [],
 			"options": {
 				"--page": {"type": "int", "default": 1, "description": "页码"},
+				"--with-score": {"type": "bool", "default": False, "description": "附加匹配分和原因"},
 			},
 		},
 		"export": {

--- a/src/boss_agent_cli/commands/search.py
+++ b/src/boss_agent_cli/commands/search.py
@@ -14,6 +14,7 @@ from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.cache.store import CacheStore
 from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_job_table
 from boss_agent_cli.index_cache import try_save_index
+from boss_agent_cli.match_score import score_job_dict
 from boss_agent_cli.search_filters import (
 	SearchFilterCriteria,
 	resolve_welfare_keywords,
@@ -34,9 +35,10 @@ from boss_agent_cli.search_filters import (
 @click.option("--welfare", default=None, help="福利筛选（如 双休、五险一金），会逐个检查职位详情")
 @click.option("--page", default=1, help="页码")
 @click.option("--no-cache", is_flag=True, default=False, help="跳过缓存")
+@click.option("--with-score", is_flag=True, default=False, help="附加匹配分和原因")
 @click.pass_context
 @handle_auth_errors("search")
-def search_cmd(ctx, query, city, salary, experience, education, industry, scale, stage, job_type, welfare, page, no_cache):
+def search_cmd(ctx, query, city, salary, experience, education, industry, scale, stage, job_type, welfare, page, no_cache, with_score):
 	"""按关键词和筛选条件搜索职位列表"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
@@ -66,7 +68,7 @@ def search_cmd(ctx, query, city, salary, experience, education, industry, scale,
 
 	with CacheStore(data_dir / "cache" / "boss_agent.db") as cache:
 		# 有福利筛选时跳过缓存（因为需要逐个查详情）
-		if not welfare_conditions and not no_cache:
+		if not welfare_conditions and not no_cache and not with_score:
 			search_params = {
 				"query": query, "city": city, "salary": salary,
 				"experience": experience, "education": education,
@@ -95,6 +97,8 @@ def search_cmd(ctx, query, city, salary, experience, education, industry, scale,
 				welfare_conditions=welfare_conditions,
 			)
 			items = pipeline_result.items
+			if with_score:
+				items = [score_job_dict(item, criteria=criteria, expect_data=None) for item in items]
 			try_save_index(data_dir, items, source=f"search:{query}", logger=logger)
 
 			# Emit search_completed hook
@@ -130,7 +134,7 @@ def search_cmd(ctx, query, city, salary, experience, education, industry, scale,
 				)
 
 			# 缓存普通搜索结果
-			if not welfare_conditions:
+			if not welfare_conditions and not with_score:
 				search_params = {
 					"query": query, "city": city, "salary": salary,
 					"experience": experience, "education": education,

--- a/src/boss_agent_cli/match_score.py
+++ b/src/boss_agent_cli/match_score.py
@@ -1,0 +1,106 @@
+from boss_agent_cli.api.models import JobItem
+from boss_agent_cli.search_filters import (
+	SearchFilterCriteria,
+	meets_education_threshold,
+	meets_experience_threshold,
+	parse_salary_range,
+)
+
+
+def _extract_expect_preferences(expect_data: dict | None) -> dict:
+	if not expect_data:
+		return {}
+	return {
+		"city": expect_data.get("city") or expect_data.get("cityName") or expect_data.get("locationName"),
+		"salary": expect_data.get("salary") or expect_data.get("salaryDesc"),
+		"education": expect_data.get("degree") or expect_data.get("education"),
+	}
+
+
+def _score_salary(candidate: str, required: str | None, match_reasons: list[str], mismatch_reasons: list[str]) -> int:
+	if not required:
+		return 0
+	candidate_range = parse_salary_range(candidate)
+	required_range = parse_salary_range(required)
+	if not candidate_range or not required_range:
+		return 0
+	if candidate_range[1] >= required_range[0]:
+		match_reasons.append("薪资满足预期")
+		return 25
+	mismatch_reasons.append("薪资低于预期")
+	return 0
+
+
+def score_job_item(job: JobItem, *, criteria: SearchFilterCriteria | None, expect_data: dict | None) -> dict:
+	preferences = _extract_expect_preferences(expect_data)
+	match_reasons: list[str] = []
+	mismatch_reasons: list[str] = []
+	score = 0
+
+	city_target = criteria.city if criteria and criteria.city else preferences.get("city")
+	if city_target:
+		if city_target in job.city:
+			score += 25
+			match_reasons.append("城市匹配")
+		else:
+			mismatch_reasons.append("城市不匹配")
+
+	salary_target = criteria.salary if criteria and criteria.salary else preferences.get("salary")
+	score += _score_salary(job.salary, salary_target, match_reasons, mismatch_reasons)
+
+	exp_target = criteria.experience if criteria else None
+	if exp_target:
+		if meets_experience_threshold(job.experience, exp_target):
+			score += 20
+			match_reasons.append("经验满足要求")
+		else:
+			mismatch_reasons.append("经验低于要求")
+
+	edu_target = criteria.education if criteria and criteria.education else preferences.get("education")
+	if edu_target:
+		if meets_education_threshold(job.education, edu_target):
+			score += 15
+			match_reasons.append("学历满足要求")
+		else:
+			mismatch_reasons.append("学历低于要求")
+
+	if criteria and criteria.query:
+		query = criteria.query.lower()
+		title_text = f"{job.title} {' '.join(job.skills)}".lower()
+		if query in title_text:
+			score += 10
+			match_reasons.append("关键词直接命中")
+
+	if job.welfare:
+		score += 5
+		match_reasons.append("福利信息完整")
+
+	return {
+		"match_score": min(score, 100),
+		"match_reasons": match_reasons,
+		"mismatch_reasons": mismatch_reasons,
+	}
+
+
+def score_job_dict(item: dict, *, criteria: SearchFilterCriteria | None, expect_data: dict | None) -> dict:
+	job = JobItem(
+		job_id=item.get("job_id", ""),
+		title=item.get("title", ""),
+		company=item.get("company", ""),
+		salary=item.get("salary", ""),
+		city=item.get("city", ""),
+		district=item.get("district", ""),
+		experience=item.get("experience", ""),
+		education=item.get("education", ""),
+		skills=item.get("skills", []),
+		welfare=item.get("welfare", []),
+		industry=item.get("industry", ""),
+		scale=item.get("scale", ""),
+		stage=item.get("stage", ""),
+		boss_name=item.get("boss_name", ""),
+		boss_title=item.get("boss_title", ""),
+		boss_active=item.get("boss_active", ""),
+		security_id=item.get("security_id", ""),
+		greeted=item.get("greeted", False),
+	)
+	return {**item, **score_job_item(job, criteria=criteria, expect_data=expect_data)}

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -223,6 +223,94 @@ def test_recommend_success(mock_auth_cls, mock_client_cls, mock_cache_cls):
 	assert parsed["hints"] is not None
 
 
+@patch("boss_agent_cli.commands.recommend.CacheStore")
+@patch("boss_agent_cli.commands.recommend.BossClient")
+@patch("boss_agent_cli.commands.recommend.AuthManager")
+def test_recommend_with_score(mock_auth_cls, mock_client_cls, mock_cache_cls):
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.is_greeted.return_value = False
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.resume_expect.return_value = {"zpData": {"city": "广州", "salary": "20-50K", "degree": "本科"}}
+	mock_client.recommend_jobs.return_value = {
+		"zpData": {
+			"hasMore": False,
+			"jobList": [
+				{
+					"encryptJobId": "j1",
+					"jobName": "Go 开发",
+					"brandName": "TestCo",
+					"salaryDesc": "20-30K",
+					"cityName": "广州",
+					"areaDistrict": "天河区",
+					"jobExperience": "3-5年",
+					"jobDegree": "本科",
+					"skills": ["Golang"],
+					"welfareList": ["双休"],
+					"brandIndustry": "互联网",
+					"brandScaleName": "100-499人",
+					"brandStageName": "A轮",
+					"bossName": "李",
+					"bossTitle": "HR",
+					"bossOnline": True,
+					"securityId": "sec_r1",
+				},
+			],
+		},
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["recommend", "--with-score"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["data"][0]["match_score"] >= 0
+	assert "match_reasons" in parsed["data"][0]
+
+
+@patch("boss_agent_cli.commands.search.run_search_pipeline")
+@patch("boss_agent_cli.commands.search.CacheStore")
+@patch("boss_agent_cli.commands.search.AuthManager")
+@patch("boss_agent_cli.commands.search.BossClient")
+def test_search_with_score(mock_client_cls, mock_auth_cls, mock_cache_cls, mock_pipeline):
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.get_search.return_value = None
+	_ctx_mock(mock_client_cls)
+	mock_pipeline.return_value = SimpleNamespace(
+		items=[{
+			"job_id": "j1",
+			"title": "Go 开发",
+			"company": "TestCo",
+			"salary": "20-30K",
+			"city": "广州",
+			"district": "天河区",
+			"experience": "3-5年",
+			"education": "本科",
+			"skills": ["Golang"],
+			"welfare": ["双休"],
+			"industry": "互联网",
+			"scale": "100-499人",
+			"stage": "A轮",
+			"boss_name": "李",
+			"boss_title": "HR",
+			"boss_active": "在线",
+			"security_id": "sec_001",
+			"greeted": False,
+		}],
+		has_more=False,
+		total=1,
+		stats=SimpleNamespace(
+			pages_scanned=1,
+			jobs_seen=1,
+			jobs_prefiltered=0,
+			detail_checks=0,
+		),
+	)
+	runner = CliRunner()
+	result = runner.invoke(cli, ["search", "golang", "--city", "广州", "--salary", "20-50K", "--with-score"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["data"][0]["match_score"] >= 0
+	assert "match_reasons" in parsed["data"][0]
+
+
 @patch("boss_agent_cli.index_cache.save_index", side_effect=PermissionError("readonly"))
 @patch("boss_agent_cli.commands.recommend.CacheStore")
 @patch("boss_agent_cli.commands.recommend.BossClient")

--- a/tests/test_match_score.py
+++ b/tests/test_match_score.py
@@ -1,0 +1,59 @@
+from boss_agent_cli.api.models import JobItem
+from boss_agent_cli.match_score import score_job_item
+from boss_agent_cli.search_filters import SearchFilterCriteria
+
+
+def _job(**overrides):
+	raw = {
+		"encryptJobId": "job_001",
+		"jobName": "Go 开发",
+		"brandName": "TestCo",
+		"salaryDesc": "20-30K",
+		"cityName": "广州",
+		"areaDistrict": "天河区",
+		"jobExperience": "3-5年",
+		"jobDegree": "本科",
+		"skills": ["Golang"],
+		"welfareList": ["双休", "五险一金"],
+		"brandIndustry": "互联网",
+		"brandScaleName": "100-499人",
+		"brandStageName": "A轮",
+		"bossName": "李",
+		"bossTitle": "HR",
+		"bossOnline": True,
+		"securityId": "sec_001",
+	}
+	raw.update(overrides)
+	return JobItem.from_api(raw)
+
+
+def test_score_job_item_prefers_exact_search_constraints():
+	job = _job()
+	criteria = SearchFilterCriteria(
+		query="golang",
+		city="广州",
+		salary="20-50K",
+		experience="3-5年",
+		education="本科",
+	)
+	result = score_job_item(job, criteria=criteria, expect_data=None)
+	assert result["match_score"] >= 80
+	assert "城市匹配" in result["match_reasons"]
+	assert "薪资满足预期" in result["match_reasons"]
+
+
+def test_score_job_item_penalizes_city_and_salary_mismatch():
+	job = _job(cityName="上海", salaryDesc="8-12K")
+	criteria = SearchFilterCriteria(query="golang", city="广州", salary="20-50K")
+	result = score_job_item(job, criteria=criteria, expect_data=None)
+	assert result["match_score"] < 60
+	assert "城市不匹配" in result["mismatch_reasons"]
+	assert "薪资低于预期" in result["mismatch_reasons"]
+
+
+def test_score_job_item_can_use_expect_data_when_criteria_missing():
+	job = _job()
+	expect_data = {"city": "广州", "salary": "20-50K", "degree": "本科"}
+	result = score_job_item(job, criteria=None, expect_data=expect_data)
+	assert result["match_score"] >= 60
+	assert result["match_reasons"]


### PR DESCRIPTION
## Summary
- 新增 match_score 评分模块，基于搜索条件和求职期望输出可解释的 match_score / match_reasons / mismatch_reasons
- 为 search 和 recommend 增加 --with-score 模式，保留默认输出兼容性
- 更新 schema 与测试，确保评分能力可发现且行为稳定

## Test Plan
- env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest tests/test_match_score.py tests/test_commands.py -q
- env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest tests/ -q
- /Users/can4hou6joeng4/Documents/code/boss-agent-cli/.worktrees/codex-p1-wave2/.venv/bin/ruff check /Users/can4hou6joeng4/Documents/code/boss-agent-cli/.worktrees/codex-p1-wave2/src /Users/can4hou6joeng4/Documents/code/boss-agent-cli/.worktrees/codex-p1-wave2/tests