### PR TITLE
fix(bridge): use user's existing zhipin tab instead of blank automation tab

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -114,13 +114,20 @@ async function evaluate(tabId, code) {
 
 // ── Tab management ───────────────────────────────────────────────────
 
-async function resolveTabId(tabId) {
+async function resolveTabId(tabId, workspace) {
 	if (tabId !== undefined) {
 		try {
 			const tab = await chrome.tabs.get(tabId);
 			if (tab.url?.startsWith('http')) return tabId;
 		} catch {}
 	}
+
+	// workspace="boss" 时，优先找已有的 zhipin tab（用户正常浏览的页面）
+	if (workspace === 'boss') {
+		const zhipinTabs = await chrome.tabs.query({ url: '*://*.zhipin.com/*' });
+		if (zhipinTabs.length > 0) return zhipinTabs[0].id;
+	}
+
 	const windowId = await getAutomationWindow();
 	const tabs = await chrome.tabs.query({ windowId });
 	const good = tabs.find(t => t.url?.startsWith('http') || t.url?.startsWith('data:'));
@@ -203,7 +210,7 @@ async function handleCommand(cmd) {
 
 async function handleExec(cmd) {
 	if (!cmd.code) return { id: cmd.id, ok: false, error: 'Missing code' };
-	const tabId = await resolveTabId(cmd.tabId);
+	const tabId = await resolveTabId(cmd.tabId, cmd.workspace);
 	const data = await evaluate(tabId, cmd.code);
 	return { id: cmd.id, ok: true, data };
 }
@@ -212,7 +219,7 @@ async function handleNavigate(cmd) {
 	if (!cmd.url) return { id: cmd.id, ok: false, error: 'Missing url' };
 	if (!cmd.url.startsWith('http')) return { id: cmd.id, ok: false, error: 'Only http(s) allowed' };
 
-	const tabId = await resolveTabId(cmd.tabId);
+	const tabId = await resolveTabId(cmd.tabId, cmd.workspace);
 	await chrome.tabs.update(tabId, { url: cmd.url });
 
 	// 等待导航完成


### PR DESCRIPTION
## Summary

When `workspace="boss"`, `resolveTabId` now queries for existing `*.zhipin.com` tabs and uses the first one found, instead of creating a blank automation tab.

## Problem

The Bridge extension's `resolveTabId` function was always creating a new blank tab in an automation window. Since the user's BOSS account was logged in their normal Chrome window (not the automation window), the API calls had no valid login session, causing all requests to fail with:

```
Cannot debug tab 1665312842: URL is data:text/html,<html></html>
```

## Solution

Before falling back to the automation window, check if there are any existing zhipin tabs in any window:

```javascript
if (workspace === 'boss') {
    const zhipinTabs = await chrome.tabs.query({ url: '*://*.zhipin.com/*' });
    if (zhipinTabs.length > 0) return zhipinTabs[0].id;
}
```

This requires the user to have BOSS opened in Chrome (already logged in), which is a reasonable requirement and actually more user-friendly since the extension just uses their existing session.

## Test plan

- [x] Load extension in Chrome
- [x] Open BOSS website in Chrome (logged in)
- [x] Run `boss search "算法工程师" --city 上海 --no-cache`
- [x] Search returns 15 results successfully

## Related

See issue #21 for full debugging history. The `browser_client.py` fix for CDP mode reuse is a separate change that should be reviewed separately.