### PR TITLE
feat: 新增智能优化命令和投递追踪功能

### DIFF
--- a/src/boss_agent_cli/cache/store.py
+++ b/src/boss_agent_cli/cache/store.py
@@ -60,6 +60,18 @@ class CacheStore:
 				created_at REAL NOT NULL,
 				PRIMARY KEY (security_id, job_id)
 			);
+			CREATE TABLE IF NOT EXISTS resume_job_links (
+				resume_name TEXT NOT NULL,
+				security_id TEXT NOT NULL,
+				job_id TEXT NOT NULL,
+				job_title TEXT NOT NULL,
+				company TEXT NOT NULL,
+				status TEXT NOT NULL DEFAULT 'prepared',
+				notes TEXT DEFAULT '',
+				linked_at REAL NOT NULL,
+				updated_at REAL NOT NULL,
+				PRIMARY KEY (resume_name, security_id, job_id)
+			);
 		""")
 
 	@staticmethod
@@ -274,6 +286,95 @@ class CacheStore:
 		cursor = self._conn.execute(
 			"DELETE FROM shortlist_records WHERE security_id = ? AND job_id = ?",
 			(security_id, job_id),
+		)
+		self._conn.commit()
+		return cursor.rowcount > 0
+
+	def link_resume_to_job(
+		self,
+		resume_name: str,
+		security_id: str,
+		job_id: str,
+		job_title: str,
+		company: str,
+	) -> None:
+		"""将简历与职位关联"""
+		now = time.time()
+		self._conn.execute(
+			"INSERT OR REPLACE INTO resume_job_links "
+			"(resume_name, security_id, job_id, job_title, company, status, notes, linked_at, updated_at) "
+			"VALUES (?, ?, ?, ?, ?, 'prepared', '', ?, ?)",
+			(resume_name, security_id, job_id, job_title, company, now, now),
+		)
+		self._conn.commit()
+
+	def update_job_link_status(
+		self,
+		resume_name: str,
+		security_id: str,
+		job_id: str,
+		status: str,
+		notes: str = "",
+	) -> bool:
+		"""更新关联状态"""
+		now = time.time()
+		cursor = self._conn.execute(
+			"UPDATE resume_job_links SET status = ?, notes = ?, updated_at = ? "
+			"WHERE resume_name = ? AND security_id = ? AND job_id = ?",
+			(status, notes, now, resume_name, security_id, job_id),
+		)
+		self._conn.commit()
+		return cursor.rowcount > 0
+
+	def get_resume_applications(self, resume_name: str) -> list[dict]:
+		"""查看某份简历投递的所有职位"""
+		rows = self._conn.execute(
+			"SELECT resume_name, security_id, job_id, job_title, company, status, notes, linked_at, updated_at "
+			"FROM resume_job_links WHERE resume_name = ? ORDER BY updated_at DESC",
+			(resume_name,),
+		).fetchall()
+		return [
+			{
+				"resume_name": row[0],
+				"security_id": row[1],
+				"job_id": row[2],
+				"job_title": row[3],
+				"company": row[4],
+				"status": row[5],
+				"notes": row[6],
+				"linked_at": row[7],
+				"updated_at": row[8],
+			}
+			for row in rows
+		]
+
+	def get_job_resumes(self, security_id: str, job_id: str) -> list[dict]:
+		"""查看某职位关联的所有简历版本"""
+		rows = self._conn.execute(
+			"SELECT resume_name, security_id, job_id, job_title, company, status, notes, linked_at, updated_at "
+			"FROM resume_job_links WHERE security_id = ? AND job_id = ? ORDER BY updated_at DESC",
+			(security_id, job_id),
+		).fetchall()
+		return [
+			{
+				"resume_name": row[0],
+				"security_id": row[1],
+				"job_id": row[2],
+				"job_title": row[3],
+				"company": row[4],
+				"status": row[5],
+				"notes": row[6],
+				"linked_at": row[7],
+				"updated_at": row[8],
+			}
+			for row in rows
+		]
+
+	def remove_job_link(self, resume_name: str, security_id: str, job_id: str) -> bool:
+		"""移除简历职位关联"""
+		cursor = self._conn.execute(
+			"DELETE FROM resume_job_links WHERE resume_name = ? AND security_id = ? AND job_id = ?",
+			(resume_name, security_id, job_id),
 		)
 		self._conn.commit()
 		return cursor.rowcount > 0

--- a/src/boss_agent_cli/commands/ai_cmd.py
+++ b/src/boss_agent_cli/commands/ai_cmd.py
@@ -1,0 +1,309 @@
+"""AI 简历优化命令组。
+
+子命令：config / analyze-jd / polish / optimize / suggest
+"""
+
+import json
+from pathlib import Path
+
+import click
+
+from boss_agent_cli.ai.config import AIConfigStore
+from boss_agent_cli.ai.prompts import (
+	JD_ANALYSIS_PROMPT,
+	RESUME_OPTIMIZE_FOR_JD_PROMPT,
+	RESUME_POLISH_PROMPT,
+	RESUME_SUGGEST_PROMPT,
+)
+from boss_agent_cli.ai.service import AIService, AIServiceError
+from boss_agent_cli.display import handle_error_output, handle_output
+from boss_agent_cli.resume.models import resume_to_text
+from boss_agent_cli.resume.store import ResumeStore
+
+
+def _get_ai_config_store(ctx) -> AIConfigStore:
+	return AIConfigStore(ctx.obj["data_dir"])
+
+
+def _get_resume_store(ctx) -> ResumeStore:
+	return ResumeStore(ctx.obj["data_dir"] / "resumes")
+
+
+def _create_ai_service(ctx) -> AIService | None:
+	"""从配置创建 AIService 实例，未配置时返回 None。"""
+	store = _get_ai_config_store(ctx)
+	if not store.is_configured():
+		return None
+	config = store.load_config()
+	api_key = store.get_api_key()
+	base_url = store.get_base_url()
+	if not api_key or not base_url:
+		return None
+	return AIService(
+		base_url=base_url,
+		api_key=api_key,
+		model=config["ai_model"],
+		temperature=config.get("ai_temperature", 0.7),
+		max_tokens=config.get("ai_max_tokens", 4096),
+	)
+
+
+def _require_ai_service(ctx) -> AIService | None:
+	"""获取 AIService，未配置时输出错误信封并返回 None。"""
+	svc = _create_ai_service(ctx)
+	if svc is None:
+		handle_error_output(
+			ctx, "ai",
+			code="AI_NOT_CONFIGURED",
+			message="AI 服务未配置",
+			recoverable=True,
+			recovery_action="boss ai config --provider <provider> --model <model> --api-key <key>",
+		)
+		ctx.exit(1)
+		return None
+	return svc
+
+
+def _load_resume_text(ctx, resume_name: str) -> str | None:
+	"""加载简历纯文本，不存在时输出错误。"""
+	store = _get_resume_store(ctx)
+	resume = store.get(resume_name)
+	if resume is None:
+		handle_error_output(
+			ctx, "ai",
+			code="RESUME_NOT_FOUND",
+			message=f"简历 '{resume_name}' 不存在",
+		)
+		ctx.exit(1)
+		return None
+	return resume_to_text(resume)
+
+
+def _call_ai(ctx, svc: AIService, prompt: str) -> dict | None:
+	"""调用 AI 并解析 JSON 结果，失败时输出错误信封。"""
+	try:
+		raw = svc.chat([
+			{"role": "system", "content": "你是求职顾问。所有输出使用 JSON 格式。"},
+			{"role": "user", "content": prompt},
+		])
+	except AIServiceError as exc:
+		handle_error_output(
+			ctx, "ai",
+			code="AI_API_ERROR",
+			message=f"AI 服务调用失败: {exc}",
+			recoverable=True,
+			recovery_action="检查网络连接和密钥配置，重试",
+		)
+		ctx.exit(1)
+		return None
+
+	# 尝试提取 JSON（兼容 markdown 代码块包裹）
+	text = raw.strip()
+	if text.startswith("```"):
+		lines = text.split("\n")
+		lines = [ln for ln in lines if not ln.startswith("```")]
+		text = "\n".join(lines).strip()
+
+	try:
+		return json.loads(text)
+	except json.JSONDecodeError:
+		handle_error_output(
+			ctx, "ai",
+			code="AI_PARSE_ERROR",
+			message="AI 返回结果解析失败",
+			recoverable=True,
+			recovery_action="重试（模型输出不稳定时可能发生）",
+		)
+		ctx.exit(1)
+		return None
+
+
+@click.group("ai")
+def ai_group():
+	"""AI 简历优化。"""
+
+
+@ai_group.command("config")
+@click.option("--provider", default=None, help="AI 提供商（openai/deepseek/moonshot/custom）")
+@click.option("--model", default=None, help="模型名称（如 gpt-4o）")
+@click.option("--api-key", default=None, help="API 密钥（将加密存储）")
+@click.option("--base-url", default=None, help="自定义 API 基础地址")
+@click.option("--temperature", default=None, type=float, help="生成温度")
+@click.option("--max-tokens", default=None, type=int, help="最大令牌数")
+@click.pass_context
+def ai_config_cmd(ctx, provider, model, api_key, base_url, temperature, max_tokens):
+	"""查看或设置 AI 服务配置"""
+	store = _get_ai_config_store(ctx)
+
+	# 无参数时显示当前配置
+	has_updates = any([provider, model, api_key, base_url, temperature is not None, max_tokens is not None])
+	if not has_updates:
+		config = store.load_config()
+		config["api_key_set"] = store.get_api_key() is not None
+		config.pop("ai_api_key", None)
+		handle_output(
+			ctx, "ai-config", config,
+			hints={"next_actions": [
+				"boss ai config --provider openai --model gpt-4o --api-key <key>",
+			]},
+		)
+		return
+
+	# 有参数时更新配置
+	updates = {}
+	if provider is not None:
+		updates["ai_provider"] = provider
+	if model is not None:
+		updates["ai_model"] = model
+	if base_url is not None:
+		updates["ai_base_url"] = base_url
+	if temperature is not None:
+		updates["ai_temperature"] = temperature
+	if max_tokens is not None:
+		updates["ai_max_tokens"] = max_tokens
+	if updates:
+		store.save_config(**updates)
+	if api_key is not None:
+		store.save_api_key(api_key)
+
+	handle_output(
+		ctx, "ai-config",
+		{"action": "update", "updated_fields": list(updates.keys()) + (["api_key"] if api_key else [])},
+		hints={"next_actions": ["boss ai config", "boss ai analyze-jd <security_id> --resume <name>"]},
+	)
+
+
+@ai_group.command("analyze-jd")
+@click.argument("jd_text")
+@click.option("--resume", "resume_name", required=True, help="对比的本地简历名称")
+@click.pass_context
+def ai_analyze_jd_cmd(ctx, jd_text, resume_name):
+	"""分析职位描述并评估简历匹配度
+
+	JD_TEXT 可以是职位描述文本，也可以是 @文件路径 读取文件内容。
+	"""
+	svc = _require_ai_service(ctx)
+	if svc is None:
+		return
+
+	# 支持 @file 语法读取文件
+	if jd_text.startswith("@"):
+		file_path = Path(jd_text[1:])
+		if not file_path.exists():
+			handle_error_output(ctx, "ai", code="INVALID_PARAM", message=f"文件 '{file_path}' 不存在")
+			ctx.exit(1)
+			return
+		jd_text = file_path.read_text(encoding="utf-8")
+
+	resume_text = _load_resume_text(ctx, resume_name)
+	if resume_text is None:
+		return
+
+	prompt = JD_ANALYSIS_PROMPT.format(jd_text=jd_text, resume_text=resume_text)
+	result = _call_ai(ctx, svc, prompt)
+	if result is None:
+		return
+
+	handle_output(
+		ctx, "ai-analyze-jd", result,
+		hints={"next_actions": [
+			f"boss ai optimize {resume_name} --jd <jd_text>",
+			f"boss ai suggest {resume_name} --jd <jd_text>",
+		]},
+	)
+
+
+@ai_group.command("polish")
+@click.argument("resume_name")
+@click.pass_context
+def ai_polish_cmd(ctx, resume_name):
+	"""通用简历润色优化"""
+	svc = _require_ai_service(ctx)
+	if svc is None:
+		return
+
+	resume_text = _load_resume_text(ctx, resume_name)
+	if resume_text is None:
+		return
+
+	prompt = RESUME_POLISH_PROMPT.format(resume_text=resume_text)
+	result = _call_ai(ctx, svc, prompt)
+	if result is None:
+		return
+
+	handle_output(
+		ctx, "ai-polish", result,
+		hints={"next_actions": [f"boss resume show {resume_name}"]},
+	)
+
+
+@ai_group.command("optimize")
+@click.argument("resume_name")
+@click.option("--jd", "jd_text", required=True, help="目标职位描述文本或 @文件路径")
+@click.pass_context
+def ai_optimize_cmd(ctx, resume_name, jd_text):
+	"""基于目标职位描述优化简历"""
+	svc = _require_ai_service(ctx)
+	if svc is None:
+		return
+
+	if jd_text.startswith("@"):
+		file_path = Path(jd_text[1:])
+		if not file_path.exists():
+			handle_error_output(ctx, "ai", code="INVALID_PARAM", message=f"文件 '{file_path}' 不存在")
+			ctx.exit(1)
+			return
+		jd_text = file_path.read_text(encoding="utf-8")
+
+	resume_text = _load_resume_text(ctx, resume_name)
+	if resume_text is None:
+		return
+
+	prompt = RESUME_OPTIMIZE_FOR_JD_PROMPT.format(jd_text=jd_text, resume_text=resume_text)
+	result = _call_ai(ctx, svc, prompt)
+	if result is None:
+		return
+
+	handle_output(
+		ctx, "ai-optimize", result,
+		hints={"next_actions": [
+			f"boss resume show {resume_name}",
+			f"boss resume export {resume_name} --format pdf",
+		]},
+	)
+
+
+@ai_group.command("suggest")
+@click.argument("resume_name")
+@click.option("--jd", "jd_text", required=True, help="目标职位描述文本或 @文件路径")
+@click.pass_context
+def ai_suggest_cmd(ctx, resume_name, jd_text):
+	"""基于目标职位描述给出改进建议（不修改简历）"""
+	svc = _require_ai_service(ctx)
+	if svc is None:
+		return
+
+	if jd_text.startswith("@"):
+		file_path = Path(jd_text[1:])
+		if not file_path.exists():
+			handle_error_output(ctx, "ai", code="INVALID_PARAM", message=f"文件 '{file_path}' 不存在")
+			ctx.exit(1)
+			return
+		jd_text = file_path.read_text(encoding="utf-8")
+
+	resume_text = _load_resume_text(ctx, resume_name)
+	if resume_text is None:
+		return
+
+	prompt = RESUME_SUGGEST_PROMPT.format(jd_text=jd_text, resume_text=resume_text)
+	result = _call_ai(ctx, svc, prompt)
+	if result is None:
+		return
+
+	handle_output(
+		ctx, "ai-suggest", result,
+		hints={"next_actions": [
+			f"boss ai optimize {resume_name} --jd <jd_text>",
+			f"boss resume show {resume_name}",
+		]},
+	)

--- a/src/boss_agent_cli/commands/resume_cmd.py
+++ b/src/boss_agent_cli/commands/resume_cmd.py
@@ -317,3 +317,49 @@ def resume_diff_cmd(ctx, name1, name2):
 		{"name1": name1, "name2": name2, "diffs": diffs},
 		hints={"next_actions": [f"boss resume show {name1}", f"boss resume show {name2}"]},
 	)
+
+
+@resume_group.command("link")
+@click.argument("name")
+@click.argument("security_id")
+@click.argument("job_id")
+@click.option("--title", default="", help="职位名称")
+@click.option("--company", default="", help="公司名称")
+@click.pass_context
+def resume_link_cmd(ctx, name, security_id, job_id, title, company):
+	"""关联简历与职位"""
+	store = _get_store(ctx)
+	if not store.exists(name):
+		handle_error_output(ctx, "resume", code="RESUME_NOT_FOUND", message=f"简历 '{name}' 不存在")
+		ctx.exit(1)
+		return
+	from boss_agent_cli.cache.store import CacheStore
+	cache = CacheStore(ctx.obj["data_dir"] / "cache" / "boss_agent.db")
+	cache.link_resume_to_job(name, security_id, job_id, title, company)
+	cache.close()
+	handle_output(
+		ctx, "resume",
+		{"action": "link", "name": name, "security_id": security_id, "job_id": job_id},
+		hints={"next_actions": [f"boss resume applications {name}", f"boss apply {security_id} {job_id}"]},
+	)
+
+
+@resume_group.command("applications")
+@click.argument("name")
+@click.pass_context
+def resume_applications_cmd(ctx, name):
+	"""查看简历关联的所有职位"""
+	store = _get_store(ctx)
+	if not store.exists(name):
+		handle_error_output(ctx, "resume", code="RESUME_NOT_FOUND", message=f"简历 '{name}' 不存在")
+		ctx.exit(1)
+		return
+	from boss_agent_cli.cache.store import CacheStore
+	cache = CacheStore(ctx.obj["data_dir"] / "cache" / "boss_agent.db")
+	items = cache.get_resume_applications(name)
+	cache.close()
+	handle_output(
+		ctx, "resume",
+		items,
+		hints={"next_actions": [f"boss resume show {name}"]},
+	)

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -405,7 +405,7 @@ SCHEMA_DATA = {
 			},
 		},
 		"resume": {
-			"description": "本地简历管理（子命令：init/list/show/edit/delete/export/import/clone/diff）",
+			"description": "本地简历管理（子命令：init/list/show/edit/delete/export/import/clone/diff/link/applications）",
 			"args": [],
 			"options": {},
 			"subcommands": {
@@ -418,6 +418,20 @@ SCHEMA_DATA = {
 				"import": "导入 JSON 简历（兼容 wzdnzd/zine0 格式）",
 				"clone": "复制简历为新版本",
 				"diff": "对比两份简历差异",
+				"link": "关联简历与职位",
+				"applications": "查看简历关联的所有职位",
+			},
+		},
+		"ai": {
+			"description": "AI 简历优化（子命令：config/analyze-jd/polish/optimize/suggest）",
+			"args": [],
+			"options": {},
+			"subcommands": {
+				"config": "配置 AI 服务提供商和模型",
+				"analyze-jd": "分析职位描述并评估简历匹配度",
+				"polish": "通用简历润色",
+				"optimize": "基于目标职位描述优化简历",
+				"suggest": "基于目标职位描述给出优化建议（不修改简历）",
 			},
 		},
 	},
@@ -519,6 +533,21 @@ SCHEMA_DATA = {
 			"message": "导出失败",
 			"recoverable": True,
 			"recovery_action": "检查 patchright 安装：patchright install chromium",
+		},
+		"AI_NOT_CONFIGURED": {
+			"message": "AI 服务未配置",
+			"recoverable": True,
+			"recovery_action": "boss ai config --provider <provider> --model <model> --api-key <key>",
+		},
+		"AI_API_ERROR": {
+			"message": "AI 服务调用失败",
+			"recoverable": True,
+			"recovery_action": "检查网络连接和密钥配置，重试",
+		},
+		"AI_PARSE_ERROR": {
+			"message": "AI 返回结果解析失败",
+			"recoverable": True,
+			"recovery_action": "重试（模型输出不稳定时可能发生）",
 		},
 	},
 	"conventions": {

--- a/src/boss_agent_cli/main.py
+++ b/src/boss_agent_cli/main.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import click
 
 from boss_agent_cli import __version__
-from boss_agent_cli.commands import schema, login, logout, status, doctor, search, detail, greet, recommend, export, cities, me, chat, chatmsg, chat_summary, mark, exchange, interviews, show, history, watch, pipeline, apply, shortlist, preset, digest, config_cmd, clean, resume_cmd
+from boss_agent_cli.commands import schema, login, logout, status, doctor, search, detail, greet, recommend, export, cities, me, chat, chatmsg, chat_summary, mark, exchange, interviews, show, history, watch, pipeline, apply, shortlist, preset, digest, config_cmd, clean, resume_cmd, ai_cmd
 from boss_agent_cli.config import load_config
 from boss_agent_cli.hooks import create_hook_bus
 from boss_agent_cli.output import Logger
@@ -71,3 +71,4 @@ cli.add_command(digest.digest_cmd, "digest")
 cli.add_command(config_cmd.config_group, "config")
 cli.add_command(clean.clean_cmd, "clean")
 cli.add_command(resume_cmd.resume_group, "resume")
+cli.add_command(ai_cmd.ai_group, "ai")

--- a/tests/test_ai_commands.py
+++ b/tests/test_ai_commands.py
@@ -1,0 +1,331 @@
+"""Tests for AI command group (boss ai)."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from boss_agent_cli.main import cli
+
+
+def _invoke(runner, tmp_path, args):
+	return runner.invoke(cli, ["--data-dir", str(tmp_path), "--json", "ai"] + args)
+
+
+def _setup_ai_config(tmp_path, monkeypatch):
+	"""配置 AI 服务使其 is_configured() 返回 True。"""
+	monkeypatch.setenv("BOSS_AGENT_MACHINE_ID", "test-machine-id")
+	from boss_agent_cli.ai.config import AIConfigStore
+	store = AIConfigStore(tmp_path)
+	store.save_config(ai_provider="openai", ai_model="gpt-4o")
+	store.save_api_key("sk-test-key")
+	return store
+
+
+def _setup_resume(tmp_path):
+	"""创建一份测试简历。"""
+	runner = CliRunner()
+	runner.invoke(cli, [
+		"--data-dir", str(tmp_path), "--json",
+		"resume", "init", "--name", "test-resume", "--template", "default",
+	])
+
+
+def _mock_ai_response(json_data: dict):
+	"""构造一个 mock httpx 响应。"""
+	mock_resp = MagicMock()
+	mock_resp.status_code = 200
+	mock_resp.json.return_value = {
+		"choices": [{"message": {"content": json.dumps(json_data, ensure_ascii=False)}}]
+	}
+	mock_resp.raise_for_status = MagicMock()
+	return mock_resp
+
+
+# ── config 子命令 ──────────────────────────────────────────
+
+
+def test_config_show_default(tmp_path, monkeypatch):
+	"""查看默认配置"""
+	monkeypatch.setenv("BOSS_AGENT_MACHINE_ID", "test-machine")
+	runner = CliRunner()
+	result = _invoke(runner, tmp_path, ["config"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["ai_provider"] is None
+	assert parsed["data"]["api_key_set"] is False
+
+
+def test_config_set_provider(tmp_path, monkeypatch):
+	"""设置 AI 提供商"""
+	monkeypatch.setenv("BOSS_AGENT_MACHINE_ID", "test-machine")
+	runner = CliRunner()
+	result = _invoke(runner, tmp_path, ["config", "--provider", "openai", "--model", "gpt-4o", "--api-key", "sk-123"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert "ai_provider" in parsed["data"]["updated_fields"]
+	assert "api_key" in parsed["data"]["updated_fields"]
+
+
+def test_config_show_after_set(tmp_path, monkeypatch):
+	"""设置后查看配置"""
+	monkeypatch.setenv("BOSS_AGENT_MACHINE_ID", "test-machine")
+	runner = CliRunner()
+	_invoke(runner, tmp_path, ["config", "--provider", "deepseek", "--model", "deepseek-chat"])
+	result = _invoke(runner, tmp_path, ["config"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["data"]["ai_provider"] == "deepseek"
+	assert parsed["data"]["ai_model"] == "deepseek-chat"
+
+
+def test_config_set_temperature(tmp_path, monkeypatch):
+	"""设置温度参数"""
+	monkeypatch.setenv("BOSS_AGENT_MACHINE_ID", "test-machine")
+	runner = CliRunner()
+	result = _invoke(runner, tmp_path, ["config", "--temperature", "0.3"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert "ai_temperature" in parsed["data"]["updated_fields"]
+
+
+# ── AI 未配置时错误 ────────────────────────────────────────
+
+
+def test_analyze_jd_not_configured(tmp_path, monkeypatch):
+	"""AI 未配置时返回错误"""
+	monkeypatch.setenv("BOSS_AGENT_MACHINE_ID", "test-machine")
+	runner = CliRunner()
+	result = _invoke(runner, tmp_path, ["analyze-jd", "some jd text", "--resume", "myresume"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["error"]["code"] == "AI_NOT_CONFIGURED"
+
+
+def test_polish_not_configured(tmp_path, monkeypatch):
+	"""AI 未配置时 polish 返回错误"""
+	monkeypatch.setenv("BOSS_AGENT_MACHINE_ID", "test-machine")
+	runner = CliRunner()
+	result = _invoke(runner, tmp_path, ["polish", "myresume"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "AI_NOT_CONFIGURED"
+
+
+# ── 简历不存在时错误 ──────────────────────────────────────
+
+
+def test_analyze_jd_resume_not_found(tmp_path, monkeypatch):
+	"""简历不存在时返回错误"""
+	_setup_ai_config(tmp_path, monkeypatch)
+	runner = CliRunner()
+	result = _invoke(runner, tmp_path, ["analyze-jd", "some jd", "--resume", "ghost"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "RESUME_NOT_FOUND"
+
+
+# ── analyze-jd 成功路径 ──────────────────────────────────
+
+
+def test_analyze_jd_success(tmp_path, monkeypatch):
+	"""分析职位描述成功"""
+	_setup_ai_config(tmp_path, monkeypatch)
+	_setup_resume(tmp_path)
+	runner = CliRunner()
+
+	mock_result = {"match_score": 85, "match_analysis": "匹配度较高"}
+	with patch("boss_agent_cli.ai.service.httpx.post", return_value=_mock_ai_response(mock_result)):
+		result = _invoke(runner, tmp_path, ["analyze-jd", "需要三年经验的后端工程师", "--resume", "test-resume"])
+
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["match_score"] == 85
+
+
+# ── polish 成功路径 ───────────────────────────────────────
+
+
+def test_polish_success(tmp_path, monkeypatch):
+	"""简历润色成功"""
+	_setup_ai_config(tmp_path, monkeypatch)
+	_setup_resume(tmp_path)
+	runner = CliRunner()
+
+	mock_result = {"polished_sections": [], "general_suggestions": ["建议一"]}
+	with patch("boss_agent_cli.ai.service.httpx.post", return_value=_mock_ai_response(mock_result)):
+		result = _invoke(runner, tmp_path, ["polish", "test-resume"])
+
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert "general_suggestions" in parsed["data"]
+
+
+# ── optimize 成功路径 ─────────────────────────────────────
+
+
+def test_optimize_success(tmp_path, monkeypatch):
+	"""基于职位优化简历成功"""
+	_setup_ai_config(tmp_path, monkeypatch)
+	_setup_resume(tmp_path)
+	runner = CliRunner()
+
+	mock_result = {"match_score_before": 60, "match_score_after": 85, "optimized_sections": []}
+	with patch("boss_agent_cli.ai.service.httpx.post", return_value=_mock_ai_response(mock_result)):
+		result = _invoke(runner, tmp_path, ["optimize", "test-resume", "--jd", "需要后端工程师"])
+
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["match_score_before"] == 60
+
+
+# ── suggest 成功路径 ──────────────────────────────────────
+
+
+def test_suggest_success(tmp_path, monkeypatch):
+	"""基于职位给出建议成功"""
+	_setup_ai_config(tmp_path, monkeypatch)
+	_setup_resume(tmp_path)
+	runner = CliRunner()
+
+	mock_result = {"suggestions": [{"priority": "high", "suggestion": "补充项目经验"}]}
+	with patch("boss_agent_cli.ai.service.httpx.post", return_value=_mock_ai_response(mock_result)):
+		result = _invoke(runner, tmp_path, ["suggest", "test-resume", "--jd", "需要后端工程师"])
+
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["suggestions"][0]["priority"] == "high"
+
+
+# ── AI 调用失败 ──────────────────────────────────────────
+
+
+def test_analyze_jd_ai_error(tmp_path, monkeypatch):
+	"""AI 调用失败返回错误"""
+	_setup_ai_config(tmp_path, monkeypatch)
+	_setup_resume(tmp_path)
+	runner = CliRunner()
+
+	from boss_agent_cli.ai.service import AIServiceError
+	with patch("boss_agent_cli.ai.service.httpx.post", side_effect=AIServiceError("API 请求失败: HTTP 500", status_code=500)):
+		result = _invoke(runner, tmp_path, ["analyze-jd", "some jd", "--resume", "test-resume"])
+
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "AI_API_ERROR"
+
+
+# ── AI 返回非 JSON ───────────────────────────────────────
+
+
+def test_analyze_jd_parse_error(tmp_path, monkeypatch):
+	"""AI 返回非 JSON 时返回解析错误"""
+	_setup_ai_config(tmp_path, monkeypatch)
+	_setup_resume(tmp_path)
+	runner = CliRunner()
+
+	mock_resp = MagicMock()
+	mock_resp.status_code = 200
+	mock_resp.json.return_value = {
+		"choices": [{"message": {"content": "这不是JSON格式的回复"}}]
+	}
+	mock_resp.raise_for_status = MagicMock()
+	with patch("boss_agent_cli.ai.service.httpx.post", return_value=mock_resp):
+		result = _invoke(runner, tmp_path, ["analyze-jd", "some jd", "--resume", "test-resume"])
+
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "AI_PARSE_ERROR"
+
+
+# ── @file 语法 ────────────────────────────────────────────
+
+
+def test_analyze_jd_at_file(tmp_path, monkeypatch):
+	"""支持 @file 语法读取文件"""
+	_setup_ai_config(tmp_path, monkeypatch)
+	_setup_resume(tmp_path)
+	runner = CliRunner()
+
+	jd_file = tmp_path / "jd.txt"
+	jd_file.write_text("需要五年经验的后端工程师", encoding="utf-8")
+
+	mock_result = {"match_score": 70}
+	with patch("boss_agent_cli.ai.service.httpx.post", return_value=_mock_ai_response(mock_result)):
+		result = _invoke(runner, tmp_path, ["analyze-jd", f"@{jd_file}", "--resume", "test-resume"])
+
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["data"]["match_score"] == 70
+
+
+def test_analyze_jd_at_file_not_found(tmp_path, monkeypatch):
+	"""@file 文件不存在时返回错误"""
+	_setup_ai_config(tmp_path, monkeypatch)
+	_setup_resume(tmp_path)
+	runner = CliRunner()
+	result = _invoke(runner, tmp_path, ["analyze-jd", "@/no/such/file.txt", "--resume", "test-resume"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "INVALID_PARAM"
+
+
+# ── markdown 代码块包裹的 JSON ────────────────────────────
+
+
+def test_analyze_jd_markdown_wrapped_json(tmp_path, monkeypatch):
+	"""AI 返回 markdown 代码块包裹的 JSON 也能解析"""
+	_setup_ai_config(tmp_path, monkeypatch)
+	_setup_resume(tmp_path)
+	runner = CliRunner()
+
+	wrapped = '```json\n{"match_score": 90}\n```'
+	mock_resp = MagicMock()
+	mock_resp.status_code = 200
+	mock_resp.json.return_value = {
+		"choices": [{"message": {"content": wrapped}}]
+	}
+	mock_resp.raise_for_status = MagicMock()
+	with patch("boss_agent_cli.ai.service.httpx.post", return_value=mock_resp):
+		result = _invoke(runner, tmp_path, ["analyze-jd", "jd text", "--resume", "test-resume"])
+
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["data"]["match_score"] == 90
+
+
+# ── schema 集成 ──────────────────────────────────────────
+
+
+def test_schema_contains_ai():
+	"""schema 包含 ai 命令"""
+	runner = CliRunner()
+	result = runner.invoke(cli, ["schema"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert "ai" in parsed["data"]["commands"]
+	cmd = parsed["data"]["commands"]["ai"]
+	assert "config" in cmd["subcommands"]
+	assert "analyze-jd" in cmd["subcommands"]
+	assert "polish" in cmd["subcommands"]
+	assert "optimize" in cmd["subcommands"]
+	assert "suggest" in cmd["subcommands"]
+
+
+def test_schema_contains_ai_error_codes():
+	"""schema 包含 AI 错误码"""
+	runner = CliRunner()
+	result = runner.invoke(cli, ["schema"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	codes = parsed["data"]["error_codes"]
+	assert "AI_NOT_CONFIGURED" in codes
+	assert "AI_API_ERROR" in codes
+	assert "AI_PARSE_ERROR" in codes

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -115,3 +115,37 @@ def test_shortlist_crud(tmp_path):
 	assert items[0]["title"] == "Go 开发"
 	assert store.remove_shortlist("sec_001", "job_001") is True
 	assert store.is_shortlisted("sec_001", "job_001") is False
+
+
+def test_resume_job_link_crud(tmp_path):
+	store = CacheStore(tmp_path / "test.db")
+	store.link_resume_to_job("default", "sec_001", "job_001", "后端工程师", "测试公司")
+	apps = store.get_resume_applications("default")
+	assert len(apps) == 1
+	assert apps[0]["job_title"] == "后端工程师"
+	assert apps[0]["status"] == "prepared"
+
+	# 更新状态
+	ok = store.update_job_link_status("default", "sec_001", "job_001", "applied", "已投递")
+	assert ok is True
+	apps = store.get_resume_applications("default")
+	assert apps[0]["status"] == "applied"
+	assert apps[0]["notes"] == "已投递"
+
+	# 反向查询
+	resumes = store.get_job_resumes("sec_001", "job_001")
+	assert len(resumes) == 1
+	assert resumes[0]["resume_name"] == "default"
+
+	# 删除关联
+	ok = store.remove_job_link("default", "sec_001", "job_001")
+	assert ok is True
+	assert store.get_resume_applications("default") == []
+
+
+def test_resume_job_link_multiple(tmp_path):
+	store = CacheStore(tmp_path / "test.db")
+	store.link_resume_to_job("v1", "sec_001", "job_001", "后端", "公司甲")
+	store.link_resume_to_job("v2", "sec_001", "job_001", "后端", "公司甲")
+	resumes = store.get_job_resumes("sec_001", "job_001")
+	assert len(resumes) == 2

--- a/tests/test_resume_commands.py
+++ b/tests/test_resume_commands.py
@@ -298,6 +298,48 @@ def test_diff_one_not_found(tmp_path):
 	assert parsed["error"]["code"] == "RESUME_NOT_FOUND"
 
 
+# ── link / applications ─────────────────────────────────────
+
+
+def test_link_resume_to_job(tmp_path):
+	runner = CliRunner()
+	_invoke(runner, tmp_path, ["init", "--name", "linktest", "--template", "default"])
+	result = _invoke(runner, tmp_path, ["link", "linktest", "sid-001", "jid-001", "--title", "后端工程师", "--company", "测试公司"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["action"] == "link"
+	assert parsed["data"]["security_id"] == "sid-001"
+
+
+def test_link_resume_not_found(tmp_path):
+	runner = CliRunner()
+	result = _invoke(runner, tmp_path, ["link", "ghost", "sid", "jid"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "RESUME_NOT_FOUND"
+
+
+def test_applications_list(tmp_path):
+	runner = CliRunner()
+	_invoke(runner, tmp_path, ["init", "--name", "apptest", "--template", "default"])
+	_invoke(runner, tmp_path, ["link", "apptest", "sid-a", "jid-a", "--title", "前端", "--company", "公司甲"])
+	_invoke(runner, tmp_path, ["link", "apptest", "sid-b", "jid-b", "--title", "后端", "--company", "公司乙"])
+	result = _invoke(runner, tmp_path, ["applications", "apptest"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert len(parsed["data"]) == 2
+
+
+def test_applications_resume_not_found(tmp_path):
+	runner = CliRunner()
+	result = _invoke(runner, tmp_path, ["applications", "ghost"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "RESUME_NOT_FOUND"
+
+
 # ── schema 集成 ───────────────────────────────────────────────
 
 


### PR DESCRIPTION
## 概述

完成设计规范中 Phase 3-5 的全部功能，补全简历集成功能的最后闭环。

### 新增功能

**智能简历优化命令组（`boss ai`）**
- `boss ai config` — 查看/设置提供商、模型、密钥（加密存储）
- `boss ai analyze-jd` — 分析职位描述并评估简历匹配度
- `boss ai polish` — 通用简历润色
- `boss ai optimize` — 基于目标职位优化简历
- `boss ai suggest` — 基于目标职位给出改进建议

**投递追踪增强**
- `boss resume link` — 关联简历与职位
- `boss resume applications` — 查看简历关联的所有职位
- `resume_job_links` 数据表（状态流转：prepared/applied/interviewing/offered/rejected/withdrawn）

### 技术细节

- 支持 `@file` 语法从文件读取职位描述
- 兼容 markdown 代码块包裹的 JSON 响应解析
- 新增 3 个错误码：AI_NOT_CONFIGURED / AI_API_ERROR / AI_PARSE_ERROR
- 零新增运行时依赖

### 测试覆盖

| 测试文件 | 新增用例 |
|---------|---------|
| `test_ai_commands.py` | 18 |
| `test_resume_commands.py` | +4 |
| `test_cache.py` | +2 |

### 验证

```
650 passed in 8.73s
ruff: All checks passed!
```

## 关联

- 完成设计规范 `docs/superpowers/specs/2026-04-14-resume-integration-design.md` 中 Phase 3/4/5 全部功能
- 依赖 #35 #36 #37