### PR TITLE
feat: 增加chat summary命令

### DIFF
--- a/docs/superpowers/plans/2026-04-11-p1-wave3.md
+++ b/docs/superpowers/plans/2026-04-11-p1-wave3.md
@@ -1,0 +1,35 @@
+# P1 Wave 3 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a deterministic conversation summary layer so agents can reason about recruiter threads without parsing raw message history every time.
+
+**Architecture:** Introduce a pure summary helper (`chat_summary.py`) that derives `stage`, `pending_action`, `key_facts`, and `risk_flags` from recent messages. Expose it through a read-only `chat-summary` command wired through the same friend lookup and history retrieval path used by `chatmsg`.
+
+**Tech Stack:** Python 3.10+, Click CLI, BossClient read APIs (`friend_list`, `chat_history`), pytest, existing JSON envelope/display helpers.
+
+---
+
+## Planned File Touches
+
+- Create: `src/boss_agent_cli/chat_summary.py`
+- Create: `src/boss_agent_cli/commands/chat_summary.py`
+- Modify: `src/boss_agent_cli/main.py`
+- Modify: `src/boss_agent_cli/commands/schema.py`
+- Create: `tests/test_chat_summary.py`
+- Create: `tests/test_chat_summary_command.py`
+- Modify: `tests/test_commands.py`
+- Create: `docs/superpowers/plans/2026-04-11-p1-wave3.md`
+
+## Scope
+
+- Deterministic, rule-based summary for a single conversation
+- `chat-summary <security_id>`
+- Structured output fields, no freeform LLM prose
+
+## Out of Scope
+
+- Multi-thread digesting
+- Persisted summary cache
+- Automatic follow-up actions
+- Model-generated summarization

--- a/src/boss_agent_cli/chat_summary.py
+++ b/src/boss_agent_cli/chat_summary.py
@@ -1,0 +1,43 @@
+def summarize_messages(messages: list[dict], *, friend_uid: str) -> dict:
+	stage = "new"
+	pending_action = "review"
+	key_facts: list[str] = []
+	risk_flags: list[str] = []
+
+	if not messages:
+		return {
+			"stage": stage,
+			"pending_action": pending_action,
+			"key_facts": key_facts,
+			"risk_flags": risk_flags,
+			"message_count": 0,
+		}
+
+	latest = messages[-1]
+	latest_from = str(latest.get("from", {}).get("uid", ""))
+	texts = " ".join((item.get("text") or item.get("body", {}).get("text", "")) for item in messages)
+
+	if "面试" in texts or "约个面" in texts:
+		stage = "interview"
+		pending_action = "confirm_interview"
+		key_facts.append("涉及面试安排")
+	elif latest_from == friend_uid:
+		stage = "reply_needed"
+		pending_action = "reply"
+		risk_flags.append("需要回复对方最新消息")
+	else:
+		stage = "waiting"
+		pending_action = "wait"
+
+	if "微信" in texts:
+		key_facts.append("涉及微信交换")
+	if "简历" in texts:
+		key_facts.append("涉及简历投递")
+
+	return {
+		"stage": stage,
+		"pending_action": pending_action,
+		"key_facts": key_facts,
+		"risk_flags": risk_flags,
+		"message_count": len(messages),
+	}

--- a/src/boss_agent_cli/commands/chat_summary.py
+++ b/src/boss_agent_cli/commands/chat_summary.py
@@ -1,0 +1,57 @@
+import click
+
+from boss_agent_cli.api.client import BossClient
+from boss_agent_cli.auth.manager import AuthManager
+from boss_agent_cli.chat_summary import summarize_messages
+from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_message_panel
+
+
+@click.command("chat-summary")
+@click.argument("security_id")
+@click.option("--page", default=1, help="页码")
+@click.option("--count", default=20, help="每页消息数量")
+@click.pass_context
+@handle_auth_errors("chat-summary")
+def chat_summary_cmd(ctx, security_id, page, count):
+	data_dir = ctx.obj["data_dir"]
+	logger = ctx.obj["logger"]
+	delay = ctx.obj["delay"]
+	cdp_url = ctx.obj.get("cdp_url")
+	auth = AuthManager(data_dir, logger=logger)
+
+	with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
+		friends_resp = client.friend_list(page=1)
+		items = friends_resp.get("zpData", {}).get("result") or friends_resp.get("zpData", {}).get("friendList") or []
+
+		gid = None
+		friend_name = "-"
+		for item in items:
+			if item.get("securityId") == security_id:
+				gid = str(item.get("uid", ""))
+				friend_name = item.get("name") or "-"
+				break
+
+		if not gid:
+			handle_error_output(
+				ctx,
+				"chat-summary",
+				code="JOB_NOT_FOUND",
+				message=f"未在沟通列表中找到 security_id={security_id}",
+			)
+			return
+
+		resp = client.chat_history(gid, security_id, page=page, count=count)
+		messages = resp.get("zpData", {}).get("messages") or resp.get("zpData", {}).get("historyMsgList") or []
+		summary = summarize_messages(messages, friend_uid=gid)
+
+	handle_output(
+		ctx,
+		"chat-summary",
+		{
+			"security_id": security_id,
+			"name": friend_name,
+			**summary,
+		},
+		render=lambda d: render_message_panel(d, title="chat-summary"),
+		hints={"next_actions": ["boss chat", f"boss chatmsg {security_id}"]},
+	)

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -299,6 +299,16 @@ SCHEMA_DATA = {
 				"--count": {"type": "int", "default": 20, "description": "每页消息数量"},
 			},
 		},
+		"chat-summary": {
+			"description": "基于聊天历史生成结构化摘要与下一步建议",
+			"args": [
+				{"name": "security_id", "required": True, "description": "联系人的 security_id（从 chat 命令获取）"},
+			],
+			"options": {
+				"--page": {"type": "int", "default": 1, "description": "页码"},
+				"--count": {"type": "int", "default": 20, "description": "每页消息数量"},
+			},
+		},
 		"mark": {
 			"description": "给联系人添加/移除标签（新招呼/沟通中/已约面/不合适/收藏等）",
 			"args": [

--- a/src/boss_agent_cli/main.py
+++ b/src/boss_agent_cli/main.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import click
 
-from boss_agent_cli.commands import schema, login, logout, status, doctor, search, detail, greet, recommend, export, cities, me, chat, chatmsg, mark, exchange, interviews, show, history, watch, pipeline, apply, shortlist
+from boss_agent_cli.commands import schema, login, logout, status, doctor, search, detail, greet, recommend, export, cities, me, chat, chatmsg, chat_summary, mark, exchange, interviews, show, history, watch, pipeline, apply, shortlist
 from boss_agent_cli.config import load_config
 from boss_agent_cli.hooks import create_hook_bus
 from boss_agent_cli.output import Logger
@@ -53,6 +53,7 @@ cli.add_command(cities.cities_cmd, "cities")
 cli.add_command(me.me_cmd, "me")
 cli.add_command(chat.chat_cmd, "chat")
 cli.add_command(chatmsg.chatmsg_cmd, "chatmsg")
+cli.add_command(chat_summary.chat_summary_cmd, "chat-summary")
 cli.add_command(mark.mark_cmd, "mark")
 cli.add_command(exchange.exchange_cmd, "exchange")
 cli.add_command(interviews.interviews_cmd, "interviews")

--- a/tests/test_chat_summary.py
+++ b/tests/test_chat_summary.py
@@ -1,0 +1,57 @@
+from boss_agent_cli.chat_summary import summarize_messages
+
+
+def _msg(uid: int, text: str, ts: int = 1700000000000, msg_type: int = 1):
+	return {
+		"from": {"uid": uid, "name": "张HR" if uid == 99 else "我"},
+		"type": msg_type,
+		"text": text,
+		"time": ts,
+	}
+
+
+def test_summary_marks_reply_needed_when_latest_message_is_from_recruiter():
+	result = summarize_messages(
+		[
+			_msg(12345, "您好，我对岗位很感兴趣", 1700000000000),
+			_msg(99, "方便的话发我一份简历", 1700000001000),
+		],
+		friend_uid="99",
+	)
+	assert result["stage"] == "reply_needed"
+	assert result["pending_action"] == "reply"
+	assert "需要回复对方最新消息" in result["risk_flags"]
+
+
+def test_summary_marks_waiting_when_latest_message_is_from_me():
+	result = summarize_messages(
+		[
+			_msg(99, "您好"),
+			_msg(12345, "好的，我稍后发您简历", 1700000001000),
+		],
+		friend_uid="99",
+	)
+	assert result["stage"] == "waiting"
+	assert result["pending_action"] == "wait"
+
+
+def test_summary_marks_interview_when_messages_contain_interview_signal():
+	result = summarize_messages(
+		[
+			_msg(99, "可以约个面试吗？"),
+			_msg(12345, "可以，明天下午方便"),
+		],
+		friend_uid="99",
+	)
+	assert result["stage"] == "interview"
+	assert "面试" in " ".join(result["key_facts"])
+
+
+def test_summary_collects_contact_exchange_fact():
+	result = summarize_messages(
+		[
+			_msg(99, "方便加个微信沟通吗？"),
+		],
+		friend_uid="99",
+	)
+	assert any("微信" in item for item in result["key_facts"])

--- a/tests/test_chat_summary_command.py
+++ b/tests/test_chat_summary_command.py
@@ -1,0 +1,64 @@
+import json
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from boss_agent_cli.main import cli
+
+
+def _ctx_mock(mock_cls):
+	instance = mock_cls.return_value
+	instance.__enter__ = lambda self: self
+	instance.__exit__ = lambda self, *a: None
+	return instance
+
+
+def _friend_list_response(items):
+	return {"zpData": {"result": items, "friendList": items}}
+
+
+def _friend():
+	return {
+		"name": "张HR",
+		"securityId": "sec_001",
+		"uid": 99,
+		"title": "HR",
+		"brandName": "TestCo",
+		"friendSource": 0,
+		"encryptJobId": "job_001",
+		"lastMsg": "发我一份简历",
+		"lastTS": 1700000001000,
+		"unreadMsgCount": 1,
+		"relationType": 1,
+		"lastMessageInfo": {"status": 1},
+	}
+
+
+@patch("boss_agent_cli.commands.chat_summary.BossClient")
+@patch("boss_agent_cli.commands.chat_summary.AuthManager")
+def test_chat_summary_command_success(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = _friend_list_response([_friend()])
+	mock_client.chat_history.return_value = {
+		"zpData": {
+			"messages": [
+				{"from": {"uid": 12345, "name": "我"}, "type": 1, "text": "您好", "time": 1700000000000},
+				{"from": {"uid": 99, "name": "张HR"}, "type": 1, "text": "发我一份简历", "time": 1700000001000},
+			]
+		}
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "chat-summary", "sec_001"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["stage"] == "reply_needed"
+	assert parsed["data"]["security_id"] == "sec_001"
+
+
+def test_chat_summary_is_exposed_in_schema():
+	runner = CliRunner()
+	result = runner.invoke(cli, ["schema"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert "chat-summary" in parsed["data"]["commands"]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -132,7 +132,8 @@ def test_schema_includes_new_commands():
 	assert "follow-up" in commands
 	assert "apply" in commands
 	assert "shortlist" in commands
-	assert len(commands) >= 23
+	assert "chat-summary" in commands
+	assert len(commands) >= 24
 
 
 @patch("boss_agent_cli.commands.doctor.extract_cookies")


### PR DESCRIPTION
## Summary
- 新增 chat_summary 纯逻辑模块，对聊天历史做结构化摘要并输出 stage、pending_action、key_facts、risk_flags
- 新增只读 chat-summary 命令，基于现有 friend_list/chat_history 路径生成单会话摘要
- 更新 schema 与测试，为后续 digest 和 pipeline 联动提供摘要层基础

## Test Plan
- env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest tests/test_chat_summary.py tests/test_chat_summary_command.py tests/test_commands.py -q
- env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest tests/ -q
- /Users/can4hou6joeng4/Documents/code/boss-agent-cli/.worktrees/codex-p1-wave3/.venv/bin/ruff check /Users/can4hou6joeng4/Documents/code/boss-agent-cli/.worktrees/codex-p1-wave3/src /Users/can4hou6joeng4/Documents/code/boss-agent-cli/.worktrees/codex-p1-wave3/tests