### PR TITLE
docs: 增加多宿主集成示例

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ boss export "Golang" --city 广州 --count 50 -o jobs.csv
 
 推荐先阅读：
 - [Agent Quickstart](docs/agent-quickstart.md)
+- [Agent Host Examples](docs/agent-hosts.md)
 - [Capability Matrix](docs/capability-matrix.md)
 
 ### 方式一：Skill 安装（推荐）

--- a/docs/agent-hosts.md
+++ b/docs/agent-hosts.md
@@ -1,0 +1,30 @@
+# Agent Host Examples
+
+面向不同 Agent 宿主的最小接入索引，目标是把 `boss-agent-cli` 变成“复制就能接”的工具，而不是需要二次猜测的协议。
+
+当前示例覆盖的 CLI 基线：
+- 通过 `boss schema` 做能力发现
+- 通过 `boss status` 确认登录态
+- 通过 `boss search` / `boss detail` / `boss greet` 跑通最小行动闭环
+- 通过 JSON 信封读取 `ok`、`data`、`error.code`、`error.recovery_action`
+
+## 示例列表
+
+| 宿主 | 适合场景 | 示例 |
+|---|---|---|
+| Codex | 在终端内直接做 Bash 编排和 JSON 解析 | [Codex](integrations/codex.md) |
+| Claude Code | 通过 skill / 规则文件接入求职动作 | [Claude Code](integrations/claude-code.md) |
+| Shell Agent | 任意支持 shell tool 的 Agent 框架或自建编排器 | [Shell Agent](integrations/shell-agent.md) |
+
+## 选型建议
+
+- 如果 Agent 原生支持终端和多步工具调用，优先看 `Codex`
+- 如果你已经在用 skill 分发和规则驱动，优先看 `Claude Code`
+- 如果你有自己的 Agent 宿主或调度器，优先看 `Shell Agent`
+
+## 共同接入原则
+
+1. 首次接入先跑 `boss schema`，不要硬编码命令表。
+2. 所有成功/失败都以 stdout JSON 信封为准，不要解析 stderr。
+3. 把 `boss doctor`、`boss login`、`boss status` 当成统一恢复入口。
+4. 用户提到福利要求时，优先把条件落到 `--welfare`。

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -16,6 +16,8 @@ boss status
 - `boss doctor` 返回 `ok=true`
 - `boss status` 返回当前登录态
 
+如果你不是直接在终端里手动跑命令，而是准备把它接进 Agent 宿主，先看 [Agent Host Examples](agent-hosts.md) 选择对应接入模板。
+
 ## 2) 三步跑通 Agent 闭环
 
 ```bash
@@ -50,4 +52,6 @@ boss status
 - `RATE_LIMITED`：等待后重试
 - `INVALID_PARAM`：校正参数（城市、福利、页码等）
 
-能力映射明细见 [Capability Matrix](capability-matrix.md)。
+延伸阅读：
+- [Agent Host Examples](agent-hosts.md)
+- [Capability Matrix](capability-matrix.md)

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -1,0 +1,63 @@
+# Claude Code Integration Example
+
+适用版本：`boss-agent-cli` 当前 CLI 契约（2026-04-13）
+
+## 适用场景
+
+- 团队通过 skill 分发统一的求职能力
+- 希望 Agent 在规则文件里固定 BOSS 直聘操作顺序
+- 需要把 `boss` 命令当成稳定 shell 能力暴露给 Claude Code
+
+## 最小接入流程
+
+优先安装 skill：
+
+```bash
+npx skills add can4hou6joeng4/boss-agent-cli
+```
+
+如果你走规则文件方式，可以直接放入以下约束：
+
+```markdown
+当用户要求搜索职位、查看职位详情、打招呼或推进招聘沟通时：
+1. 先运行 boss schema
+2. 再运行 boss status
+3. 未登录时运行 boss login
+4. 搜索使用 boss search
+5. 查看详情使用 boss detail
+6. 执行动作使用 boss greet
+7. 只读取 stdout JSON，不解析 stderr
+```
+
+最小命令链路：
+
+```bash
+boss schema
+boss status
+boss search "Golang" --city 广州 --welfare "双休,五险一金"
+boss detail <security_id>
+boss greet <security_id> <job_id>
+```
+
+接入建议：
+
+- 把 `boss schema` 结果当成能力真源
+- 把 `boss detail` 返回结果拼回上下文，再决定是否 `boss greet`
+- 遇到 `ok=false` 时优先消费 `error.recovery_action`
+
+## 失败恢复
+
+推荐恢复顺序：
+
+```bash
+boss doctor
+boss status
+boss login
+boss search "Golang" --city 广州
+```
+
+常见恢复动作：
+
+- 登录失效：重新执行 `boss login`
+- 参数错误：回到 `boss schema` 或 `boss cities`
+- 环境异常：先跑 `boss doctor`，再决定是否继续 `boss greet`

--- a/docs/integrations/codex.md
+++ b/docs/integrations/codex.md
@@ -1,0 +1,59 @@
+# Codex Integration Example
+
+适用版本：`boss-agent-cli` 当前 CLI 契约（2026-04-13）
+
+## 适用场景
+
+- Agent 直接运行终端命令
+- 需要多步串联 `schema -> status -> search -> detail -> greet`
+- 需要把 stdout JSON 结果继续喂给后续决策
+
+## 最小接入流程
+
+先让 Agent 遵守这条工作习惯：
+
+```text
+当任务涉及 BOSS 直聘搜索、查看详情、打招呼或推进候选流程时：
+1. 先运行 boss schema 获取能力与参数
+2. 再运行 boss status 检查登录态
+3. 未登录时执行 boss login，并提示用户完成扫码
+4. 搜索时优先调用 boss search
+5. 命中目标后调用 boss detail
+6. 需要主动触达时调用 boss greet
+7. 只解析 stdout JSON，ok=false 时读取 error.code 与 error.recovery_action
+```
+
+最小命令链路：
+
+```bash
+boss schema
+boss status
+boss search "Golang" --city 广州 --welfare "双休,五险一金"
+boss detail <security_id>
+boss greet <security_id> <job_id>
+```
+
+推荐解析字段：
+
+- `ok`: 判断命令是否成功
+- `data`: 读取职位、详情或动作结果
+- `hints.next_actions`: 决定下一条命令
+- `error.code`: 做恢复分流
+- `error.recovery_action`: 告诉 Agent 如何修复
+
+## 失败恢复
+
+优先按这个顺序恢复：
+
+```bash
+boss doctor
+boss status
+boss login
+boss search "Golang" --city 广州
+```
+
+常见分流：
+
+- `AUTH_REQUIRED` / `AUTH_EXPIRED`: 重新执行 `boss login`
+- `INVALID_PARAM`: 回退到 `boss schema` 校验参数
+- `RATE_LIMITED`: 等待后重试，不要盲目连发 `boss greet`

--- a/docs/integrations/shell-agent.md
+++ b/docs/integrations/shell-agent.md
@@ -1,0 +1,61 @@
+# Shell Agent Integration Example
+
+适用版本：`boss-agent-cli` 当前 CLI 契约（2026-04-13）
+
+## 适用场景
+
+- 你的 Agent 框架只需要一个 shell/subprocess tool
+- 你希望把 `boss` 作为可复用外部命令挂到已有编排器
+- 你需要最通用、最少依赖的接入方式
+
+## 最小接入流程
+
+核心原则：让宿主只负责“运行命令 + 解析 JSON”，不要自己重写 BOSS 直聘协议。
+
+推荐包装流程：
+
+```text
+1. 运行 boss schema
+2. 运行 boss status
+3. 未登录时运行 boss login
+4. 运行 boss search
+5. 运行 boss detail
+6. 满足条件时运行 boss greet
+```
+
+最小命令链路：
+
+```bash
+boss schema
+boss status
+boss search "Golang" --city 广州 --welfare "双休,五险一金"
+boss detail <security_id>
+boss greet <security_id> <job_id>
+```
+
+如果宿主支持单函数包装，建议包装成：
+
+```python
+def run_boss(*args: str) -> dict:
+	result = subprocess.run(["boss", *args], check=False, capture_output=True, text=True)
+	return json.loads(result.stdout)
+```
+
+然后让上层只依赖返回的 JSON 信封字段。
+
+## 失败恢复
+
+标准恢复顺序：
+
+```bash
+boss doctor
+boss status
+boss login
+boss search "Golang" --city 广州
+```
+
+通用处理建议：
+
+- `ok=false` 时不要继续后续动作
+- `AUTH_REQUIRED` 时先恢复登录，再重试 `boss search`
+- `RATE_LIMITED` 时暂停，不要继续 `boss greet`

--- a/docs/superpowers/plans/2026-04-13-p2-wave1.md
+++ b/docs/superpowers/plans/2026-04-13-p2-wave1.md
@@ -1,0 +1,27 @@
+# P2 Wave 1 Implementation Plan
+
+> **Goal:** Add first-class multi-host integration examples so downstream agents can adopt `boss-agent-cli` with copy/paste effort instead of manual interpretation.
+
+## Planned File Touches
+
+- Create: `docs/agent-hosts.md`
+- Create: `docs/integrations/codex.md`
+- Create: `docs/integrations/claude-code.md`
+- Create: `docs/integrations/shell-agent.md`
+- Modify: `docs/agent-quickstart.md`
+- Modify: `README.md`
+- Create: `tests/test_agent_host_examples.py`
+- Create: `docs/superpowers/plans/2026-04-13-p2-wave1.md`
+
+## Scope
+
+- Multi-host integration index
+- Codex / Claude Code / generic shell host examples
+- Centralized README and quickstart links
+- Doc contract tests to reduce drift
+
+## Out of Scope
+
+- Live host-specific SDK packages
+- Networked integration tests
+- New CLI surface area

--- a/tests/test_agent_host_examples.py
+++ b/tests/test_agent_host_examples.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCS_ROOT = REPO_ROOT / "docs"
+INDEX_DOC = DOCS_ROOT / "agent-hosts.md"
+HOST_DOCS = {
+	"Codex": DOCS_ROOT / "integrations" / "codex.md",
+	"Claude Code": DOCS_ROOT / "integrations" / "claude-code.md",
+	"Shell Agent": DOCS_ROOT / "integrations" / "shell-agent.md",
+}
+REQUIRED_COMMANDS = [
+	"boss schema",
+	"boss status",
+	"boss search",
+	"boss detail",
+	"boss greet",
+]
+
+
+def _read(path: Path) -> str:
+	return path.read_text(encoding="utf-8")
+
+
+def test_agent_host_index_links_all_examples():
+	assert INDEX_DOC.exists()
+	index_text = _read(INDEX_DOC)
+
+	for host_name, path in HOST_DOCS.items():
+		assert path.exists()
+		assert f"[{host_name}](" in index_text
+		assert path.name in index_text
+
+
+def test_agent_host_examples_cover_core_agent_loop():
+	for host_name, path in HOST_DOCS.items():
+		text = _read(path)
+		assert "## 适用场景" in text, host_name
+		assert "## 最小接入流程" in text, host_name
+		assert "## 失败恢复" in text, host_name
+		for command in REQUIRED_COMMANDS:
+			assert command in text, f"{host_name} missing {command}"
+
+
+def test_readme_and_quickstart_link_to_host_examples():
+	readme_text = _read(REPO_ROOT / "README.md")
+	quickstart_text = _read(DOCS_ROOT / "agent-quickstart.md")
+
+	assert "docs/agent-hosts.md" in readme_text
+	assert "agent-hosts.md" in quickstart_text


### PR DESCRIPTION
## 改动内容

- 新增 `docs/agent-hosts.md` 多宿主接入索引
- 新增 `docs/integrations/` 下三份集成指南（Codex / Claude Code / Shell Agent）
- 更新 `README.md` 和 `docs/agent-quickstart.md` 添加索引链接
- 新增 `tests/test_agent_host_examples.py` 文档合约测试
- 新增 `docs/superpowers/plans/2026-04-13-p2-wave1.md` 实施计划

## 审查修复

- 恢复 `detail.py` 快速通道失败降级到浏览器通道的逻辑（被误删）
- 恢复 `test_new_commands.py` 中两个降级测试用例（被误删）
- 恢复 `CHANGELOG.md` 的 Unreleased 段和正确的版本历史（被破坏）

## 测试

255 个测试全绿，lint 通过