### PR TITLE
feat: 新增智能服务模块和简历模板渲染导出功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ GEMINI.md
 .ace-tool/
 .agents/skills/
 .trellis/
+*.html
+!src/**/*.html
+*.pdf

--- a/src/boss_agent_cli/ai/config.py
+++ b/src/boss_agent_cli/ai/config.py
@@ -1,0 +1,132 @@
+"""AI service configuration management.
+
+Handles API key encryption (Fernet), provider settings, and model configuration.
+Reuses the auth salt file for key derivation.
+"""
+
+import hashlib
+import json
+import os
+import platform
+from base64 import urlsafe_b64encode
+from pathlib import Path
+
+from cryptography.fernet import Fernet, InvalidToken
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+PROVIDER_BASE_URLS: dict[str, str | None] = {
+	"openai": "https://api.openai.com/v1",
+	"deepseek": "https://api.deepseek.com/v1",
+	"moonshot": "https://api.moonshot.cn/v1",
+	"custom": None,
+}
+
+_DEFAULT_CONFIG: dict = {
+	"ai_provider": None,
+	"ai_model": None,
+	"ai_base_url": None,
+	"ai_temperature": 0.7,
+	"ai_max_tokens": 4096,
+}
+
+
+class AIConfigStore:
+	"""Manages AI service configuration with encrypted API key storage."""
+
+	def __init__(self, data_dir: Path):
+		self._data_dir = data_dir
+		self._ai_dir = data_dir / "ai"
+		self._ai_dir.mkdir(parents=True, exist_ok=True)
+		self._key_path = self._ai_dir / "api_key.enc"
+		self._config_path = self._ai_dir / "config.json"
+		self._auth_dir = data_dir / "auth"
+
+	def _get_machine_id(self) -> str:
+		"""Get a stable machine identifier for key derivation."""
+		if override := os.getenv("BOSS_AGENT_MACHINE_ID"):
+			return override
+		fingerprint = "|".join([
+			platform.node() or "unknown-node",
+			platform.system() or "unknown-system",
+			platform.machine() or "unknown-machine",
+		])
+		return hashlib.sha256(fingerprint.encode()).hexdigest()
+
+	def _get_salt(self) -> bytes:
+		"""Reuse auth salt file, or create one if it doesn't exist."""
+		self._auth_dir.mkdir(parents=True, exist_ok=True)
+		salt_path = self._auth_dir / "salt"
+		if salt_path.exists():
+			return salt_path.read_bytes()
+		salt = os.urandom(16)
+		salt_path.write_bytes(salt)
+		return salt
+
+	def _derive_key(self) -> bytes:
+		"""Derive a Fernet key from machine ID and salt."""
+		salt = self._get_salt()
+		machine_id = self._get_machine_id()
+		kdf = PBKDF2HMAC(
+			algorithm=hashes.SHA256(),
+			length=32,
+			salt=salt,
+			iterations=480000,
+		)
+		key = kdf.derive(machine_id.encode())
+		return urlsafe_b64encode(key)
+
+	def save_api_key(self, key: str) -> None:
+		"""Encrypt and persist the API key."""
+		fernet = Fernet(self._derive_key())
+		encrypted = fernet.encrypt(key.encode("utf-8"))
+		self._key_path.write_bytes(encrypted)
+
+	def get_api_key(self) -> str | None:
+		"""Load and decrypt the API key. Returns None if not set or decryption fails."""
+		if not self._key_path.exists():
+			return None
+		fernet = Fernet(self._derive_key())
+		try:
+			plaintext = fernet.decrypt(self._key_path.read_bytes())
+		except (InvalidToken, ValueError):
+			return None
+		return plaintext.decode("utf-8")
+
+	def save_config(self, **kwargs) -> None:
+		"""Save configuration, merging with existing values."""
+		current = self.load_config()
+		current.update(kwargs)
+		self._config_path.write_text(
+			json.dumps(current, ensure_ascii=False, indent=2),
+			encoding="utf-8",
+		)
+
+	def load_config(self) -> dict:
+		"""Load configuration with defaults for missing keys."""
+		config = dict(_DEFAULT_CONFIG)
+		if self._config_path.exists():
+			try:
+				saved = json.loads(self._config_path.read_text(encoding="utf-8"))
+				config.update(saved)
+			except (json.JSONDecodeError, OSError):
+				pass
+		return config
+
+	def get_base_url(self) -> str | None:
+		"""Get the API base URL: user config takes priority, then provider lookup."""
+		config = self.load_config()
+		if config.get("ai_base_url"):
+			return config["ai_base_url"]
+		provider = config.get("ai_provider")
+		if provider and provider in PROVIDER_BASE_URLS:
+			return PROVIDER_BASE_URLS[provider]
+		return None
+
+	def is_configured(self) -> bool:
+		"""Check if all required settings are present (provider + model + api_key)."""
+		config = self.load_config()
+		provider = config.get("ai_provider")
+		model = config.get("ai_model")
+		api_key = self.get_api_key()
+		return all([provider, model, api_key])

--- a/src/boss_agent_cli/ai/prompts.py
+++ b/src/boss_agent_cli/ai/prompts.py
@@ -1,0 +1,126 @@
+"""Prompt templates for AI-powered resume and job analysis.
+
+All templates use Python str.format() placeholders:
+- {jd_text} — Job description text
+- {resume_text} — Resume plain text
+
+Note: JSON braces in templates are doubled ({{ }}) to avoid format conflicts.
+"""
+
+JD_ANALYSIS_PROMPT = """你是一位资深的招聘顾问和职业规划专家。请分析以下职位描述（JD）与候选人简历的匹配程度。
+
+## 职位描述
+{jd_text}
+
+## 候选人简历
+{resume_text}
+
+## 输出要求
+请以 JSON 格式返回分析结果，包含以下字段：
+```json
+{{
+  "match_score": 85,
+  "match_analysis": "整体匹配度分析...",
+  "matching_points": ["匹配点1", "匹配点2"],
+  "gap_points": ["差距点1", "差距点2"],
+  "suggestions": ["建议1", "建议2"],
+  "risk_factors": ["风险因素1"],
+  "overall_recommendation": "推荐/谨慎推荐/不推荐"
+}}
+```
+
+只返回 JSON，不要包含其他内容。"""
+
+RESUME_POLISH_PROMPT = """你是一位专业的简历优化顾问。请对以下简历进行润色和优化，重点关注：
+
+1. 使用 STAR 法则（情境-任务-行动-结果）重新组织工作经历
+2. 量化成果：尽可能用数据说明影响力
+3. 关键词优化：确保包含行业常用术语
+4. 语言精炼：去除冗余表述，突出核心价值
+
+## 当前简历
+{resume_text}
+
+## 输出要求
+请以 JSON 格式返回优化后的内容：
+```json
+{{
+  "polished_sections": [
+    {{
+      "section": "模块名称",
+      "original": "原始内容",
+      "polished": "优化后内容",
+      "changes": ["修改说明1", "修改说明2"]
+    }}
+  ],
+  "general_suggestions": ["全局建议1", "全局建议2"],
+  "keyword_additions": ["建议添加的关键词1", "关键词2"]
+}}
+```
+
+只返回 JSON，不要包含其他内容。"""
+
+RESUME_OPTIMIZE_FOR_JD_PROMPT = """你是一位资深的求职顾问。请针对指定职位优化候选人的简历，提升匹配度。
+
+## 目标职位描述
+{jd_text}
+
+## 当前简历
+{resume_text}
+
+## 优化要求
+1. 调整简历措辞以匹配 JD 中的关键技能和经验要求
+2. 突出与目标职位最相关的经历
+3. 弱化或省略不相关的内容
+4. 确保真实性 — 只调整表述，不捏造经历
+
+## 输出要求
+请以 JSON 格式返回：
+```json
+{{
+  "match_score_before": 65,
+  "match_score_after": 82,
+  "optimized_sections": [
+    {{
+      "section": "模块名称",
+      "original": "原始内容",
+      "optimized": "优化后内容",
+      "reason": "优化理由"
+    }}
+  ],
+  "key_adjustments": ["关键调整1", "关键调整2"],
+  "warnings": ["注意事项1"]
+}}
+```
+
+只返回 JSON，不要包含其他内容。"""
+
+RESUME_SUGGEST_PROMPT = """你是一位职业发展顾问。请根据候选人的简历和目标职位，提供具体的改进建议。
+
+## 目标职位描述
+{jd_text}
+
+## 候选人简历
+{resume_text}
+
+## 输出要求
+请以 JSON 格式返回改进建议，按优先级排序：
+```json
+{{
+  "suggestions": [
+    {{
+      "priority": "high",
+      "category": "技能补充",
+      "suggestion": "具体建议内容",
+      "action_items": ["行动项1", "行动项2"],
+      "expected_impact": "预期效果说明"
+    }}
+  ],
+  "short_term_plan": "1-2周内可完成的改进计划",
+  "long_term_plan": "1-3个月的提升方案"
+}}
+```
+
+priority 取值: "high", "medium", "low"
+
+只返回 JSON，不要包含其他内容。"""

--- a/src/boss_agent_cli/ai/service.py
+++ b/src/boss_agent_cli/ai/service.py
@@ -1,0 +1,82 @@
+"""AI service client for OpenAI-compatible APIs.
+
+Provides a simple interface for chat completions with error handling.
+"""
+
+import httpx
+
+
+class AIServiceError(Exception):
+	"""Raised when an AI service call fails."""
+
+	def __init__(self, message: str, *, status_code: int | None = None):
+		super().__init__(message)
+		self.status_code = status_code
+
+
+class AIService:
+	"""Client for OpenAI-compatible chat completion APIs."""
+
+	def __init__(
+		self,
+		base_url: str,
+		api_key: str,
+		model: str,
+		temperature: float = 0.7,
+		max_tokens: int = 4096,
+	):
+		# Normalize base_url: strip trailing slash
+		self.base_url = base_url.rstrip("/")
+		self.api_key = api_key
+		self.model = model
+		self.temperature = temperature
+		self.max_tokens = max_tokens
+
+	def chat(
+		self,
+		messages: list[dict],
+		*,
+		temperature: float | None = None,
+		max_tokens: int | None = None,
+	) -> str:
+		"""Send a chat completion request and return the assistant's reply text.
+
+		Args:
+			messages: List of message dicts with 'role' and 'content' keys.
+			temperature: Override default temperature for this call.
+			max_tokens: Override default max_tokens for this call.
+
+		Returns:
+			The assistant's reply text.
+
+		Raises:
+			AIServiceError: On HTTP errors, network errors, or unexpected response format.
+		"""
+		url = f"{self.base_url}/chat/completions"
+		headers = {
+			"Authorization": f"Bearer {self.api_key}",
+			"Content-Type": "application/json",
+		}
+		payload = {
+			"model": self.model,
+			"messages": messages,
+			"temperature": temperature if temperature is not None else self.temperature,
+			"max_tokens": max_tokens if max_tokens is not None else self.max_tokens,
+		}
+
+		try:
+			response = httpx.post(url, json=payload, headers=headers, timeout=60)
+			response.raise_for_status()
+		except httpx.HTTPStatusError as exc:
+			raise AIServiceError(
+				f"API 请求失败: HTTP {exc.response.status_code}",
+				status_code=exc.response.status_code,
+			) from exc
+		except httpx.RequestError as exc:
+			raise AIServiceError(f"网络请求失败: {exc}") from exc
+
+		try:
+			data = response.json()
+			return data["choices"][0]["message"]["content"]
+		except (KeyError, IndexError, TypeError) as exc:
+			raise AIServiceError(f"响应格式异常: {exc}") from exc

--- a/src/boss_agent_cli/commands/resume_cmd.py
+++ b/src/boss_agent_cli/commands/resume_cmd.py
@@ -192,14 +192,35 @@ def resume_export_cmd(ctx, name, fmt, output_path):
 		ctx.exit(1)
 		return
 	if fmt in ("pdf", "html"):
-		handle_error_output(
+		resume = store.get(name)
+		if resume is None:
+			handle_error_output(ctx, "resume", code="RESUME_NOT_FOUND", message=f"简历 '{name}' 不存在")
+			ctx.exit(1)
+			return
+		if output_path is None:
+			output_path = f"{name}.{fmt}"
+		out = Path(output_path)
+		try:
+			from boss_agent_cli.resume.export import export_html, export_pdf
+			if fmt == "html":
+				export_html(resume, out)
+			else:
+				export_pdf(resume, out)
+		except Exception as exc:
+			handle_error_output(
+				ctx, "resume",
+				code="EXPORT_FAILED",
+				message=f"{fmt.upper()} 导出失败: {exc}",
+				recoverable=True,
+				recovery_action="请确认 patchright 已安装并执行 uv run playwright install chromium",
+			)
+			ctx.exit(1)
+			return
+		handle_output(
 			ctx, "resume",
-			code="EXPORT_FAILED",
-			message=f"{fmt.upper()} 导出将在后续版本支持",
-			recoverable=True,
-			recovery_action="当前请使用 --format json",
+			{"action": "export", "name": name, "format": fmt, "path": str(out.resolve())},
+			hints={"next_actions": [f"boss resume show {name}"]},
 		)
-		ctx.exit(1)
 		return
 	json_str = store.export_json(name)
 	export_data = json.loads(json_str)

--- a/src/boss_agent_cli/resume/export.py
+++ b/src/boss_agent_cli/resume/export.py
@@ -1,0 +1,46 @@
+"""Resume export to HTML and PDF.
+
+HTML export: renders to a self-contained HTML file.
+PDF export: renders HTML then uses patchright (headless Chromium) to generate PDF.
+"""
+
+from pathlib import Path
+
+from boss_agent_cli.resume.models import ResumeData
+from boss_agent_cli.resume.templates import render_resume_html
+
+
+def export_html(resume: ResumeData, output_path: Path) -> Path:
+	"""Export resume as a self-contained HTML file.
+
+	Creates parent directories if they don't exist.
+	Returns the output path.
+	"""
+	output_path.parent.mkdir(parents=True, exist_ok=True)
+	html = render_resume_html(resume)
+	output_path.write_text(html, encoding="utf-8")
+	return output_path
+
+
+def export_pdf(resume: ResumeData, output_path: Path) -> Path:
+	"""Export resume as a PDF file using patchright (headless Chromium).
+
+	Creates parent directories if they don't exist.
+	Returns the output path.
+	"""
+	from patchright.sync_api import sync_playwright
+
+	html = render_resume_html(resume)
+	output_path.parent.mkdir(parents=True, exist_ok=True)
+	with sync_playwright() as p:
+		browser = p.chromium.launch(headless=True)
+		page = browser.new_page()
+		page.set_content(html, wait_until="networkidle")
+		page.pdf(
+			path=str(output_path),
+			format="A4",
+			print_background=True,
+			margin={"top": "10mm", "bottom": "10mm", "left": "10mm", "right": "10mm"},
+		)
+		browser.close()
+	return output_path

--- a/src/boss_agent_cli/resume/templates.py
+++ b/src/boss_agent_cli/resume/templates.py
@@ -1,0 +1,241 @@
+"""Resume HTML template rendering.
+
+Renders ResumeData to a self-contained HTML document with inline CSS,
+optimized for A4 printing and PDF export.
+"""
+
+import html
+
+from boss_agent_cli.resume.models import ResumeData
+
+
+def _esc(text: str | None) -> str:
+	"""Escape HTML entities to prevent XSS."""
+	if text is None:
+		return ""
+	return html.escape(str(text))
+
+
+def _render_personal_info(resume: ResumeData) -> str:
+	"""Render personal info section."""
+	if not resume.personal_info.items:
+		return ""
+	items_html = []
+	for item in resume.personal_info.items:
+		label = _esc(item.label)
+		value = _esc(item.value)
+		if item.link:
+			value = f'<a href="{_esc(item.link)}" style="color:#2563eb;text-decoration:none;">{value}</a>'
+		items_html.append(f'<span class="info-item"><span class="info-label">{label}:</span> {value}</span>')
+	separator = " " if resume.personal_info.layout == "inline" else "<br>"
+	return f'<div class="personal-info">{separator.join(items_html)}</div>'
+
+
+def _render_job_intention(resume: ResumeData) -> str:
+	"""Render job intention section if present."""
+	ji = resume.job_intention
+	if ji is None:
+		return ""
+	title = _esc(ji.title)
+	items_html = []
+	for item in ji.items:
+		items_html.append(
+			f'<div class="ji-item"><span class="ji-label">{_esc(item.label)}:</span> {_esc(item.value)}</div>'
+		)
+	bg_style = ' style="background:#f0f7ff;padding:12px 16px;border-radius:6px;margin:12px 0;"' if ji.show_background else ""
+	return f"""<div class="job-intention"{bg_style}>
+<h3 style="color:#2563eb;margin:0 0 8px 0;font-size:14px;">{title}</h3>
+{''.join(items_html)}
+</div>"""
+
+
+def _render_row(row: dict) -> str:
+	"""Render a single module row (richtext or tags)."""
+	row_type = row.get("type", "")
+	if row_type == "tags":
+		tags = row.get("tags", [])
+		if not tags:
+			return ""
+		tags_html = "".join(
+			f'<span class="tag">{_esc(tag)}</span>' for tag in tags
+		)
+		return f'<div class="tags-row">{tags_html}</div>'
+	elif row_type == "richtext":
+		content = row.get("content", [])
+		columns = row.get("columns", 1)
+		if not content:
+			return ""
+		if columns > 1:
+			col_width = f"{100 // columns}%"
+			cells = "".join(
+				f'<div style="width:{col_width};display:inline-block;vertical-align:top;">{_esc(line)}</div>'
+				for line in content
+			)
+			return f'<div class="richtext-row multi-col">{cells}</div>'
+		lines_html = "".join(f"<p>{_esc(line)}</p>" for line in content)
+		return f'<div class="richtext-row">{lines_html}</div>'
+	else:
+		# Unknown row type: render content if available
+		content = row.get("content", [])
+		if not content:
+			return ""
+		lines_html = "".join(f"<p>{_esc(str(line))}</p>" for line in content)
+		return f'<div class="row">{lines_html}</div>'
+
+
+def _render_modules(resume: ResumeData) -> str:
+	"""Render all resume modules."""
+	parts = []
+	for mod in resume.modules:
+		title = _esc(mod.title)
+		rows_html = "".join(_render_row(row) for row in mod.rows)
+		parts.append(f"""<div class="module">
+<h2 class="module-title">{title}</h2>
+<div class="module-content">{rows_html}</div>
+</div>""")
+	return "\n".join(parts)
+
+
+def render_resume_html(resume: ResumeData) -> str:
+	"""Render a ResumeData object to a complete HTML document.
+
+	Features:
+	- All CSS inline, A4 paper size (210mm x 297mm), print-friendly
+	- Chinese font stack
+	- Primary color #2563eb, tag background #e8f0fe
+	- XSS-safe: all user input is HTML-escaped
+	"""
+	title = _esc(resume.title)
+	title_align = "center" if resume.center_title else "left"
+
+	avatar_html = ""
+	if resume.avatar:
+		avatar_html = f'<img src="{_esc(resume.avatar)}" class="avatar" alt="avatar">'
+
+	personal_info_html = _render_personal_info(resume)
+	job_intention_html = _render_job_intention(resume)
+	modules_html = _render_modules(resume)
+
+	return f"""<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{title}</title>
+<style>
+@page {{
+  size: A4;
+  margin: 10mm;
+}}
+* {{
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}}
+body {{
+  font-family: "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+  font-size: 13px;
+  line-height: 1.6;
+  color: #333;
+  background: #fff;
+  width: 210mm;
+  min-height: 297mm;
+  margin: 0 auto;
+  padding: 16mm 14mm;
+}}
+.header {{
+  text-align: {title_align};
+  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}}
+.header-text {{
+  flex: 1;
+}}
+.avatar {{
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  object-fit: cover;
+}}
+h1 {{
+  font-size: 22px;
+  color: #2563eb;
+  margin-bottom: 4px;
+}}
+.personal-info {{
+  color: #555;
+  font-size: 12px;
+  margin-top: 6px;
+}}
+.info-item {{
+  margin-right: 16px;
+}}
+.info-label {{
+  color: #888;
+}}
+.job-intention {{
+  margin: 12px 0;
+  font-size: 12px;
+}}
+.ji-item {{
+  display: inline-block;
+  margin-right: 20px;
+  margin-top: 4px;
+}}
+.ji-label {{
+  color: #888;
+}}
+.module {{
+  margin-top: 16px;
+}}
+.module-title {{
+  font-size: 15px;
+  color: #2563eb;
+  border-bottom: 2px solid #2563eb;
+  padding-bottom: 4px;
+  margin-bottom: 8px;
+}}
+.module-content p {{
+  margin: 2px 0;
+}}
+.tags-row {{
+  margin: 6px 0;
+}}
+.tag {{
+  display: inline-block;
+  background: #e8f0fe;
+  color: #2563eb;
+  padding: 2px 10px;
+  border-radius: 12px;
+  font-size: 12px;
+  margin: 2px 4px 2px 0;
+}}
+.richtext-row {{
+  margin: 4px 0;
+}}
+.multi-col {{
+  display: flex;
+  flex-wrap: wrap;
+}}
+@media print {{
+  body {{
+    width: auto;
+    padding: 0;
+  }}
+}}
+</style>
+</head>
+<body>
+<div class="header">
+{avatar_html}
+<div class="header-text">
+<h1>{title}</h1>
+{personal_info_html}
+</div>
+</div>
+{job_intention_html}
+{modules_html}
+</body>
+</html>"""

--- a/tests/test_ai_config.py
+++ b/tests/test_ai_config.py
@@ -1,0 +1,170 @@
+"""Tests for AI configuration store."""
+
+from boss_agent_cli.ai.config import AIConfigStore, PROVIDER_BASE_URLS
+
+
+def _make_store(tmp_path, monkeypatch) -> AIConfigStore:
+	"""Create a store with stable machine ID."""
+	monkeypatch.setenv("BOSS_AGENT_MACHINE_ID", "test-machine-id")
+	return AIConfigStore(tmp_path)
+
+
+# ── API key encryption ───────────────────────────────────────
+
+
+def test_api_key_roundtrip(tmp_path, monkeypatch):
+	"""Saved API key can be loaded back."""
+	store = _make_store(tmp_path, monkeypatch)
+	store.save_api_key("sk-test-key-12345")
+	assert store.get_api_key() == "sk-test-key-12345"
+
+
+def test_api_key_not_set(tmp_path, monkeypatch):
+	"""Returns None when no API key is saved."""
+	store = _make_store(tmp_path, monkeypatch)
+	assert store.get_api_key() is None
+
+
+def test_api_key_overwrite(tmp_path, monkeypatch):
+	"""Overwriting API key works."""
+	store = _make_store(tmp_path, monkeypatch)
+	store.save_api_key("old-key")
+	store.save_api_key("new-key")
+	assert store.get_api_key() == "new-key"
+
+
+def test_api_key_different_machine_id(tmp_path, monkeypatch):
+	"""Different machine_id cannot decrypt the key."""
+	monkeypatch.setenv("BOSS_AGENT_MACHINE_ID", "machine-a")
+	store_a = AIConfigStore(tmp_path)
+	store_a.save_api_key("secret-key")
+
+	monkeypatch.setenv("BOSS_AGENT_MACHINE_ID", "machine-b")
+	store_b = AIConfigStore(tmp_path)
+	assert store_b.get_api_key() is None
+
+
+# ── config save/load ─────────────────────────────────────────
+
+
+def test_config_save_and_load(tmp_path, monkeypatch):
+	"""Config can be saved and loaded."""
+	store = _make_store(tmp_path, monkeypatch)
+	store.save_config(ai_provider="openai", ai_model="gpt-4")
+	config = store.load_config()
+	assert config["ai_provider"] == "openai"
+	assert config["ai_model"] == "gpt-4"
+
+
+def test_config_defaults(tmp_path, monkeypatch):
+	"""Default config values are returned when nothing is saved."""
+	store = _make_store(tmp_path, monkeypatch)
+	config = store.load_config()
+	assert config["ai_provider"] is None
+	assert config["ai_model"] is None
+	assert config["ai_base_url"] is None
+	assert config["ai_temperature"] == 0.7
+	assert config["ai_max_tokens"] == 4096
+
+
+def test_config_partial_update(tmp_path, monkeypatch):
+	"""Partial updates merge with existing config."""
+	store = _make_store(tmp_path, monkeypatch)
+	store.save_config(ai_provider="openai")
+	store.save_config(ai_model="gpt-4o")
+	config = store.load_config()
+	assert config["ai_provider"] == "openai"
+	assert config["ai_model"] == "gpt-4o"
+
+
+def test_config_preserves_defaults_on_partial(tmp_path, monkeypatch):
+	"""Unset keys keep their defaults after partial save."""
+	store = _make_store(tmp_path, monkeypatch)
+	store.save_config(ai_provider="deepseek")
+	config = store.load_config()
+	assert config["ai_temperature"] == 0.7
+	assert config["ai_max_tokens"] == 4096
+
+
+# ── base_url ─────────────────────────────────────────────────
+
+
+def test_base_url_provider_lookup(tmp_path, monkeypatch):
+	"""Base URL is resolved from PROVIDER_BASE_URLS when not explicitly set."""
+	store = _make_store(tmp_path, monkeypatch)
+	store.save_config(ai_provider="openai")
+	assert store.get_base_url() == "https://api.openai.com/v1"
+
+
+def test_base_url_user_override(tmp_path, monkeypatch):
+	"""Explicit ai_base_url overrides provider lookup."""
+	store = _make_store(tmp_path, monkeypatch)
+	store.save_config(ai_provider="openai", ai_base_url="https://my-proxy.com/v1")
+	assert store.get_base_url() == "https://my-proxy.com/v1"
+
+
+def test_base_url_custom_provider(tmp_path, monkeypatch):
+	"""Custom provider returns None base_url when no explicit URL set."""
+	store = _make_store(tmp_path, monkeypatch)
+	store.save_config(ai_provider="custom")
+	assert store.get_base_url() is None
+
+
+def test_base_url_deepseek(tmp_path, monkeypatch):
+	"""Deepseek provider returns correct URL."""
+	store = _make_store(tmp_path, monkeypatch)
+	store.save_config(ai_provider="deepseek")
+	assert store.get_base_url() == "https://api.deepseek.com/v1"
+
+
+def test_base_url_moonshot(tmp_path, monkeypatch):
+	"""Moonshot provider returns correct URL."""
+	store = _make_store(tmp_path, monkeypatch)
+	store.save_config(ai_provider="moonshot")
+	assert store.get_base_url() == "https://api.moonshot.cn/v1"
+
+
+# ── is_configured ────────────────────────────────────────────
+
+
+def test_is_configured_complete(tmp_path, monkeypatch):
+	"""is_configured returns True when all required settings are present."""
+	store = _make_store(tmp_path, monkeypatch)
+	store.save_config(ai_provider="openai", ai_model="gpt-4")
+	store.save_api_key("sk-test-key")
+	assert store.is_configured() is True
+
+
+def test_is_configured_missing_key(tmp_path, monkeypatch):
+	"""is_configured returns False when API key is missing."""
+	store = _make_store(tmp_path, monkeypatch)
+	store.save_config(ai_provider="openai", ai_model="gpt-4")
+	assert store.is_configured() is False
+
+
+def test_is_configured_missing_provider(tmp_path, monkeypatch):
+	"""is_configured returns False when provider is missing."""
+	store = _make_store(tmp_path, monkeypatch)
+	store.save_config(ai_model="gpt-4")
+	store.save_api_key("sk-test-key")
+	assert store.is_configured() is False
+
+
+def test_is_configured_missing_model(tmp_path, monkeypatch):
+	"""is_configured returns False when model is missing."""
+	store = _make_store(tmp_path, monkeypatch)
+	store.save_config(ai_provider="openai")
+	store.save_api_key("sk-test-key")
+	assert store.is_configured() is False
+
+
+# ── provider base URLs ───────────────────────────────────────
+
+
+def test_provider_base_urls_completeness():
+	"""All expected providers are in the map."""
+	assert "openai" in PROVIDER_BASE_URLS
+	assert "deepseek" in PROVIDER_BASE_URLS
+	assert "moonshot" in PROVIDER_BASE_URLS
+	assert "custom" in PROVIDER_BASE_URLS
+	assert PROVIDER_BASE_URLS["custom"] is None

--- a/tests/test_ai_prompts.py
+++ b/tests/test_ai_prompts.py
@@ -1,0 +1,110 @@
+"""Tests for AI prompt templates."""
+
+from boss_agent_cli.ai.prompts import (
+	JD_ANALYSIS_PROMPT,
+	RESUME_OPTIMIZE_FOR_JD_PROMPT,
+	RESUME_POLISH_PROMPT,
+	RESUME_SUGGEST_PROMPT,
+)
+
+
+# ── placeholder existence ────────────────────────────────────
+
+
+def test_jd_analysis_has_placeholders():
+	"""JD_ANALYSIS_PROMPT contains {jd_text} and {resume_text}."""
+	assert "{jd_text}" in JD_ANALYSIS_PROMPT
+	assert "{resume_text}" in JD_ANALYSIS_PROMPT
+
+
+def test_resume_polish_has_placeholder():
+	"""RESUME_POLISH_PROMPT contains {resume_text}."""
+	assert "{resume_text}" in RESUME_POLISH_PROMPT
+
+
+def test_resume_optimize_has_placeholders():
+	"""RESUME_OPTIMIZE_FOR_JD_PROMPT contains both placeholders."""
+	assert "{jd_text}" in RESUME_OPTIMIZE_FOR_JD_PROMPT
+	assert "{resume_text}" in RESUME_OPTIMIZE_FOR_JD_PROMPT
+
+
+def test_resume_suggest_has_placeholders():
+	"""RESUME_SUGGEST_PROMPT contains both placeholders."""
+	assert "{jd_text}" in RESUME_SUGGEST_PROMPT
+	assert "{resume_text}" in RESUME_SUGGEST_PROMPT
+
+
+# ── format correctness ───────────────────────────────────────
+
+
+def test_jd_analysis_format():
+	"""JD_ANALYSIS_PROMPT can be formatted without errors."""
+	result = JD_ANALYSIS_PROMPT.format(jd_text="Test JD", resume_text="Test Resume")
+	assert "Test JD" in result
+	assert "Test Resume" in result
+
+
+def test_resume_polish_format():
+	"""RESUME_POLISH_PROMPT can be formatted without errors."""
+	result = RESUME_POLISH_PROMPT.format(resume_text="My Resume")
+	assert "My Resume" in result
+
+
+def test_resume_optimize_format():
+	"""RESUME_OPTIMIZE_FOR_JD_PROMPT can be formatted without errors."""
+	result = RESUME_OPTIMIZE_FOR_JD_PROMPT.format(jd_text="JD Text", resume_text="Resume Text")
+	assert "JD Text" in result
+	assert "Resume Text" in result
+
+
+def test_resume_suggest_format():
+	"""RESUME_SUGGEST_PROMPT can be formatted without errors."""
+	result = RESUME_SUGGEST_PROMPT.format(jd_text="JD", resume_text="Resume")
+	assert "JD" in result
+	assert "Resume" in result
+
+
+# ── content keyword checks ───────────────────────────────────
+
+
+def test_jd_analysis_keywords():
+	"""JD_ANALYSIS_PROMPT mentions match_score and JSON output."""
+	assert "match_score" in JD_ANALYSIS_PROMPT
+	assert "JSON" in JD_ANALYSIS_PROMPT
+	assert "match_analysis" in JD_ANALYSIS_PROMPT
+
+
+def test_resume_polish_mentions_star():
+	"""RESUME_POLISH_PROMPT references the STAR method."""
+	assert "STAR" in RESUME_POLISH_PROMPT
+
+
+def test_resume_optimize_mentions_score():
+	"""RESUME_OPTIMIZE_FOR_JD_PROMPT references match_score_before/after."""
+	assert "match_score_before" in RESUME_OPTIMIZE_FOR_JD_PROMPT
+	assert "match_score_after" in RESUME_OPTIMIZE_FOR_JD_PROMPT
+
+
+def test_resume_suggest_mentions_priority():
+	"""RESUME_SUGGEST_PROMPT includes priority levels."""
+	assert "high" in RESUME_SUGGEST_PROMPT
+	assert "medium" in RESUME_SUGGEST_PROMPT
+	assert "low" in RESUME_SUGGEST_PROMPT
+
+
+# ── JSON template integrity ──────────────────────────────────
+
+
+def test_jd_analysis_json_template():
+	"""After format, the JSON template has valid braces."""
+	result = JD_ANALYSIS_PROMPT.format(jd_text="test", resume_text="test")
+	# Should not contain unresolved {placeholders}, but should contain JSON { }
+	assert "{" in result  # JSON structure still present
+	assert "}" in result
+
+
+def test_all_prompts_non_empty():
+	"""All prompts are non-empty strings."""
+	for prompt in [JD_ANALYSIS_PROMPT, RESUME_POLISH_PROMPT, RESUME_OPTIMIZE_FOR_JD_PROMPT, RESUME_SUGGEST_PROMPT]:
+		assert isinstance(prompt, str)
+		assert len(prompt) > 100

--- a/tests/test_ai_service.py
+++ b/tests/test_ai_service.py
@@ -1,0 +1,187 @@
+"""Tests for AI service client."""
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from boss_agent_cli.ai.service import AIService, AIServiceError
+
+
+def _make_service(**kwargs) -> AIService:
+	defaults = {
+		"base_url": "https://api.example.com/v1",
+		"api_key": "sk-test-key",
+		"model": "gpt-4",
+		"temperature": 0.7,
+		"max_tokens": 4096,
+	}
+	defaults.update(kwargs)
+	return AIService(**defaults)
+
+
+def _mock_response(status_code: int = 200, json_data: dict | None = None) -> httpx.Response:
+	"""Create a mock httpx.Response."""
+	if json_data is None:
+		json_data = {
+			"choices": [{"message": {"content": "Hello, world!"}}]
+		}
+	return httpx.Response(
+		status_code=status_code,
+		json=json_data,
+		request=httpx.Request("POST", "https://api.example.com/v1/chat/completions"),
+	)
+
+
+# ── successful call ──────────────────────────────────────────
+
+
+@patch("boss_agent_cli.ai.service.httpx.post")
+def test_chat_success(mock_post):
+	"""Successful chat call returns the assistant's reply."""
+	mock_post.return_value = _mock_response(200, {"choices": [{"message": {"content": "Test reply"}}]})
+	service = _make_service()
+	result = service.chat([{"role": "user", "content": "Hi"}])
+	assert result == "Test reply"
+
+
+# ── request validation ───────────────────────────────────────
+
+
+@patch("boss_agent_cli.ai.service.httpx.post")
+def test_chat_request_headers(mock_post):
+	"""Request includes Authorization header and Content-Type."""
+	mock_post.return_value = _mock_response()
+	service = _make_service(api_key="sk-my-key")
+	service.chat([{"role": "user", "content": "Hi"}])
+
+	call_kwargs = mock_post.call_args
+	headers = call_kwargs.kwargs["headers"]
+	assert headers["Authorization"] == "Bearer sk-my-key"
+	assert headers["Content-Type"] == "application/json"
+
+
+@patch("boss_agent_cli.ai.service.httpx.post")
+def test_chat_request_body(mock_post):
+	"""Request body includes model, messages, temperature, max_tokens."""
+	mock_post.return_value = _mock_response()
+	service = _make_service(model="gpt-4o", temperature=0.5, max_tokens=2048)
+	service.chat([{"role": "user", "content": "Hello"}])
+
+	call_kwargs = mock_post.call_args
+	payload = call_kwargs.kwargs["json"]
+	assert payload["model"] == "gpt-4o"
+	assert payload["messages"] == [{"role": "user", "content": "Hello"}]
+	assert payload["temperature"] == 0.5
+	assert payload["max_tokens"] == 2048
+
+
+@patch("boss_agent_cli.ai.service.httpx.post")
+def test_chat_url_construction(mock_post):
+	"""URL is base_url + /chat/completions."""
+	mock_post.return_value = _mock_response()
+	service = _make_service(base_url="https://api.example.com/v1")
+	service.chat([{"role": "user", "content": "Hi"}])
+
+	call_args = mock_post.call_args
+	assert call_args.args[0] == "https://api.example.com/v1/chat/completions"
+
+
+# ── HTTP errors ──────────────────────────────────────────────
+
+
+@patch("boss_agent_cli.ai.service.httpx.post")
+def test_chat_http_401(mock_post):
+	"""HTTP 401 raises AIServiceError with status_code."""
+	mock_post.return_value = _mock_response(401, {"error": {"message": "Unauthorized"}})
+	service = _make_service()
+	with pytest.raises(AIServiceError) as exc_info:
+		service.chat([{"role": "user", "content": "Hi"}])
+	assert exc_info.value.status_code == 401
+
+
+@patch("boss_agent_cli.ai.service.httpx.post")
+def test_chat_http_500(mock_post):
+	"""HTTP 500 raises AIServiceError with status_code."""
+	mock_post.return_value = _mock_response(500, {"error": {"message": "Internal Server Error"}})
+	service = _make_service()
+	with pytest.raises(AIServiceError) as exc_info:
+		service.chat([{"role": "user", "content": "Hi"}])
+	assert exc_info.value.status_code == 500
+
+
+# ── network error ────────────────────────────────────────────
+
+
+@patch("boss_agent_cli.ai.service.httpx.post")
+def test_chat_network_error(mock_post):
+	"""Network error raises AIServiceError without status_code."""
+	mock_post.side_effect = httpx.ConnectError("Connection refused")
+	service = _make_service()
+	with pytest.raises(AIServiceError) as exc_info:
+		service.chat([{"role": "user", "content": "Hi"}])
+	assert exc_info.value.status_code is None
+	assert "网络请求失败" in str(exc_info.value)
+
+
+# ── response format error ────────────────────────────────────
+
+
+@patch("boss_agent_cli.ai.service.httpx.post")
+def test_chat_malformed_response(mock_post):
+	"""Malformed response raises AIServiceError."""
+	mock_post.return_value = _mock_response(200, {"unexpected": "format"})
+	service = _make_service()
+	with pytest.raises(AIServiceError) as exc_info:
+		service.chat([{"role": "user", "content": "Hi"}])
+	assert "响应格式异常" in str(exc_info.value)
+
+
+@patch("boss_agent_cli.ai.service.httpx.post")
+def test_chat_empty_choices(mock_post):
+	"""Empty choices array raises AIServiceError."""
+	mock_post.return_value = _mock_response(200, {"choices": []})
+	service = _make_service()
+	with pytest.raises(AIServiceError) as exc_info:
+		service.chat([{"role": "user", "content": "Hi"}])
+	assert "响应格式异常" in str(exc_info.value)
+
+
+# ── parameter overrides ──────────────────────────────────────
+
+
+@patch("boss_agent_cli.ai.service.httpx.post")
+def test_chat_temperature_override(mock_post):
+	"""Per-call temperature override works."""
+	mock_post.return_value = _mock_response()
+	service = _make_service(temperature=0.7)
+	service.chat([{"role": "user", "content": "Hi"}], temperature=0.2)
+
+	payload = mock_post.call_args.kwargs["json"]
+	assert payload["temperature"] == 0.2
+
+
+@patch("boss_agent_cli.ai.service.httpx.post")
+def test_chat_max_tokens_override(mock_post):
+	"""Per-call max_tokens override works."""
+	mock_post.return_value = _mock_response()
+	service = _make_service(max_tokens=4096)
+	service.chat([{"role": "user", "content": "Hi"}], max_tokens=1024)
+
+	payload = mock_post.call_args.kwargs["json"]
+	assert payload["max_tokens"] == 1024
+
+
+# ── base_url normalization ───────────────────────────────────
+
+
+@patch("boss_agent_cli.ai.service.httpx.post")
+def test_chat_base_url_trailing_slash(mock_post):
+	"""Trailing slash in base_url is handled."""
+	mock_post.return_value = _mock_response()
+	service = _make_service(base_url="https://api.example.com/v1/")
+	service.chat([{"role": "user", "content": "Hi"}])
+
+	url = mock_post.call_args.args[0]
+	assert url == "https://api.example.com/v1/chat/completions"
+	assert "//" not in url.replace("https://", "")

--- a/tests/test_resume_commands.py
+++ b/tests/test_resume_commands.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 
@@ -163,13 +164,29 @@ def test_export_json(tmp_path):
 	assert parsed["data"]["data"]["name"] == "exportme"
 
 
-def test_export_unsupported_format(tmp_path):
+def test_export_pdf_success(tmp_path):
+	"""PDF 导出使用 mock patchright 验证成功路径"""
 	runner = CliRunner()
-	_invoke(runner, tmp_path, ["init", "--name", "nopdf", "--template", "default"])
-	result = _invoke(runner, tmp_path, ["export", "nopdf", "--format", "pdf"])
-	assert result.exit_code == 1
+	_invoke(runner, tmp_path, ["init", "--name", "pdftest", "--template", "default"])
+
+	mock_page = MagicMock()
+	mock_browser = MagicMock()
+	mock_browser.new_page.return_value = mock_page
+	mock_chromium = MagicMock()
+	mock_chromium.launch.return_value = mock_browser
+	mock_pw = MagicMock()
+	mock_pw.chromium = mock_chromium
+	mock_cm = MagicMock()
+	mock_cm.__enter__ = MagicMock(return_value=mock_pw)
+	mock_cm.__exit__ = MagicMock(return_value=False)
+
+	out_file = tmp_path / "test_output.pdf"
+	with patch("patchright.sync_api.sync_playwright", return_value=mock_cm):
+		result = _invoke(runner, tmp_path, ["export", "pdftest", "--format", "pdf", "-o", str(out_file)])
+	assert result.exit_code == 0
 	parsed = json.loads(result.output)
-	assert parsed["error"]["code"] == "EXPORT_FAILED"
+	assert parsed["ok"] is True
+	assert parsed["data"]["format"] == "pdf"
 
 
 def test_export_not_found(tmp_path):

--- a/tests/test_resume_export.py
+++ b/tests/test_resume_export.py
@@ -1,0 +1,208 @@
+"""Tests for resume export (HTML + PDF)."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from boss_agent_cli.main import cli
+from boss_agent_cli.resume.export import export_html, export_pdf
+from boss_agent_cli.resume.models import (
+	PersonalInfoSection,
+	ResumeData,
+)
+
+
+def _make_resume(**kwargs) -> ResumeData:
+	defaults = {
+		"name": "test",
+		"title": "Test Resume",
+		"center_title": False,
+		"personal_info": PersonalInfoSection(items=[], layout="inline"),
+		"job_intention": None,
+		"modules": [],
+		"avatar": "",
+	}
+	defaults.update(kwargs)
+	return ResumeData(**defaults)
+
+
+def _invoke(runner, tmp_path, args):
+	return runner.invoke(cli, ["--data-dir", str(tmp_path), "--json", "resume"] + args)
+
+
+# ── export_html ──────────────────────────────────────────────
+
+
+def test_export_html_creates_file(tmp_path):
+	"""export_html writes an HTML file to the specified path."""
+	resume = _make_resume()
+	out = tmp_path / "resume.html"
+	result = export_html(resume, out)
+	assert result == out
+	assert out.exists()
+	content = out.read_text(encoding="utf-8")
+	assert "<html" in content
+	assert "Test Resume" in content
+
+
+def test_export_html_creates_parent_dirs(tmp_path):
+	"""export_html creates parent directories if they don't exist."""
+	resume = _make_resume()
+	out = tmp_path / "deep" / "nested" / "dir" / "resume.html"
+	result = export_html(resume, out)
+	assert result == out
+	assert out.exists()
+
+
+def test_export_html_overwrites_existing(tmp_path):
+	"""export_html overwrites an existing file."""
+	resume = _make_resume(title="Version 1")
+	out = tmp_path / "resume.html"
+	export_html(resume, out)
+
+	resume2 = _make_resume(title="Version 2")
+	export_html(resume2, out)
+	content = out.read_text(encoding="utf-8")
+	assert "Version 2" in content
+	assert "Version 1" not in content
+
+
+# ── export_pdf ───────────────────────────────────────────────
+
+
+def test_export_pdf_mock_patchright(tmp_path):
+	"""export_pdf calls patchright correctly (mocked)."""
+	resume = _make_resume()
+	out = tmp_path / "resume.pdf"
+
+	mock_page = MagicMock()
+	mock_browser = MagicMock()
+	mock_browser.new_page.return_value = mock_page
+	mock_chromium = MagicMock()
+	mock_chromium.launch.return_value = mock_browser
+	mock_playwright = MagicMock()
+	mock_playwright.chromium = mock_chromium
+
+	mock_context_manager = MagicMock()
+	mock_context_manager.__enter__ = MagicMock(return_value=mock_playwright)
+	mock_context_manager.__exit__ = MagicMock(return_value=False)
+
+	with patch("patchright.sync_api.sync_playwright", return_value=mock_context_manager):
+		result = export_pdf(resume, out)
+
+	assert result == out
+	mock_chromium.launch.assert_called_once_with(headless=True)
+	mock_browser.new_page.assert_called_once()
+	mock_page.set_content.assert_called_once()
+	mock_page.pdf.assert_called_once()
+	mock_browser.close.assert_called_once()
+
+
+def test_export_pdf_call_params(tmp_path):
+	"""export_pdf passes correct PDF parameters."""
+	resume = _make_resume()
+	out = tmp_path / "output.pdf"
+
+	mock_page = MagicMock()
+	mock_browser = MagicMock()
+	mock_browser.new_page.return_value = mock_page
+	mock_chromium = MagicMock()
+	mock_chromium.launch.return_value = mock_browser
+	mock_playwright = MagicMock()
+	mock_playwright.chromium = mock_chromium
+
+	mock_context_manager = MagicMock()
+	mock_context_manager.__enter__ = MagicMock(return_value=mock_playwright)
+	mock_context_manager.__exit__ = MagicMock(return_value=False)
+
+	with patch("patchright.sync_api.sync_playwright", return_value=mock_context_manager):
+		export_pdf(resume, out)
+
+	pdf_call = mock_page.pdf.call_args
+	assert pdf_call.kwargs["format"] == "A4"
+	assert pdf_call.kwargs["print_background"] is True
+	assert pdf_call.kwargs["margin"]["top"] == "10mm"
+	assert pdf_call.kwargs["margin"]["bottom"] == "10mm"
+	assert pdf_call.kwargs["margin"]["left"] == "10mm"
+	assert pdf_call.kwargs["margin"]["right"] == "10mm"
+	assert pdf_call.kwargs["path"] == str(out)
+
+
+def test_export_pdf_creates_parent_dirs(tmp_path):
+	"""export_pdf creates parent directories."""
+	resume = _make_resume()
+	out = tmp_path / "sub" / "dir" / "resume.pdf"
+
+	mock_page = MagicMock()
+	mock_browser = MagicMock()
+	mock_browser.new_page.return_value = mock_page
+	mock_chromium = MagicMock()
+	mock_chromium.launch.return_value = mock_browser
+	mock_playwright = MagicMock()
+	mock_playwright.chromium = mock_chromium
+
+	mock_context_manager = MagicMock()
+	mock_context_manager.__enter__ = MagicMock(return_value=mock_playwright)
+	mock_context_manager.__exit__ = MagicMock(return_value=False)
+
+	with patch("patchright.sync_api.sync_playwright", return_value=mock_context_manager):
+		export_pdf(resume, out)
+
+	assert out.parent.exists()
+
+
+# ── CLI integration: --format html ───────────────────────────
+
+
+def test_cli_export_html(tmp_path):
+	"""boss resume export <name> --format html creates an HTML file."""
+	runner = CliRunner()
+	# Init a resume first
+	_invoke(runner, tmp_path, ["init", "--name", "htmltest", "--template", "default"])
+	out_file = tmp_path / "test_output.html"
+	result = _invoke(runner, tmp_path, ["export", "htmltest", "--format", "html", "-o", str(out_file)])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["format"] == "html"
+	assert out_file.exists()
+
+
+def test_cli_export_html_default_path(tmp_path):
+	"""When no -o is given, export defaults to <name>.html."""
+	runner = CliRunner()
+	_invoke(runner, tmp_path, ["init", "--name", "autopath", "--template", "default"])
+	result = _invoke(runner, tmp_path, ["export", "autopath", "--format", "html"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["format"] == "html"
+
+
+# ── CLI integration: --format pdf chromium unavailable ───────
+
+
+def test_cli_export_pdf_chromium_unavailable(tmp_path):
+	"""When patchright/chromium is not available, export returns EXPORT_FAILED."""
+	runner = CliRunner()
+	_invoke(runner, tmp_path, ["init", "--name", "pdffail", "--template", "default"])
+
+	with patch(
+		"patchright.sync_api.sync_playwright",
+		side_effect=Exception("Chromium not installed"),
+	):
+		result = _invoke(runner, tmp_path, ["export", "pdffail", "--format", "pdf"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["error"]["code"] == "EXPORT_FAILED"
+
+
+def test_cli_export_not_found(tmp_path):
+	"""Exporting a non-existent resume returns RESUME_NOT_FOUND."""
+	runner = CliRunner()
+	result = _invoke(runner, tmp_path, ["export", "ghost", "--format", "html"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "RESUME_NOT_FOUND"

--- a/tests/test_resume_templates.py
+++ b/tests/test_resume_templates.py
@@ -1,0 +1,271 @@
+"""Tests for resume HTML template rendering."""
+
+from boss_agent_cli.resume.models import (
+	JobIntentionItem,
+	JobIntentionSection,
+	PersonalInfoItem,
+	PersonalInfoSection,
+	ResumeData,
+	ResumeModule,
+)
+from boss_agent_cli.resume.templates import render_resume_html
+
+
+def _make_resume(**kwargs) -> ResumeData:
+	"""Create a minimal ResumeData for testing."""
+	defaults = {
+		"name": "test",
+		"title": "Test Resume",
+		"center_title": False,
+		"personal_info": PersonalInfoSection(items=[], layout="inline"),
+		"job_intention": None,
+		"modules": [],
+		"avatar": "",
+	}
+	defaults.update(kwargs)
+	return ResumeData(**defaults)
+
+
+# ── basic HTML structure ──────────────────────────────────────
+
+
+def test_html_basic_structure():
+	"""Output contains <html>, <head>, <body> tags."""
+	resume = _make_resume()
+	html = render_resume_html(resume)
+	assert "<html" in html
+	assert "<head>" in html
+	assert "<body>" in html
+	assert "</html>" in html
+	assert "<!DOCTYPE html>" in html
+
+
+def test_html_charset_and_viewport():
+	"""Output includes UTF-8 charset and viewport meta."""
+	resume = _make_resume()
+	html = render_resume_html(resume)
+	assert 'charset="UTF-8"' in html
+	assert "viewport" in html
+
+
+# ── title rendering ──────────────────────────────────────────
+
+
+def test_title_rendered():
+	"""Resume title appears in the HTML output."""
+	resume = _make_resume(title="Senior Python Developer")
+	html = render_resume_html(resume)
+	assert "Senior Python Developer" in html
+
+
+def test_title_centered():
+	"""When center_title=True, the header is center-aligned."""
+	resume = _make_resume(center_title=True)
+	html = render_resume_html(resume)
+	assert "center" in html
+
+
+def test_title_left_aligned():
+	"""When center_title=False, the header is left-aligned."""
+	resume = _make_resume(center_title=False)
+	html = render_resume_html(resume)
+	assert "left" in html
+
+
+# ── personal info ────────────────────────────────────────────
+
+
+def test_personal_info_rendered():
+	"""Personal info items appear in the HTML."""
+	items = [
+		PersonalInfoItem(label="Email", value="test@example.com"),
+		PersonalInfoItem(label="Phone", value="1234567890"),
+	]
+	resume = _make_resume(personal_info=PersonalInfoSection(items=items, layout="inline"))
+	html = render_resume_html(resume)
+	assert "Email" in html
+	assert "test@example.com" in html
+	assert "Phone" in html
+	assert "1234567890" in html
+
+
+def test_personal_info_with_link():
+	"""Personal info items with links render as <a> tags."""
+	items = [
+		PersonalInfoItem(label="GitHub", value="github.com/user", link="https://github.com/user"),
+	]
+	resume = _make_resume(personal_info=PersonalInfoSection(items=items))
+	html = render_resume_html(resume)
+	assert "https://github.com/user" in html
+	assert "<a " in html
+
+
+# ── avatar ───────────────────────────────────────────────────
+
+
+def test_avatar_rendered():
+	"""When avatar is set, an <img> tag appears."""
+	resume = _make_resume(avatar="https://example.com/photo.jpg")
+	html = render_resume_html(resume)
+	assert '<img src="https://example.com/photo.jpg"' in html
+
+
+def test_avatar_not_rendered_when_empty():
+	"""When avatar is empty, no <img> tag appears."""
+	resume = _make_resume(avatar="")
+	html = render_resume_html(resume)
+	assert "<img" not in html
+
+
+# ── job intention ────────────────────────────────────────────
+
+
+def test_job_intention_rendered():
+	"""Job intention section appears when set."""
+	ji = JobIntentionSection(
+		title="求职意向",
+		items=[
+			JobIntentionItem(label="期望职位", value="Python 工程师"),
+			JobIntentionItem(label="期望城市", value="北京"),
+		],
+	)
+	resume = _make_resume(job_intention=ji)
+	html = render_resume_html(resume)
+	assert "求职意向" in html
+	assert "Python 工程师" in html
+	assert "北京" in html
+	assert "#f0f7ff" in html  # background color
+
+
+def test_job_intention_not_rendered_when_none():
+	"""No job intention section content when it is None."""
+	resume = _make_resume(job_intention=None)
+	html = render_resume_html(resume)
+	# CSS class definitions exist in <style>, but no actual rendered elements in <body>
+	body = html.split("</style>")[-1]
+	assert "ji-item" not in body
+	assert "ji-label" not in body
+
+
+# ── richtext and tags modules ────────────────────────────────
+
+
+def test_richtext_module_rendered():
+	"""Richtext rows render their content."""
+	mod = ResumeModule(
+		id="exp",
+		title="工作经历",
+		rows=[
+			{"type": "richtext", "columns": 1, "content": ["负责后端开发", "维护微服务架构"]},
+		],
+	)
+	resume = _make_resume(modules=[mod])
+	html = render_resume_html(resume)
+	assert "工作经历" in html
+	assert "负责后端开发" in html
+	assert "维护微服务架构" in html
+
+
+def test_tags_module_rendered():
+	"""Tags rows render as tag badges."""
+	mod = ResumeModule(
+		id="skills",
+		title="技能标签",
+		rows=[
+			{"type": "tags", "tags": ["Python", "Go", "Docker"]},
+		],
+	)
+	resume = _make_resume(modules=[mod])
+	html = render_resume_html(resume)
+	assert "技能标签" in html
+	assert "Python" in html
+	assert "Go" in html
+	assert "Docker" in html
+	assert "#e8f0fe" in html  # tag background
+
+
+def test_richtext_multi_column():
+	"""Multi-column richtext renders with inline-block."""
+	mod = ResumeModule(
+		id="info",
+		title="基本信息",
+		rows=[
+			{"type": "richtext", "columns": 2, "content": ["左列内容", "右列内容"]},
+		],
+	)
+	resume = _make_resume(modules=[mod])
+	html = render_resume_html(resume)
+	assert "50%" in html
+	assert "左列内容" in html
+	assert "右列内容" in html
+
+
+# ── XSS prevention ──────────────────────────────────────────
+
+
+def test_xss_title_escaped():
+	"""Title with HTML tags is escaped."""
+	resume = _make_resume(title="<script>alert('xss')</script>")
+	html = render_resume_html(resume)
+	assert "<script>" not in html
+	assert "&lt;script&gt;" in html
+
+
+def test_xss_personal_info_escaped():
+	"""Personal info values with HTML are escaped."""
+	items = [PersonalInfoItem(label="Name", value="<b>Evil</b>")]
+	resume = _make_resume(personal_info=PersonalInfoSection(items=items))
+	html = render_resume_html(resume)
+	assert "<b>Evil</b>" not in html
+	assert "&lt;b&gt;Evil&lt;/b&gt;" in html
+
+
+def test_xss_module_content_escaped():
+	"""Module content with HTML is escaped."""
+	mod = ResumeModule(
+		id="test",
+		title="Test",
+		rows=[{"type": "richtext", "content": ['<img src=x onerror="alert(1)">']}],
+	)
+	resume = _make_resume(modules=[mod])
+	html = render_resume_html(resume)
+	assert 'onerror="alert(1)"' not in html
+	assert "&lt;img" in html
+
+
+def test_xss_tags_escaped():
+	"""Tags with HTML are escaped."""
+	mod = ResumeModule(
+		id="skills",
+		title="Skills",
+		rows=[{"type": "tags", "tags": ['<script>evil</script>']}],
+	)
+	resume = _make_resume(modules=[mod])
+	html = render_resume_html(resume)
+	assert "<script>evil</script>" not in html
+	assert "&lt;script&gt;" in html
+
+
+# ── CSS and font ─────────────────────────────────────────────
+
+
+def test_chinese_font_stack():
+	"""HTML includes the Chinese font stack."""
+	resume = _make_resume()
+	html = render_resume_html(resume)
+	assert "PingFang SC" in html
+	assert "Microsoft YaHei" in html
+
+
+def test_a4_page_size():
+	"""CSS includes A4 page size for printing."""
+	resume = _make_resume()
+	html = render_resume_html(resume)
+	assert "A4" in html
+
+
+def test_primary_color():
+	"""CSS includes the primary color #2563eb."""
+	resume = _make_resume()
+	html = render_resume_html(resume)
+	assert "#2563eb" in html

--- a/uv.lock
+++ b/uv.lock
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "boss-agent-cli"
-version = "1.3.0"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },


### PR DESCRIPTION
## 概述

在 #35（简历数据模型）和 #36（简历管理命令）基础上，完成简历集成功能的最后两个核心模块：

- **智能服务模块**（`ai/`）：支持多模型配置（密钥加密存储）、提示词模板、对话补全客户端
- **简历模板渲染和导出**（`resume/export.py` + `resume/templates.py`）：支持导出为 JSON / HTML / PDF 三种格式

## 变更内容

### 新增模块

| 模块 | 文件 | 职责 |
|------|------|------|
| `ai/config.py` | 智能服务配置 | 多模型提供商配置、密钥加密存储（复用认证模块的盐文件） |
| `ai/prompts.py` | 提示词模板 | 职位分析、简历润色、针对性优化、改进建议四组模板 |
| `ai/service.py` | 对话补全客户端 | 兼容多种大模型接口的统一客户端，含错误处理 |
| `resume/templates.py` | 简历模板渲染 | 将简历数据渲染为自包含的打印友好型页面，含防注入处理 |
| `resume/export.py` | 简历导出 | 支持导出到页面和文档两种格式 |

### 修改文件

- `commands/resume_cmd.py`：导出命令扩展支持页面和文档格式
- `tests/test_resume_commands.py`：更新旧测试以反映文档导出已实现
- `.gitignore`：增加测试副产品过滤规则

### 测试覆盖

新增 6 个测试文件，75 个测试用例：

| 测试文件 | 覆盖范围 | 用例数 |
|---------|---------|-------|
| `test_ai_config.py` | 密钥加解密、配置读写、多提供商 | 18 |
| `test_ai_prompts.py` | 模板占位符、格式化、关键词 | 15 |
| `test_ai_service.py` | 请求构造、错误处理、参数覆盖 | 12 |
| `test_resume_templates.py` | 渲染结构、防注入、样式 | 20 |
| `test_resume_export.py` | 文件导出、命令集成 | 10 |

## 测试验证

```
626 passed in 4.87s
ruff: All checks passed!
```

## 关联

- 依赖 #35 简历数据模型
- 依赖 #36 简历管理命令
- 简历集成功能完整闭环