### PR TITLE
test: 补齐四个核心模块测试覆盖

### DIFF
--- a/tests/test_chat_export_extended.py
+++ b/tests/test_chat_export_extended.py
@@ -1,0 +1,517 @@
+"""chat_export.py 扩展测试 — CSV/MD/HTML/JSON 渲染、注入防护、边界场景。"""
+
+import json
+
+from boss_agent_cli.commands.chat_export import (
+	render_export,
+	prepare_render_data,
+)
+from boss_agent_cli.commands.chat_utils import sanitize_csv_cell, escape_md_cell
+
+
+# ── 测试数据工厂 ────────────────────────────────────────────────────
+
+
+def _make_friend(
+	name="张HR",
+	brand_name="阿里",
+	initiated_by="对方主动",
+	last_msg="你好",
+	security_id="sec_001",
+	unread=0,
+	msg_status="已读",
+	**overrides,
+):
+	base = {
+		"name": name,
+		"title": "招聘经理",
+		"brand_name": brand_name,
+		"initiated_by": initiated_by,
+		"last_msg": last_msg,
+		"last_time": "今天 10:00",
+		"last_ts": 1700000000000,
+		"msg_status": msg_status,
+		"security_id": security_id,
+		"encrypt_job_id": "job_001",
+		"unread": unread,
+	}
+	base.update(overrides)
+	return base
+
+
+_NO_DIFF = {"is_first": True, "added": [], "removed": [], "new_unread": []}
+
+
+# ── CSV 公式注入防护 ────────────────────────────────────────────────
+
+
+def test_sanitize_csv_cell_equal_sign():
+	"""以 = 开头的值应被前置单引号"""
+	assert sanitize_csv_cell("=cmd|' /C calc'!A0") == "'=cmd|' /C calc'!A0"
+
+
+def test_sanitize_csv_cell_plus_sign():
+	"""以 + 开头的值应被前置单引号"""
+	assert sanitize_csv_cell("+SUM(A1:A2)") == "'+SUM(A1:A2)"
+
+
+def test_sanitize_csv_cell_minus_sign():
+	"""以 - 开头的值应被前置单引号"""
+	assert sanitize_csv_cell("-1+2") == "'-1+2"
+
+
+def test_sanitize_csv_cell_at_sign():
+	"""以 @ 开头的值应被前置单引号"""
+	assert sanitize_csv_cell("@risk") == "'@risk"
+
+
+def test_sanitize_csv_cell_normal_text():
+	"""正常文本不应被修改"""
+	assert sanitize_csv_cell("正常文本") == "正常文本"
+	assert sanitize_csv_cell("") == ""
+	assert sanitize_csv_cell("hello world") == "hello world"
+
+
+def test_sanitize_csv_cell_tab_and_cr_stripped():
+	"""Tab 和回车应被替换/移除"""
+	assert "\t" not in sanitize_csv_cell("有\tTab")
+	assert "\r" not in sanitize_csv_cell("有\r回车")
+
+
+def test_sanitize_csv_cell_non_string_input():
+	"""非字符串输入应被转为字符串"""
+	assert sanitize_csv_cell(123) == "123"
+	assert sanitize_csv_cell(None) == "None"
+
+
+def test_csv_export_formula_injection_in_render():
+	"""CSV 渲染结果中以危险字符开头的字段应被转义"""
+	friends = [_make_friend(
+		name="=cmd|' /C calc'!A0",
+		last_msg="+SUM(A1)",
+		brand_name="@evil_corp",
+	)]
+	csv_text = render_export(friends, "csv", None, None, _NO_DIFF)
+	# 所有危险开头都应被转义
+	assert "'=cmd" in csv_text
+	assert "'+SUM" in csv_text
+	assert "'@evil" in csv_text
+
+
+# ── MD 表格注入防护 ─────────────────────────────────────────────────
+
+
+def test_escape_md_cell_pipe():
+	"""管道符应被转义为 \\|"""
+	assert escape_md_cell("消息|含管道符") == "消息\\|含管道符"
+
+
+def test_escape_md_cell_newline():
+	"""换行应被替换为空格"""
+	assert escape_md_cell("多行\n消息") == "多行 消息"
+
+
+def test_escape_md_cell_carriage_return():
+	"""回车应被移除"""
+	assert escape_md_cell("带\r回车") == "带回车"
+
+
+def test_escape_md_cell_normal():
+	"""正常文本不应被修改"""
+	assert escape_md_cell("正常") == "正常"
+
+
+def test_escape_md_cell_non_string():
+	"""非字符串输入应被转为字符串"""
+	assert escape_md_cell(42) == "42"
+
+
+def test_md_export_pipe_injection_in_render():
+	"""MD 渲染结果中管道符和换行应被正确转义"""
+	friends = [_make_friend(
+		name="张|HR",
+		last_msg="你好\n请看简历",
+		brand_name="测试公司",
+	)]
+	md_text = render_export(friends, "md", None, None, _NO_DIFF)
+	# 管道符应被转义，换行应被替换
+	assert "张\\|HR" in md_text
+	assert "你好 请看简历" in md_text
+	# 主数据表格行中（排除 id_map 映射表）应有转义后的管道符
+	for line in md_text.split("\n"):
+		# 主表行以 "| S" 或 "| NEW S" 开头，且包含联系人名
+		if line.startswith("|") and "测试公司" in line and "张" in line:
+			assert "张\\|HR" in line
+			break
+
+
+# ── HTML 导出格式正确性 ─────────────────────────────────────────────
+
+
+def test_html_export_basic_structure():
+	"""HTML 导出应包含基本 HTML 结构"""
+	friends = [_make_friend()]
+	html = render_export(friends, "html", None, None, _NO_DIFF)
+	assert "<!DOCTYPE html>" in html
+	assert "<html" in html
+	assert "BOSS 直聘沟通列表" in html
+	assert "<table>" in html
+	assert "</html>" in html
+
+
+def test_html_export_contains_data():
+	"""HTML 导出应包含实际数据"""
+	friends = [_make_friend(name="李HR", brand_name="腾讯")]
+	html = render_export(friends, "html", None, None, _NO_DIFF)
+	assert "李HR" in html
+	assert "腾讯" in html
+	assert "S1" in html  # 编号
+
+
+def test_html_export_xss_prevention():
+	"""HTML 导出应转义危险字符，防止 XSS"""
+	friends = [_make_friend(
+		name="<script>alert(1)</script>",
+		brand_name="公司&名",
+		last_msg='<img onerror="alert(1)">',
+	)]
+	html = render_export(friends, "html", None, None, _NO_DIFF)
+	assert "<script>" not in html
+	assert '<img onerror' not in html
+	assert "&lt;script&gt;" in html
+	assert "&amp;名" in html
+
+
+def test_html_export_with_diff():
+	"""HTML 导出应包含 diff 摘要"""
+	diff_result = {
+		"is_first": False,
+		"prev_date": "2026-04-12",
+		"added": [_make_friend(security_id="sec_new")],
+		"removed": [],
+		"new_unread": [],
+	}
+	friends = [_make_friend(), _make_friend(security_id="sec_new", name="新HR")]
+	html = render_export(friends, "html", None, None, diff_result)
+	assert "新增 1 条" in html
+	assert "2026-04-12" in html
+
+
+def test_html_export_with_removed():
+	"""HTML 导出包含消失条目时应渲染消失表格"""
+	diff_result = {
+		"is_first": False,
+		"prev_date": "2026-04-12",
+		"added": [],
+		"removed": [{"brand_name": "旧公司", "name": "旧HR", "last_time": "昨天"}],
+		"new_unread": [],
+	}
+	friends = [_make_friend()]
+	html = render_export(friends, "html", None, None, diff_result)
+	assert "已消失" in html
+	assert "旧公司" in html
+	assert "旧HR" in html
+
+
+def test_html_export_unread_badge():
+	"""有未读消息时应渲染 unread badge"""
+	friends = [_make_friend(unread=3)]
+	html = render_export(friends, "html", None, None, _NO_DIFF)
+	assert 'class="unread"' in html
+	assert ">3<" in html
+
+
+def test_html_export_new_badge():
+	"""新增条目应渲染 NEW badge"""
+	new_friend = _make_friend(security_id="sec_new", name="新HR")
+	diff_result = {
+		"is_first": False,
+		"prev_date": "2026-04-12",
+		"added": [new_friend],
+		"removed": [],
+		"new_unread": [],
+	}
+	friends = [new_friend]
+	html = render_export(friends, "html", None, None, diff_result)
+	assert "badge-new" in html
+	assert "NEW" in html
+
+
+# ── JSON 导出格式正确性 ─────────────────────────────────────────────
+
+
+def test_json_export_basic():
+	"""JSON 导出应返回有效的 JSON 数组"""
+	friends = [_make_friend(), _make_friend(name="李HR", security_id="sec_002")]
+	json_text = render_export(friends, "json", None, None, _NO_DIFF)
+	parsed = json.loads(json_text)
+	assert isinstance(parsed, list)
+	assert len(parsed) == 2
+	assert parsed[0]["name"] == "张HR"
+	assert parsed[1]["name"] == "李HR"
+
+
+def test_json_export_preserves_all_fields():
+	"""JSON 导出应保留所有字段"""
+	friends = [_make_friend()]
+	json_text = render_export(friends, "json", None, None, _NO_DIFF)
+	parsed = json.loads(json_text)
+	item = parsed[0]
+	assert "name" in item
+	assert "title" in item
+	assert "brand_name" in item
+	assert "security_id" in item
+	assert "encrypt_job_id" in item
+	assert "unread" in item
+	assert "msg_status" in item
+
+
+def test_json_export_ensure_ascii_false():
+	"""JSON 导出应保留中文字符（不转为 unicode escape）"""
+	friends = [_make_friend(name="中文名")]
+	json_text = render_export(friends, "json", None, None, _NO_DIFF)
+	assert "中文名" in json_text
+	assert "\\u" not in json_text
+
+
+def test_json_export_empty():
+	"""空列表 JSON 导出应返回空数组"""
+	json_text = render_export([], "json", None, None, _NO_DIFF)
+	parsed = json.loads(json_text)
+	assert parsed == []
+
+
+# ── 空数据导出边界 ──────────────────────────────────────────────────
+
+
+def test_csv_export_empty():
+	"""空列表 CSV 导出应返回空字符串"""
+	csv_text = render_export([], "csv", None, None, _NO_DIFF)
+	assert csv_text == ""
+
+
+def test_md_export_empty():
+	"""空列表 MD 导出应包含标题但无数据行"""
+	md_text = render_export([], "md", None, None, _NO_DIFF)
+	assert "BOSS 直聘沟通列表" in md_text
+	assert "总计：0 条" in md_text
+	# 不应有数据编号
+	assert "S1" not in md_text
+
+
+def test_html_export_empty():
+	"""空列表 HTML 导出应包含基本结构但无数据行"""
+	html = render_export([], "html", None, None, _NO_DIFF)
+	assert "<!DOCTYPE html>" in html
+	assert "总计：0 条" in html
+	assert "S1" not in html
+
+
+# ── None 字段兜底 ───────────────────────────────────────────────────
+
+
+def test_none_fields_md_no_crash():
+	"""字段为 None 时 MD 渲染不应崩溃"""
+	friends = [{
+		"name": None,
+		"title": None,
+		"brand_name": None,
+		"initiated_by": "对方主动",
+		"last_msg": None,
+		"last_time": None,
+		"last_ts": 0,
+		"msg_status": None,
+		"security_id": "sec_null",
+		"encrypt_job_id": None,
+		"unread": None,
+	}]
+	md_text = render_export(friends, "md", None, None, _NO_DIFF)
+	assert "sec_null" in md_text
+	# None 应被兜底为 "-"
+	assert "S1" in md_text
+
+
+def test_none_fields_html_no_crash():
+	"""字段为 None 时 HTML 渲染不应崩溃"""
+	friends = [{
+		"name": None,
+		"title": None,
+		"brand_name": None,
+		"initiated_by": "我主动",
+		"last_msg": None,
+		"last_time": None,
+		"last_ts": 0,
+		"msg_status": None,
+		"security_id": "sec_null",
+		"encrypt_job_id": None,
+		"unread": None,
+	}]
+	html = render_export(friends, "html", None, None, _NO_DIFF)
+	assert "<!DOCTYPE html>" in html
+	assert "sec_null" in html
+
+
+def test_none_fields_csv_no_crash():
+	"""字段为 None 时 CSV 渲染不应崩溃"""
+	friends = [{
+		"name": None,
+		"title": None,
+		"brand_name": None,
+		"initiated_by": "对方主动",
+		"last_msg": None,
+		"last_time": None,
+		"msg_status": None,
+		"security_id": "sec_null",
+		"encrypt_job_id": None,
+		"unread": None,
+	}]
+	csv_text = render_export(friends, "csv", None, None, _NO_DIFF)
+	assert "name" in csv_text  # 表头
+	assert "None" in csv_text or "sec_null" in csv_text
+
+
+# ── prepare_render_data 逻辑 ────────────────────────────────────────
+
+
+def test_prepare_render_data_grouping():
+	"""数据应按 initiated_by 分组"""
+	friends = [
+		_make_friend(initiated_by="对方主动", security_id="sec_1"),
+		_make_friend(initiated_by="我主动", security_id="sec_2"),
+		_make_friend(initiated_by="对方主动", security_id="sec_3"),
+	]
+	rd = prepare_render_data(friends, None, _NO_DIFF)
+	assert rd["total"] == 3
+	# 应有两个分组
+	assert len(rd["sections"]) == 2
+	# 对方主动应有 2 条
+	boss_section = [s for s in rd["sections"] if "对方主动" in s["subtitle"]][0]
+	assert len(boss_section["rows"]) == 2
+
+
+def test_prepare_render_data_filter_boss():
+	"""from_who='boss' 只应返回对方主动分组"""
+	friends = [
+		_make_friend(initiated_by="对方主动", security_id="sec_1"),
+		_make_friend(initiated_by="我主动", security_id="sec_2"),
+	]
+	rd = prepare_render_data(friends, "boss", _NO_DIFF)
+	assert len(rd["sections"]) == 1
+	assert "对方主动" in rd["sections"][0]["subtitle"]
+
+
+def test_prepare_render_data_filter_me():
+	"""from_who='me' 只应返回我主动分组"""
+	friends = [
+		_make_friend(initiated_by="对方主动", security_id="sec_1"),
+		_make_friend(initiated_by="我主动", security_id="sec_2"),
+	]
+	rd = prepare_render_data(friends, "me", _NO_DIFF)
+	assert len(rd["sections"]) == 1
+	assert "我主动" in rd["sections"][0]["subtitle"]
+
+
+def test_prepare_render_data_unknown_group():
+	"""未知的 initiated_by 值应创建独立分组"""
+	friends = [_make_friend(initiated_by="神秘来源", security_id="sec_1")]
+	rd = prepare_render_data(friends, None, _NO_DIFF)
+	assert len(rd["sections"]) == 1
+	assert "神秘来源" in rd["sections"][0]["subtitle"]
+
+
+def test_prepare_render_data_diff_summary():
+	"""有 diff 时应生成摘要"""
+	diff_result = {
+		"is_first": False,
+		"prev_date": "2026-04-12",
+		"added": [_make_friend(security_id="sec_new")],
+		"removed": [_make_friend(security_id="sec_old")],
+		"new_unread": [_make_friend(security_id="sec_unread")],
+	}
+	friends = [_make_friend()]
+	rd = prepare_render_data(friends, None, diff_result)
+	assert rd["diff_summary"] is not None
+	assert "新增 1 条" in rd["diff_summary"]["change"]
+	assert "消失 1 条" in rd["diff_summary"]["change"]
+	assert "新消息 1 条" in rd["diff_summary"]["change"]
+	assert rd["diff_summary"]["prev_date"] == "2026-04-12"
+
+
+def test_prepare_render_data_diff_no_change():
+	"""diff 无变化时应显示'无变化'"""
+	diff_result = {
+		"is_first": False,
+		"prev_date": "2026-04-12",
+		"added": [],
+		"removed": [],
+		"new_unread": [],
+	}
+	rd = prepare_render_data([], None, diff_result)
+	assert rd["diff_summary"]["change"] == "无变化"
+
+
+def test_prepare_render_data_id_map():
+	"""id_map 应记录编号到 security_id 的映射"""
+	friends = [
+		_make_friend(security_id="sec_a", name="A", brand_name="公司A"),
+		_make_friend(security_id="sec_b", name="B", brand_name="公司B"),
+	]
+	rd = prepare_render_data(friends, None, _NO_DIFF)
+	assert len(rd["id_map"]) == 2
+	refs = [item[0] for item in rd["id_map"]]
+	sids = [item[1] for item in rd["id_map"]]
+	assert "S1" in refs
+	assert "S2" in refs
+	assert "sec_a" in sids
+	assert "sec_b" in sids
+
+
+def test_prepare_render_data_me_read_unread_stats():
+	"""我主动分组应统计已读/未读数"""
+	friends = [
+		_make_friend(initiated_by="我主动", msg_status="已读", security_id="sec_1"),
+		_make_friend(initiated_by="我主动", msg_status="已读", security_id="sec_2"),
+		_make_friend(initiated_by="我主动", msg_status="未读", security_id="sec_3"),
+	]
+	rd = prepare_render_data(friends, None, _NO_DIFF)
+	me_section = [s for s in rd["sections"] if "我主动" in s["subtitle"]][0]
+	assert "已读 2" in me_section["subtitle"]
+	assert "未读 1" in me_section["subtitle"]
+
+
+# ── MD 长消息截断 ───────────────────────────────────────────────────
+
+
+def test_md_long_message_truncated():
+	"""MD 渲染时超过 40 字符的消息应被截断"""
+	long_msg = "这是一条非常非常非常非常非常非常非常非常非常非常非常非常非常非常非常非常非常长的消息"
+	friends = [_make_friend(last_msg=long_msg)]
+	md_text = render_export(friends, "md", None, None, _NO_DIFF)
+	# 截断标记
+	assert "\u2026" in md_text  # "..."
+
+
+# ── HTML 长消息截断 ─────────────────────────────────────────────────
+
+
+def test_html_long_message_truncated():
+	"""HTML 渲染时超过 60 字符的消息应被截断"""
+	long_msg = "A" * 100
+	friends = [_make_friend(last_msg=long_msg)]
+	html = render_export(friends, "html", None, None, _NO_DIFF)
+	assert "\u2026" in html
+	# 原始完整消息不应出现
+	assert "A" * 100 not in html
+
+
+# ── MD security_id 映射表 ──────────────────────────────────────────
+
+
+def test_md_export_contains_id_map():
+	"""MD 导出应包含 security_id 折叠映射表"""
+	friends = [_make_friend(security_id="sec_abc123")]
+	md_text = render_export(friends, "md", None, None, _NO_DIFF)
+	assert "<details>" in md_text
+	assert "security_id 映射表" in md_text
+	assert "sec_abc123" in md_text
+	assert "S1" in md_text

--- a/tests/test_chat_snapshot_extended.py
+++ b/tests/test_chat_snapshot_extended.py
@@ -1,0 +1,381 @@
+"""chat_snapshot.py 扩展测试 — 覆盖快照保存、增量对比、边界与降级。"""
+
+import datetime
+import json
+import os
+from unittest.mock import MagicMock
+
+from boss_agent_cli.commands.chat_snapshot import (
+	save_snapshot_and_diff,
+	load_snapshot,
+	_find_previous_snapshot,
+)
+
+
+def _make_logger():
+	logger = MagicMock()
+	return logger
+
+
+def _make_items(*entries):
+	"""快速构造 friends 列表。entries: [(name, sid, unread), ...]"""
+	result = []
+	for name, sid, unread in entries:
+		result.append({
+			"name": name,
+			"security_id": sid,
+			"unread": unread,
+			"brand_name": "TestCo",
+		})
+	return result
+
+
+# ── 1. 首次快照（无历史文件） ────────────────────────────────────────
+
+def test_first_snapshot_no_history(tmp_path):
+	"""无任何历史快照时应返回 is_first=True。"""
+	snapshot_dir = str(tmp_path / "snapshots")
+	friends = _make_items(("张三", "sid_a", 0), ("李四", "sid_b", 2))
+	logger = _make_logger()
+
+	result = save_snapshot_and_diff(snapshot_dir, friends, logger)
+
+	assert result["is_first"] is True
+	assert result["added"] == []
+	assert result["removed"] == []
+	assert result["new_unread"] == []
+
+	# 验证快照文件已写入
+	today = datetime.date.today().isoformat()
+	snapshot_path = os.path.join(snapshot_dir, f"{today}.json")
+	assert os.path.exists(snapshot_path)
+
+	with open(snapshot_path, encoding="utf-8") as f:
+		saved = json.load(f)
+	assert len(saved) == 2
+	sids = {item["security_id"] for item in saved}
+	assert sids == {"sid_a", "sid_b"}
+
+
+def test_first_snapshot_empty_dir(tmp_path):
+	"""快照目录存在但无文件时应返回 is_first=True。"""
+	snapshot_dir = str(tmp_path / "snapshots")
+	os.makedirs(snapshot_dir)
+	friends = _make_items(("HR", "sid_x", 0))
+	result = save_snapshot_and_diff(snapshot_dir, friends, _make_logger())
+	assert result["is_first"] is True
+
+
+# ── 2. 增量对比 — 检测新增联系人 ─────────────────────────────────────
+
+def test_diff_detects_added_contacts(tmp_path):
+	"""新增联系人应出现在 added 列表中。"""
+	snapshot_dir = str(tmp_path / "snapshots")
+	os.makedirs(snapshot_dir)
+
+	# 写入昨天的快照
+	yesterday = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
+	prev_data = _make_items(("张三", "sid_a", 0))
+	with open(os.path.join(snapshot_dir, f"{yesterday}.json"), "w", encoding="utf-8") as f:
+		json.dump(prev_data, f)
+
+	# 今天新增了李四
+	friends = _make_items(("张三", "sid_a", 0), ("李四", "sid_b", 1))
+	result = save_snapshot_and_diff(snapshot_dir, friends, _make_logger())
+
+	assert result["is_first"] is False
+	assert result["prev_date"] == yesterday
+	assert len(result["added"]) == 1
+	assert result["added"][0]["security_id"] == "sid_b"
+	assert len(result["removed"]) == 0
+
+
+# ── 3. 增量对比 — 检测消失联系人 ─────────────────────────────────────
+
+def test_diff_detects_removed_contacts(tmp_path):
+	"""消失的联系人应出现在 removed 列表中。"""
+	snapshot_dir = str(tmp_path / "snapshots")
+	os.makedirs(snapshot_dir)
+
+	yesterday = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
+	prev_data = _make_items(("张三", "sid_a", 0), ("李四", "sid_b", 0))
+	with open(os.path.join(snapshot_dir, f"{yesterday}.json"), "w", encoding="utf-8") as f:
+		json.dump(prev_data, f)
+
+	# 今天只剩张三
+	friends = _make_items(("张三", "sid_a", 0))
+	result = save_snapshot_and_diff(snapshot_dir, friends, _make_logger())
+
+	assert result["is_first"] is False
+	assert len(result["removed"]) == 1
+	assert result["removed"][0]["security_id"] == "sid_b"
+	assert len(result["added"]) == 0
+
+
+# ── 4. 增量对比 — 检测新消息（未读增量） ──────────────────────────────
+
+def test_diff_detects_new_unread(tmp_path):
+	"""联系人 unread 增加时应出现在 new_unread 列表中。"""
+	snapshot_dir = str(tmp_path / "snapshots")
+	os.makedirs(snapshot_dir)
+
+	yesterday = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
+	prev_data = _make_items(("张三", "sid_a", 0), ("李四", "sid_b", 2))
+	with open(os.path.join(snapshot_dir, f"{yesterday}.json"), "w", encoding="utf-8") as f:
+		json.dump(prev_data, f)
+
+	# 今天张三有 3 条新未读，李四未读数没变
+	friends = _make_items(("张三", "sid_a", 3), ("李四", "sid_b", 2))
+	result = save_snapshot_and_diff(snapshot_dir, friends, _make_logger())
+
+	assert len(result["new_unread"]) == 1
+	assert result["new_unread"][0]["security_id"] == "sid_a"
+
+
+def test_diff_no_new_unread_when_decreased(tmp_path):
+	"""联系人 unread 减少（已读）不应出现在 new_unread。"""
+	snapshot_dir = str(tmp_path / "snapshots")
+	os.makedirs(snapshot_dir)
+
+	yesterday = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
+	prev_data = _make_items(("张三", "sid_a", 5))
+	with open(os.path.join(snapshot_dir, f"{yesterday}.json"), "w", encoding="utf-8") as f:
+		json.dump(prev_data, f)
+
+	friends = _make_items(("张三", "sid_a", 2))
+	result = save_snapshot_and_diff(snapshot_dir, friends, _make_logger())
+
+	assert result["new_unread"] == []
+
+
+# ── 5. 损坏快照文件降级处理 ──────────────────────────────────────────
+
+def test_corrupted_previous_snapshot_treated_as_first(tmp_path):
+	"""上一份快照损坏（非法 JSON）时应降级为首次快照。"""
+	snapshot_dir = str(tmp_path / "snapshots")
+	os.makedirs(snapshot_dir)
+
+	yesterday = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
+	with open(os.path.join(snapshot_dir, f"{yesterday}.json"), "w") as f:
+		f.write("{invalid json!!!")
+
+	friends = _make_items(("张三", "sid_a", 0))
+	logger = _make_logger()
+	result = save_snapshot_and_diff(snapshot_dir, friends, logger)
+
+	assert result["is_first"] is True
+	logger.warning.assert_called()
+
+
+def test_non_array_previous_snapshot_treated_as_first(tmp_path):
+	"""上一份快照是 JSON 但非数组时应降级为首次快照。"""
+	snapshot_dir = str(tmp_path / "snapshots")
+	os.makedirs(snapshot_dir)
+
+	yesterday = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
+	with open(os.path.join(snapshot_dir, f"{yesterday}.json"), "w") as f:
+		json.dump({"not": "an array"}, f)
+
+	friends = _make_items(("张三", "sid_a", 0))
+	logger = _make_logger()
+	result = save_snapshot_and_diff(snapshot_dir, friends, logger)
+
+	assert result["is_first"] is True
+	logger.warning.assert_called()
+
+
+def test_corrupted_today_snapshot_still_works(tmp_path):
+	"""当日已有损坏快照时，应能正常覆盖写入。"""
+	snapshot_dir = str(tmp_path / "snapshots")
+	os.makedirs(snapshot_dir)
+
+	today = datetime.date.today().isoformat()
+	with open(os.path.join(snapshot_dir, f"{today}.json"), "w") as f:
+		f.write("not valid json")
+
+	friends = _make_items(("张三", "sid_a", 0))
+	save_snapshot_and_diff(snapshot_dir, friends, _make_logger())
+
+	# 不会崩溃，且写入了新的快照
+	with open(os.path.join(snapshot_dir, f"{today}.json"), encoding="utf-8") as f:
+		saved = json.load(f)
+	assert len(saved) == 1
+	assert saved[0]["security_id"] == "sid_a"
+
+
+# ── 6. 空数据/None 数据兜底 ──────────────────────────────────────────
+
+def test_empty_friends_list(tmp_path):
+	"""传入空列表时应正常保存空快照。"""
+	snapshot_dir = str(tmp_path / "snapshots")
+	result = save_snapshot_and_diff(snapshot_dir, [], _make_logger())
+	assert result["is_first"] is True
+
+	today = datetime.date.today().isoformat()
+	with open(os.path.join(snapshot_dir, f"{today}.json"), encoding="utf-8") as f:
+		saved = json.load(f)
+	assert saved == []
+
+
+def test_friends_with_no_security_id(tmp_path):
+	"""security_id 缺失的项不应进入去重 map。"""
+	snapshot_dir = str(tmp_path / "snapshots")
+	friends = [
+		{"name": "无ID", "unread": 0},  # 无 security_id
+		{"name": "有ID", "security_id": "sid_x", "unread": 1},
+	]
+	save_snapshot_and_diff(snapshot_dir, friends, _make_logger())
+
+	today = datetime.date.today().isoformat()
+	with open(os.path.join(snapshot_dir, f"{today}.json"), encoding="utf-8") as f:
+		saved = json.load(f)
+	# 无 security_id 的项不参与 merge（dict key 为 None），但仍保留在 merged
+	# 具体行为取决于 existing dict 的处理，有 ID 的那条一定在
+	assert any(item.get("security_id") == "sid_x" for item in saved)
+
+
+def test_unread_none_treated_as_zero(tmp_path):
+	"""unread 为 None 时应兜底为 0，不抛异常。"""
+	snapshot_dir = str(tmp_path / "snapshots")
+	os.makedirs(snapshot_dir)
+
+	yesterday = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
+	prev_data = [{"name": "张三", "security_id": "sid_a", "unread": None}]
+	with open(os.path.join(snapshot_dir, f"{yesterday}.json"), "w", encoding="utf-8") as f:
+		json.dump(prev_data, f)
+
+	friends = [{"name": "张三", "security_id": "sid_a", "unread": 3}]
+	result = save_snapshot_and_diff(snapshot_dir, friends, _make_logger())
+
+	# unread: None -> 3 应检测为新消息
+	assert len(result["new_unread"]) == 1
+
+
+# ── 7. 分页合并（同天多次调用不覆盖） ────────────────────────────────
+
+def test_same_day_merge_not_overwrite(tmp_path):
+	"""同天第二次调用应合并而非覆盖已有快照。"""
+	snapshot_dir = str(tmp_path / "snapshots")
+	os.makedirs(snapshot_dir)
+
+	today = datetime.date.today().isoformat()
+	first_page = _make_items(("张三", "sid_a", 0))
+	with open(os.path.join(snapshot_dir, f"{today}.json"), "w", encoding="utf-8") as f:
+		json.dump(first_page, f)
+
+	# 第二页数据
+	second_page = _make_items(("李四", "sid_b", 1))
+	save_snapshot_and_diff(snapshot_dir, second_page, _make_logger())
+
+	with open(os.path.join(snapshot_dir, f"{today}.json"), encoding="utf-8") as f:
+		merged = json.load(f)
+	sids = {item["security_id"] for item in merged}
+	assert "sid_a" in sids
+	assert "sid_b" in sids
+
+
+def test_same_day_update_existing_entry(tmp_path):
+	"""同天重复 security_id 应以最新数据覆盖旧数据。"""
+	snapshot_dir = str(tmp_path / "snapshots")
+	os.makedirs(snapshot_dir)
+
+	today = datetime.date.today().isoformat()
+	old_data = [{"name": "张三", "security_id": "sid_a", "unread": 0}]
+	with open(os.path.join(snapshot_dir, f"{today}.json"), "w", encoding="utf-8") as f:
+		json.dump(old_data, f)
+
+	# 同一个 sid，unread 更新
+	new_data = [{"name": "张三", "security_id": "sid_a", "unread": 5}]
+	save_snapshot_and_diff(snapshot_dir, new_data, _make_logger())
+
+	with open(os.path.join(snapshot_dir, f"{today}.json"), encoding="utf-8") as f:
+		merged = json.load(f)
+	assert len(merged) == 1
+	assert merged[0]["unread"] == 5
+
+
+# ── 8. load_snapshot 单元测试 ────────────────────────────────────────
+
+def test_load_snapshot_valid(tmp_path):
+	"""正常 JSON 数组文件应返回列表。"""
+	path = str(tmp_path / "snap.json")
+	data = [{"security_id": "a"}, {"security_id": "b"}]
+	with open(path, "w") as f:
+		json.dump(data, f)
+	result = load_snapshot(path, _make_logger())
+	assert result == data
+
+
+def test_load_snapshot_invalid_json(tmp_path):
+	"""非法 JSON 应返回 None。"""
+	path = str(tmp_path / "bad.json")
+	with open(path, "w") as f:
+		f.write("not json")
+	logger = _make_logger()
+	result = load_snapshot(path, logger)
+	assert result is None
+	logger.warning.assert_called()
+
+
+def test_load_snapshot_not_array(tmp_path):
+	"""JSON 非数组应返回 None。"""
+	path = str(tmp_path / "obj.json")
+	with open(path, "w") as f:
+		json.dump({"key": "val"}, f)
+	logger = _make_logger()
+	result = load_snapshot(path, logger)
+	assert result is None
+	logger.warning.assert_called()
+
+
+def test_load_snapshot_filters_non_dict_items(tmp_path):
+	"""数组中的非 dict 项应被过滤掉。"""
+	path = str(tmp_path / "mixed.json")
+	data = [{"security_id": "ok"}, "string_item", 123, None, {"security_id": "ok2"}]
+	with open(path, "w") as f:
+		json.dump(data, f)
+	result = load_snapshot(path, _make_logger())
+	assert len(result) == 2
+	assert result[0]["security_id"] == "ok"
+	assert result[1]["security_id"] == "ok2"
+
+
+# ── 9. _find_previous_snapshot 单元测试 ──────────────────────────────
+
+def test_find_previous_snapshot_picks_latest(tmp_path):
+	"""应选取 today 之前最近的一份快照。"""
+	snapshot_dir = str(tmp_path)
+	# 创建多个历史文件
+	for fname in ["2026-04-10.json", "2026-04-11.json", "2026-04-12.json"]:
+		with open(os.path.join(snapshot_dir, fname), "w") as f:
+			json.dump([], f)
+
+	result = _find_previous_snapshot(snapshot_dir, "2026-04-13")
+	assert result is not None
+	assert result.endswith("2026-04-12.json")
+
+
+def test_find_previous_snapshot_excludes_today(tmp_path):
+	"""不应选取当天的快照。"""
+	snapshot_dir = str(tmp_path)
+	with open(os.path.join(snapshot_dir, "2026-04-13.json"), "w") as f:
+		json.dump([], f)
+
+	result = _find_previous_snapshot(snapshot_dir, "2026-04-13")
+	assert result is None
+
+
+def test_find_previous_snapshot_empty_dir(tmp_path):
+	"""空目录应返回 None。"""
+	result = _find_previous_snapshot(str(tmp_path), "2026-04-13")
+	assert result is None
+
+
+def test_find_previous_snapshot_ignores_non_json(tmp_path):
+	"""非 .json 文件不应被选取。"""
+	snapshot_dir = str(tmp_path)
+	with open(os.path.join(snapshot_dir, "2026-04-12.txt"), "w") as f:
+		f.write("not a snapshot")
+
+	result = _find_previous_snapshot(snapshot_dir, "2026-04-13")
+	assert result is None

--- a/tests/test_chatmsg_extended.py
+++ b/tests/test_chatmsg_extended.py
@@ -1,0 +1,407 @@
+"""chatmsg.py 扩展测试 — 消息历史、空列表、无效好友、格式化逻辑。"""
+
+import json
+from unittest.mock import patch, MagicMock
+
+from click.testing import CliRunner
+from boss_agent_cli.main import cli
+
+
+def _ctx_mock(mock_cls):
+	"""让 mock 类支持 context manager。"""
+	instance = mock_cls.return_value
+	instance.__enter__ = lambda self: self
+	instance.__exit__ = lambda self, *a: None
+	return instance
+
+
+def _friend_list_response(items):
+	return {"zpData": {"result": items, "friendList": items}}
+
+
+def _make_friend(name="张HR", sid="sec_001", uid=12345):
+	return {
+		"name": name, "securityId": sid, "uid": uid,
+		"title": "HR", "brandName": "TestCo",
+		"friendSource": 0, "encryptJobId": "job_001",
+		"lastMsg": "你好", "lastTS": 1700000000000,
+		"unreadMsgCount": 0, "relationType": 1,
+		"lastMessageInfo": {"status": 2},
+	}
+
+
+# ── 正常消息历史返回 ────────────────────────────────────────────────
+
+
+@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.AuthManager")
+def test_chatmsg_returns_correct_messages(mock_auth_cls, mock_client_cls):
+	"""正常返回消息列表，包含正确的字段。
+	注意：gid = friend.uid，from.uid == gid 表示好友发的，否则是自己发的。
+	"""
+	mock_client = _ctx_mock(mock_client_cls)
+	# 好友 uid=12345
+	mock_client.friend_list.return_value = _friend_list_response([_make_friend(uid=12345)])
+	mock_client.chat_history.return_value = {
+		"zpData": {
+			"messages": [
+				# from.uid=12345 == gid -> 好友发的
+				{"from": {"uid": 12345, "name": "张HR"}, "type": 1, "text": "你好，看到你的简历", "time": 1700000000000},
+				# from.uid=99999 != gid -> 自己发的
+				{"from": {"uid": 99999, "name": "我本人"}, "type": 1, "text": "谢谢关注", "time": 1700000001000},
+				# from.uid=12345 == gid -> 好友发的
+				{"from": {"uid": 12345, "name": "张HR"}, "type": 1, "text": "方便聊聊吗", "time": 1700000002000},
+			],
+		},
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chatmsg", "sec_001"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert len(parsed["data"]) == 3
+	# 验证消息内容和发送方
+	assert parsed["data"][0]["text"] == "你好，看到你的简历"
+	assert parsed["data"][0]["from"] == "张HR"
+	assert parsed["data"][1]["from"] == "我"
+	assert parsed["data"][2]["text"] == "方便聊聊吗"
+
+
+@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.AuthManager")
+def test_chatmsg_message_fields_complete(mock_auth_cls, mock_client_cls):
+	"""返回的每条消息应包含 from/type/text/time 四个字段"""
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = _friend_list_response([_make_friend()])
+	mock_client.chat_history.return_value = {
+		"zpData": {
+			"messages": [
+				{"from": {"uid": 99, "name": "张HR"}, "type": 1, "text": "你好", "time": 1700000000000},
+			],
+		},
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chatmsg", "sec_001"])
+	parsed = json.loads(result.output)
+	msg = parsed["data"][0]
+	assert "from" in msg
+	assert "type" in msg
+	assert "text" in msg
+	assert "time" in msg
+
+
+@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.AuthManager")
+def test_chatmsg_hints_present(mock_auth_cls, mock_client_cls):
+	"""返回结果应包含 hints.next_actions"""
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = _friend_list_response([_make_friend()])
+	mock_client.chat_history.return_value = {
+		"zpData": {"messages": []},
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chatmsg", "sec_001"])
+	parsed = json.loads(result.output)
+	assert "hints" in parsed
+	assert "next_actions" in parsed["hints"]
+	# hints 应包含 chat 和 detail 建议
+	actions_text = " ".join(parsed["hints"]["next_actions"])
+	assert "chat" in actions_text
+	assert "detail" in actions_text
+
+
+# ── 空消息列表边界 ──────────────────────────────────────────────────
+
+
+@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.AuthManager")
+def test_chatmsg_empty_messages(mock_auth_cls, mock_client_cls):
+	"""好友存在但消息列表为空时应返回空数组"""
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = _friend_list_response([_make_friend()])
+	mock_client.chat_history.return_value = {
+		"zpData": {"messages": []},
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chatmsg", "sec_001"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"] == []
+
+
+@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.AuthManager")
+def test_chatmsg_messages_key_missing(mock_auth_cls, mock_client_cls):
+	"""API 返回中缺少 messages 键时应安全降级为空列表"""
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = _friend_list_response([_make_friend()])
+	mock_client.chat_history.return_value = {
+		"zpData": {},
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chatmsg", "sec_001"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"] == []
+
+
+@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.AuthManager")
+def test_chatmsg_uses_history_msg_list_fallback(mock_auth_cls, mock_client_cls):
+	"""API 返回 historyMsgList 而非 messages 时应正确解析"""
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = _friend_list_response([_make_friend()])
+	mock_client.chat_history.return_value = {
+		"zpData": {
+			"historyMsgList": [
+				{"from": {"uid": 99, "name": "张HR"}, "type": 1, "text": "备选字段", "time": 1700000000000},
+			],
+		},
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chatmsg", "sec_001"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert len(parsed["data"]) == 1
+	assert parsed["data"][0]["text"] == "备选字段"
+
+
+# ── 无效好友 ID 处理 ────────────────────────────────────────────────
+
+
+@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.AuthManager")
+def test_chatmsg_invalid_security_id(mock_auth_cls, mock_client_cls):
+	"""不存在的 security_id 应返回 JOB_NOT_FOUND 错误"""
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = _friend_list_response([_make_friend()])
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chatmsg", "sec_nonexistent"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["error"]["code"] == "JOB_NOT_FOUND"
+	assert "sec_nonexistent" in parsed["error"]["message"]
+
+
+@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.AuthManager")
+def test_chatmsg_empty_friend_list(mock_auth_cls, mock_client_cls):
+	"""好友列表为空时应返回 JOB_NOT_FOUND"""
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = _friend_list_response([])
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chatmsg", "sec_001"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "JOB_NOT_FOUND"
+
+
+# ── 消息格式化逻辑 ─────────────────────────────────────────────────
+
+
+@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.AuthManager")
+def test_chatmsg_message_type_mapping(mock_auth_cls, mock_client_cls):
+	"""消息类型应被正确映射为可读标签"""
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = _friend_list_response([_make_friend()])
+	mock_client.chat_history.return_value = {
+		"zpData": {
+			"messages": [
+				{"from": {"uid": 99, "name": "张HR"}, "type": 1, "text": "文本消息", "time": 1700000000000},
+				{"from": {"uid": 99, "name": "张HR"}, "type": 2, "text": "", "time": 1700000001000},
+				{"from": {"uid": 99, "name": "张HR"}, "type": 3, "text": "打招呼", "time": 1700000002000},
+				{"from": {"uid": 99, "name": "张HR"}, "type": 4, "text": "", "time": 1700000003000},
+				{"from": {"uid": 99, "name": "张HR"}, "type": 5, "text": "系统通知", "time": 1700000004000},
+			],
+		},
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chatmsg", "sec_001"])
+	parsed = json.loads(result.output)
+	types = [m["type"] for m in parsed["data"]]
+	assert types[0] == "文本"
+	assert types[1] == "图片"
+	assert types[2] == "招呼"
+	assert types[3] == "简历"
+	assert types[4] == "系统"
+
+
+@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.AuthManager")
+def test_chatmsg_unknown_message_type(mock_auth_cls, mock_client_cls):
+	"""未知消息类型应显示为 '其他(N)' 格式"""
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = _friend_list_response([_make_friend()])
+	mock_client.chat_history.return_value = {
+		"zpData": {
+			"messages": [
+				{"from": {"uid": 99, "name": "张HR"}, "type": 99, "text": "未知类型", "time": 1700000000000},
+			],
+		},
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chatmsg", "sec_001"])
+	parsed = json.loads(result.output)
+	assert parsed["data"][0]["type"] == "其他(99)"
+
+
+@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.AuthManager")
+def test_chatmsg_self_message_identified(mock_auth_cls, mock_client_cls):
+	"""自己发的消息 from 应显示为 '我'。
+	逻辑：gid = friend.uid，from.uid != gid 则为自己发的。
+	"""
+	mock_client = _ctx_mock(mock_client_cls)
+	# 好友 uid=12345
+	mock_client.friend_list.return_value = _friend_list_response([_make_friend(uid=12345)])
+	mock_client.chat_history.return_value = {
+		"zpData": {
+			"messages": [
+				# from.uid=99999 != gid(12345) -> 自己发的
+				{"from": {"uid": 99999, "name": "我本人"}, "type": 1, "text": "我发的", "time": 1700000000000},
+				# from.uid=12345 == gid(12345) -> 好友发的
+				{"from": {"uid": 12345, "name": "张HR"}, "type": 1, "text": "好友发的", "time": 1700000001000},
+			],
+		},
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chatmsg", "sec_001"])
+	parsed = json.loads(result.output)
+	assert parsed["data"][0]["from"] == "我"
+	assert parsed["data"][1]["from"] == "张HR"
+
+
+@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.AuthManager")
+def test_chatmsg_time_formatting(mock_auth_cls, mock_client_cls):
+	"""消息时间应被格式化为 MM-DD HH:MM 格式"""
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = _friend_list_response([_make_friend()])
+	# 2023-11-14 22:13:20 UTC = 1700000000000 ms
+	mock_client.chat_history.return_value = {
+		"zpData": {
+			"messages": [
+				{"from": {"uid": 99, "name": "张HR"}, "type": 1, "text": "你好", "time": 1700000000000},
+			],
+		},
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chatmsg", "sec_001"])
+	parsed = json.loads(result.output)
+	time_str = parsed["data"][0]["time"]
+	# 时间应为 "MM-DD HH:MM" 格式
+	assert len(time_str) > 0
+	assert "-" in time_str
+	assert ":" in time_str
+
+
+@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.AuthManager")
+def test_chatmsg_no_time_field(mock_auth_cls, mock_client_cls):
+	"""消息缺少 time 字段时应返回空字符串"""
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = _friend_list_response([_make_friend()])
+	mock_client.chat_history.return_value = {
+		"zpData": {
+			"messages": [
+				{"from": {"uid": 99, "name": "张HR"}, "type": 1, "text": "无时间"},
+			],
+		},
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chatmsg", "sec_001"])
+	parsed = json.loads(result.output)
+	assert parsed["data"][0]["time"] == ""
+
+
+@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.AuthManager")
+def test_chatmsg_text_fallback_to_body(mock_auth_cls, mock_client_cls):
+	"""text 为空时应从 body.text 取值"""
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = _friend_list_response([_make_friend()])
+	mock_client.chat_history.return_value = {
+		"zpData": {
+			"messages": [
+				{
+					"from": {"uid": 99, "name": "张HR"},
+					"type": 1,
+					"text": None,
+					"body": {"text": "来自body的内容"},
+					"time": 1700000000000,
+				},
+			],
+		},
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chatmsg", "sec_001"])
+	parsed = json.loads(result.output)
+	assert parsed["data"][0]["text"] == "来自body的内容"
+
+
+@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.AuthManager")
+def test_chatmsg_text_both_empty(mock_auth_cls, mock_client_cls):
+	"""text 和 body.text 都为空时应返回空字符串"""
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = _friend_list_response([_make_friend()])
+	mock_client.chat_history.return_value = {
+		"zpData": {
+			"messages": [
+				{
+					"from": {"uid": 99, "name": "张HR"},
+					"type": 2,
+					"text": None,
+					"body": {},
+					"time": 1700000000000,
+				},
+			],
+		},
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chatmsg", "sec_001"])
+	parsed = json.loads(result.output)
+	assert parsed["data"][0]["text"] == ""
+
+
+# ── 分页参数 ────────────────────────────────────────────────────────
+
+
+@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.AuthManager")
+def test_chatmsg_page_and_count_params(mock_auth_cls, mock_client_cls):
+	"""--page 和 --count 参数应传递给 chat_history"""
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = _friend_list_response([_make_friend()])
+	mock_client.chat_history.return_value = {"zpData": {"messages": []}}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chatmsg", "sec_001", "--page", "2", "--count", "50"])
+	assert result.exit_code == 0
+	mock_client.chat_history.assert_called_once()
+	call_args = mock_client.chat_history.call_args
+	# page 和 count 应作为关键字参数传入
+	assert call_args.kwargs.get("page") == 2 or (len(call_args.args) >= 3 and call_args.args[2] == 2)
+	assert call_args.kwargs.get("count") == 50 or (len(call_args.args) >= 4 and call_args.args[3] == 50)
+
+
+# ── Context manager 验证 ──────────────────────────────────────────
+
+
+@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.AuthManager")
+def test_chatmsg_uses_client_context_manager(mock_auth_cls, mock_client_cls):
+	"""应使用 BossClient 的 context manager"""
+	instance = mock_client_cls.return_value
+	instance.__enter__ = MagicMock(return_value=instance)
+	instance.__exit__ = MagicMock(return_value=None)
+	instance.friend_list.return_value = _friend_list_response([_make_friend()])
+	instance.chat_history.return_value = {"zpData": {"messages": []}}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chatmsg", "sec_001"])
+	assert result.exit_code == 0
+	instance.__enter__.assert_called_once()
+	instance.__exit__.assert_called_once()

--- a/tests/test_doctor_extended.py
+++ b/tests/test_doctor_extended.py
@@ -1,0 +1,356 @@
+"""doctor.py 扩展测试 — 覆盖各检查项的正常/异常路径。"""
+
+import json
+import sys
+from unittest.mock import patch, MagicMock
+
+from click.testing import CliRunner
+from boss_agent_cli.main import cli
+
+
+# ── 辅助 ─────────────────────────────────────────────────────────────
+
+def _base_patches():
+	"""返回 doctor 命令核心 mock 的 patch 路径字典。"""
+	return {
+		"auth": "boss_agent_cli.commands.doctor.AuthManager",
+		"cdp": "boss_agent_cli.commands.doctor.probe_cdp",
+		"httpx": "boss_agent_cli.commands.doctor.httpx.get",
+		"cookie": "boss_agent_cli.commands.doctor.extract_cookies",
+	}
+
+
+def _invoke_doctor(tmp_path=None, **overrides):
+	"""执行 doctor 命令并返回 (exit_code, parsed_json)。
+
+	overrides 可以覆盖 token / cdp_ws / cookie / http_status / http_exc。
+	传入 tmp_path 以使用隔离的 data-dir，避免读取本机真实文件。
+	"""
+	runner = CliRunner()
+	paths = _base_patches()
+	with (
+		patch(paths["auth"]) as mock_auth,
+		patch(paths["cdp"]) as mock_cdp,
+		patch(paths["httpx"]) as mock_httpx,
+		patch(paths["cookie"]) as mock_cookie,
+		patch("boss_agent_cli.bridge.client.BridgeClient") as mock_bridge,
+	):
+		# BridgeClient 构造不抛异常，但 is_running 返回 False
+		mock_bridge.return_value.is_running.return_value = False
+		# 默认值
+		mock_auth.return_value.check_status.return_value = overrides.get("token", None)
+		mock_cdp.return_value = overrides.get("cdp_ws", None)
+		mock_cookie.return_value = overrides.get("cookie", None)
+
+		if "http_exc" in overrides:
+			mock_httpx.side_effect = overrides["http_exc"]
+		else:
+			mock_httpx.return_value = MagicMock(status_code=overrides.get("http_status", 200))
+
+		cli_args = []
+		if tmp_path is not None:
+			cli_args.extend(["--data-dir", str(tmp_path)])
+		cli_args.append("doctor")
+		result = runner.invoke(cli, cli_args)
+	parsed = json.loads(result.output)
+	return result.exit_code, parsed
+
+
+def _find_check(checks, name):
+	return next((c for c in checks if c["name"] == name), None)
+
+
+# ── 1. 所有检查项正常通过 ────────────────────────────────────────────
+
+def test_all_checks_pass(tmp_path):
+	"""所有检查项均为 ok 时 summary 应为 healthy（环境依赖项除外）。"""
+	token = {"cookies": {"wt2": "tok"}, "stoken": "st_ok", "user_agent": "ua"}
+	code, parsed = _invoke_doctor(
+		tmp_path,
+		token=token,
+		cdp_ws="ws://127.0.0.1:9222/devtools/browser/abc",
+		cookie={"cookies": {"wt2": "tok"}},
+		http_status=200,
+	)
+	assert code == 0
+	assert parsed["ok"] is True
+	# 核心逻辑检查项（不依赖本机工具链）应全部为 ok
+	env_dependent = {"patchright", "patchright_chromium", "browser", "auth_salt"}
+	for check in parsed["data"]["checks"]:
+		if check["name"] in env_dependent:
+			continue
+		assert check["status"] == "ok", f"{check['name']} 状态应为 ok，实际为 {check['status']}"
+
+
+# ── 2. Python 版本不满足 ─────────────────────────────────────────────
+
+def test_python_version_below_310(tmp_path):
+	"""Python 版本低于 3.10 时 python 检查应为 error。"""
+
+	class FakeVersionInfo(tuple):
+		"""模拟 sys.version_info：同时支持元组比较和属性访问。"""
+		major = 3
+		minor = 9
+		micro = 1
+		def __new__(cls):
+			return tuple.__new__(cls, (3, 9, 1))
+
+	original = sys.version_info
+	sys.version_info = FakeVersionInfo()
+	try:
+		code, parsed = _invoke_doctor(tmp_path)
+	finally:
+		sys.version_info = original
+	python_check = _find_check(parsed["data"]["checks"], "python")
+	assert python_check is not None
+	assert python_check["status"] == "error"
+	assert "3.10" in python_check["detail"]
+
+
+def test_python_version_satisfies(tmp_path):
+	"""当前测试运行的 Python 应满足 >=3.10。"""
+	code, parsed = _invoke_doctor(tmp_path)
+	python_check = _find_check(parsed["data"]["checks"], "python")
+	assert python_check["status"] == "ok"
+
+
+# ── 3. 依赖缺失 ─────────────────────────────────────────────────────
+
+@patch("boss_agent_cli.commands.doctor.shutil.which", return_value=None)
+def test_patchright_missing(mock_which, tmp_path):
+	"""patchright 可执行文件不在 PATH 中时应为 warn。"""
+	code, parsed = _invoke_doctor(tmp_path)
+	pr_check = _find_check(parsed["data"]["checks"], "patchright")
+	assert pr_check["status"] == "warn"
+	assert "未找到" in pr_check["detail"]
+
+
+# ── 4. 网络不通 ──────────────────────────────────────────────────────
+
+def test_network_failure(tmp_path):
+	"""访问 zhipin.com 抛异常时 network 应为 warn。"""
+	code, parsed = _invoke_doctor(tmp_path, http_exc=ConnectionError("network down"))
+	network_check = _find_check(parsed["data"]["checks"], "network")
+	assert network_check is not None
+	assert network_check["status"] == "warn"
+	assert "失败" in network_check["detail"]
+
+
+def test_network_http_error_status(tmp_path):
+	"""zhipin.com 返回 HTTP 5xx 时 network 应为 warn。"""
+	code, parsed = _invoke_doctor(tmp_path, http_status=503)
+	network_check = _find_check(parsed["data"]["checks"], "network")
+	assert network_check["status"] == "warn"
+
+
+def test_network_ok(tmp_path):
+	"""zhipin.com 返回 200 时 network 应为 ok。"""
+	code, parsed = _invoke_doctor(tmp_path, http_status=200)
+	network_check = _find_check(parsed["data"]["checks"], "network")
+	assert network_check["status"] == "ok"
+
+
+# ── 5. 登录态检查 ────────────────────────────────────────────────────
+
+def test_auth_logged_in_full(tmp_path):
+	"""wt2 + stoken 均在时 auth_token_quality 应为 ok。"""
+	token = {"cookies": {"wt2": "tok"}, "stoken": "stoken_val"}
+	code, parsed = _invoke_doctor(tmp_path, token=token)
+	quality = _find_check(parsed["data"]["checks"], "auth_token_quality")
+	assert quality["status"] == "ok"
+	assert "完整" in quality["detail"]
+
+
+def test_auth_logged_in_no_stoken(tmp_path):
+	"""wt2 存在但 stoken 缺失时 quality 应为 warn。"""
+	token = {"cookies": {"wt2": "tok"}, "stoken": ""}
+	code, parsed = _invoke_doctor(tmp_path, token=token)
+	quality = _find_check(parsed["data"]["checks"], "auth_token_quality")
+	assert quality["status"] == "warn"
+	assert "stoken 缺失" in quality["detail"]
+
+
+def test_auth_logged_in_no_wt2(tmp_path):
+	"""stoken 存在但 wt2 缺失时 quality 应为 error。"""
+	token = {"cookies": {}, "stoken": "stoken_val"}
+	code, parsed = _invoke_doctor(tmp_path, token=token)
+	quality = _find_check(parsed["data"]["checks"], "auth_token_quality")
+	assert quality["status"] == "error"
+	assert "wt2 缺失" in quality["detail"]
+
+
+def test_auth_logged_in_both_missing(tmp_path):
+	"""wt2 和 stoken 均缺失时 quality 应为 error。"""
+	token = {"cookies": {}, "stoken": ""}
+	code, parsed = _invoke_doctor(tmp_path, token=token)
+	quality = _find_check(parsed["data"]["checks"], "auth_token_quality")
+	assert quality["status"] == "error"
+	assert "均缺失" in quality["detail"]
+
+
+def test_auth_not_logged_in(tmp_path):
+	"""未登录时（无 session 文件）auth_session 应为 warn，quality 也应为 warn。"""
+	code, parsed = _invoke_doctor(tmp_path, token=None)
+	session = _find_check(parsed["data"]["checks"], "auth_session")
+	assert session["status"] == "warn"
+	quality = _find_check(parsed["data"]["checks"], "auth_token_quality")
+	assert quality["status"] == "warn"
+	# next_actions 应包含 login 提示
+	assert any("boss login" in a for a in parsed["hints"]["next_actions"])
+
+
+def test_auth_session_file_exists_but_undecryptable(tmp_path):
+	"""session.enc 存在但无法解密时 auth_session 应为 error。"""
+	auth_dir = tmp_path / "auth"
+	auth_dir.mkdir(parents=True)
+	(auth_dir / "session.enc").write_text("corrupted")
+	code, parsed = _invoke_doctor(tmp_path, token=None)
+	session = _find_check(parsed["data"]["checks"], "auth_session")
+	assert session["status"] == "error"
+	assert "损坏" in session["detail"]
+
+
+# ── 6. CDP 可用/不可用 ───────────────────────────────────────────────
+
+def test_cdp_available(tmp_path):
+	"""CDP 探测返回 ws url 时 cdp 检查应为 ok。"""
+	code, parsed = _invoke_doctor(tmp_path, cdp_ws="ws://127.0.0.1:9222/devtools/browser/abc")
+	cdp_check = _find_check(parsed["data"]["checks"], "cdp")
+	assert cdp_check["status"] == "ok"
+
+
+def test_cdp_unavailable(tmp_path):
+	"""CDP 探测返回 None 时 cdp 检查应为 warn。"""
+	code, parsed = _invoke_doctor(tmp_path, cdp_ws=None)
+	cdp_check = _find_check(parsed["data"]["checks"], "cdp")
+	assert cdp_check["status"] == "warn"
+
+
+def test_cdp_probe_exception(tmp_path):
+	"""CDP 探测抛异常时 cdp 检查应为 error。"""
+	paths = _base_patches()
+	runner = CliRunner()
+	with (
+		patch(paths["auth"]) as mock_auth,
+		patch(paths["cdp"]) as mock_cdp,
+		patch(paths["httpx"]) as mock_httpx,
+		patch(paths["cookie"]) as mock_cookie,
+		patch("boss_agent_cli.bridge.client.BridgeClient") as mock_bridge,
+	):
+		mock_bridge.return_value.is_running.return_value = False
+		mock_auth.return_value.check_status.return_value = None
+		mock_cdp.side_effect = RuntimeError("probe boom")
+		mock_cookie.return_value = None
+		mock_httpx.return_value = MagicMock(status_code=200)
+
+		result = runner.invoke(cli, ["--data-dir", str(tmp_path), "doctor"])
+	parsed = json.loads(result.output)
+	cdp_check = _find_check(parsed["data"]["checks"], "cdp")
+	assert cdp_check["status"] == "error"
+	assert "probe boom" in cdp_check["detail"]
+
+
+# ── 7. 输出 JSON 格式正确性 ─────────────────────────────────────────
+
+def test_json_envelope_structure(tmp_path):
+	"""验证 doctor 输出的 JSON 信封结构完整。"""
+	code, parsed = _invoke_doctor(tmp_path)
+	assert code == 0
+	# 顶层字段
+	assert "ok" in parsed
+	assert "command" in parsed
+	assert "data" in parsed
+	assert "hints" in parsed
+	# data 子字段
+	data = parsed["data"]
+	assert "summary" in data
+	assert "data_dir" in data
+	assert "check_count" in data
+	assert "checks" in data
+	assert isinstance(data["checks"], list)
+	assert data["check_count"] == len(data["checks"])
+	# 每条 check 的字段
+	for check in data["checks"]:
+		assert "name" in check
+		assert "status" in check
+		assert "detail" in check
+		assert check["status"] in ("ok", "warn", "error")
+
+
+def test_summary_degraded_when_warn_only(tmp_path):
+	"""只有 warn（无 error）时 summary 应为 degraded。"""
+	code, parsed = _invoke_doctor(tmp_path, token=None, cdp_ws=None, cookie=None)
+	summary = parsed["data"]["summary"]
+	has_error = any(c["status"] == "error" for c in parsed["data"]["checks"])
+	has_warn = any(c["status"] == "warn" for c in parsed["data"]["checks"])
+	if has_error:
+		assert summary == "broken"
+	elif has_warn:
+		assert summary == "degraded"
+
+
+def test_summary_broken_when_error_exists(tmp_path):
+	"""存在 error 检查项时 summary 应为 broken。"""
+	token = {"cookies": {}, "stoken": "stoken_val"}  # no wt2 => error
+	code, parsed = _invoke_doctor(tmp_path, token=token)
+	quality = _find_check(parsed["data"]["checks"], "auth_token_quality")
+	assert quality["status"] == "error"
+	assert parsed["data"]["summary"] == "broken"
+
+
+# ── 8. browser_channel 检查 ──────────────────────────────────────────
+
+def test_browser_channel_ok_with_cdp(tmp_path):
+	"""CDP 可用时 browser_channel 应为 ok 且提示 CDP 模式。"""
+	code, parsed = _invoke_doctor(tmp_path, cdp_ws="ws://127.0.0.1:9222/devtools/browser/abc")
+	ch = _find_check(parsed["data"]["checks"], "browser_channel")
+	assert ch is not None
+	assert ch["status"] == "ok"
+	assert "CDP" in ch["detail"]
+
+
+def test_browser_channel_warn_without_cdp_or_bridge(tmp_path):
+	"""CDP 和 Bridge 均不可用时 browser_channel 应为 warn。"""
+	code, parsed = _invoke_doctor(tmp_path, cdp_ws=None)
+	ch = _find_check(parsed["data"]["checks"], "browser_channel")
+	assert ch is not None
+	assert ch["status"] == "warn"
+	assert "降级" in ch["detail"]
+
+
+# ── 9. cookie 提取检查 ───────────────────────────────────────────────
+
+def test_cookie_extract_ok(tmp_path):
+	"""本地浏览器可提取 Cookie 时应为 ok。"""
+	code, parsed = _invoke_doctor(tmp_path, cookie={"cookies": {"wt2": "v", "token": "t"}})
+	ce = _find_check(parsed["data"]["checks"], "cookie_extract")
+	assert ce["status"] == "ok"
+	assert "提取" in ce["detail"]
+
+
+def test_cookie_extract_not_available(tmp_path):
+	"""无法从本地浏览器提取 Cookie 时应为 warn。"""
+	code, parsed = _invoke_doctor(tmp_path, cookie=None)
+	ce = _find_check(parsed["data"]["checks"], "cookie_extract")
+	assert ce["status"] == "warn"
+
+
+# ── 10. next_actions 提示逻辑 ────────────────────────────────────────
+
+def test_next_actions_suggests_login_when_not_logged_in(tmp_path):
+	code, parsed = _invoke_doctor(tmp_path, token=None)
+	actions = parsed["hints"]["next_actions"]
+	assert any("boss login" in a for a in actions)
+
+
+def test_next_actions_suggests_cdp_when_cdp_unavailable(tmp_path):
+	code, parsed = _invoke_doctor(tmp_path, cdp_ws=None)
+	actions = parsed["hints"]["next_actions"]
+	assert any("cdp" in a.lower() for a in actions)
+
+
+def test_next_actions_suggests_status_when_logged_in(tmp_path):
+	token = {"cookies": {"wt2": "tok"}, "stoken": "st"}
+	code, parsed = _invoke_doctor(tmp_path, token=token, cdp_ws="ws://x")
+	actions = parsed["hints"]["next_actions"]
+	assert any("boss status" in a for a in actions)


### PR DESCRIPTION
## 改动内容

- 新增环境诊断模块扩展测试，覆盖全部检查项正常和异常路径（26 个）
- 新增快照对比模块扩展测试，覆盖首次快照、增量对比、损坏降级（22 个）
- 新增导出模块扩展测试，覆盖公式注入防护、格式校验、空数据边界（42 个）
- 新增消息历史模块扩展测试，覆盖格式化、分页、降级逻辑（17 个）
- 全量测试从 261 增至 368，lint 全绿