### PR TITLE
fix: 检测风控 code 36 并输出明确错误码 ACCOUNT_RISK

### DIFF
--- a/src/boss_agent_cli/api/boss.yaml
+++ b/src/boss_agent_cli/api/boss.yaml
@@ -23,6 +23,7 @@ response_codes:
   success: 0
   stoken_expired: 37
   rate_limited: 9
+  account_risk: 36
 
 endpoints:
   search:

--- a/src/boss_agent_cli/api/client.py
+++ b/src/boss_agent_cli/api/client.py
@@ -29,6 +29,14 @@ class AuthError(Exception):
 	pass
 
 
+class AccountRiskError(Exception):
+	"""BOSS 直聘风控拦截（code 36）：检测到异常行为（通常为 headless 浏览器）。"""
+
+	def __init__(self, message: str = "", is_cdp: bool = False):
+		self.is_cdp = is_cdp
+		super().__init__(message)
+
+
 class BossClient:
 	"""Hybrid API client: browser channel for high-risk ops, httpx for low-risk ops."""
 
@@ -143,7 +151,20 @@ class BossClient:
 	# ── Browser request (high-risk ops) ──────────────────────────────
 
 	def _browser_request(self, method: str, url: str, *, params: dict | None = None, data: dict | None = None) -> dict:
-		return self._get_browser().request(method, url, params=params, data=data)
+		result = self._get_browser().request(method, url, params=params, data=data)
+		code = result.get("code")
+		if code == endpoints.CODE_ACCOUNT_RISK:
+			msg = result.get("message", "账户存在异常行为")
+			browser = self._get_browser()
+			is_cdp = getattr(browser, "_is_cdp", False)
+			mode = "CDP" if is_cdp else ("Bridge" if getattr(browser, "_is_bridge", False) else "headless patchright")
+			raise AccountRiskError(
+				f"BOSS 直聘风控拦截 (code {code}): {msg}。"
+				f"当前浏览器模式: {mode}。"
+				f"建议：以 --remote-debugging-port=9222 启动 Chrome 后重试（CDP 模式可规避风控检测）",
+				is_cdp=is_cdp,
+			)
+		return result
 
 	# ── Public API ───────────────────────────────────────────────────
 	# High-risk: search, recommend, greet, job_card → browser channel

--- a/src/boss_agent_cli/api/endpoints.py
+++ b/src/boss_agent_cli/api/endpoints.py
@@ -41,6 +41,7 @@ EXCHANGE_REQUEST_URL = _url("exchange_request")
 CODE_SUCCESS = _spec.response_codes.get("success", 0)
 CODE_STOKEN_EXPIRED = _spec.response_codes.get("stoken_expired", 37)
 CODE_RATE_LIMITED = _spec.response_codes.get("rate_limited", 9)
+CODE_ACCOUNT_RISK = _spec.response_codes.get("account_risk", 36)
 
 # ── Browser-like headers ─────────────────────────────────────────────
 DEFAULT_HEADERS = dict(_spec.default_headers)

--- a/src/boss_agent_cli/commands/doctor.py
+++ b/src/boss_agent_cli/commands/doctor.py
@@ -177,6 +177,31 @@ def doctor_cmd(ctx):
 	except Exception as e:
 		add_check("network", "warn", f"访问 zhipin.com 失败: {e}", "检查网络、代理或风控拦截")
 
+	# 5.5) Browser channel risk assessment
+	cdp_ok = any(item["name"] == "cdp" and item["status"] == "ok" for item in checks)
+	bridge_ok = False
+	try:
+		from boss_agent_cli.bridge.client import BridgeClient
+		bc = BridgeClient()
+		bridge_ok = bc.is_running() and bc.is_extension_connected()
+	except Exception:
+		pass
+
+	if cdp_ok or bridge_ok:
+		mode = "CDP" if cdp_ok else "Bridge"
+		add_check(
+			"browser_channel",
+			"ok",
+			f"高风险操作将使用 {mode} 模式（真实浏览器指纹，不触发风控）",
+		)
+	else:
+		add_check(
+			"browser_channel",
+			"warn",
+			"CDP 和 Bridge 均不可用，搜索/推荐/打招呼将降级到 headless patchright（可能触发 BOSS 直聘风控 code 36）",
+			"以 --remote-debugging-port=9222 启动 Chrome（推荐），或安装 Bridge 扩展",
+		)
+
 	# 6) Data dir writable
 	try:
 		auth_dir.mkdir(parents=True, exist_ok=True)

--- a/src/boss_agent_cli/display.py
+++ b/src/boss_agent_cli/display.py
@@ -283,6 +283,7 @@ def handle_auth_errors(command_name: str):
 	def decorator(func):
 		@wraps(func)
 		def wrapper(ctx, *args, **kwargs):
+			from boss_agent_cli.api.client import AccountRiskError
 			from boss_agent_cli.auth.manager import AuthRequired, TokenRefreshFailed
 			try:
 				return func(ctx, *args, **kwargs)
@@ -297,6 +298,22 @@ def handle_auth_errors(command_name: str):
 					ctx, command_name, code="TOKEN_REFRESH_FAILED",
 					message="Token 刷新失败，请重新登录",
 					recoverable=True, recovery_action="boss login",
+				)
+			except AccountRiskError as e:
+				recovery = (
+					"以 --remote-debugging-port=9222 启动 Chrome，然后重试（CDP 模式）"
+					if not e.is_cdp
+					else "联系 BOSS 直聘客服解除风控限制"
+				)
+				handle_error_output(
+					ctx, command_name, code="ACCOUNT_RISK",
+					message=str(e),
+					recoverable=not e.is_cdp,
+					recovery_action=recovery,
+					hints={"next_actions": [
+						"boss-chrome  # 启动带调试端口的 Chrome",
+						"boss search <query>  # CDP 模式自动生效",
+					]} if not e.is_cdp else None,
 				)
 			except Exception as e:
 				handle_error_output(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,7 @@
-from boss_agent_cli.api.endpoints import CITY_CODES, SALARY_CODES, EXPERIENCE_CODES
+from boss_agent_cli.api.endpoints import (
+	CITY_CODES, SALARY_CODES, EXPERIENCE_CODES,
+	CODE_ACCOUNT_RISK, CODE_STOKEN_EXPIRED, CODE_RATE_LIMITED,
+)
 from boss_agent_cli.api.models import JobItem
 
 
@@ -16,6 +19,13 @@ def test_salary_code_lookup():
 def test_experience_code_lookup():
 	assert EXPERIENCE_CODES["应届"] == "108"
 	assert EXPERIENCE_CODES["3-5年"] == "104"
+
+
+def test_response_code_constants():
+	"""验证 BOSS API 返回码常量加载正确（含风控 code 36）"""
+	assert CODE_STOKEN_EXPIRED == 37
+	assert CODE_RATE_LIMITED == 9
+	assert CODE_ACCOUNT_RISK == 36
 
 
 def test_job_item_from_api():
@@ -77,3 +87,56 @@ def test_job_item_to_dict():
 	assert d["greeted"] is False
 	assert d["welfare"] == ["五险一金"]
 	assert d["skills"] == ["Golang"]
+
+
+def test_account_risk_error_raised_on_code_36():
+	"""_browser_request 收到 code 36 时应抛出 AccountRiskError"""
+	from unittest.mock import MagicMock
+	from boss_agent_cli.api.client import BossClient, AccountRiskError
+
+	auth = MagicMock()
+	auth.get_token.return_value = {"cookies": {}, "user_agent": "ua", "stoken": "s"}
+	client = BossClient(auth)
+
+	# 模拟 browser session 返回 code 36
+	mock_browser = MagicMock()
+	mock_browser.request.return_value = {
+		"code": 36,
+		"message": "您的账户存在异常行为.",
+		"zpData": {},
+	}
+	mock_browser._is_cdp = False
+	mock_browser._is_bridge = False
+	client._browser_session = mock_browser
+
+	import pytest
+	with pytest.raises(AccountRiskError) as exc_info:
+		client._browser_request("GET", "/wapi/zpgeek/search/joblist.json")
+
+	assert "code 36" in str(exc_info.value)
+	assert "风控拦截" in str(exc_info.value)
+	assert exc_info.value.is_cdp is False
+	client.close()
+
+
+def test_account_risk_error_not_raised_on_success():
+	"""_browser_request 收到 code 0 时正常返回"""
+	from unittest.mock import MagicMock
+	from boss_agent_cli.api.client import BossClient
+
+	auth = MagicMock()
+	auth.get_token.return_value = {"cookies": {}, "user_agent": "ua", "stoken": "s"}
+	client = BossClient(auth)
+
+	mock_browser = MagicMock()
+	mock_browser.request.return_value = {
+		"code": 0,
+		"message": "Success",
+		"zpData": {"jobList": [{"jobName": "test"}]},
+	}
+	client._browser_session = mock_browser
+
+	result = client._browser_request("GET", "/wapi/zpgeek/search/joblist.json")
+	assert result["code"] == 0
+	assert result["zpData"]["jobList"][0]["jobName"] == "test"
+	client.close()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -884,3 +884,31 @@ def test_chat_export_html_xss_prevention(mock_auth_cls, mock_client_cls, tmp_pat
 	# 转义后的实体应该存在
 	assert "&lt;script&gt;" in content
 	assert "&amp;名" in content
+
+
+@patch("boss_agent_cli.commands.search.run_search_pipeline")
+@patch("boss_agent_cli.commands.search.CacheStore")
+@patch("boss_agent_cli.commands.search.AuthManager")
+@patch("boss_agent_cli.commands.search.BossClient")
+def test_search_account_risk_returns_error(mock_client_cls, mock_auth_cls, mock_cache_cls, mock_pipeline):
+	"""搜索触发风控 code 36 时应返回 ACCOUNT_RISK 错误码"""
+	from boss_agent_cli.api.client import AccountRiskError
+
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.get_search.return_value = None
+	_ctx_mock(mock_client_cls)
+	mock_pipeline.side_effect = AccountRiskError(
+		"BOSS 直聘风控拦截 (code 36): 您的账户存在异常行为。当前浏览器模式: headless patchright。"
+		"建议：以 --remote-debugging-port=9222 启动 Chrome 后重试（CDP 模式可规避风控检测）",
+		is_cdp=False,
+	)
+	runner = CliRunner()
+	result = runner.invoke(cli, ["search", "golang"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["error"]["code"] == "ACCOUNT_RISK"
+	assert "风控拦截" in parsed["error"]["message"]
+	assert parsed["error"]["recoverable"] is True
+	assert "Chrome" in parsed["error"]["recovery_action"]
+	assert parsed["hints"]["next_actions"]


### PR DESCRIPTION
## Summary

Closes #21

- 新增 `CODE_ACCOUNT_RISK = 36` 响应码常量（`boss.yaml` + `endpoints.py`）
- `BossClient._browser_request` 检测 code 36 时抛出 `AccountRiskError`（含浏览器模式和恢复建议）
- `handle_auth_errors` 装饰器捕获 `AccountRiskError`，输出 `ACCOUNT_RISK` 错误码 + `hints.next_actions`
- `boss doctor` 新增 `browser_channel` 检查项，提前预警 headless 降级风控风险
- CLAUDE.md 错误码表补充 `ACCOUNT_RISK`

## Root Cause

当 CDP 和 Bridge 均不可用时，降级到 headless patchright，BOSS 直聘风控系统检测到异常行为返回 `code: 36`。
原代码未检查该错误码，`zpData` 为空被��作"0 条结果"静默返回，用户无法得知真实原因。

## Changes

| 文件 | 变更 |
|------|------|
| `api/boss.yaml` | 新增 `account_risk: 36` |
| `api/endpoints.py` | 新增 `CODE_ACCOUNT_RISK` 常量 |
| `api/client.py` | 新增 `AccountRiskError` 异常类 + `_browser_request` 检测逻辑 |
| `display.py` | `handle_auth_errors` 增加 `AccountRiskError` 捕获分支 |
| `commands/doctor.py` | 新增 `browser_channel` 检查项 |
| `tests/test_api.py` | 新增 3 个测试（常量、code 36 抛异常、code 0 正常） |
| `tests/test_commands.py` | 新增 1 个测试（CLI 层 ACCOUNT_RISK 错误输出） |

## Test plan

- [x] `test_response_code_constants` — 验证 CODE_ACCOUNT_RISK == 36
- [x] `test_account_risk_error_raised_on_code_36` — 验证 _browser_request 检测 code 36 抛 AccountRiskError
- [x] `test_account_risk_error_not_raised_on_success` — 验证 code 0 正常返回
- [x] `test_search_account_risk_returns_error` — 验证 CLI 输出 ACCOUNT_RISK 错误码 + hints
- [x] 全量 235 测试通过，0 回归