### PR TITLE
feat: 新增简历数据模型和本地存储模块

### DIFF
--- a/src/boss_agent_cli/resume/models.py
+++ b/src/boss_agent_cli/resume/models.py
@@ -1,0 +1,234 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+
+
+@dataclass
+class PersonalInfoItem:
+	"""个人信息条目"""
+
+	label: str
+	value: str
+	icon: str = ""
+	link: str = ""
+
+
+@dataclass
+class PersonalInfoSection:
+	"""个人信息区块"""
+
+	items: list[PersonalInfoItem] = field(default_factory=list)
+	layout: str = "inline"
+
+
+@dataclass
+class JobIntentionItem:
+	"""求职意向条目"""
+
+	label: str
+	value: str
+
+
+@dataclass
+class JobIntentionSection:
+	"""求职意向区块"""
+
+	title: str = "求职意向"
+	icon: str = "mdi:target"
+	items: list[JobIntentionItem] = field(default_factory=list)
+	show_background: bool = True
+
+
+@dataclass
+class TagsRow:
+	"""标签行"""
+
+	type: str = "tags"
+	tags: list[str] = field(default_factory=list)
+
+
+@dataclass
+class RichTextRow:
+	"""富文本行"""
+
+	type: str = "richtext"
+	columns: int = 1
+	content: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ResumeModule:
+	"""简历模块"""
+
+	id: str
+	title: str
+	icon: str = ""
+	rows: list[dict] = field(default_factory=list)
+
+
+@dataclass
+class ResumeData:
+	"""简历完整数据结构"""
+
+	name: str
+	title: str
+	center_title: bool = False
+	personal_info: PersonalInfoSection = field(default_factory=PersonalInfoSection)
+	job_intention: JobIntentionSection | None = None
+	modules: list[ResumeModule] = field(default_factory=list)
+	avatar: str = ""
+	created_at: str = ""
+	updated_at: str = ""
+
+	def __post_init__(self):
+		now = datetime.now().isoformat()
+		if not self.created_at:
+			self.created_at = now
+		if not self.updated_at:
+			self.updated_at = now
+
+
+@dataclass
+class ResumeFile:
+	"""简历文件信封格式"""
+
+	version: str = "1.0"
+	data: ResumeData | None = None
+	metadata: dict = field(
+		default_factory=lambda: {
+			"exported_at": "",
+			"app_version": "",
+			"source": "boss-agent-cli",
+		}
+	)
+
+
+def resume_to_dict(resume: ResumeData) -> dict:
+	"""将 ResumeData 转为可 JSON 序列化的 dict"""
+	d: dict = {
+		"name": resume.name,
+		"title": resume.title,
+		"center_title": resume.center_title,
+		"personal_info": {
+			"items": [
+				{"label": item.label, "value": item.value, "icon": item.icon, "link": item.link}
+				for item in resume.personal_info.items
+			],
+			"layout": resume.personal_info.layout,
+		},
+		"job_intention": None,
+		"modules": [
+			{
+				"id": mod.id,
+				"title": mod.title,
+				"icon": mod.icon,
+				"rows": mod.rows,
+			}
+			for mod in resume.modules
+		],
+		"avatar": resume.avatar,
+		"created_at": resume.created_at,
+		"updated_at": resume.updated_at,
+	}
+	if resume.job_intention is not None:
+		d["job_intention"] = {
+			"title": resume.job_intention.title,
+			"icon": resume.job_intention.icon,
+			"items": [{"label": item.label, "value": item.value} for item in resume.job_intention.items],
+			"show_background": resume.job_intention.show_background,
+		}
+	return d
+
+
+def dict_to_resume(data: dict) -> ResumeData:
+	"""从 dict 恢复 ResumeData（处理嵌套对象）"""
+	pi_data = data.get("personal_info") or data.get("personalInfoSection") or {}
+	pi_items = [
+		PersonalInfoItem(
+			label=item.get("label", ""),
+			value=item.get("value", ""),
+			icon=item.get("icon", ""),
+			link=item.get("link", ""),
+		)
+		for item in pi_data.get("items", [])
+	]
+	personal_info = PersonalInfoSection(
+		items=pi_items,
+		layout=pi_data.get("layout", "inline"),
+	)
+
+	ji_data = data.get("job_intention") or data.get("jobIntentionSection")
+	job_intention = None
+	if ji_data is not None:
+		ji_items = [
+			JobIntentionItem(label=item.get("label", ""), value=item.get("value", ""))
+			for item in ji_data.get("items", [])
+		]
+		job_intention = JobIntentionSection(
+			title=ji_data.get("title", "求职意向"),
+			icon=ji_data.get("icon", "mdi:target"),
+			items=ji_items,
+			show_background=ji_data.get("show_background", ji_data.get("showBackground", True)),
+		)
+
+	modules_data = data.get("modules", [])
+	modules = [
+		ResumeModule(
+			id=mod.get("id", ""),
+			title=mod.get("title", ""),
+			icon=mod.get("icon", ""),
+			rows=mod.get("rows", []),
+		)
+		for mod in modules_data
+	]
+
+	return ResumeData(
+		name=data.get("name", ""),
+		title=data.get("title", ""),
+		center_title=data.get("center_title", data.get("centerTitle", False)),
+		personal_info=personal_info,
+		job_intention=job_intention,
+		modules=modules,
+		avatar=data.get("avatar", ""),
+		created_at=data.get("created_at", data.get("createdAt", "")),
+		updated_at=data.get("updated_at", data.get("updatedAt", "")),
+	)
+
+
+def resume_to_text(resume: ResumeData) -> str:
+	"""将简历转为纯文本（用于 AI 输入）"""
+	lines: list[str] = []
+
+	lines.append(resume.name)
+	lines.append(resume.title)
+	lines.append("")
+
+	if resume.personal_info.items:
+		for item in resume.personal_info.items:
+			lines.append(f"{item.label}: {item.value}")
+		lines.append("")
+
+	if resume.job_intention is not None:
+		lines.append(resume.job_intention.title)
+		for item in resume.job_intention.items:
+			lines.append(f"{item.label}: {item.value}")
+		lines.append("")
+
+	for mod in resume.modules:
+		lines.append(mod.title)
+		for row in mod.rows:
+			row_type = row.get("type", "")
+			if row_type == "tags":
+				tags = row.get("tags", [])
+				if tags:
+					lines.append(", ".join(tags))
+			elif row_type == "richtext":
+				content = row.get("content", [])
+				for line in content:
+					lines.append(line)
+			else:
+				content = row.get("content", [])
+				for line in content:
+					lines.append(str(line))
+		lines.append("")
+
+	return "\n".join(lines).strip()

--- a/src/boss_agent_cli/resume/store.py
+++ b/src/boss_agent_cli/resume/store.py
@@ -1,0 +1,109 @@
+import json
+from datetime import datetime
+from pathlib import Path
+
+from boss_agent_cli.resume.models import ResumeData, ResumeFile, dict_to_resume, resume_to_dict
+
+
+def _safe_filename(name: str) -> str:
+	"""将简历名称转为安全的文件名"""
+	return name.replace("/", "_").replace("\\", "_").replace("\0", "_")
+
+
+class ResumeStore:
+	"""简历文件存储（JSON 文件），存储路径 ~/.boss-agent/resumes/"""
+
+	def __init__(self, resumes_dir: Path):
+		self._dir = resumes_dir
+		self._dir.mkdir(parents=True, exist_ok=True)
+
+	def _path_for(self, name: str) -> Path:
+		return self._dir / f"{_safe_filename(name)}.json"
+
+	def list_all(self) -> list[dict]:
+		"""列出所有简历摘要（name, title, updated_at）"""
+		results: list[dict] = []
+		for path in sorted(self._dir.glob("*.json")):
+			try:
+				raw = json.loads(path.read_text(encoding="utf-8"))
+				results.append({
+					"name": raw.get("name", ""),
+					"title": raw.get("title", ""),
+					"updated_at": raw.get("updated_at", ""),
+				})
+			except (json.JSONDecodeError, OSError):
+				continue
+		return results
+
+	def get(self, name: str) -> ResumeData | None:
+		"""按名称读取简历"""
+		path = self._path_for(name)
+		if not path.exists():
+			return None
+		try:
+			raw = json.loads(path.read_text(encoding="utf-8"))
+			return dict_to_resume(raw)
+		except (json.JSONDecodeError, OSError):
+			return None
+
+	def save(self, resume: ResumeData) -> None:
+		"""保存/更新简历，自动更新 updated_at"""
+		resume.updated_at = datetime.now().isoformat()
+		d = resume_to_dict(resume)
+		path = self._path_for(resume.name)
+		path.write_text(json.dumps(d, ensure_ascii=False, indent=2), encoding="utf-8")
+
+	def delete(self, name: str) -> bool:
+		"""删除简历，返回是否成功"""
+		path = self._path_for(name)
+		if not path.exists():
+			return False
+		path.unlink()
+		return True
+
+	def exists(self, name: str) -> bool:
+		"""检查简历是否存在"""
+		return self._path_for(name).exists()
+
+	def import_file(self, file_path: Path) -> ResumeData:
+		"""导入 JSON 文件（兼容 wzdnzd/zine0 camelCase 格式）"""
+		raw_text = file_path.read_text(encoding="utf-8")
+		raw = json.loads(raw_text)
+
+		if "version" in raw and "data" in raw and isinstance(raw["data"], dict):
+			raw = raw["data"]
+
+		resume = dict_to_resume(raw)
+		self.save(resume)
+		return resume
+
+	def export_json(self, name: str) -> str:
+		"""导出为 ResumeFile JSON 字符串"""
+		resume = self.get(name)
+		if resume is None:
+			raise FileNotFoundError(f"简历 '{name}' 不存在")
+
+		from boss_agent_cli import __version__
+
+		envelope = ResumeFile(data=resume)
+		envelope.metadata["exported_at"] = datetime.now().isoformat()
+		envelope.metadata["app_version"] = __version__
+
+		d = {
+			"version": envelope.version,
+			"data": resume_to_dict(resume),
+			"metadata": envelope.metadata,
+		}
+		return json.dumps(d, ensure_ascii=False, indent=2)
+
+	def clone(self, name: str, new_name: str) -> ResumeData:
+		"""复制简历为新版本"""
+		resume = self.get(name)
+		if resume is None:
+			raise FileNotFoundError(f"简历 '{name}' 不存在")
+		resume.name = new_name
+		resume.created_at = ""
+		resume.updated_at = ""
+		resume.__post_init__()
+		self.save(resume)
+		return resume

--- a/tests/test_resume_import_compat.py
+++ b/tests/test_resume_import_compat.py
@@ -1,6 +1,5 @@
 import json
 
-from boss_agent_cli.resume.models import ResumeData
 from boss_agent_cli.resume.store import ResumeStore
 
 

--- a/tests/test_resume_import_compat.py
+++ b/tests/test_resume_import_compat.py
@@ -1,0 +1,154 @@
+import json
+
+from boss_agent_cli.resume.models import ResumeData
+from boss_agent_cli.resume.store import ResumeStore
+
+
+def _write_json(path, data):
+	path.parent.mkdir(parents=True, exist_ok=True)
+	path.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+
+
+def test_import_camelcase_format(tmp_path):
+	"""导入 wzdnzd/zine0 camelCase 格式"""
+	store = ResumeStore(tmp_path / "resumes")
+	src = tmp_path / "input.json"
+	_write_json(src, {
+		"name": "张三",
+		"title": "Python 开发",
+		"centerTitle": True,
+		"personalInfoSection": {
+			"items": [
+				{"label": "邮箱", "value": "test@example.com", "icon": "mdi:email", "link": ""},
+			],
+			"layout": "inline",
+		},
+		"jobIntentionSection": {
+			"title": "求职意向",
+			"icon": "mdi:target",
+			"items": [{"label": "期望城市", "value": "广州"}],
+			"showBackground": True,
+		},
+		"modules": [
+			{
+				"id": "skills",
+				"title": "技能",
+				"icon": "",
+				"rows": [{"type": "tags", "tags": ["Python", "Go"]}],
+			},
+		],
+		"avatar": "",
+		"createdAt": "2026-01-01T00:00:00",
+		"updatedAt": "2026-01-02T00:00:00",
+	})
+	r = store.import_file(src)
+	assert r.name == "张三"
+	assert r.center_title is True
+	assert r.personal_info.items[0].label == "邮箱"
+	assert r.job_intention is not None
+	assert r.job_intention.items[0].value == "广州"
+	assert r.modules[0].id == "skills"
+	assert store.exists("张三")
+
+
+def test_import_snake_case_format(tmp_path):
+	"""导入本地 snake_case 格式"""
+	store = ResumeStore(tmp_path / "resumes")
+	src = tmp_path / "input.json"
+	_write_json(src, {
+		"name": "李四",
+		"title": "Go 开发",
+		"center_title": False,
+		"personal_info": {
+			"items": [{"label": "手机", "value": "13900139000"}],
+			"layout": "inline",
+		},
+		"modules": [],
+	})
+	r = store.import_file(src)
+	assert r.name == "李四"
+	assert r.center_title is False
+	assert r.personal_info.items[0].value == "13900139000"
+
+
+def test_import_with_envelope(tmp_path):
+	"""导入带 ResumeFile 信封的格式"""
+	store = ResumeStore(tmp_path / "resumes")
+	src = tmp_path / "input.json"
+	_write_json(src, {
+		"version": "1.0",
+		"data": {
+			"name": "王五",
+			"title": "前端工程师",
+			"personal_info": {"items": [], "layout": "inline"},
+			"modules": [],
+		},
+		"metadata": {"source": "other-tool"},
+	})
+	r = store.import_file(src)
+	assert r.name == "王五"
+	assert r.title == "前端工程师"
+	assert store.exists("王五")
+
+
+def test_import_bare_resume_data(tmp_path):
+	"""导入无信封的裸 ResumeData 格式"""
+	store = ResumeStore(tmp_path / "resumes")
+	src = tmp_path / "input.json"
+	_write_json(src, {
+		"name": "赵六",
+		"title": "后端开发",
+	})
+	r = store.import_file(src)
+	assert r.name == "赵六"
+	assert r.modules == []
+	assert r.job_intention is None
+
+
+def test_import_missing_optional_fields(tmp_path):
+	"""导入缺失可选字段的格式"""
+	store = ResumeStore(tmp_path / "resumes")
+	src = tmp_path / "input.json"
+	_write_json(src, {
+		"name": "钱七",
+		"title": "测试工程师",
+		"modules": [
+			{"id": "edu", "title": "教育"},
+		],
+	})
+	r = store.import_file(src)
+	assert r.name == "钱七"
+	assert r.personal_info.items == []
+	assert r.modules[0].icon == ""
+	assert r.modules[0].rows == []
+
+
+def test_import_invalid_json(tmp_path):
+	"""导入无效 JSON 报错"""
+	store = ResumeStore(tmp_path / "resumes")
+	src = tmp_path / "input.json"
+	src.write_text("not valid json {{{", encoding="utf-8")
+	try:
+		store.import_file(src)
+		assert False, "Should raise"
+	except (json.JSONDecodeError, ValueError):
+		pass
+
+
+def test_import_camelcase_show_background(tmp_path):
+	"""camelCase showBackground 正确映射"""
+	store = ResumeStore(tmp_path / "resumes")
+	src = tmp_path / "input.json"
+	_write_json(src, {
+		"name": "测试",
+		"title": "开发",
+		"jobIntentionSection": {
+			"title": "求职意向",
+			"icon": "mdi:target",
+			"items": [{"label": "薪资", "value": "20K"}],
+			"showBackground": False,
+		},
+	})
+	r = store.import_file(src)
+	assert r.job_intention is not None
+	assert r.job_intention.show_background is False

--- a/tests/test_resume_models.py
+++ b/tests/test_resume_models.py
@@ -1,0 +1,215 @@
+from boss_agent_cli.resume.models import (
+	PersonalInfoItem,
+	PersonalInfoSection,
+	JobIntentionItem,
+	JobIntentionSection,
+	ResumeData,
+	ResumeFile,
+	ResumeModule,
+	resume_to_dict,
+	dict_to_resume,
+	resume_to_text,
+)
+
+
+def test_resume_data_defaults():
+	r = ResumeData(name="张三", title="Python 开发工程师")
+	assert r.name == "张三"
+	assert r.title == "Python 开发工程师"
+	assert r.center_title is False
+	assert r.avatar == ""
+	assert r.created_at != ""
+	assert r.updated_at != ""
+	assert r.modules == []
+	assert r.job_intention is None
+
+
+def test_resume_data_auto_timestamps():
+	r = ResumeData(name="张三", title="开发")
+	assert r.created_at == r.updated_at
+	assert "T" in r.created_at
+
+
+def test_resume_data_preserves_explicit_timestamps():
+	r = ResumeData(name="张三", title="开发", created_at="2026-01-01T00:00:00", updated_at="2026-01-02T00:00:00")
+	assert r.created_at == "2026-01-01T00:00:00"
+	assert r.updated_at == "2026-01-02T00:00:00"
+
+
+def test_personal_info_item():
+	item = PersonalInfoItem(label="邮箱", value="test@example.com", icon="mdi:email", link="mailto:test@example.com")
+	assert item.label == "邮箱"
+	assert item.value == "test@example.com"
+	assert item.icon == "mdi:email"
+	assert item.link == "mailto:test@example.com"
+
+
+def test_personal_info_item_defaults():
+	item = PersonalInfoItem(label="手机", value="13800138000")
+	assert item.icon == ""
+	assert item.link == ""
+
+
+def test_personal_info_section():
+	section = PersonalInfoSection(
+		items=[PersonalInfoItem(label="手机", value="13800138000")],
+		layout="grid",
+	)
+	assert len(section.items) == 1
+	assert section.layout == "grid"
+
+
+def test_personal_info_section_defaults():
+	section = PersonalInfoSection()
+	assert section.items == []
+	assert section.layout == "inline"
+
+
+def test_job_intention_section():
+	section = JobIntentionSection(
+		title="求职意向",
+		icon="mdi:target",
+		items=[
+			JobIntentionItem(label="期望职位", value="Python 开发"),
+			JobIntentionItem(label="期望城市", value="广州"),
+		],
+		show_background=True,
+	)
+	assert section.title == "求职意向"
+	assert len(section.items) == 2
+	assert section.items[0].value == "Python 开发"
+
+
+def test_resume_module():
+	module = ResumeModule(
+		id="work_experience",
+		title="工作经历",
+		icon="mdi:briefcase",
+		rows=[
+			{"type": "richtext", "columns": 1, "content": ["5 年 Python 开发经验"]},
+			{"type": "tags", "tags": ["Python", "Django", "FastAPI"]},
+		],
+	)
+	assert module.id == "work_experience"
+	assert module.title == "工作经历"
+	assert len(module.rows) == 2
+
+
+def test_resume_file_envelope():
+	r = ResumeData(name="张三", title="开发")
+	f = ResumeFile(data=r)
+	assert f.version == "1.0"
+	assert f.data is not None
+	assert f.data.name == "张三"
+	assert f.metadata["source"] == "boss-agent-cli"
+
+
+def test_resume_to_dict_serialization():
+	r = ResumeData(
+		name="张三",
+		title="Python 开发",
+		center_title=True,
+		personal_info=PersonalInfoSection(
+			items=[PersonalInfoItem(label="邮箱", value="test@example.com")],
+			layout="inline",
+		),
+		job_intention=JobIntentionSection(
+			items=[JobIntentionItem(label="期望城市", value="广州")],
+		),
+		modules=[
+			ResumeModule(
+				id="skills",
+				title="技能",
+				rows=[{"type": "tags", "tags": ["Python", "Go"]}],
+			),
+		],
+	)
+	d = resume_to_dict(r)
+	assert d["name"] == "张三"
+	assert d["center_title"] is True
+	assert len(d["personal_info"]["items"]) == 1
+	assert d["personal_info"]["items"][0]["label"] == "邮箱"
+	assert d["job_intention"]["items"][0]["value"] == "广州"
+	assert d["modules"][0]["id"] == "skills"
+	assert d["modules"][0]["rows"][0]["tags"] == ["Python", "Go"]
+
+
+def test_dict_to_resume_roundtrip():
+	original = ResumeData(
+		name="李四",
+		title="全栈工程师",
+		personal_info=PersonalInfoSection(
+			items=[
+				PersonalInfoItem(label="手机", value="13900139000"),
+				PersonalInfoItem(label="邮箱", value="li@example.com", icon="mdi:email"),
+			],
+		),
+		job_intention=JobIntentionSection(
+			items=[JobIntentionItem(label="薪资", value="20-30K")],
+		),
+		modules=[
+			ResumeModule(id="edu", title="教育经历", icon="mdi:school"),
+		],
+	)
+	d = resume_to_dict(original)
+	restored = dict_to_resume(d)
+	assert restored.name == original.name
+	assert restored.title == original.title
+	assert len(restored.personal_info.items) == 2
+	assert restored.personal_info.items[1].icon == "mdi:email"
+	assert restored.job_intention is not None
+	assert restored.job_intention.items[0].value == "20-30K"
+	assert restored.modules[0].id == "edu"
+	assert restored.modules[0].icon == "mdi:school"
+
+
+def test_dict_to_resume_without_optional_fields():
+	d = {"name": "王五", "title": "前端工程师"}
+	r = dict_to_resume(d)
+	assert r.name == "王五"
+	assert r.job_intention is None
+	assert r.modules == []
+	assert r.personal_info.items == []
+
+
+def test_resume_to_text():
+	r = ResumeData(
+		name="张三",
+		title="Python 开发工程师",
+		personal_info=PersonalInfoSection(
+			items=[
+				PersonalInfoItem(label="邮箱", value="test@example.com"),
+				PersonalInfoItem(label="手机", value="13800138000"),
+			],
+		),
+		job_intention=JobIntentionSection(
+			items=[
+				JobIntentionItem(label="期望职位", value="Python 开发"),
+				JobIntentionItem(label="期望城市", value="广州"),
+			],
+		),
+		modules=[
+			ResumeModule(
+				id="skills",
+				title="技能特长",
+				rows=[
+					{"type": "tags", "tags": ["Python", "Go", "Rust"]},
+					{"type": "richtext", "content": ["精通 Python 后端开发"]},
+				],
+			),
+		],
+	)
+	text = resume_to_text(r)
+	assert "张三" in text
+	assert "Python 开发工程师" in text
+	assert "test@example.com" in text
+	assert "期望职位" in text
+	assert "技能特长" in text
+	assert "Python" in text
+	assert "精通 Python 后端开发" in text
+
+
+def test_resume_to_dict_no_job_intention():
+	r = ResumeData(name="张三", title="开发")
+	d = resume_to_dict(r)
+	assert d["job_intention"] is None

--- a/tests/test_resume_store.py
+++ b/tests/test_resume_store.py
@@ -1,6 +1,6 @@
 import json
 
-from boss_agent_cli.resume.models import ResumeData, PersonalInfoSection, PersonalInfoItem, ResumeModule, resume_to_dict
+from boss_agent_cli.resume.models import ResumeData, PersonalInfoSection, PersonalInfoItem, ResumeModule
 from boss_agent_cli.resume.store import ResumeStore
 
 

--- a/tests/test_resume_store.py
+++ b/tests/test_resume_store.py
@@ -1,0 +1,151 @@
+import json
+
+from boss_agent_cli.resume.models import ResumeData, PersonalInfoSection, PersonalInfoItem, ResumeModule, resume_to_dict
+from boss_agent_cli.resume.store import ResumeStore
+
+
+def test_save_and_get(tmp_path):
+	store = ResumeStore(tmp_path / "resumes")
+	r = ResumeData(name="张三", title="Python 开发")
+	store.save(r)
+	loaded = store.get("张三")
+	assert loaded is not None
+	assert loaded.name == "张三"
+	assert loaded.title == "Python 开发"
+
+
+def test_get_nonexistent(tmp_path):
+	store = ResumeStore(tmp_path / "resumes")
+	assert store.get("不存在") is None
+
+
+def test_save_updates_timestamp(tmp_path):
+	store = ResumeStore(tmp_path / "resumes")
+	r = ResumeData(name="张三", title="开发", updated_at="2026-01-01T00:00:00")
+	store.save(r)
+	loaded = store.get("张三")
+	assert loaded is not None
+	assert loaded.updated_at != "2026-01-01T00:00:00"
+
+
+def test_list_all(tmp_path):
+	store = ResumeStore(tmp_path / "resumes")
+	store.save(ResumeData(name="张三", title="Python 开发"))
+	store.save(ResumeData(name="李四", title="Go 开发"))
+	store.save(ResumeData(name="王五", title="前端工程师"))
+	items = store.list_all()
+	assert len(items) == 3
+	names = [item["name"] for item in items]
+	assert "张三" in names
+	assert "李四" in names
+	assert "王五" in names
+	for item in items:
+		assert "name" in item
+		assert "title" in item
+		assert "updated_at" in item
+
+
+def test_delete_success(tmp_path):
+	store = ResumeStore(tmp_path / "resumes")
+	store.save(ResumeData(name="张三", title="开发"))
+	assert store.delete("张三") is True
+	assert store.get("张三") is None
+
+
+def test_delete_nonexistent(tmp_path):
+	store = ResumeStore(tmp_path / "resumes")
+	assert store.delete("不存在") is False
+
+
+def test_exists(tmp_path):
+	store = ResumeStore(tmp_path / "resumes")
+	assert store.exists("张三") is False
+	store.save(ResumeData(name="张三", title="开发"))
+	assert store.exists("张三") is True
+
+
+def test_export_json(tmp_path):
+	store = ResumeStore(tmp_path / "resumes")
+	r = ResumeData(
+		name="张三",
+		title="Python 开发",
+		personal_info=PersonalInfoSection(
+			items=[PersonalInfoItem(label="邮箱", value="test@example.com")],
+		),
+		modules=[ResumeModule(id="skills", title="技能", rows=[{"type": "tags", "tags": ["Python"]}])],
+	)
+	store.save(r)
+	exported = store.export_json("张三")
+	data = json.loads(exported)
+	assert data["version"] == "1.0"
+	assert data["data"]["name"] == "张三"
+	assert data["metadata"]["source"] == "boss-agent-cli"
+
+
+def test_export_json_nonexistent(tmp_path):
+	store = ResumeStore(tmp_path / "resumes")
+	try:
+		store.export_json("不存在")
+		assert False, "Should raise"
+	except FileNotFoundError:
+		pass
+
+
+def test_clone(tmp_path):
+	store = ResumeStore(tmp_path / "resumes")
+	store.save(ResumeData(name="张三", title="Python 开发"))
+	cloned = store.clone("张三", "张三-v2")
+	assert cloned.name == "张三-v2"
+	assert cloned.title == "Python 开发"
+	assert store.exists("张三")
+	assert store.exists("张三-v2")
+
+
+def test_clone_nonexistent(tmp_path):
+	store = ResumeStore(tmp_path / "resumes")
+	try:
+		store.clone("不存在", "新版本")
+		assert False, "Should raise"
+	except FileNotFoundError:
+		pass
+
+
+def test_save_overwrite(tmp_path):
+	store = ResumeStore(tmp_path / "resumes")
+	store.save(ResumeData(name="张三", title="Python 开发"))
+	store.save(ResumeData(name="张三", title="Go 开发"))
+	loaded = store.get("张三")
+	assert loaded is not None
+	assert loaded.title == "Go 开发"
+	assert len(store.list_all()) == 1
+
+
+def test_save_preserves_full_data(tmp_path):
+	store = ResumeStore(tmp_path / "resumes")
+	r = ResumeData(
+		name="张三",
+		title="全栈",
+		center_title=True,
+		personal_info=PersonalInfoSection(
+			items=[
+				PersonalInfoItem(label="手机", value="13800138000"),
+				PersonalInfoItem(label="邮箱", value="z@example.com", icon="mdi:email"),
+			],
+			layout="grid",
+		),
+		modules=[
+			ResumeModule(id="work", title="工作经历", icon="mdi:briefcase", rows=[
+				{"type": "richtext", "columns": 2, "content": ["A 公司", "2020-2026"]},
+			]),
+		],
+		avatar="https://example.com/avatar.jpg",
+	)
+	store.save(r)
+	loaded = store.get("张三")
+	assert loaded is not None
+	assert loaded.center_title is True
+	assert loaded.personal_info.layout == "grid"
+	assert len(loaded.personal_info.items) == 2
+	assert loaded.personal_info.items[1].icon == "mdi:email"
+	assert loaded.modules[0].icon == "mdi:briefcase"
+	assert loaded.avatar == "https://example.com/avatar.jpg"


### PR DESCRIPTION
## 改动内容

- 新增简历数据模型，支持结构化解析个人信息、教育、工作经历等模块
- 新增简历本地存储模块，支持保存和加载简历快照
- 新增四十六个测试覆盖模型构建、序列化和存储逻辑
- 全量五百二十六个测试通过