### PR TITLE
feat: 增加preset命令和搜索预设

### DIFF
--- a/docs/superpowers/plans/2026-04-13-p1-wave4.md
+++ b/docs/superpowers/plans/2026-04-13-p1-wave4.md
@@ -1,0 +1,34 @@
+# P1 Wave 4 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add reusable search presets so users and agents can save named search configurations and replay them through `search`.
+
+**Architecture:** Reuse the existing `saved_searches` storage introduced with `watch`, but expose it as a dedicated `preset` command group. Keep the first version simple: `preset add/list/remove`, plus `search --preset` to hydrate filters from stored params. Do not couple presets to automation scheduling or remote sync yet.
+
+**Tech Stack:** Python 3.10+, Click CLI groups, SQLite WAL via `CacheStore`, pytest, existing JSON envelope/output helpers.
+
+---
+
+## Planned File Touches
+
+- Create: `src/boss_agent_cli/commands/preset.py`
+- Modify: `src/boss_agent_cli/commands/search.py`
+- Modify: `src/boss_agent_cli/main.py`
+- Modify: `src/boss_agent_cli/commands/schema.py`
+- Create: `tests/test_preset.py`
+- Modify: `tests/test_commands.py`
+- Create: `docs/superpowers/plans/2026-04-13-p1-wave4.md`
+
+## Scope
+
+- `boss preset add`
+- `boss preset list`
+- `boss preset remove`
+- `boss search --preset <name>`
+
+## Out of Scope
+
+- `export --preset`
+- Preset inheritance / merge rules beyond simple CLI override
+- Preset notes / sharing / versioning

--- a/src/boss_agent_cli/commands/preset.py
+++ b/src/boss_agent_cli/commands/preset.py
@@ -1,0 +1,82 @@
+import click
+
+from boss_agent_cli.api.endpoints import (
+	CITY_CODES,
+	INDUSTRY_CODES,
+	JOB_TYPE_CODES,
+	SCALE_CODES,
+	STAGE_CODES,
+)
+from boss_agent_cli.cache.store import CacheStore
+from boss_agent_cli.display import handle_error_output, handle_output
+
+
+def _build_params(query, city, salary, experience, education, industry, scale, stage, job_type, welfare) -> dict:
+	return {
+		"query": query,
+		"city": city,
+		"salary": salary,
+		"experience": experience,
+		"education": education,
+		"industry": industry,
+		"scale": scale,
+		"stage": stage,
+		"job_type": job_type,
+		"welfare": welfare,
+	}
+
+
+@click.group("preset")
+def preset_group():
+	"""管理可复用搜索预设。"""
+
+
+@preset_group.command("add")
+@click.argument("name")
+@click.argument("query")
+@click.option("--city", default=None, help="城市名称")
+@click.option("--salary", default=None, help="薪资范围")
+@click.option("--experience", default=None, help="经验要求")
+@click.option("--education", default=None, help="学历要求")
+@click.option("--industry", default=None, type=click.Choice(list(INDUSTRY_CODES.keys()), case_sensitive=False), help="行业类型")
+@click.option("--scale", default=None, type=click.Choice(list(SCALE_CODES.keys()), case_sensitive=False), help="公司规模")
+@click.option("--stage", default=None, type=click.Choice(list(STAGE_CODES.keys()), case_sensitive=False), help="融资阶段")
+@click.option("--job-type", default=None, type=click.Choice(list(JOB_TYPE_CODES.keys()), case_sensitive=False), help="职位类型")
+@click.option("--welfare", default=None, help="福利筛选")
+@click.pass_context
+def preset_add_cmd(ctx, name, query, city, salary, experience, education, industry, scale, stage, job_type, welfare):
+	if city and city not in CITY_CODES:
+		handle_error_output(ctx, "preset", code="INVALID_PARAM", message=f"未知城市: {city}")
+		return
+
+	params = _build_params(query, city, salary, experience, education, industry, scale, stage, job_type, welfare)
+	with CacheStore(ctx.obj["data_dir"] / "cache" / "boss_agent.db") as cache:
+		cache.save_saved_search(name, params)
+	handle_output(
+		ctx,
+		"preset",
+		{"action": "add", "name": name, "params": params},
+		hints={"next_actions": [f"boss search --preset {name}", "boss preset list"]},
+	)
+
+
+@preset_group.command("list")
+@click.pass_context
+def preset_list_cmd(ctx):
+	with CacheStore(ctx.obj["data_dir"] / "cache" / "boss_agent.db") as cache:
+		items = cache.list_saved_searches()
+	handle_output(
+		ctx,
+		"preset",
+		items,
+		hints={"next_actions": ["boss search --preset <name>", "boss preset remove <name>"]},
+	)
+
+
+@preset_group.command("remove")
+@click.argument("name")
+@click.pass_context
+def preset_remove_cmd(ctx, name):
+	with CacheStore(ctx.obj["data_dir"] / "cache" / "boss_agent.db") as cache:
+		removed = cache.delete_saved_search(name)
+	handle_output(ctx, "preset", {"action": "remove", "name": name, "removed": removed})

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -343,6 +343,11 @@ SCHEMA_DATA = {
 			"args": [],
 			"options": {},
 		},
+		"preset": {
+			"description": "管理可复用搜索预设（子命令：add/list/remove）",
+			"args": [],
+			"options": {},
+		},
 		"pipeline": {
 			"description": "聚合聊天和面试数据，生成统一候选进度视图",
 			"args": [],

--- a/src/boss_agent_cli/commands/search.py
+++ b/src/boss_agent_cli/commands/search.py
@@ -23,7 +23,8 @@ from boss_agent_cli.search_filters import (
 
 
 @click.command("search")
-@click.argument("query")
+@click.argument("query", required=False)
+@click.option("--preset", default=None, help="预设名称（从 boss preset add 保存）")
 @click.option("--city", default=None, help="城市名称（如 北京、上海）")
 @click.option("--salary", default=None, help="薪资范围（如 10-20K）")
 @click.option("--experience", default=None, help="经验要求（如 3-5年）")
@@ -38,12 +39,34 @@ from boss_agent_cli.search_filters import (
 @click.option("--with-score", is_flag=True, default=False, help="附加匹配分和原因")
 @click.pass_context
 @handle_auth_errors("search")
-def search_cmd(ctx, query, city, salary, experience, education, industry, scale, stage, job_type, welfare, page, no_cache, with_score):
+def search_cmd(ctx, query, preset, city, salary, experience, education, industry, scale, stage, job_type, welfare, page, no_cache, with_score):
 	"""按关键词和筛选条件搜索职位列表"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
 	delay = ctx.obj["delay"]
 	cdp_url = ctx.obj.get("cdp_url")
+
+	if preset:
+		with CacheStore(data_dir / "cache" / "boss_agent.db") as cache:
+			record = cache.get_saved_search(preset)
+		if record is None:
+			handle_error_output(ctx, "search", code="JOB_NOT_FOUND", message=f"未找到 preset: {preset}")
+			return
+		params = record["params"]
+		query = params.get("query") or query
+		city = city or params.get("city")
+		salary = salary or params.get("salary")
+		experience = experience or params.get("experience")
+		education = education or params.get("education")
+		industry = industry or params.get("industry")
+		scale = scale or params.get("scale")
+		stage = stage or params.get("stage")
+		job_type = job_type or params.get("job_type")
+		welfare = welfare or params.get("welfare")
+
+	if not query:
+		handle_error_output(ctx, "search", code="INVALID_PARAM", message="未提供 query，请传入搜索关键词或 --preset")
+		return
 
 	if city and city not in CITY_CODES:
 		handle_error_output(

--- a/src/boss_agent_cli/main.py
+++ b/src/boss_agent_cli/main.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import click
 
-from boss_agent_cli.commands import schema, login, logout, status, doctor, search, detail, greet, recommend, export, cities, me, chat, chatmsg, chat_summary, mark, exchange, interviews, show, history, watch, pipeline, apply, shortlist
+from boss_agent_cli.commands import schema, login, logout, status, doctor, search, detail, greet, recommend, export, cities, me, chat, chatmsg, chat_summary, mark, exchange, interviews, show, history, watch, pipeline, apply, shortlist, preset
 from boss_agent_cli.config import load_config
 from boss_agent_cli.hooks import create_hook_bus
 from boss_agent_cli.output import Logger
@@ -64,3 +64,4 @@ cli.add_command(pipeline.pipeline_cmd, "pipeline")
 cli.add_command(pipeline.follow_up_cmd, "follow-up")
 cli.add_command(apply.apply_cmd, "apply")
 cli.add_command(shortlist.shortlist_group, "shortlist")
+cli.add_command(preset.preset_group, "preset")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -133,7 +133,8 @@ def test_schema_includes_new_commands():
 	assert "apply" in commands
 	assert "shortlist" in commands
 	assert "chat-summary" in commands
-	assert len(commands) >= 24
+	assert "preset" in commands
+	assert len(commands) >= 25
 
 
 @patch("boss_agent_cli.commands.doctor.extract_cookies")

--- a/tests/test_preset.py
+++ b/tests/test_preset.py
@@ -1,0 +1,107 @@
+import json
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from boss_agent_cli.main import cli
+
+
+def _ctx_mock(mock_cls):
+	instance = mock_cls.return_value
+	instance.__enter__ = lambda self: self
+	instance.__exit__ = lambda self, *a: None
+	return instance
+
+
+def _job():
+	return {
+		"encryptJobId": "job_001",
+		"jobName": "Go 开发",
+		"brandName": "TestCo",
+		"salaryDesc": "20-30K",
+		"cityName": "广州",
+		"areaDistrict": "天河区",
+		"jobExperience": "3-5年",
+		"jobDegree": "本科",
+		"skills": ["Go"],
+		"welfareList": ["双休"],
+		"brandIndustry": "互联网",
+		"brandScaleName": "100-499人",
+		"brandStageName": "A轮",
+		"bossName": "李",
+		"bossTitle": "HR",
+		"bossOnline": True,
+		"securityId": "sec_001",
+	}
+
+
+def test_preset_add_list_remove(tmp_path):
+	runner = CliRunner()
+	add_result = runner.invoke(
+		cli,
+		[
+			"--data-dir", str(tmp_path),
+			"--json",
+			"preset", "add", "golang-gz", "golang",
+			"--city", "广州",
+			"--salary", "20-50K",
+		],
+	)
+	assert add_result.exit_code == 0
+	add_parsed = json.loads(add_result.output)
+	assert add_parsed["data"]["name"] == "golang-gz"
+
+	list_result = runner.invoke(cli, ["--data-dir", str(tmp_path), "--json", "preset", "list"])
+	assert list_result.exit_code == 0
+	list_parsed = json.loads(list_result.output)
+	assert list_parsed["data"][0]["name"] == "golang-gz"
+
+	remove_result = runner.invoke(cli, ["--data-dir", str(tmp_path), "--json", "preset", "remove", "golang-gz"])
+	assert remove_result.exit_code == 0
+	remove_parsed = json.loads(remove_result.output)
+	assert remove_parsed["data"]["removed"] is True
+
+
+@patch("boss_agent_cli.commands.search.BossClient")
+@patch("boss_agent_cli.commands.search.AuthManager")
+@patch("boss_agent_cli.commands.search.CacheStore")
+@patch("boss_agent_cli.commands.search.try_save_index")
+def test_search_can_use_preset(mock_save, mock_cache_cls, mock_auth_cls, mock_client_cls, tmp_path):
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.get_search.return_value = None
+	mock_cache.get_saved_search.return_value = {
+		"name": "golang-gz",
+		"params": {"query": "golang", "city": "广州", "salary": "20-50K"},
+	}
+	mock_cache.is_greeted.return_value = False
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.search_jobs.return_value = {"zpData": {"hasMore": False, "jobList": [_job()]}}
+
+	runner = CliRunner()
+	runner.invoke(
+		cli,
+		[
+			"--data-dir", str(tmp_path),
+			"--json",
+			"preset", "add", "golang-gz", "golang",
+			"--city", "广州",
+			"--salary", "20-50K",
+		],
+	)
+
+	result = runner.invoke(cli, ["--data-dir", str(tmp_path), "--json", "search", "--preset", "golang-gz"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"][0]["title"] == "Go 开发"
+	mock_client.search_jobs.assert_called_once()
+	assert mock_client.search_jobs.call_args.kwargs["city"] == "广州"
+	assert mock_client.search_jobs.call_args.kwargs["salary"] == "20-50K"
+
+
+def test_preset_schema_is_exposed():
+	runner = CliRunner()
+	result = runner.invoke(cli, ["schema"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert "preset" in parsed["data"]["commands"]


### PR DESCRIPTION
## Summary
- 新增 preset 命令组（add/list/remove），把已存在的 saved_searches 存储提升为可复用搜索预设能力
- 为 search 增加 --preset 入口，支持从预设恢复搜索参数并允许命令行参数覆盖
- 更新 schema 与测试，为后续 export/pipeline/digest 复用搜索预设打基础

## Test Plan
- env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest tests/test_preset.py tests/test_commands.py -q
- env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest tests/ -q
- /Users/can4hou6joeng4/Documents/code/boss-agent-cli/.worktrees/codex-p1-wave4/.venv/bin/ruff check /Users/can4hou6joeng4/Documents/code/boss-agent-cli/.worktrees/codex-p1-wave4/src /Users/can4hou6joeng4/Documents/code/boss-agent-cli/.worktrees/codex-p1-wave4/tests