### PR TITLE
feat: 重构落地页为暗色主题多文件架构

### DIFF
--- a/demo/assets/icons.svg
+++ b/demo/assets/icons.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <symbol id="icon-github" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/>
+  </symbol>
+  <symbol id="icon-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M5 12h14M12 5l7 7-7 7"/>
+  </symbol>
+  <symbol id="icon-search" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/>
+  </symbol>
+  <symbol id="icon-shield" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+  </symbol>
+  <symbol id="icon-terminal" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/>
+  </symbol>
+  <symbol id="icon-brain" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M12 2a5 5 0 0 1 5 5c0 1.1-.4 2.1-1 2.9A5 5 0 0 1 19 14c0 2.2-1.5 4.1-3.5 4.7A4 4 0 0 1 12 22a4 4 0 0 1-3.5-3.3A5 5 0 0 1 5 14a5 5 0 0 1 3-4.1A5 5 0 0 1 7 7a5 5 0 0 1 5-5z"/>
+    <path d="M12 2v20"/>
+  </symbol>
+  <symbol id="icon-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <polyline points="20 6 9 17 4 12"/>
+  </symbol>
+</svg>

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,384 +3,321 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>boss-agent-cli — AI Agent 求职 CLI 工具</title>
+<title>boss-agent-cli — 让 Agent 帮你找工作</title>
 <meta name="description" content="专为 AI Agent 设计的 BOSS 直聘求职 CLI 工具。搜索职位、福利筛选、自动打招呼、求职流水线、简历管理、AI 优化。">
-<meta property="og:title" content="boss-agent-cli">
-<meta property="og:description" content="专为 AI Agent 设计的 BOSS 直聘求职 CLI 工具">
+<meta property="og:title" content="boss-agent-cli — 让 Agent 帮你找工作">
+<meta property="og:description" content="专为 AI Agent 设计的 BOSS 直聘求职 CLI 工具。30+ 命令覆盖搜索、投递、沟通、简历管理和 AI 优化全流程。">
 <meta property="og:type" content="website">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" defer></script>
-<style>
-:root {
-  --bg: #fafafa; --bg-surface: #ffffff; --bg-code: #1e1e2e; --bg-code-header: #181825;
-  --ink: #1a1a2e; --ink-muted: #64748b; --ink-code: #cdd6f4;
-  --accent: #2563eb; --accent-soft: rgba(37,99,235,0.08); --accent-hover: #1d4ed8;
-  --green: #10b981; --green-soft: rgba(16,185,129,0.1);
-  --orange: #f59e0b; --orange-soft: rgba(245,158,11,0.1);
-  --red: #ef4444; --red-soft: rgba(239,68,68,0.1);
-  --purple: #8b5cf6; --purple-soft: rgba(139,92,246,0.1);
-  --line: rgba(0,0,0,0.06);
-  --font-body: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-  --font-mono: 'JetBrains Mono', 'Menlo', monospace;
-  --radius: 12px; --radius-lg: 16px;
-  --shadow: 0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04);
-  --shadow-lg: 0 10px 40px rgba(0,0,0,0.08);
-}
-[data-theme="dark"] {
-  --bg: #0f0f1a; --bg-surface: #1a1a2e; --bg-code: #11111b; --bg-code-header: #0a0a14;
-  --ink: #e2e8f0; --ink-muted: #94a3b8; --ink-code: #cdd6f4;
-  --accent: #60a5fa; --accent-soft: rgba(96,165,250,0.1); --accent-hover: #93c5fd;
-  --line: rgba(255,255,255,0.06);
-  --shadow: 0 1px 3px rgba(0,0,0,0.3); --shadow-lg: 0 10px 40px rgba(0,0,0,0.4);
-}
-* { box-sizing: border-box; margin: 0; padding: 0; }
-html { scroll-behavior: smooth; }
-body { background: var(--bg); color: var(--ink); font-family: var(--font-body); line-height: 1.6; -webkit-font-smoothing: antialiased; overflow-x: hidden; }
-a { color: var(--accent); text-decoration: none; transition: color 0.2s; }
-a:hover { color: var(--accent-hover); }
-.container { max-width: 1100px; margin: 0 auto; padding: 0 24px; }
-:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 4px; }
-@media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; } }
-
-/* ── Theme Toggle ── */
-.theme-toggle { position: fixed; top: 1.2rem; right: 1.2rem; z-index: 100; width: 40px; height: 40px; border-radius: 50%; background: var(--bg-surface); border: 1px solid var(--line); cursor: pointer; display: flex; align-items: center; justify-content: center; transition: all 0.3s; box-shadow: var(--shadow); }
-.theme-toggle:hover { transform: scale(1.1); }
-.theme-toggle svg { width: 18px; height: 18px; stroke: var(--ink); fill: none; stroke-width: 2; }
-.theme-toggle .icon-moon { display: none; }
-[data-theme="dark"] .theme-toggle .icon-sun { display: none; }
-[data-theme="dark"] .theme-toggle .icon-moon { display: block; }
-
-/* ── Nav ── */
-.nav { position: sticky; top: 0; z-index: 50; background: var(--bg); border-bottom: 1px solid var(--line); backdrop-filter: blur(12px); background: rgba(250,250,250,0.85); }
-[data-theme="dark"] .nav { background: rgba(15,15,26,0.85); }
-.nav-inner { display: flex; align-items: center; justify-content: space-between; padding: 12px 0; }
-.nav-brand { font-weight: 700; font-size: 1.1rem; display: flex; align-items: center; gap: 8px; color: var(--ink); }
-.nav-brand span { color: var(--accent); }
-.nav-links { display: flex; gap: 24px; font-size: 0.9rem; }
-.nav-links a { color: var(--ink-muted); font-weight: 500; }
-.nav-links a:hover { color: var(--accent); }
-@media (max-width: 640px) { .nav-links { display: none; } }
-
-/* ── Hero ── */
-.hero { padding: 80px 0 60px; text-align: center; }
-.hero-badge { display: inline-flex; align-items: center; gap: 6px; padding: 6px 16px; background: var(--accent-soft); border-radius: 100px; font-size: 0.8rem; color: var(--accent); font-weight: 600; margin-bottom: 24px; }
-.hero h1 { font-size: clamp(2.2rem, 5vw, 3.5rem); font-weight: 700; line-height: 1.15; margin-bottom: 16px; letter-spacing: -0.02em; }
-.hero h1 em { font-style: normal; color: var(--accent); }
-.hero p { font-size: clamp(1rem, 1.5vw, 1.15rem); color: var(--ink-muted); max-width: 600px; margin: 0 auto 32px; }
-.hero-actions { display: flex; justify-content: center; gap: 12px; flex-wrap: wrap; }
-.btn { display: inline-flex; align-items: center; gap: 8px; padding: 12px 28px; border-radius: 100px; font-family: var(--font-body); font-weight: 600; font-size: 0.95rem; cursor: pointer; transition: all 0.2s; border: none; min-height: 48px; text-decoration: none; }
-.btn-primary { background: var(--accent); color: #fff; }
-.btn-primary:hover { background: var(--accent-hover); color: #fff; transform: translateY(-1px); box-shadow: 0 4px 12px rgba(37,99,235,0.3); }
-.btn-outline { background: transparent; color: var(--ink); border: 1.5px solid var(--line); }
-.btn-outline:hover { border-color: var(--accent); color: var(--accent); }
-.badges { display: flex; justify-content: center; gap: 8px; margin-top: 24px; flex-wrap: wrap; }
-.badges img { height: 22px; }
-
-/* ── Terminal ── */
-.terminal-section { padding: 60px 0; }
-.terminal { background: var(--bg-code); border-radius: var(--radius-lg); overflow: hidden; box-shadow: var(--shadow-lg); max-width: 780px; margin: 0 auto; }
-.terminal-header { background: var(--bg-code-header); padding: 12px 16px; display: flex; align-items: center; gap: 8px; }
-.terminal-dot { width: 12px; height: 12px; border-radius: 50%; }
-.terminal-dot.r { background: #ff5f57; }
-.terminal-dot.y { background: #febc2e; }
-.terminal-dot.g { background: #28c840; }
-.terminal-title { color: #585b70; font-size: 0.8rem; font-family: var(--font-mono); margin-left: 8px; }
-.terminal-body { padding: 20px 24px; font-family: var(--font-mono); font-size: 0.85rem; line-height: 1.8; color: var(--ink-code); min-height: 320px; }
-.terminal-line { opacity: 0; transform: translateY(4px); }
-.terminal-line .prompt { color: #a6e3a1; }
-.terminal-line .cmd { color: #89b4fa; }
-.terminal-line .flag { color: #fab387; }
-.terminal-line .str { color: #f9e2af; }
-.terminal-line .comment { color: #585b70; font-style: italic; }
-.terminal-line .output { color: #94a3b8; }
-.terminal-line .success { color: #a6e3a1; }
-.terminal-line .json-key { color: #89b4fa; }
-.terminal-line .json-val { color: #a6e3a1; }
-.terminal-line .json-str { color: #f9e2af; }
-.terminal-line .json-brace { color: #cdd6f4; }
-.terminal-tabs { display: flex; gap: 0; margin: 0 auto; max-width: 780px; }
-.terminal-tab { flex: 1; padding: 10px 16px; background: var(--bg-surface); border: 1px solid var(--line); cursor: pointer; font-size: 0.85rem; font-weight: 500; color: var(--ink-muted); text-align: center; transition: all 0.2s; }
-.terminal-tab:first-child { border-radius: var(--radius) 0 0 0; }
-.terminal-tab:last-child { border-radius: 0 var(--radius) 0 0; }
-.terminal-tab.active { background: var(--bg-code); color: var(--accent); border-color: var(--bg-code); border-bottom-color: transparent; }
-
-/* ── Stats ── */
-.stats { padding: 40px 0; }
-.stats-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; }
-@media (max-width: 640px) { .stats-grid { grid-template-columns: repeat(2, 1fr); } }
-.stat-card { text-align: center; padding: 24px 16px; background: var(--bg-surface); border-radius: var(--radius); border: 1px solid var(--line); }
-.stat-num { font-size: 2rem; font-weight: 700; color: var(--accent); line-height: 1.2; }
-.stat-label { font-size: 0.85rem; color: var(--ink-muted); margin-top: 4px; }
-
-/* ── Features ── */
-.features { padding: 80px 0; }
-.section-title { text-align: center; font-size: clamp(1.6rem, 3vw, 2.2rem); font-weight: 700; margin-bottom: 12px; letter-spacing: -0.01em; }
-.section-subtitle { text-align: center; color: var(--ink-muted); font-size: 1rem; margin-bottom: 48px; max-width: 500px; margin-left: auto; margin-right: auto; }
-.features-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
-@media (max-width: 768px) { .features-grid { grid-template-columns: 1fr; } }
-.feature-card { padding: 28px 24px; background: var(--bg-surface); border-radius: var(--radius); border: 1px solid var(--line); transition: all 0.3s; }
-.feature-card:hover { transform: translateY(-2px); box-shadow: var(--shadow-lg); border-color: var(--accent); }
-.feature-icon { width: 44px; height: 44px; border-radius: 10px; display: flex; align-items: center; justify-content: center; font-size: 1.3rem; margin-bottom: 16px; }
-.feature-card h3 { font-size: 1.05rem; font-weight: 600; margin-bottom: 8px; }
-.feature-card p { font-size: 0.88rem; color: var(--ink-muted); line-height: 1.6; }
-
-/* ── Command Matrix ── */
-.commands { padding: 80px 0; }
-.cmd-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; }
-@media (max-width: 768px) { .cmd-grid { grid-template-columns: 1fr; } }
-.cmd-item { display: flex; align-items: baseline; gap: 12px; padding: 12px 16px; background: var(--bg-surface); border-radius: var(--radius); border: 1px solid var(--line); font-size: 0.88rem; transition: border-color 0.2s; }
-.cmd-item:hover { border-color: var(--accent); }
-.cmd-name { font-family: var(--font-mono); font-weight: 500; color: var(--accent); white-space: nowrap; font-size: 0.82rem; }
-.cmd-desc { color: var(--ink-muted); }
-
-/* ── Architecture ── */
-.architecture { padding: 80px 0; }
-.arch-flow { display: flex; flex-direction: column; gap: 0; align-items: center; max-width: 700px; margin: 0 auto; }
-.arch-node { padding: 16px 32px; border-radius: var(--radius); font-weight: 600; font-size: 0.95rem; text-align: center; width: 100%; max-width: 480px; border: 1.5px solid; }
-.arch-arrow { color: var(--ink-muted); font-size: 1.2rem; padding: 4px 0; }
-.arch-row { display: flex; gap: 12px; width: 100%; max-width: 600px; justify-content: center; }
-.arch-row .arch-node { flex: 1; max-width: none; padding: 12px 16px; font-size: 0.85rem; }
-
-/* ── JSON Output ── */
-.json-section { padding: 60px 0; }
-.json-block { background: var(--bg-code); border-radius: var(--radius-lg); padding: 24px; font-family: var(--font-mono); font-size: 0.82rem; line-height: 1.7; color: var(--ink-code); max-width: 680px; margin: 0 auto; overflow-x: auto; box-shadow: var(--shadow-lg); }
-
-/* ── Install ── */
-.install { padding: 80px 0; text-align: center; }
-.install-code { display: inline-block; background: var(--bg-code); color: var(--ink-code); font-family: var(--font-mono); font-size: 0.95rem; padding: 16px 32px; border-radius: var(--radius); margin: 24px 0; box-shadow: var(--shadow); }
-
-/* ── Footer ── */
-.footer { padding: 40px 0; border-top: 1px solid var(--line); text-align: center; }
-.footer p { color: var(--ink-muted); font-size: 0.85rem; }
-.footer-links { display: flex; justify-content: center; gap: 24px; margin-top: 12px; }
-.footer-links a { color: var(--ink-muted); font-size: 0.85rem; }
-</style>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
 </head>
 <body>
 
-<!-- Theme Toggle -->
-<button class="theme-toggle" onclick="toggleTheme()" aria-label="切换主题">
-  <svg class="icon-sun" viewBox="0 0 24 24"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
-  <svg class="icon-moon" viewBox="0 0 24 24"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
-</button>
+<!-- SVG Sprite -->
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <symbol id="icon-github" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/>
+  </symbol>
+  <symbol id="icon-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M5 12h14M12 5l7 7-7 7"/>
+  </symbol>
+</svg>
 
-<!-- Nav -->
-<nav class="nav">
-  <div class="container nav-inner">
-    <a href="#" class="nav-brand"><span>&gt;_</span> boss-agent-cli</a>
-    <div class="nav-links">
-      <a href="#features">特性</a>
-      <a href="#demo">演示</a>
-      <a href="#commands">命令</a>
-      <a href="#architecture">架构</a>
-      <a href="https://github.com/can4hou6joeng4/boss-agent-cli">GitHub</a>
-    </div>
+<!-- Nav: Split Centered -->
+<nav class="split-nav" id="nav">
+  <div class="nav-left">
+    <a href="#features">特性</a>
+    <a href="#faq">常见问题</a>
   </div>
+  <a href="#" class="nav-logo"><span class="logo-prompt">&gt;_</span> boss-agent-cli</a>
+  <div class="nav-right">
+    <a href="https://github.com/can4hou6joeng4/boss-agent-cli">GitHub</a>
+    <a href="#install" class="nav-cta">快速开始</a>
+  </div>
+  <button class="nav-toggle" aria-label="菜单" aria-expanded="false">
+    <span></span><span></span><span></span>
+  </button>
 </nav>
 
-<!-- Hero -->
-<section class="hero">
-  <div class="container">
-    <div class="hero-badge">专为 AI Agent 设计</div>
-    <h1>让 Agent 帮你<em>找工作</em></h1>
-    <p>BOSS 直聘全链路求职 CLI 工具。结构化 JSON 输出，30+ 命令覆盖搜索、投递、沟通、简历管理和 AI 优化全流程。</p>
-    <div class="hero-actions">
-      <a href="https://github.com/can4hou6joeng4/boss-agent-cli" class="btn btn-primary">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></svg>
+<!-- Mobile Nav Overlay -->
+<div class="mobile-nav-overlay">
+  <a href="#features" class="mobile-nav-item">特性</a>
+  <a href="#faq" class="mobile-nav-item">常见问题</a>
+  <a href="https://github.com/can4hou6joeng4/boss-agent-cli" class="mobile-nav-item">GitHub</a>
+  <a href="#install" class="mobile-nav-item">快速开始</a>
+</div>
+
+<!-- Hero: Minimal Descent -->
+<section class="hero" id="hero">
+  <div class="hero-inner">
+    <div class="hero-eyebrow js-hero-el">
+      <span class="hero-rule"></span>
+      <span>专为 AI Agent 设计</span>
+      <span class="hero-rule"></span>
+    </div>
+
+    <h1 class="hero-title js-hero-el">让 Agent 帮你<em>找工作</em></h1>
+
+    <p class="hero-desc js-hero-el">BOSS 直聘全链路求职 CLI 工具。结构化 JSON 输出，30+ 命令覆盖搜索、投递、沟通、简历管理和 AI 优化全流程。</p>
+
+    <div class="hero-actions js-hero-el">
+      <a href="https://github.com/can4hou6joeng4/boss-agent-cli" class="btn-primary">
+        <svg width="18" height="18"><use href="#icon-github"/></svg>
         GitHub
       </a>
-      <a href="#demo" class="btn btn-outline">查看演示</a>
+      <a href="#features" class="btn-ghost">探索特性</a>
     </div>
-    <div class="badges">
+
+    <div class="hero-badges js-hero-el">
       <img src="https://github.com/can4hou6joeng4/boss-agent-cli/actions/workflows/ci.yml/badge.svg" alt="CI">
       <img src="https://img.shields.io/badge/Python-%E2%89%A53.10-3776AB?logo=python&logoColor=white" alt="Python">
       <img src="https://img.shields.io/badge/License-MIT-green.svg" alt="License">
       <img src="https://img.shields.io/github/v/release/can4hou6joeng4/boss-agent-cli" alt="Release">
     </div>
-  </div>
-</section>
 
-<!-- Stats -->
-<section class="stats">
-  <div class="container">
-    <div class="stats-grid">
-      <div class="stat-card"><div class="stat-num">30+</div><div class="stat-label">CLI 命令</div></div>
-      <div class="stat-card"><div class="stat-num">650+</div><div class="stat-label">测试用例</div></div>
-      <div class="stat-card"><div class="stat-num">0</div><div class="stat-label">新增运行时依赖</div></div>
-      <div class="stat-card"><div class="stat-num">4</div><div class="stat-label">Python 版本支持</div></div>
-    </div>
-  </div>
-</section>
-
-<!-- Terminal Demo -->
-<section class="terminal-section" id="demo">
-  <div class="container">
-    <h2 class="section-title">终端演示</h2>
-    <p class="section-subtitle">从搜索到投递，一条命令链闭环</p>
-
-    <div class="terminal-tabs">
-      <button class="terminal-tab active" onclick="showDemo('search')">搜索投递</button>
-      <button class="terminal-tab" onclick="showDemo('pipeline')">求职流水线</button>
-      <button class="terminal-tab" onclick="showDemo('ai')">AI 优化</button>
-    </div>
-
-    <div class="terminal">
-      <div class="terminal-header">
-        <span class="terminal-dot r"></span>
-        <span class="terminal-dot y"></span>
-        <span class="terminal-dot g"></span>
-        <span class="terminal-title">boss-agent-cli</span>
+    <div class="hero-stats js-hero-el">
+      <div class="stat">
+        <span class="stat-num" data-target="30">0</span><span class="stat-suffix">+</span>
+        <span class="stat-label">CLI 命令</span>
       </div>
-      <div class="terminal-body" id="terminal-content">
+      <div class="stat">
+        <span class="stat-num" data-target="650">0</span><span class="stat-suffix">+</span>
+        <span class="stat-label">测试用例</span>
+      </div>
+      <div class="stat">
+        <span class="stat-num" data-target="0">0</span>
+        <span class="stat-label">运行时依赖</span>
       </div>
     </div>
   </div>
+
+  <svg class="hero-backdrop" viewBox="0 0 1000 300" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0,150 L1000,150" stroke="currentColor" stroke-width="0.5"/>
+    <path d="M500,0 L500,300" stroke="currentColor" stroke-width="0.5"/>
+    <circle cx="500" cy="150" r="100" fill="none" stroke="currentColor" stroke-width="0.5"/>
+  </svg>
 </section>
 
-<!-- Features -->
-<section class="features" id="features">
-  <div class="container">
-    <h2 class="section-title">核心特性</h2>
-    <p class="section-subtitle">不只是 API 封装，是完整的 Agent 求职基础设施</p>
-    <div class="features-grid">
-      <div class="feature-card">
-        <div class="feature-icon" style="background:var(--accent-soft); color:var(--accent);">&#x1F50D;</div>
-        <h3>福利精准筛选</h3>
-        <p>--welfare "双休,五险一金" 自动翻页逐个查详情，只返回真正匹配的结果。核心差异化功能。</p>
-      </div>
-      <div class="feature-card">
-        <div class="feature-icon" style="background:var(--green-soft); color:var(--green);">&#x1F916;</div>
-        <h3>Agent 友好协议</h3>
-        <p>所有输出为 JSON 信封。boss schema 一次调用理解全部能力，hints.next_actions 引导下一步。</p>
-      </div>
-      <div class="feature-card">
-        <div class="feature-icon" style="background:var(--purple-soft); color:var(--purple);">&#x1F9E0;</div>
-        <h3>AI 简历优化</h3>
-        <p>JD 匹配分析、简历润色、针对性优化、改进建议。支持 OpenAI 兼容的任意大模型。</p>
-      </div>
-      <div class="feature-card">
-        <div class="feature-icon" style="background:var(--orange-soft); color:var(--orange);">&#x1F6E1;</div>
-        <h3>智能反检测</h3>
-        <p>基于 patchright 反检测浏览器 + 高斯分布请求延迟 + CDP 真实指纹，从根本上规避风控。</p>
-      </div>
-      <div class="feature-card">
-        <div class="feature-icon" style="background:var(--red-soft); color:var(--red);">&#x1F4CA;</div>
-        <h3>求职流水线</h3>
-        <p>pipeline 聚合沟通和面试数据，follow-up 筛选待跟进，digest 生成每日摘要。</p>
-      </div>
-      <div class="feature-card">
-        <div class="feature-icon" style="background:var(--green-soft); color:var(--green);">&#x1F4DD;</div>
-        <h3>本地简历管理</h3>
-        <p>多版本简历管理、HTML/PDF 导出、格式兼容导入、简历-职位关联追踪。</p>
+<!-- Features: Alternating Showcase -->
+<section class="features section-rule" id="features">
+
+  <!-- Block 1: 智能搜索 (text left, terminal right) -->
+  <div class="feature-block js-feature">
+    <div class="feature-content">
+      <span class="feature-eyebrow">智能搜索</span>
+      <h2 class="feature-headline">福利精准筛选，不再大海捞针</h2>
+      <p class="feature-body">--welfare "双休,五险一金" 自动翻页逐个查详情，只返回真正匹配的结果。配合城市、薪资、学历多维度过滤，一次搜索即可获得精准匹配。</p>
+      <a href="https://github.com/can4hou6joeng4/boss-agent-cli#搜索职位" class="feature-link">
+        查看文档 <svg width="14" height="14"><use href="#icon-arrow"/></svg>
+      </a>
+    </div>
+    <div class="feature-visual">
+      <div class="terminal">
+        <div class="terminal-header">
+          <span class="terminal-dot r"></span>
+          <span class="terminal-dot y"></span>
+          <span class="terminal-dot g"></span>
+          <span class="terminal-title">boss-agent-cli</span>
+        </div>
+        <div class="terminal-body">
+          <div class="tl"><span class="t-comment"># 搜索广州的 Golang 职位，要求双休+五险一金</span></div>
+          <div class="tl"><span class="t-prompt">$</span> <span class="t-cmd">boss search</span> <span class="t-str">"Golang"</span> <span class="t-flag">--city</span> <span class="t-str">广州</span> <span class="t-flag">--welfare</span> <span class="t-str">"双休,五险一金"</span></div>
+          <div class="tl"><span class="t-ok">ok</span> <span class="t-muted">找到 15 个匹配职位（已过滤福利）</span></div>
+          <div class="tl">&nbsp;</div>
+          <div class="tl"><span class="t-comment"># 查看第一个职位详情</span></div>
+          <div class="tl"><span class="t-prompt">$</span> <span class="t-cmd">boss detail</span> <span class="t-str">sec_abc123</span> <span class="t-flag">--job-id</span> <span class="t-str">enc_xyz</span></div>
+          <div class="tl"><span class="t-ok">ok</span> <span class="t-muted">Golang 高级工程师 · 某科技 · 25-50K · 广州天河</span></div>
+          <div class="tl">&nbsp;</div>
+          <div class="tl"><span class="t-comment"># 向招聘者打招呼</span></div>
+          <div class="tl"><span class="t-prompt">$</span> <span class="t-cmd">boss greet</span> <span class="t-str">sec_abc123</span> <span class="t-str">job_xyz</span></div>
+          <div class="tl"><span class="t-ok">ok</span> <span class="t-muted">打招呼成功 ✔</span></div>
+        </div>
       </div>
     </div>
   </div>
-</section>
 
-<!-- Commands -->
-<section class="commands" id="commands">
-  <div class="container">
-    <h2 class="section-title">命令矩阵</h2>
-    <p class="section-subtitle">覆盖求职全流程的 30+ 命令</p>
-    <div class="cmd-grid">
-      <div class="cmd-item"><span class="cmd-name">boss schema</span><span class="cmd-desc">工具能力自描述（Agent 首先调用）</span></div>
-      <div class="cmd-item"><span class="cmd-name">boss login</span><span class="cmd-desc">三级降级登录（Cookie / CDP / 扫码）</span></div>
-      <div class="cmd-item"><span class="cmd-name">boss doctor</span><span class="cmd-desc">环境诊断（依赖、网络、登录态）</span></div>
-      <div class="cmd-item"><span class="cmd-name">boss search</span><span class="cmd-desc">搜索职位（支持福利筛选 + 预设）</span></div>
-      <div class="cmd-item"><span class="cmd-name">boss detail</span><span class="cmd-desc">职位详情（httpx 快速通道）</span></div>
-      <div class="cmd-item"><span class="cmd-name">boss recommend</span><span class="cmd-desc">个性化推荐</span></div>
-      <div class="cmd-item"><span class="cmd-name">boss greet</span><span class="cmd-desc">向招聘者打招呼</span></div>
-      <div class="cmd-item"><span class="cmd-name">boss batch-greet</span><span class="cmd-desc">批量打招呼（上限 10）</span></div>
-      <div class="cmd-item"><span class="cmd-name">boss apply</span><span class="cmd-desc">发起投递/立即沟通（幂等）</span></div>
-      <div class="cmd-item"><span class="cmd-name">boss chat</span><span class="cmd-desc">沟通列表（支持多格式导出）</span></div>
-      <div class="cmd-item"><span class="cmd-name">boss chatmsg</span><span class="cmd-desc">聊天消息历史</span></div>
-      <div class="cmd-item"><span class="cmd-name">boss chat-summary</span><span class="cmd-desc">沟通结构化摘要</span></div>
-      <div class="cmd-item"><span class="cmd-name">boss pipeline</span><span class="cmd-desc">求职进度流水线</span></div>
-      <div class="cmd-item"><span class="cmd-name">boss follow-up</span><span class="cmd-desc">跟进提醒（超时/未读）</span></div>
-      <div class="cmd-item"><span class="cmd-name">boss digest</span><span class="cmd-desc">每日求职摘要</span></div>
-      <div class="cmd-item"><span class="cmd-name">boss watch</span><span class="cmd-desc">搜索订阅与增量监控</span></div>
-      <div class="cmd-item"><span class="cmd-name">boss shortlist</span><span class="cmd-desc">职位候选池管理</span></div>
-      <div class="cmd-item"><span class="cmd-name">boss preset</span><span class="cmd-desc">搜索预设管理</span></div>
-      <div class="cmd-item"><span class="cmd-name">boss resume</span><span class="cmd-desc">本地简历管理（11 个子命令）</span></div>
-      <div class="cmd-item"><span class="cmd-name">boss ai</span><span class="cmd-desc">AI 简历优化（5 个子命令）</span></div>
-      <div class="cmd-item"><span class="cmd-name">boss export</span><span class="cmd-desc">搜索结果导出（CSV / JSON）</span></div>
-      <div class="cmd-item"><span class="cmd-name">boss me</span><span class="cmd-desc">我的信息（用户/简历/期望）</span></div>
-      <div class="cmd-item"><span class="cmd-name">boss mark</span><span class="cmd-desc">联系人标签管理</span></div>
-      <div class="cmd-item"><span class="cmd-name">boss exchange</span><span class="cmd-desc">交换联系方式（手机/微信）</span></div>
+  <!-- Block 2: 结构化协议 (visual left, text right) -->
+  <div class="feature-block feature-block--reverse js-feature">
+    <div class="feature-content">
+      <span class="feature-eyebrow">结构化协议</span>
+      <h2 class="feature-headline">JSON 信封，Agent 零猜测</h2>
+      <p class="feature-body">每个命令输出标准 JSON 信封——ok、data、pagination、hints 字段固定不变。boss schema 一次调用即可理解全部命令的参数和语义，hints 引导下一步。</p>
+      <a href="https://github.com/can4hou6joeng4/boss-agent-cli#输出协议" class="feature-link">
+        查看协议 <svg width="14" height="14"><use href="#icon-arrow"/></svg>
+      </a>
     </div>
-  </div>
-</section>
-
-<!-- Architecture -->
-<section class="architecture" id="architecture">
-  <div class="container">
-    <h2 class="section-title">技术架构</h2>
-    <p class="section-subtitle">清晰的分层设计，每一层职责明确</p>
-    <div class="arch-flow">
-      <div class="arch-node" style="background:var(--accent-soft); border-color:var(--accent); color:var(--accent);">CLI 入口 (Click) — 30+ 命令</div>
-      <div class="arch-arrow">&#x2193;</div>
-      <div class="arch-row">
-        <div class="arch-node" style="background:var(--green-soft); border-color:var(--green); color:var(--green);">AuthManager<br><small>Token 生命周期</small></div>
-        <div class="arch-node" style="background:var(--purple-soft); border-color:var(--purple); color:var(--purple);">AIService<br><small>多模型对话补全</small></div>
-      </div>
-      <div class="arch-arrow">&#x2193;</div>
-      <div class="arch-node" style="background:var(--orange-soft); border-color:var(--orange); color:var(--orange);">BossClient (httpx + BrowserSession + CDP)</div>
-      <div class="arch-arrow">&#x2193;</div>
-      <div class="arch-row">
-        <div class="arch-node" style="background:var(--red-soft); border-color:var(--red); color:var(--red);">CacheStore<br><small>SQLite WAL</small></div>
-        <div class="arch-node" style="background:var(--accent-soft); border-color:var(--accent); color:var(--accent);">ResumeStore<br><small>JSON 文件</small></div>
-      </div>
-      <div class="arch-arrow">&#x2193;</div>
-      <div class="arch-node" style="background:var(--green-soft); border-color:var(--green); color:var(--green);">JSON 信封 &#x2192; stdout</div>
-    </div>
-  </div>
-</section>
-
-<!-- JSON Output -->
-<section class="json-section">
-  <div class="container">
-    <h2 class="section-title">结构化输出协议</h2>
-    <p class="section-subtitle">每个命令都输出标准 JSON 信封，Agent 无需猜测</p>
-    <div class="json-block"><pre>{
-  <span class="json-key">"ok"</span>: <span class="json-val">true</span>,
-  <span class="json-key">"schema_version"</span>: <span class="json-str">"1.0"</span>,
-  <span class="json-key">"command"</span>: <span class="json-str">"search"</span>,
-  <span class="json-key">"data"</span>: [
+    <div class="feature-visual">
+      <div class="json-block"><pre>{
+  <span class="jk">"ok"</span>: <span class="jv">true</span>,
+  <span class="jk">"schema_version"</span>: <span class="js">"1.0"</span>,
+  <span class="jk">"command"</span>: <span class="js">"search"</span>,
+  <span class="jk">"data"</span>: [
     {
-      <span class="json-key">"title"</span>: <span class="json-str">"Golang 高级工程师"</span>,
-      <span class="json-key">"company"</span>: <span class="json-str">"某科技有限公司"</span>,
-      <span class="json-key">"salary"</span>: <span class="json-str">"25-50K"</span>,
-      <span class="json-key">"welfare_match"</span>: { <span class="json-key">"双休"</span>: <span class="json-str">"tag"</span>, <span class="json-key">"五险一金"</span>: <span class="json-str">"tag"</span> }
+      <span class="jk">"title"</span>: <span class="js">"Golang 高级工程师"</span>,
+      <span class="jk">"company"</span>: <span class="js">"某科技有限公司"</span>,
+      <span class="jk">"salary"</span>: <span class="js">"25-50K"</span>,
+      <span class="jk">"welfare_match"</span>: {
+        <span class="jk">"双休"</span>: <span class="js">"tag"</span>,
+        <span class="jk">"五险一金"</span>: <span class="js">"tag"</span>
+      }
     }
   ],
-  <span class="json-key">"pagination"</span>: { <span class="json-key">"page"</span>: <span class="json-val">1</span>, <span class="json-key">"has_more"</span>: <span class="json-val">true</span> },
-  <span class="json-key">"hints"</span>: { <span class="json-key">"next_actions"</span>: [<span class="json-str">"boss detail &lt;security_id&gt;"</span>] }
+  <span class="jk">"pagination"</span>: { <span class="jk">"page"</span>: <span class="jv">1</span>, <span class="jk">"has_more"</span>: <span class="jv">true</span> },
+  <span class="jk">"hints"</span>: {
+    <span class="jk">"next_actions"</span>: [<span class="js">"boss detail &lt;sid&gt;"</span>]
+  }
 }</pre></div>
+    </div>
+  </div>
+
+  <!-- Block 3: 全链路 (focal — accent bg, text left, pipeline right) -->
+  <div class="feature-block feature-block--focal js-feature">
+    <div class="feature-content">
+      <span class="feature-eyebrow">全链路覆盖</span>
+      <h2 class="feature-headline">一条命令链闭环</h2>
+      <p class="feature-body">从搜索到入职，完整求职流程无需切换工具。30+ 命令覆盖搜索筛选、职位投递、沟通管理、简历优化、进度追踪和每日摘要。</p>
+      <a href="https://github.com/can4hou6joeng4/boss-agent-cli#命令列表" class="feature-link">
+        全部命令 <svg width="14" height="14"><use href="#icon-arrow"/></svg>
+      </a>
+    </div>
+    <div class="feature-visual">
+      <div class="pipeline-flow">
+        <div class="pipeline-step pipeline-step--active">
+          <span class="step-icon">1</span>
+          <span>search</span>
+        </div>
+        <span class="pipeline-arrow">→</span>
+        <div class="pipeline-step">
+          <span class="step-icon">2</span>
+          <span>detail</span>
+        </div>
+        <span class="pipeline-arrow">→</span>
+        <div class="pipeline-step">
+          <span class="step-icon">3</span>
+          <span>greet</span>
+        </div>
+        <span class="pipeline-arrow">→</span>
+        <div class="pipeline-step">
+          <span class="step-icon">4</span>
+          <span>apply</span>
+        </div>
+        <span class="pipeline-arrow">→</span>
+        <div class="pipeline-step">
+          <span class="step-icon">5</span>
+          <span>chat</span>
+        </div>
+        <span class="pipeline-arrow">→</span>
+        <div class="pipeline-step">
+          <span class="step-icon">6</span>
+          <span>pipeline</span>
+        </div>
+        <span class="pipeline-arrow">→</span>
+        <div class="pipeline-step">
+          <span class="step-icon">7</span>
+          <span>follow-up</span>
+        </div>
+        <span class="pipeline-arrow">→</span>
+        <div class="pipeline-step">
+          <span class="step-icon">8</span>
+          <span>digest</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</section>
+
+<!-- FAQ: Editorial (sticky anchor + accordion) -->
+<section class="faq section-rule" id="faq">
+  <div class="faq-container">
+    <div>
+      <h2 class="faq-title">常见<br>问题</h2>
+    </div>
+    <div class="faq-right">
+
+      <div class="faq-item" data-open="false">
+        <button class="faq-trigger" aria-expanded="false">
+          <span class="faq-question">安全吗？账号会被检测吗？</span>
+          <svg class="faq-icon" viewBox="0 0 24 24" fill="none"><line class="horizontal" x1="5" y1="12" x2="19" y2="12"/><line class="vertical" x1="12" y1="5" x2="12" y2="19"/></svg>
+        </button>
+        <div class="faq-content-grid"><div class="faq-content-inner">
+          <p class="faq-answer">基于 patchright 反检测浏览器 + 高斯分布请求延迟 + CDP 真实 Chrome 指纹三重保护。CDP 模式连接你的真实浏览器，指纹完全真实，请求频率由 RequestThrottle 统一管理，从根本上规避风控。</p>
+        </div></div>
+      </div>
+
+      <div class="faq-item" data-open="false">
+        <button class="faq-trigger" aria-expanded="false">
+          <span class="faq-question">需要哪些环境依赖？</span>
+          <svg class="faq-icon" viewBox="0 0 24 24" fill="none"><line class="horizontal" x1="5" y1="12" x2="19" y2="12"/><line class="vertical" x1="12" y1="5" x2="12" y2="19"/></svg>
+        </button>
+        <div class="faq-content-grid"><div class="faq-content-inner">
+          <p class="faq-answer">Python ≥3.10 和 Chromium（通过 patchright install chromium 自动安装）。推荐使用 uv 作为包管理器。两行命令完成安装，无额外运行时依赖。</p>
+        </div></div>
+      </div>
+
+      <div class="faq-item" data-open="false">
+        <button class="faq-trigger" aria-expanded="false">
+          <span class="faq-question">支持哪些 AI 模型？</span>
+          <svg class="faq-icon" viewBox="0 0 24 24" fill="none"><line class="horizontal" x1="5" y1="12" x2="19" y2="12"/><line class="vertical" x1="12" y1="5" x2="12" y2="19"/></svg>
+        </button>
+        <div class="faq-content-grid"><div class="faq-content-inner">
+          <p class="faq-answer">任何 OpenAI 兼容 API 均可使用——GPT-4o、Claude、Deepseek、Qwen、本地部署的 LLM 等。通过 boss ai config 一行命令配置提供商、模型和密钥，密钥自动加密存储。</p>
+        </div></div>
+      </div>
+
+      <div class="faq-item" data-open="false">
+        <button class="faq-trigger" aria-expanded="false">
+          <span class="faq-question">AI Agent 如何调用这个工具？</span>
+          <svg class="faq-icon" viewBox="0 0 24 24" fill="none"><line class="horizontal" x1="5" y1="12" x2="19" y2="12"/><line class="vertical" x1="12" y1="5" x2="12" y2="19"/></svg>
+        </button>
+        <div class="faq-content-grid"><div class="faq-content-inner">
+          <p class="faq-answer">Agent 通过 subprocess 调用 CLI，读取 stdout 的 JSON 输出。先调用 boss schema 获取完整能力描述，再根据 hints.next_actions 链式执行。兼容 Claude Code、Cursor、任何支持 shell 调用的 Agent 框架。</p>
+        </div></div>
+      </div>
+
+      <div class="faq-item" data-open="false">
+        <button class="faq-trigger" aria-expanded="false">
+          <span class="faq-question">开源免费吗？</span>
+          <svg class="faq-icon" viewBox="0 0 24 24" fill="none"><line class="horizontal" x1="5" y1="12" x2="19" y2="12"/><line class="vertical" x1="12" y1="5" x2="12" y2="19"/></svg>
+        </button>
+        <div class="faq-content-grid"><div class="faq-content-inner">
+          <p class="faq-answer">MIT 协议，完全开源免费。代码托管在 GitHub，欢迎 Star、Issue 和 PR 贡献。</p>
+        </div></div>
+      </div>
+
+    </div>
   </div>
 </section>
 
-<!-- Install -->
-<section class="install" id="install">
-  <div class="container">
-    <h2 class="section-title">快速开始</h2>
-    <p class="section-subtitle">两行命令，秒级安装</p>
-    <div class="install-code">
-      <span style="color:#a6e3a1;">$</span> <span style="color:#89b4fa;">uv tool install</span> <span style="color:#f9e2af;">boss-agent-cli</span><br>
-      <span style="color:#a6e3a1;">$</span> <span style="color:#89b4fa;">patchright install</span> <span style="color:#f9e2af;">chromium</span>
+<!-- CTA -->
+<section class="cta section-rule" id="install">
+  <div class="cta-container">
+    <div class="cta-text">
+      <h2 class="cta-headline">
+        <span>两行命令</span>
+        <span class="cta-accent">开始使用</span>
+      </h2>
+      <p class="cta-subtext">从安装到第一次搜索，不到一分钟。</p>
     </div>
-    <div style="margin-top:24px;">
-      <a href="https://github.com/can4hou6joeng4/boss-agent-cli#安装" class="btn btn-primary">查看完整文档</a>
+    <div class="cta-actions-wrap">
+      <div class="install-code">
+        <span class="t-prompt">$</span> <span class="t-cmd">uv tool install</span> <span class="t-str">boss-agent-cli</span><br>
+        <span class="t-prompt">$</span> <span class="t-cmd">patchright install</span> <span class="t-str">chromium</span>
+      </div>
+      <div class="cta-buttons">
+        <a href="https://github.com/can4hou6joeng4/boss-agent-cli#安装" class="btn-primary">查看完整文档</a>
+        <a href="https://github.com/can4hou6joeng4/boss-agent-cli" class="btn-ghost-link">GitHub →</a>
+      </div>
     </div>
   </div>
 </section>
 
 <!-- Footer -->
 <footer class="footer">
-  <div class="container">
-    <p>boss-agent-cli &mdash; 专为 AI Agent 设计的 BOSS 直聘求职 CLI 工具</p>
+  <div>
+    <p>boss-agent-cli — 专为 AI Agent 设计的 BOSS 直聘求职 CLI 工具</p>
     <div class="footer-links">
       <a href="https://github.com/can4hou6joeng4/boss-agent-cli">GitHub</a>
       <a href="https://github.com/can4hou6joeng4/boss-agent-cli/releases">Releases</a>
@@ -389,162 +326,8 @@ a:hover { color: var(--accent-hover); }
   </div>
 </footer>
 
-<script>
-// ── Theme ──
-function toggleTheme() {
-  const t = document.documentElement.getAttribute('data-theme') === 'dark' ? '' : 'dark';
-  document.documentElement.setAttribute('data-theme', t);
-  localStorage.setItem('theme', t);
-}
-(function() {
-  const saved = localStorage.getItem('theme');
-  if (saved === 'dark' || (!saved && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-    document.documentElement.setAttribute('data-theme', 'dark');
-  }
-})();
-
-// ── Terminal Demos ──
-const demos = {
-  search: [
-    { type: 'comment', text: '# 搜索广州的 Golang 职位，要求双休+五险一金' },
-    { type: 'cmd', text: '<span class="prompt">$</span> <span class="cmd">boss search</span> <span class="str">"Golang"</span> <span class="flag">--city</span> <span class="str">广州</span> <span class="flag">--welfare</span> <span class="str">"双休,五险一金"</span>' },
-    { type: 'output', text: '<span class="success">ok</span>  找到 15 个匹配职位（已过滤福利）' },
-    { type: 'blank' },
-    { type: 'comment', text: '# 查看第一个职位详情' },
-    { type: 'cmd', text: '<span class="prompt">$</span> <span class="cmd">boss detail</span> <span class="str">sec_abc123</span> <span class="flag">--job-id</span> <span class="str">enc_xyz</span>' },
-    { type: 'output', text: '<span class="success">ok</span>  Golang 高级工程师 · 某科技 · 25-50K · 广州天河' },
-    { type: 'blank' },
-    { type: 'comment', text: '# 向招聘者打招呼' },
-    { type: 'cmd', text: '<span class="prompt">$</span> <span class="cmd">boss greet</span> <span class="str">sec_abc123</span> <span class="str">job_xyz</span>' },
-    { type: 'output', text: '<span class="success">ok</span>  打招呼成功 &#x2714;' },
-  ],
-  pipeline: [
-    { type: 'comment', text: '# 查看求职进度流水线' },
-    { type: 'cmd', text: '<span class="prompt">$</span> <span class="cmd">boss pipeline</span>' },
-    { type: 'output', text: '<span class="success">ok</span>  stages: 待回复 3 · 沟通中 5 · 面试 2 · 已投递 8' },
-    { type: 'blank' },
-    { type: 'comment', text: '# 筛出需要跟进的联系人' },
-    { type: 'cmd', text: '<span class="prompt">$</span> <span class="cmd">boss follow-up</span>' },
-    { type: 'output', text: '<span class="success">ok</span>  3 个联系人超过 48 小时未回复' },
-    { type: 'blank' },
-    { type: 'comment', text: '# 生成每日求职摘要' },
-    { type: 'cmd', text: '<span class="prompt">$</span> <span class="cmd">boss digest</span>' },
-    { type: 'output', text: '<span class="success">ok</span>  新增职位 12 · 待跟进 3 · 面试邀请 1' },
-    { type: 'blank' },
-    { type: 'comment', text: '# 增量监控：只看新出现的职位' },
-    { type: 'cmd', text: '<span class="prompt">$</span> <span class="cmd">boss watch run</span> <span class="str">my-golang</span>' },
-    { type: 'output', text: '<span class="success">ok</span>  发现 4 个新职位（已标记）' },
-  ],
-  ai: [
-    { type: 'comment', text: '# 配置 AI 服务' },
-    { type: 'cmd', text: '<span class="prompt">$</span> <span class="cmd">boss ai config</span> <span class="flag">--provider</span> <span class="str">openai</span> <span class="flag">--model</span> <span class="str">gpt-4o</span> <span class="flag">--api-key</span> <span class="str">sk-***</span>' },
-    { type: 'output', text: '<span class="success">ok</span>  配置已保存（密钥已加密存储）' },
-    { type: 'blank' },
-    { type: 'comment', text: '# 分析 JD 与简历匹配度' },
-    { type: 'cmd', text: '<span class="prompt">$</span> <span class="cmd">boss ai analyze-jd</span> <span class="str">@jd.txt</span> <span class="flag">--resume</span> <span class="str">default</span>' },
-    { type: 'output', text: '<span class="success">ok</span>  匹配分 85/100 · 优势 3 · 差距 2 · 建议 4' },
-    { type: 'blank' },
-    { type: 'comment', text: '# 基于 JD 优化简历' },
-    { type: 'cmd', text: '<span class="prompt">$</span> <span class="cmd">boss ai optimize</span> <span class="str">default</span> <span class="flag">--jd</span> <span class="str">@jd.txt</span>' },
-    { type: 'output', text: '<span class="success">ok</span>  匹配分 65 &#x2192; 87 · 优化 5 个模块' },
-    { type: 'blank' },
-    { type: 'comment', text: '# 导出为 PDF' },
-    { type: 'cmd', text: '<span class="prompt">$</span> <span class="cmd">boss resume export</span> <span class="str">default</span> <span class="flag">--format</span> <span class="str">pdf</span>' },
-    { type: 'output', text: '<span class="success">ok</span>  已导出到 default.pdf' },
-  ],
-};
-
-let currentDemo = 'search';
-let animTimeline = null;
-
-function showDemo(name) {
-  currentDemo = name;
-  document.querySelectorAll('.terminal-tab').forEach(t => t.classList.remove('active'));
-  event.target.classList.add('active');
-  renderTerminal(name);
-}
-
-function renderTerminal(name) {
-  if (animTimeline) { animTimeline.kill(); }
-  const body = document.getElementById('terminal-content');
-  const lines = demos[name];
-  body.innerHTML = lines.map((line, i) => {
-    if (line.type === 'blank') return '<div class="terminal-line" style="height:8px;"></div>';
-    if (line.type === 'comment') return `<div class="terminal-line"><span class="comment">${line.text}</span></div>`;
-    if (line.type === 'cmd') return `<div class="terminal-line">${line.text}</div>`;
-    return `<div class="terminal-line"><span class="output">${line.text}</span></div>`;
-  }).join('');
-
-  animTimeline = gsap.timeline();
-  body.querySelectorAll('.terminal-line').forEach((el, i) => {
-    animTimeline.to(el, { opacity: 1, y: 0, duration: 0.3, ease: 'power2.out' }, i * 0.15);
-  });
-}
-
-// ── GSAP Scroll Animations ──
-document.addEventListener('DOMContentLoaded', function() {
-  gsap.registerPlugin(ScrollTrigger);
-
-  // Hero entrance
-  gsap.from('.hero-badge', { opacity: 0, y: 20, duration: 0.6, delay: 0.1 });
-  gsap.from('.hero h1', { opacity: 0, y: 30, duration: 0.8, delay: 0.2 });
-  gsap.from('.hero p', { opacity: 0, y: 20, duration: 0.6, delay: 0.4 });
-  gsap.from('.hero-actions', { opacity: 0, y: 20, duration: 0.6, delay: 0.5 });
-  gsap.from('.badges', { opacity: 0, duration: 0.6, delay: 0.6 });
-
-  // Stats counter
-  document.querySelectorAll('.stat-num').forEach(el => {
-    const target = parseInt(el.textContent);
-    gsap.from(el, {
-      textContent: 0, duration: 1.5, ease: 'power2.out', snap: { textContent: 1 },
-      scrollTrigger: { trigger: el, start: 'top 85%', once: true },
-      onUpdate: function() { el.textContent = Math.round(this.targets()[0].textContent) + (el.dataset.suffix || ''); }
-    });
-  });
-
-  // Stat cards
-  gsap.utils.toArray('.stat-card').forEach((card, i) => {
-    gsap.from(card, { opacity: 0, y: 30, duration: 0.5, delay: i * 0.1,
-      scrollTrigger: { trigger: card, start: 'top 85%', once: true }
-    });
-  });
-
-  // Feature cards
-  gsap.utils.toArray('.feature-card').forEach((card, i) => {
-    gsap.from(card, { opacity: 0, y: 40, duration: 0.6, delay: i * 0.1,
-      scrollTrigger: { trigger: card, start: 'top 85%', once: true }
-    });
-  });
-
-  // Command items
-  gsap.utils.toArray('.cmd-item').forEach((item, i) => {
-    gsap.from(item, { opacity: 0, x: i % 2 === 0 ? -20 : 20, duration: 0.4, delay: (i % 12) * 0.05,
-      scrollTrigger: { trigger: item, start: 'top 90%', once: true }
-    });
-  });
-
-  // Architecture nodes
-  gsap.utils.toArray('.arch-node, .arch-arrow').forEach((node, i) => {
-    gsap.from(node, { opacity: 0, scale: 0.9, duration: 0.5, delay: i * 0.12,
-      scrollTrigger: { trigger: node, start: 'top 85%', once: true }
-    });
-  });
-
-  // Section titles
-  gsap.utils.toArray('.section-title').forEach(title => {
-    gsap.from(title, { opacity: 0, y: 20, duration: 0.6,
-      scrollTrigger: { trigger: title, start: 'top 85%', once: true }
-    });
-  });
-
-  // JSON block
-  gsap.from('.json-block', { opacity: 0, y: 30, duration: 0.8,
-    scrollTrigger: { trigger: '.json-block', start: 'top 85%', once: true }
-  });
-
-  // Init terminal
-  renderTerminal('search');
-});
-</script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js"></script>
+<script src="main.js"></script>
 </body>
 </html>

--- a/demo/main.js
+++ b/demo/main.js
@@ -1,0 +1,191 @@
+gsap.registerPlugin(ScrollTrigger);
+
+document.addEventListener('DOMContentLoaded', function () {
+
+  initHeroEntrance('.hero-inner', '.js-hero-el');
+
+  initParallax([
+    { selector: '.hero-backdrop', speed: 0.5 },
+    { selector: '.hero::before', speed: 0.7 }
+  ]);
+
+  initNavScroll();
+  initMobileNav();
+  initFeatureReveals();
+  initFaqAccordion();
+  initStatCounters();
+  initSectionReveals();
+
+  ScrollTrigger.refresh();
+});
+
+function initHeroEntrance(containerSelector, itemSelector) {
+  gsap.from(itemSelector || containerSelector + ' > *', {
+    y: 32,
+    opacity: 0,
+    filter: 'blur(6px)',
+    duration: 0.9,
+    ease: 'power3.out',
+    stagger: 0.12,
+    clearProps: 'filter'
+  });
+}
+
+function initParallax(layers) {
+  layers.forEach(function (layer) {
+    var el = document.querySelector(layer.selector);
+    if (!el) return;
+    gsap.to(layer.selector, {
+      y: function () { return window.innerHeight * (layer.speed - 1) * -0.4; },
+      ease: 'none',
+      scrollTrigger: {
+        trigger: 'body',
+        start: 'top top',
+        end: 'bottom bottom',
+        scrub: layer.speed
+      }
+    });
+  });
+}
+
+function initNavScroll() {
+  var nav = document.querySelector('.split-nav');
+  if (!nav) return;
+  var scrolled = false;
+  ScrollTrigger.create({
+    start: 'top top',
+    end: '+=80',
+    onUpdate: function (self) {
+      if (self.progress > 0.5 && !scrolled) {
+        nav.classList.add('is-scrolled');
+        scrolled = true;
+      } else if (self.progress <= 0.5 && scrolled) {
+        nav.classList.remove('is-scrolled');
+        scrolled = false;
+      }
+    }
+  });
+}
+
+function initMobileNav() {
+  var toggle = document.querySelector('.nav-toggle');
+  var overlay = document.querySelector('.mobile-nav-overlay');
+  if (!toggle || !overlay) return;
+  toggle.addEventListener('click', function () {
+    var isOpen = toggle.classList.toggle('is-open');
+    overlay.classList.toggle('is-open');
+    toggle.setAttribute('aria-expanded', isOpen);
+    document.body.style.overflow = isOpen ? 'hidden' : '';
+  });
+  overlay.querySelectorAll('.mobile-nav-item').forEach(function (item) {
+    item.addEventListener('click', function () {
+      toggle.classList.remove('is-open');
+      overlay.classList.remove('is-open');
+      toggle.setAttribute('aria-expanded', 'false');
+      document.body.style.overflow = '';
+    });
+  });
+}
+
+function initFeatureReveals() {
+  document.querySelectorAll('.js-feature').forEach(function (block) {
+    ScrollTrigger.create({
+      trigger: block,
+      start: 'top 85%',
+      once: true,
+      onEnter: function () { block.classList.add('is-visible'); }
+    });
+  });
+}
+
+function initFaqAccordion() {
+  document.querySelectorAll('.faq-item').forEach(function (item) {
+    var trigger = item.querySelector('.faq-trigger');
+    trigger.addEventListener('click', function () {
+      var isOpen = item.getAttribute('data-open') === 'true';
+      document.querySelectorAll('.faq-item').forEach(function (other) {
+        other.setAttribute('data-open', 'false');
+        other.querySelector('.faq-trigger').setAttribute('aria-expanded', 'false');
+      });
+      if (!isOpen) {
+        item.setAttribute('data-open', 'true');
+        trigger.setAttribute('aria-expanded', 'true');
+      }
+    });
+  });
+}
+
+function initStatCounters() {
+  document.querySelectorAll('.stat-num').forEach(function (el) {
+    var target = parseInt(el.getAttribute('data-target'), 10);
+    if (isNaN(target) || target === 0) return;
+    var obj = { val: 0 };
+    gsap.to(obj, {
+      val: target,
+      duration: 1.8,
+      ease: 'power2.out',
+      scrollTrigger: {
+        trigger: el,
+        start: 'top 85%',
+        once: true
+      },
+      onUpdate: function () { el.textContent = Math.round(obj.val); }
+    });
+  });
+}
+
+function initSectionReveals() {
+  document.querySelectorAll('.faq-title, .cta-headline').forEach(function (el) {
+    gsap.from(el, {
+      opacity: 0,
+      y: 30,
+      duration: 0.8,
+      ease: 'power3.out',
+      scrollTrigger: {
+        trigger: el,
+        start: 'top 85%',
+        once: true
+      }
+    });
+  });
+
+  document.querySelectorAll('.faq-item').forEach(function (item, i) {
+    gsap.from(item, {
+      opacity: 0,
+      x: 20,
+      duration: 0.5,
+      delay: i * 0.06,
+      scrollTrigger: {
+        trigger: item,
+        start: 'top 90%',
+        once: true
+      }
+    });
+  });
+
+  document.querySelectorAll('.pipeline-step').forEach(function (step, i) {
+    gsap.from(step, {
+      opacity: 0,
+      scale: 0.9,
+      duration: 0.4,
+      delay: i * 0.08,
+      ease: 'back.out(1.5)',
+      scrollTrigger: {
+        trigger: step,
+        start: 'top 90%',
+        once: true
+      }
+    });
+  });
+
+  gsap.from('.install-code', {
+    opacity: 0,
+    y: 20,
+    duration: 0.6,
+    scrollTrigger: {
+      trigger: '.install-code',
+      start: 'top 85%',
+      once: true
+    }
+  });
+}

--- a/demo/style.css
+++ b/demo/style.css
@@ -1,0 +1,698 @@
+:root {
+  --bg: #0e0c09;
+  --bg-surface: #1a1714;
+  --bg-code: #12100c;
+  --bg-code-header: #0a0906;
+  --ink: #f2ede4;
+  --ink-muted: #8c7c77;
+  --accent: #008b8b;
+  --accent-soft: rgba(0,139,139,0.12);
+  --accent-glow: rgba(0,139,139,0.25);
+  --line: rgba(242,237,228,0.08);
+  --font-display: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono: 'JetBrains Mono', 'Menlo', 'Consolas', monospace;
+  --section-pad: 100px;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; }
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--font-body);
+  line-height: 1.6;
+  overflow-x: hidden;
+  -webkit-font-smoothing: antialiased;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='ruin'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.05' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23ruin)' opacity='0.04'/%3E%3C/svg%3E");
+}
+a { color: var(--accent); text-decoration: none; transition: color 0.3s; }
+a:hover { color: #00b3b3; }
+:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 4px; }
+@media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; } }
+.line-wrap { display: block; overflow: hidden; padding-top: 0.15em; margin-top: -0.15em; }
+.line-inner { display: block; }
+
+.section-rule {
+  position: relative;
+  padding-top: calc(var(--section-pad) + 32px);
+}
+.section-rule::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 10%;
+  right: 10%;
+  height: 1px;
+  background: linear-gradient(to right, transparent, var(--accent) 25%, var(--accent) 75%, transparent);
+  opacity: 0.35;
+}
+
+.split-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px 5vw;
+  transition: padding 0.4s cubic-bezier(0.16,1,0.3,1), background 0.4s;
+}
+.split-nav.is-scrolled {
+  padding: 12px 5vw;
+  background: rgba(14,12,9,0.92);
+  backdrop-filter: blur(16px);
+  border-bottom: 1px solid var(--line);
+}
+.nav-left, .nav-right {
+  display: flex;
+  align-items: center;
+  gap: 32px;
+  flex: 1;
+}
+.nav-right { justify-content: flex-end; }
+.nav-left a, .nav-right a:not(.nav-cta) {
+  color: var(--ink-muted);
+  font-size: 0.88rem;
+  font-weight: 400;
+  letter-spacing: 0.04em;
+  transition: color 0.3s;
+}
+.nav-left a:hover, .nav-right a:not(.nav-cta):hover { color: var(--ink); }
+.nav-logo {
+  font-family: var(--font-display);
+  font-size: 1.15rem;
+  color: var(--ink);
+  white-space: nowrap;
+  padding: 0 40px;
+  transition: font-size 0.4s cubic-bezier(0.16,1,0.3,1);
+}
+.split-nav.is-scrolled .nav-logo { font-size: 1rem; }
+.logo-prompt { color: var(--accent); }
+.nav-cta {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 20px;
+  border: 1px solid rgba(0,139,139,0.4);
+  border-radius: 100px;
+  color: var(--accent) !important;
+  font-size: 0.85rem;
+  font-weight: 500;
+  transition: all 0.3s;
+}
+.nav-cta:hover {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+}
+.nav-toggle {
+  display: none;
+  position: absolute;
+  right: 5vw;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 28px;
+  height: 20px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  z-index: 101;
+}
+.nav-toggle span {
+  display: block;
+  width: 100%;
+  height: 1.5px;
+  background: var(--ink);
+  margin: 5px 0;
+  transition: all 0.3s;
+  transform-origin: center;
+}
+.nav-toggle.is-open span:nth-child(1) { transform: translateY(6.5px) rotate(45deg); }
+.nav-toggle.is-open span:nth-child(2) { opacity: 0; }
+.nav-toggle.is-open span:nth-child(3) { transform: translateY(-6.5px) rotate(-45deg); }
+.mobile-nav-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 99;
+  background: rgba(14,12,9,0.97);
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 32px;
+}
+.mobile-nav-overlay.is-open { display: flex; }
+.mobile-nav-item {
+  font-family: var(--font-display);
+  font-size: clamp(1.8rem, 5vw, 2.5rem);
+  color: var(--ink);
+  opacity: 0;
+  transform: translateY(20px);
+}
+.mobile-nav-overlay.is-open .mobile-nav-item {
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity 0.5s ease, transform 0.5s ease;
+}
+.mobile-nav-overlay.is-open .mobile-nav-item:nth-child(1) { transition-delay: 0.05s; }
+.mobile-nav-overlay.is-open .mobile-nav-item:nth-child(2) { transition-delay: 0.1s; }
+.mobile-nav-overlay.is-open .mobile-nav-item:nth-child(3) { transition-delay: 0.15s; }
+.mobile-nav-overlay.is-open .mobile-nav-item:nth-child(4) { transition-delay: 0.2s; }
+@media (max-width: 768px) {
+  .nav-left, .nav-right { display: none; }
+  .nav-toggle { display: block; }
+  .nav-logo { padding: 0; }
+  .split-nav { justify-content: center; }
+}
+
+.hero {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  overflow: hidden;
+  padding: 120px 24px 80px;
+}
+.hero::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 60vw;
+  height: 60vh;
+  background: radial-gradient(ellipse at top, var(--accent-soft) 0%, transparent 70%);
+  pointer-events: none;
+}
+.hero-inner {
+  position: relative;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 860px;
+}
+.hero-eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 2.5rem;
+}
+.hero-rule {
+  width: 40px;
+  height: 1px;
+  background: var(--accent);
+}
+.hero-title {
+  font-family: var(--font-display);
+  font-size: clamp(2.8rem, 7vw, 5.5rem);
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+  color: var(--ink);
+  margin-bottom: 1.5rem;
+}
+.hero-title em {
+  font-style: normal;
+  color: var(--accent);
+}
+.hero-desc {
+  font-size: clamp(1rem, 1.4vw, 1.15rem);
+  color: var(--ink-muted);
+  line-height: 1.7;
+  max-width: 44ch;
+  margin-bottom: 2.5rem;
+}
+.hero-actions {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+.btn-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 32px;
+  border-radius: 100px;
+  background: var(--ink);
+  color: var(--bg);
+  font-family: var(--font-body);
+  font-weight: 500;
+  font-size: 0.95rem;
+  border: none;
+  cursor: pointer;
+  transition: all 0.3s;
+  text-decoration: none;
+}
+.btn-primary:hover {
+  background: var(--accent);
+  color: var(--ink);
+  box-shadow: 0 0 24px var(--accent-glow);
+  transform: translateY(-1px);
+}
+.btn-primary svg { width: 18px; height: 18px; }
+.btn-ghost {
+  display: inline-flex;
+  align-items: center;
+  padding: 14px 32px;
+  border-radius: 100px;
+  background: transparent;
+  color: var(--ink);
+  font-family: var(--font-body);
+  font-weight: 500;
+  font-size: 0.95rem;
+  border: 1px solid rgba(242,237,228,0.15);
+  cursor: pointer;
+  transition: all 0.3s;
+  text-decoration: none;
+}
+.btn-ghost:hover {
+  border-color: var(--ink);
+  color: var(--ink);
+}
+.hero-badges {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 3rem;
+}
+.hero-badges img { height: 22px; }
+.hero-stats {
+  display: flex;
+  gap: 48px;
+  padding-top: 2rem;
+  border-top: 1px solid var(--line);
+}
+.stat { text-align: center; }
+.stat-num {
+  font-family: var(--font-display);
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  color: var(--accent);
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+}
+.stat-suffix {
+  font-family: var(--font-display);
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  color: var(--accent);
+}
+.stat-label {
+  display: block;
+  font-size: 0.82rem;
+  color: var(--ink-muted);
+  margin-top: 4px;
+}
+.hero-backdrop {
+  position: absolute;
+  bottom: -5%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100vw;
+  height: auto;
+  color: var(--ink);
+  opacity: 0.03;
+  pointer-events: none;
+  z-index: 0;
+}
+@media (max-width: 640px) {
+  .hero-stats { gap: 24px; }
+}
+
+.features {
+  padding-bottom: var(--section-pad);
+}
+.feature-block {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 48px;
+  align-items: center;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 5vw 80px;
+  opacity: 0;
+  transform: translateY(40px);
+}
+.feature-block.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity 0.8s ease, transform 0.8s ease;
+}
+@media (min-width: 900px) {
+  .feature-block {
+    grid-template-columns: 1fr 1fr;
+    gap: 6vw;
+    padding-bottom: 100px;
+  }
+  .feature-block--reverse .feature-content { order: 2; }
+  .feature-block--reverse .feature-visual { order: 1; }
+}
+.feature-block--focal {
+  background: var(--bg-surface);
+  border-radius: 20px;
+  padding: 48px 5vw;
+  border: 1px solid var(--line);
+}
+@media (min-width: 900px) {
+  .feature-block--focal { padding: 64px; }
+}
+.feature-content { max-width: 500px; }
+.feature-eyebrow {
+  display: inline-block;
+  font-size: 0.82rem;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent);
+  padding: 4px 12px;
+  background: var(--accent-soft);
+  border-radius: 100px;
+  margin-bottom: 1.2rem;
+}
+.feature-headline {
+  font-family: var(--font-display);
+  font-size: clamp(1.6rem, 3vw, 2.4rem);
+  font-weight: 700;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  margin-bottom: 1.2rem;
+}
+.feature-body {
+  color: var(--ink-muted);
+  font-size: 1rem;
+  line-height: 1.7;
+  margin-bottom: 2rem;
+}
+.feature-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--ink);
+  font-weight: 500;
+  font-size: 0.9rem;
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 2px;
+  transition: color 0.3s;
+}
+.feature-link:hover { color: var(--accent); }
+
+.terminal {
+  background: var(--bg-code);
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.4);
+  border: 1px solid var(--line);
+}
+.terminal-header {
+  background: var(--bg-code-header);
+  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.terminal-dot { width: 10px; height: 10px; border-radius: 50%; }
+.terminal-dot.r { background: #ff5f57; }
+.terminal-dot.y { background: #febc2e; }
+.terminal-dot.g { background: #28c840; }
+.terminal-title {
+  color: var(--ink-muted);
+  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  margin-left: 8px;
+  opacity: 0.5;
+}
+.terminal-body {
+  padding: 20px;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  line-height: 1.9;
+}
+.tl + .tl { margin-top: 2px; }
+.t-comment { color: #585b70; font-style: italic; }
+.t-prompt { color: #a6e3a1; }
+.t-cmd { color: #89b4fa; }
+.t-flag { color: #fab387; }
+.t-str { color: #f9e2af; }
+.t-ok { color: #a6e3a1; font-weight: 500; }
+.t-muted { color: #94a3b8; }
+
+.json-block {
+  background: var(--bg-code);
+  border-radius: 12px;
+  padding: 24px;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  line-height: 1.8;
+  overflow-x: auto;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.4);
+  border: 1px solid var(--line);
+}
+.json-block pre { margin: 0; }
+.jk { color: #89b4fa; }
+.jv { color: #a6e3a1; }
+.js { color: #f9e2af; }
+.jb { color: #cdd6f4; }
+
+.pipeline-flow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+.pipeline-step {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background: var(--bg-code);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--ink);
+  white-space: nowrap;
+  transition: border-color 0.3s, transform 0.3s;
+}
+.pipeline-step:hover {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+}
+.pipeline-step .step-icon {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--accent-soft);
+  color: var(--accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.65rem;
+  flex-shrink: 0;
+}
+.pipeline-arrow {
+  color: var(--ink-muted);
+  font-size: 0.9rem;
+  opacity: 0.4;
+}
+.pipeline-step--active {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.faq {
+  padding-bottom: var(--section-pad);
+}
+.faq-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 5vw;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 3rem;
+}
+@media (min-width: 900px) {
+  .faq-container {
+    grid-template-columns: 3fr 7fr;
+    gap: 6vw;
+  }
+}
+.faq-title {
+  font-family: var(--font-display);
+  font-size: clamp(3rem, 8vw, 7rem);
+  line-height: 0.9;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  position: sticky;
+  top: 6rem;
+}
+.faq-right { display: flex; flex-direction: column; }
+.faq-item {
+  border-top: 1px solid var(--line);
+}
+.faq-item:last-child {
+  border-bottom: 1px solid var(--line);
+}
+.faq-trigger {
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: 2rem 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+  color: var(--ink);
+  text-align: left;
+  gap: 2rem;
+  font-family: var(--font-body);
+}
+.faq-trigger:hover .faq-question {
+  transform: translateX(8px);
+  color: var(--accent);
+}
+.faq-question {
+  font-size: clamp(1.1rem, 1.8vw, 1.4rem);
+  font-weight: 400;
+  transition: transform 0.4s cubic-bezier(0.16,1,0.3,1), color 0.3s;
+}
+.faq-icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  color: var(--ink-muted);
+}
+.faq-icon line {
+  stroke: currentColor;
+  stroke-width: 1.5;
+  transition: transform 0.4s cubic-bezier(0.16,1,0.3,1), opacity 0.4s;
+  transform-origin: center;
+}
+.faq-item[data-open="true"] .faq-icon .vertical {
+  transform: rotate(90deg);
+  opacity: 0;
+}
+.faq-content-grid {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.5s cubic-bezier(0.16,1,0.3,1);
+}
+.faq-item[data-open="true"] .faq-content-grid {
+  grid-template-rows: 1fr;
+}
+.faq-content-inner { overflow: hidden; }
+.faq-answer {
+  font-size: 0.95rem;
+  color: var(--ink-muted);
+  line-height: 1.7;
+  padding-bottom: 2rem;
+  max-width: 85%;
+}
+
+.cta {
+  padding-bottom: var(--section-pad);
+}
+.cta-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 5vw;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 3rem;
+  align-items: center;
+}
+@media (min-width: 900px) {
+  .cta-container {
+    grid-template-columns: 1fr 1fr;
+    gap: 6rem;
+  }
+}
+.cta-headline {
+  font-family: var(--font-display);
+  font-size: clamp(2.5rem, 5vw, 4.5rem);
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+  margin-bottom: 1rem;
+}
+.cta-headline span { display: block; }
+.cta-accent {
+  color: var(--accent);
+  font-weight: 700;
+}
+.cta-subtext {
+  font-size: clamp(1rem, 1.4vw, 1.1rem);
+  color: var(--ink-muted);
+  max-width: 400px;
+}
+.cta-actions-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+.install-code {
+  background: var(--bg-code);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 20px 24px;
+  font-family: var(--font-mono);
+  font-size: 0.88rem;
+  line-height: 2;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.3);
+}
+.cta-buttons {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.btn-ghost-link {
+  color: var(--ink-muted);
+  font-weight: 500;
+  position: relative;
+  transition: color 0.3s;
+}
+.btn-ghost-link::after {
+  content: '';
+  position: absolute;
+  bottom: -3px;
+  left: 0;
+  width: 100%;
+  height: 1px;
+  background: var(--ink-muted);
+  transform: scaleX(0);
+  transform-origin: right;
+  transition: transform 0.3s;
+}
+.btn-ghost-link:hover { color: var(--ink); }
+.btn-ghost-link:hover::after { transform: scaleX(1); transform-origin: left; background: var(--ink); }
+
+.footer {
+  padding: 48px 5vw;
+  border-top: 1px solid var(--line);
+  text-align: center;
+}
+.footer p {
+  color: var(--ink-muted);
+  font-size: 0.85rem;
+}
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 24px;
+  margin-top: 12px;
+}
+.footer-links a {
+  color: var(--ink-muted);
+  font-size: 0.85rem;
+}
+.footer-links a:hover { color: var(--ink); }


### PR DESCRIPTION
## Summary

- 使用 citycraft 工作流重构 Demo 落地页，从单文件模板升级为多文件架构
- 应用 Beirut 暗色主题（地中海青 `#008B8B` + 砂岩噪声纹理）
- 字体对齐开发者工具行业标准（Inter + JetBrains Mono）
- 新增 Split Centered 导航（滚动压缩动画）、GSAP blur 入场、视差分层、FAQ 手风琴、Pipeline 流程图

## 变更内容

| 文件 | 说明 |
|------|------|
| `demo/index.html` | 重写 HTML 结构：Hero(极简下降) + Features(交替展示) + FAQ(编辑排版) + CTA |
| `demo/style.css` | 独立样式：设计 token、fractalNoise 纹理、section-rule 过渡、响应式 |
| `demo/main.js` | GSAP 动画：blur 入场、视差、导航压缩、FAQ 手风琴、stats 计数器 |
| `demo/assets/icons.svg` | SVG sprite：统一 1.5px 描边风格 |

## 设计决策

- **字体**: Prata(衬线) → Inter(无衬线)，参考 Linear/Tailwind/Vercel 等 11/12 开发者工具标准
- **主题**: Beirut 暗色变体（`#0e0c09` 暖黑底 + `#008B8B` 地中海青）
- **过渡**: 极简线条（section-rule），不使用 clip-path
- **克隆网格**: 3 个 Feature 块分别为普通/反向/focal 三种视觉层级

## Test plan

- [ ] 本地打开 `demo/index.html` 验证页面渲染正常
- [ ] 检查移动端响应式（nav 折叠、grid 单列）
- [ ] 验证 GSAP 动画（滚动触发、FAQ 展开）
- [ ] 合并后确认 GitHub Pages 自动部署成功