### PR TITLE
fix: CDP 模式复用用户 context 规避 automation 检测

### DIFF
--- a/src/boss_agent_cli/api/browser_client.py
+++ b/src/boss_agent_cli/api/browser_client.py
@@ -124,24 +124,29 @@ class BrowserSession:
 		return False
 
 	def _try_connect(self, url: str) -> bool:
-		"""Attempt a single CDP connection with context isolation.
+		"""Attempt a single CDP connection, reusing user's existing context.
 
-		Extracts cookies from user's existing context, then creates an isolated
-		context to avoid tab leakage into user's daily browsing.
+		Reuses the first existing browser context (preserves login state and
+		avoids Chrome's automation detection on new contexts). Only creates
+		a new context when none exists.
 		"""
 		try:
 			self._browser = self._pw.chromium.connect_over_cdp(url)
 			contexts = self._browser.contexts
 
-			# 从用户现有 context 提取 Cookie（保留登录态），然后创建隔离 context
 			if contexts:
-				user_cookies = contexts[0].cookies()
-				self._context = self._browser.new_context()
-				if user_cookies:
-					self._context.add_cookies(user_cookies)
+				# 复用用户现有 context（保留登录态 + 规避 automation 检测）
+				self._context = contexts[0]
+				self._own_context = False  # 非我们创建，close 时不关闭
 			else:
+				# 没有已存在 context，创建新的并注入 cookies
 				self._context = self._browser.new_context()
-			self._own_context = True  # 标记：由我们创建，close 时需清理
+				if self._cookies:
+					self._context.add_cookies([
+						{"name": name, "value": value, "domain": ".zhipin.com", "path": "/"}
+						for name, value in self._cookies.items()
+					])
+				self._own_context = True
 
 			self._page = self._context.new_page()
 			# CDP 模式下用较长超时 + commit 级等待（避免 networkidle 卡住）
@@ -151,7 +156,8 @@ class BrowserSession:
 				pass  # 即使导航超时，页面 JS 环境已可用
 			self._started = True
 			self._is_cdp = True
-			self._log(f"[boss] CDP 连接成功 ({url})，使用用户 Chrome（隔离 context）")
+			reuse_label = "复用用户 context" if not self._own_context else "新建 context"
+			self._log(f"[boss] CDP 连接成功 ({url})，{reuse_label}")
 			return True
 		except Exception:
 			if self._browser:

--- a/tests/test_browser_client.py
+++ b/tests/test_browser_client.py
@@ -39,11 +39,29 @@ def test_read_devtools_active_port_found(tmp_path):
 		assert ws == "ws://127.0.0.1:9222/devtools/browser/test-id"
 
 
-def test_close_cdp_mode_closes_page_and_own_context():
-	"""CDP 模式下 close() 关闭 page 和自建 context，不关闭 browser"""
+def test_close_cdp_mode_reused_context_not_closed():
+	"""CDP 复用用户 context 时 close() 只关闭 page，不关闭 context"""
 	session = BrowserSession(cookies={}, user_agent="")
 	session._is_cdp = True
-	session._own_context = True
+	session._own_context = False  # 复用的 context
+	session._started = True
+	session._page = MagicMock()
+	session._context = MagicMock()
+	session._browser = MagicMock()
+	session._pw = MagicMock()
+
+	session.close()
+
+	session._page.close.assert_called_once()
+	session._context.close.assert_not_called()  # 不关闭用户的 context
+	session._browser.close.assert_not_called()
+
+
+def test_close_cdp_mode_own_context_closed():
+	"""CDP 自建 context 时 close() 关闭 page 和 context"""
+	session = BrowserSession(cookies={}, user_agent="")
+	session._is_cdp = True
+	session._own_context = True  # 自建的 context
 	session._started = True
 	session._page = MagicMock()
 	session._context = MagicMock()
@@ -54,7 +72,6 @@ def test_close_cdp_mode_closes_page_and_own_context():
 
 	session._page.close.assert_called_once()
 	session._context.close.assert_called_once()
-	session._browser.close.assert_not_called()
 
 
 def test_close_headless_mode_closes_browser():
@@ -71,17 +88,38 @@ def test_close_headless_mode_closes_browser():
 	session._browser.close.assert_called_once()
 
 
-def test_try_connect_creates_isolated_context():
-	"""CDP 连接应从用户 context 提取 Cookie 后创建隔离 context"""
+def test_try_connect_reuses_existing_context():
+	"""CDP 连接应复用用户现有 context（规避 automation 检测）"""
 	session = BrowserSession(cookies={}, user_agent="")
 	session._pw = MagicMock()
 
 	mock_browser = MagicMock()
 	mock_user_context = MagicMock()
-	mock_user_context.cookies.return_value = [
-		{"name": "wt2", "value": "abc", "domain": ".zhipin.com", "path": "/"},
-	]
 	mock_browser.contexts = [mock_user_context]
+	mock_page = MagicMock()
+	mock_user_context.new_page.return_value = mock_page
+
+	session._pw.chromium.connect_over_cdp.return_value = mock_browser
+
+	result = session._try_connect("ws://localhost:9222/test")
+
+	assert result is True
+	assert session._is_cdp is True
+	assert session._own_context is False  # 复用，非自建
+	assert session._context is mock_user_context  # 直接使用用户 context
+	# 验证：没有创建新 context
+	mock_browser.new_context.assert_not_called()
+	# 验证：page 在用户 context 中创建
+	mock_user_context.new_page.assert_called_once()
+
+
+def test_try_connect_creates_new_context_when_none_exists():
+	"""CDP 连接无已存在 context 时创建新 context 并注入 cookies"""
+	session = BrowserSession(cookies={"wt2": "abc"}, user_agent="")
+	session._pw = MagicMock()
+
+	mock_browser = MagicMock()
+	mock_browser.contexts = []  # 无已存在 context
 	mock_new_context = MagicMock()
 	mock_browser.new_context.return_value = mock_new_context
 	mock_page = MagicMock()
@@ -93,14 +131,10 @@ def test_try_connect_creates_isolated_context():
 
 	assert result is True
 	assert session._is_cdp is True
-	assert session._own_context is True
-	# 验证：从用户 context 提取了 Cookie
-	mock_user_context.cookies.assert_called_once()
-	# 验证：创建了新的隔离 context（不是复用 contexts[0]）
+	assert session._own_context is True  # 自建
+	# 验证：创建了新 context
 	mock_browser.new_context.assert_called_once()
-	# 验证：Cookie 被注入到新 context
+	# 验证：cookies 被注入
 	mock_new_context.add_cookies.assert_called_once()
-	# 验证：page 在新 context 中创建
-	mock_new_context.new_page.assert_called_once()
-	# 验证：用户原始 context 没有被创建新 page
-	mock_user_context.new_page.assert_not_called()
+	cookies_arg = mock_new_context.add_cookies.call_args[0][0]
+	assert any(c["name"] == "wt2" for c in cookies_arg)


### PR DESCRIPTION
## Summary

Relates to #21 — 用户 @onlysyz 反馈的第二个 bug

### 问题

`_try_connect` 在 CDP 连接成功后创建新的隔离 context (`browser.new_context()`)，Chrome 会给新 context 打上 **automation 标记**，导致 BOSS 直聘风控检测到并拒绝请求（code 36）。

### 修复

- **有已存在 context 时**：直接复用 `contexts[0]`（用户真实浏览环境），`_own_context = False`
- **无 context 时**：创建新 context 并注入 cookies（fallback），`_own_context = True`
- `close()` 根据 `_own_context` 决定是否关闭 context（不关闭用户的 context）

### 变更文件

| 文件 | 变更 |
|------|------|
| `api/browser_client.py` | `_try_connect` 改为复用已有 context |
| `tests/test_browser_client.py` | 拆分为 4 个测试覆盖复用/自建/close 行为 |

## Test plan

- [x] `test_try_connect_reuses_existing_context` — 有 context 时复用，不创建新的
- [x] `test_try_connect_creates_new_context_when_none_exists` — 无 context 时创建并注入 cookies
- [x] `test_close_cdp_mode_reused_context_not_closed` — 复用 context 时 close 不关闭它
- [x] `test_close_cdp_mode_own_context_closed` — 自建 context 时 close 关闭它
- [x] 全量 237 测试通过，0 回归