### PR TITLE
fix: detail 命令 httpx 快速通道失败时降级到浏览器通道

### DIFF
--- a/src/boss_agent_cli/commands/detail.py
+++ b/src/boss_agent_cli/commands/detail.py
@@ -1,6 +1,6 @@
 import click
 
-from boss_agent_cli.api.client import AuthError, BossClient
+from boss_agent_cli.api.client import BossClient
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.cache.store import CacheStore
 from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_job_detail
@@ -32,7 +32,7 @@ def detail_cmd(ctx, security_id, lid, job_id):
 		if job_id:
 			try:
 				result = _detail_via_httpx(client, security_id, job_id, data_dir)
-			except (AuthError, Exception) as e:
+			except Exception as e:
 				logger.info(f"httpx 快速通道失败（{e}），降级到浏览器通道")
 				result = None
 		if result is None:

--- a/src/boss_agent_cli/commands/detail.py
+++ b/src/boss_agent_cli/commands/detail.py
@@ -1,6 +1,6 @@
 import click
 
-from boss_agent_cli.api.client import BossClient
+from boss_agent_cli.api.client import AuthError, BossClient
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.cache.store import CacheStore
 from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_job_detail
@@ -28,9 +28,14 @@ def detail_cmd(ctx, security_id, lid, job_id):
 			if job_id:
 				logger.info("从缓存命中 job_id，走 httpx 快速通道")
 
+		result = None
 		if job_id:
-			result = _detail_via_httpx(client, security_id, job_id, data_dir)
-		else:
+			try:
+				result = _detail_via_httpx(client, security_id, job_id, data_dir)
+			except (AuthError, Exception) as e:
+				logger.info(f"httpx 快速通道失败（{e}），降级到浏览器通道")
+				result = None
+		if result is None:
 			result = _detail_via_browser(client, security_id, lid, data_dir)
 
 	if result is None:

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -288,6 +288,84 @@ def test_detail_uses_client_context_manager(mock_auth_cls, mock_client_cls, mock
 	instance.__exit__.assert_called_once()
 
 
+@patch("boss_agent_cli.commands.detail.CacheStore")
+@patch("boss_agent_cli.commands.detail.BossClient")
+@patch("boss_agent_cli.commands.detail.AuthManager")
+def test_detail_httpx_fallback_to_browser_on_auth_error(mock_auth_cls, mock_client_cls, mock_cache_cls):
+	"""httpx 快速通道因 AuthError 失败时，应降级到浏览器通道而非直接报错"""
+	from boss_agent_cli.api.client import AuthError
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.is_greeted.return_value = False
+	mock_cache.get_job_id.return_value = ""
+	mock_client = _ctx_mock(mock_client_cls)
+	# httpx 通道抛 AuthError（stoken 过期刷新失败）
+	mock_client.job_detail.side_effect = AuthError("stoken refresh failed")
+	# 浏览器通道返回正常数据
+	mock_client.job_card.return_value = {
+		"zpData": {
+			"jobCard": {
+				"encryptJobId": "enc_001",
+				"jobName": "Go 开发",
+				"brandName": "TestCo",
+				"salaryDesc": "30K",
+				"cityName": "北京",
+				"experienceName": "3-5年",
+				"degreeName": "本科",
+				"postDescription": "JD 描述",
+				"bossName": "张总",
+				"bossTitle": "CTO",
+				"activeTimeDesc": "刚刚活跃",
+			}
+		}
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["detail", "sec_001", "--job-id", "enc_001"])
+	assert result.exit_code == 0, f"exit_code={result.exit_code}, output={result.output}"
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["title"] == "Go 开发"
+	# 确认 httpx 被调用后又降级到了浏览器通道
+	mock_client.job_detail.assert_called_once()
+	mock_client.job_card.assert_called_once()
+
+
+@patch("boss_agent_cli.commands.detail.CacheStore")
+@patch("boss_agent_cli.commands.detail.BossClient")
+@patch("boss_agent_cli.commands.detail.AuthManager")
+def test_detail_httpx_fallback_to_browser_on_none(mock_auth_cls, mock_client_cls, mock_cache_cls):
+	"""httpx 快速通道返回空 jobInfo 时，应降级到浏览器通道"""
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.is_greeted.return_value = False
+	mock_cache.get_job_id.return_value = ""
+	mock_client = _ctx_mock(mock_client_cls)
+	# httpx 返回无 jobInfo（解析后 result=None）
+	mock_client.job_detail.return_value = {"zpData": {"jobInfo": {}}}
+	# 浏览器通道返回正常数据
+	mock_client.job_card.return_value = {
+		"zpData": {
+			"jobCard": {
+				"encryptJobId": "enc_001",
+				"jobName": "Go 开发",
+				"brandName": "FallbackCo",
+				"salaryDesc": "25K",
+				"cityName": "深圳",
+				"experienceName": "1-3年",
+				"degreeName": "大专",
+				"postDescription": "降级 JD",
+				"bossName": "李总",
+				"bossTitle": "HR",
+				"activeTimeDesc": "在线",
+			}
+		}
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["detail", "sec_001", "--job-id", "enc_001"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["company"] == "FallbackCo"
+
+
 @patch("boss_agent_cli.commands.show.CacheStore")
 @patch("boss_agent_cli.commands.show.get_job_by_index")
 @patch("boss_agent_cli.commands.show.BossClient")


### PR DESCRIPTION
## Summary
- `boss detail --job-id` 走 httpx 快速通道时，若 stoken 过期导致 `AuthError` 或 API 返回空数据，现在会自动降级到浏览器通道（`job_card`）获取职位详情，而非直接报 `JOB_NOT_FOUND`
- 新增 2 个测试用例覆盖 AuthError 降级和空数据降级场景

## 问题复现
1. stoken 过期且 CDP Chrome 未启动
2. `boss detail <sid> --job-id <jid>` → httpx 通道 stoken 刷新失败 → 报 `JOB_NOT_FOUND`
3. 实际上职位存在，只是 httpx 通道鉴权失败

## 修复方案
`detail_cmd` 中 `_detail_via_httpx` 失败时 catch 异常，降级到 `_detail_via_browser`（浏览器通道自身生成 stoken，不依赖本地存储）

## Test plan
- [x] `test_detail_httpx_fallback_to_browser_on_auth_error` — AuthError 降级
- [x] `test_detail_httpx_fallback_to_browser_on_none` — 空数据降级
- [x] 原有 `test_detail_with_job_id` / `test_detail_uses_client_context_manager` 无回归
- [x] 全量 252 测试通过