### PR TITLE
feat: 增加简历管理命令支持多版本和导出

### DIFF
--- a/src/boss_agent_cli/commands/resume_cmd.py
+++ b/src/boss_agent_cli/commands/resume_cmd.py
@@ -1,0 +1,299 @@
+import json
+import sys
+from pathlib import Path
+
+import click
+
+from boss_agent_cli.display import handle_error_output, handle_output
+from boss_agent_cli.resume.models import ResumeData, PersonalInfoSection, resume_to_dict
+from boss_agent_cli.resume.store import ResumeStore
+
+
+def _get_store(ctx) -> ResumeStore:
+	resumes_dir: Path = ctx.obj["data_dir"] / "resumes"
+	return ResumeStore(resumes_dir)
+
+
+def _build_default_template(name: str) -> ResumeData:
+	"""从默认模板创建空白简历"""
+	return ResumeData(
+		name=name,
+		title="我的简历",
+		center_title=False,
+		personal_info=PersonalInfoSection(items=[], layout="inline"),
+		job_intention=None,
+		modules=[],
+		avatar="",
+	)
+
+
+def _set_nested(data: dict, path: str, value: str) -> bool:
+	"""通过 . 分隔路径设置嵌套 dict 字段，返回是否成功"""
+	keys = path.split(".")
+	current = data
+	for key in keys[:-1]:
+		if isinstance(current, dict) and key in current:
+			current = current[key]
+		else:
+			return False
+	last = keys[-1]
+	if isinstance(current, dict) and last in current:
+		current[last] = value
+		return True
+	return False
+
+
+def _flat_diff(left: dict, right: dict, prefix: str = "") -> list[dict]:
+	"""对比两个 dict 的差异，返回 [{field, left, right}, ...]"""
+	diffs: list[dict] = []
+	all_keys = sorted(set(list(left.keys()) + list(right.keys())))
+	for key in all_keys:
+		full_key = f"{prefix}.{key}" if prefix else key
+		lv = left.get(key)
+		rv = right.get(key)
+		if isinstance(lv, dict) and isinstance(rv, dict):
+			diffs.extend(_flat_diff(lv, rv, full_key))
+		elif isinstance(lv, list) and isinstance(rv, list):
+			if lv != rv:
+				diffs.append({"field": full_key, "left": lv, "right": rv})
+		elif lv != rv:
+			diffs.append({"field": full_key, "left": lv, "right": rv})
+	return diffs
+
+
+@click.group("resume")
+def resume_group():
+	"""本地简历管理。"""
+
+
+@resume_group.command("init")
+@click.option("--name", default=None, help="简历名称")
+@click.option("--template", default=None, help="模板名称（如 default）")
+@click.pass_context
+def resume_init_cmd(ctx, name, template):
+	"""从默认模板初始化本地简历"""
+	store = _get_store(ctx)
+	if template is None:
+		# TODO: 从 BOSS 直聘 API 拉取简历（需登录态）
+		template = "default"
+	if name is None:
+		name = "default"
+	if store.exists(name):
+		handle_error_output(
+			ctx, "resume",
+			code="RESUME_ALREADY_EXISTS",
+			message=f"简历 '{name}' 已存在",
+			recovery_action="使用不同名称或先删除已有简历",
+		)
+		ctx.exit(1)
+		return
+	resume = _build_default_template(name)
+	store.save(resume)
+	handle_output(
+		ctx, "resume",
+		{"action": "init", "name": name, "template": template},
+		hints={"next_actions": [f"boss resume show {name}", f"boss resume edit {name} --field title --value <新标题>"]},
+	)
+
+
+@resume_group.command("list")
+@click.pass_context
+def resume_list_cmd(ctx):
+	"""列出所有本地简历"""
+	store = _get_store(ctx)
+	items = store.list_all()
+	handle_output(
+		ctx, "resume", items,
+		hints={"next_actions": ["boss resume show <name>", "boss resume init --template default"]},
+	)
+
+
+@resume_group.command("show")
+@click.argument("name")
+@click.pass_context
+def resume_show_cmd(ctx, name):
+	"""查看简历详情"""
+	store = _get_store(ctx)
+	resume = store.get(name)
+	if resume is None:
+		handle_error_output(ctx, "resume", code="RESUME_NOT_FOUND", message=f"简历 '{name}' 不存在")
+		ctx.exit(1)
+		return
+	handle_output(
+		ctx, "resume", resume_to_dict(resume),
+		hints={"next_actions": [
+			f"boss resume edit {name} --field title --value <新标题>",
+			f"boss resume export {name} --format json",
+		]},
+	)
+
+
+@resume_group.command("edit")
+@click.argument("name")
+@click.option("--field", required=True, help="字段路径（如 title, personal_info.layout）")
+@click.option("--value", required=True, help="新值")
+@click.pass_context
+def resume_edit_cmd(ctx, name, field, value):
+	"""编辑简历字段"""
+	store = _get_store(ctx)
+	resume = store.get(name)
+	if resume is None:
+		handle_error_output(ctx, "resume", code="RESUME_NOT_FOUND", message=f"简历 '{name}' 不存在")
+		ctx.exit(1)
+		return
+	data = resume_to_dict(resume)
+	ok = _set_nested(data, field, value)
+	if not ok:
+		handle_error_output(
+			ctx, "resume",
+			code="INVALID_PARAM",
+			message=f"字段 '{field}' 不存在",
+		)
+		ctx.exit(1)
+		return
+	from boss_agent_cli.resume.models import dict_to_resume
+	updated = dict_to_resume(data)
+	updated.name = name
+	store.save(updated)
+	handle_output(
+		ctx, "resume",
+		{"action": "edit", "name": name, "field": field, "value": value},
+		hints={"next_actions": [f"boss resume show {name}"]},
+	)
+
+
+@resume_group.command("delete")
+@click.argument("name")
+@click.pass_context
+def resume_delete_cmd(ctx, name):
+	"""删除简历"""
+	store = _get_store(ctx)
+	if not store.exists(name):
+		handle_error_output(ctx, "resume", code="RESUME_NOT_FOUND", message=f"简历 '{name}' 不存在")
+		ctx.exit(1)
+		return
+	store.delete(name)
+	handle_output(
+		ctx, "resume",
+		{"action": "delete", "name": name, "deleted": True},
+		hints={"next_actions": ["boss resume list"]},
+	)
+
+
+@resume_group.command("export")
+@click.argument("name")
+@click.option("--format", "fmt", default="json", type=click.Choice(["pdf", "json", "html"]), help="导出格式")
+@click.option("-o", "--output", "output_path", default=None, help="输出文件路径")
+@click.pass_context
+def resume_export_cmd(ctx, name, fmt, output_path):
+	"""导出简历"""
+	store = _get_store(ctx)
+	if not store.exists(name):
+		handle_error_output(ctx, "resume", code="RESUME_NOT_FOUND", message=f"简历 '{name}' 不存在")
+		ctx.exit(1)
+		return
+	if fmt in ("pdf", "html"):
+		handle_error_output(
+			ctx, "resume",
+			code="EXPORT_FAILED",
+			message=f"{fmt.upper()} 导出将在后续版本支持",
+			recoverable=True,
+			recovery_action="当前请使用 --format json",
+		)
+		ctx.exit(1)
+		return
+	json_str = store.export_json(name)
+	export_data = json.loads(json_str)
+	if output_path:
+		Path(output_path).write_text(json_str, encoding="utf-8")
+	handle_output(
+		ctx, "resume", export_data,
+		hints={"next_actions": [f"boss resume show {name}"]},
+	)
+
+
+@resume_group.command("import")
+@click.argument("file_path", type=click.Path())
+@click.pass_context
+def resume_import_cmd(ctx, file_path):
+	"""导入 JSON 简历"""
+	path = Path(file_path)
+	if not path.exists():
+		handle_error_output(
+			ctx, "resume",
+			code="INVALID_PARAM",
+			message=f"文件 '{file_path}' 不存在",
+		)
+		ctx.exit(1)
+		return
+	store = _get_store(ctx)
+	try:
+		resume = store.import_file(path)
+	except (json.JSONDecodeError, KeyError, TypeError) as exc:
+		handle_error_output(
+			ctx, "resume",
+			code="INVALID_PARAM",
+			message=f"文件解析失败: {exc}",
+		)
+		ctx.exit(1)
+		return
+	handle_output(
+		ctx, "resume",
+		{"action": "import", "name": resume.name, "title": resume.title},
+		hints={"next_actions": [f"boss resume show {resume.name}"]},
+	)
+
+
+@resume_group.command("clone")
+@click.argument("name")
+@click.argument("new_name")
+@click.pass_context
+def resume_clone_cmd(ctx, name, new_name):
+	"""复制简历为新版本"""
+	store = _get_store(ctx)
+	if not store.exists(name):
+		handle_error_output(ctx, "resume", code="RESUME_NOT_FOUND", message=f"简历 '{name}' 不存在")
+		ctx.exit(1)
+		return
+	if store.exists(new_name):
+		handle_error_output(
+			ctx, "resume",
+			code="RESUME_ALREADY_EXISTS",
+			message=f"简历 '{new_name}' 已存在",
+			recovery_action="使用不同名称或先删除已有简历",
+		)
+		ctx.exit(1)
+		return
+	resume = store.clone(name, new_name)
+	handle_output(
+		ctx, "resume",
+		{"action": "clone", "name": resume.name, "source": name},
+		hints={"next_actions": [f"boss resume show {new_name}", f"boss resume diff {name} {new_name}"]},
+	)
+
+
+@resume_group.command("diff")
+@click.argument("name1")
+@click.argument("name2")
+@click.pass_context
+def resume_diff_cmd(ctx, name1, name2):
+	"""对比两份简历差异"""
+	store = _get_store(ctx)
+	r1 = store.get(name1)
+	if r1 is None:
+		handle_error_output(ctx, "resume", code="RESUME_NOT_FOUND", message=f"简历 '{name1}' 不存在")
+		ctx.exit(1)
+		return
+	r2 = store.get(name2)
+	if r2 is None:
+		handle_error_output(ctx, "resume", code="RESUME_NOT_FOUND", message=f"简历 '{name2}' 不存在")
+		ctx.exit(1)
+		return
+	d1 = resume_to_dict(r1)
+	d2 = resume_to_dict(r2)
+	diffs = _flat_diff(d1, d2)
+	handle_output(
+		ctx, "resume",
+		{"name1": name1, "name2": name2, "diffs": diffs},
+		hints={"next_actions": [f"boss resume show {name1}", f"boss resume show {name2}"]},
+	)

--- a/src/boss_agent_cli/commands/resume_cmd.py
+++ b/src/boss_agent_cli/commands/resume_cmd.py
@@ -1,5 +1,4 @@
 import json
-import sys
 from pathlib import Path
 
 import click

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -404,6 +404,22 @@ SCHEMA_DATA = {
 				"--days": {"type": "int", "default": 30, "description": "清理超过指定天数的快照和导出"},
 			},
 		},
+		"resume": {
+			"description": "本地简历管理（子命令：init/list/show/edit/delete/export/import/clone/diff）",
+			"args": [],
+			"options": {},
+			"subcommands": {
+				"init": "从 BOSS 直聘简历或默认模板初始化本地简历",
+				"list": "列出所有本地简历",
+				"show": "查看简历详情",
+				"edit": "编辑简历字段",
+				"delete": "删除简历",
+				"export": "导出为 PDF/JSON/HTML",
+				"import": "导入 JSON 简历（兼容 wzdnzd/zine0 格式）",
+				"clone": "复制简历为新版本",
+				"diff": "对比两份简历差异",
+			},
+		},
 	},
 	"global_options": {
 		"--data-dir": {
@@ -488,6 +504,21 @@ SCHEMA_DATA = {
 			"message": "参数校验失败",
 			"recoverable": False,
 			"recovery_action": "修正参数",
+		},
+		"RESUME_NOT_FOUND": {
+			"message": "简历不存在",
+			"recoverable": False,
+			"recovery_action": None,
+		},
+		"RESUME_ALREADY_EXISTS": {
+			"message": "简历名称已存在",
+			"recoverable": False,
+			"recovery_action": "使用不同名称或先删除已有简历",
+		},
+		"EXPORT_FAILED": {
+			"message": "导出失败",
+			"recoverable": True,
+			"recovery_action": "检查 patchright 安装：patchright install chromium",
 		},
 	},
 	"conventions": {

--- a/src/boss_agent_cli/config.py
+++ b/src/boss_agent_cli/config.py
@@ -11,6 +11,8 @@ DEFAULTS = {
 	"login_timeout": 120,
 	"cdp_url": None,
 	"export_dir": None,
+	"resume_default_template": "default",
+	"resume_export_format": "pdf",
 }
 
 

--- a/src/boss_agent_cli/main.py
+++ b/src/boss_agent_cli/main.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import click
 
 from boss_agent_cli import __version__
-from boss_agent_cli.commands import schema, login, logout, status, doctor, search, detail, greet, recommend, export, cities, me, chat, chatmsg, chat_summary, mark, exchange, interviews, show, history, watch, pipeline, apply, shortlist, preset, digest, config_cmd, clean
+from boss_agent_cli.commands import schema, login, logout, status, doctor, search, detail, greet, recommend, export, cities, me, chat, chatmsg, chat_summary, mark, exchange, interviews, show, history, watch, pipeline, apply, shortlist, preset, digest, config_cmd, clean, resume_cmd
 from boss_agent_cli.config import load_config
 from boss_agent_cli.hooks import create_hook_bus
 from boss_agent_cli.output import Logger
@@ -70,3 +70,4 @@ cli.add_command(preset.preset_group, "preset")
 cli.add_command(digest.digest_cmd, "digest")
 cli.add_command(config_cmd.config_group, "config")
 cli.add_command(clean.clean_cmd, "clean")
+cli.add_command(resume_cmd.resume_group, "resume")

--- a/tests/test_resume_commands.py
+++ b/tests/test_resume_commands.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 
 from click.testing import CliRunner
 

--- a/tests/test_resume_commands.py
+++ b/tests/test_resume_commands.py
@@ -1,0 +1,308 @@
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from boss_agent_cli.main import cli
+
+
+def _invoke(runner, tmp_path, args):
+	return runner.invoke(cli, ["--data-dir", str(tmp_path), "--json", "resume"] + args)
+
+
+# ── init ──────────────────────────────────────────────────────
+
+
+def test_init_with_template(tmp_path):
+	runner = CliRunner()
+	result = _invoke(runner, tmp_path, ["init", "--name", "myresume", "--template", "default"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["name"] == "myresume"
+	assert parsed["data"]["action"] == "init"
+
+
+def test_init_default_name(tmp_path):
+	"""不传 --name 时应使用默认名称"""
+	runner = CliRunner()
+	result = _invoke(runner, tmp_path, ["init", "--template", "default"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["name"] != ""
+
+
+def test_init_already_exists(tmp_path):
+	runner = CliRunner()
+	_invoke(runner, tmp_path, ["init", "--name", "dup", "--template", "default"])
+	result = _invoke(runner, tmp_path, ["init", "--name", "dup", "--template", "default"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["error"]["code"] == "RESUME_ALREADY_EXISTS"
+
+
+# ── list ──────────────────────────────────────────────────────
+
+
+def test_list_empty(tmp_path):
+	runner = CliRunner()
+	result = _invoke(runner, tmp_path, ["list"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"] == []
+
+
+def test_list_with_items(tmp_path):
+	runner = CliRunner()
+	_invoke(runner, tmp_path, ["init", "--name", "r1", "--template", "default"])
+	_invoke(runner, tmp_path, ["init", "--name", "r2", "--template", "default"])
+	result = _invoke(runner, tmp_path, ["list"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert len(parsed["data"]) == 2
+
+
+# ── show ──────────────────────────────────────────────────────
+
+
+def test_show_existing(tmp_path):
+	runner = CliRunner()
+	_invoke(runner, tmp_path, ["init", "--name", "showme", "--template", "default"])
+	result = _invoke(runner, tmp_path, ["show", "showme"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["name"] == "showme"
+	assert "title" in parsed["data"]
+	assert "personal_info" in parsed["data"]
+
+
+def test_show_not_found(tmp_path):
+	runner = CliRunner()
+	result = _invoke(runner, tmp_path, ["show", "nonexist"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["error"]["code"] == "RESUME_NOT_FOUND"
+
+
+# ── edit ──────────────────────────────────────────────────────
+
+
+def test_edit_existing_field(tmp_path):
+	runner = CliRunner()
+	_invoke(runner, tmp_path, ["init", "--name", "editable", "--template", "default"])
+	result = _invoke(runner, tmp_path, ["edit", "editable", "--field", "title", "--value", "Senior Dev"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["field"] == "title"
+	assert parsed["data"]["value"] == "Senior Dev"
+
+	# 验证确实修改了
+	show_result = _invoke(runner, tmp_path, ["show", "editable"])
+	show_parsed = json.loads(show_result.output)
+	assert show_parsed["data"]["title"] == "Senior Dev"
+
+
+def test_edit_nested_field(tmp_path):
+	runner = CliRunner()
+	_invoke(runner, tmp_path, ["init", "--name", "nested", "--template", "default"])
+	result = _invoke(runner, tmp_path, ["edit", "nested", "--field", "personal_info.layout", "--value", "block"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+
+
+def test_edit_not_found(tmp_path):
+	runner = CliRunner()
+	result = _invoke(runner, tmp_path, ["edit", "ghost", "--field", "title", "--value", "X"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "RESUME_NOT_FOUND"
+
+
+# ── delete ────────────────────────────────────────────────────
+
+
+def test_delete_existing(tmp_path):
+	runner = CliRunner()
+	_invoke(runner, tmp_path, ["init", "--name", "todel", "--template", "default"])
+	result = _invoke(runner, tmp_path, ["delete", "todel"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["deleted"] is True
+
+	# 验证已删除
+	show_result = _invoke(runner, tmp_path, ["show", "todel"])
+	assert show_result.exit_code == 1
+
+
+def test_delete_not_found(tmp_path):
+	runner = CliRunner()
+	result = _invoke(runner, tmp_path, ["delete", "nope"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "RESUME_NOT_FOUND"
+
+
+# ── export ────────────────────────────────────────────────────
+
+
+def test_export_json(tmp_path):
+	runner = CliRunner()
+	_invoke(runner, tmp_path, ["init", "--name", "exportme", "--template", "default"])
+	result = _invoke(runner, tmp_path, ["export", "exportme", "--format", "json"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert "version" in parsed["data"]
+	assert parsed["data"]["data"]["name"] == "exportme"
+
+
+def test_export_unsupported_format(tmp_path):
+	runner = CliRunner()
+	_invoke(runner, tmp_path, ["init", "--name", "nopdf", "--template", "default"])
+	result = _invoke(runner, tmp_path, ["export", "nopdf", "--format", "pdf"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "EXPORT_FAILED"
+
+
+def test_export_not_found(tmp_path):
+	runner = CliRunner()
+	result = _invoke(runner, tmp_path, ["export", "missing", "--format", "json"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "RESUME_NOT_FOUND"
+
+
+# ── import ────────────────────────────────────────────────────
+
+
+def test_import_valid(tmp_path):
+	runner = CliRunner()
+	# 创建一个合法的 JSON 简历文件
+	resume_file = tmp_path / "import_resume.json"
+	resume_data = {
+		"name": "imported",
+		"title": "Imported Resume",
+		"center_title": False,
+		"personal_info": {"items": [], "layout": "inline"},
+		"modules": [],
+		"avatar": "",
+	}
+	resume_file.write_text(json.dumps(resume_data), encoding="utf-8")
+	result = _invoke(runner, tmp_path, ["import", str(resume_file)])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["name"] == "imported"
+
+
+def test_import_invalid_file(tmp_path):
+	runner = CliRunner()
+	bad_file = tmp_path / "bad.json"
+	bad_file.write_text("not json at all", encoding="utf-8")
+	result = _invoke(runner, tmp_path, ["import", str(bad_file)])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+
+
+def test_import_file_not_found(tmp_path):
+	runner = CliRunner()
+	result = _invoke(runner, tmp_path, ["import", str(tmp_path / "no_such_file.json")])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+
+
+# ── clone ─────────────────────────────────────────────────────
+
+
+def test_clone_existing(tmp_path):
+	runner = CliRunner()
+	_invoke(runner, tmp_path, ["init", "--name", "original", "--template", "default"])
+	result = _invoke(runner, tmp_path, ["clone", "original", "copy1"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["name"] == "copy1"
+
+
+def test_clone_source_not_found(tmp_path):
+	runner = CliRunner()
+	result = _invoke(runner, tmp_path, ["clone", "nosrc", "dst"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "RESUME_NOT_FOUND"
+
+
+def test_clone_target_already_exists(tmp_path):
+	runner = CliRunner()
+	_invoke(runner, tmp_path, ["init", "--name", "src", "--template", "default"])
+	_invoke(runner, tmp_path, ["init", "--name", "dst", "--template", "default"])
+	result = _invoke(runner, tmp_path, ["clone", "src", "dst"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "RESUME_ALREADY_EXISTS"
+
+
+# ── diff ──────────────────────────────────────────────────────
+
+
+def test_diff_two_resumes(tmp_path):
+	runner = CliRunner()
+	_invoke(runner, tmp_path, ["init", "--name", "a", "--template", "default"])
+	_invoke(runner, tmp_path, ["init", "--name", "b", "--template", "default"])
+	# 修改 b 的 title
+	_invoke(runner, tmp_path, ["edit", "b", "--field", "title", "--value", "Modified Title"])
+	result = _invoke(runner, tmp_path, ["diff", "a", "b"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	diffs = parsed["data"]["diffs"]
+	assert isinstance(diffs, list)
+	# 应有 title 和 updated_at 差异
+	fields = [d["field"] for d in diffs]
+	assert "title" in fields
+
+
+def test_diff_one_not_found(tmp_path):
+	runner = CliRunner()
+	_invoke(runner, tmp_path, ["init", "--name", "exists", "--template", "default"])
+	result = _invoke(runner, tmp_path, ["diff", "exists", "missing"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "RESUME_NOT_FOUND"
+
+
+# ── schema 集成 ───────────────────────────────────────────────
+
+
+def test_schema_contains_resume():
+	runner = CliRunner()
+	result = runner.invoke(cli, ["schema"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert "resume" in parsed["data"]["commands"]
+	cmd = parsed["data"]["commands"]["resume"]
+	assert "subcommands" in cmd
+	assert "init" in cmd["subcommands"]
+	assert "diff" in cmd["subcommands"]
+
+
+def test_schema_contains_resume_error_codes():
+	runner = CliRunner()
+	result = runner.invoke(cli, ["schema"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	codes = parsed["data"]["error_codes"]
+	assert "RESUME_NOT_FOUND" in codes
+	assert "RESUME_ALREADY_EXISTS" in codes
+	assert "EXPORT_FAILED" in codes


### PR DESCRIPTION
## 改动内容

- 新增简历管理命令组，支持初始化、查看、编辑、删除、导出、导入、复制和对比九个子命令
- 注册到主入口和协议自描述中
- 新增三十个测试覆盖全部子命令
- 全量五百五十一个测试通过