### PR TITLE
feat: 协议发现命令支持导出主流大模型工具格式

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 ## [Unreleased]
 
 ### Added
+- `boss schema --format openai-tools` 和 `--format anthropic-tools` — 一键导出 OpenAI Functions / Claude Tool Use 兼容的 JSON Schema，免手动转换即可喂给 SDK
 - `boss stats --format html -o <path>` 输出自包含交互式漏斗报表（纯 CSS + SVG，无外部 CDN）
 - 协议服务文档补齐传输层章节（stdio 当前支持 / SSE 规划中）和贡献指引
+- Issue / PR 模板全面升级：bug_report 强制 doctor 输出和版本号，feature_request 新增贡献意愿字段，新增 documentation 专用模板，PR 模板新增 Closes 关联和 Breaking Change 声明
 
 ## [1.7.0] - 2026-04-17
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -135,11 +135,19 @@ python3 mcp-server/server.py --transport sse --host 127.0.0.1 --port 8765
 - HTTP 传输默认绑定 `127.0.0.1`，远程暴露需用户显式 `--host 0.0.0.0`
 - 不内置鉴权 / TLS，需要时通过反向代理（nginx / Caddy / Cloudflare Tunnel）处理
 
-## 注意事项
+## 其他 Agent 宿主接入
 
-- 首次使用需要先登录：在终端执行 `boss login`
-- MCP Server 通过 subprocess 调用 `boss` CLI，确保 `boss` 在 PATH 中
-- 不暴露 login/logout 等交互式命令（需要浏览器界面）
+本 MCP Server 专注 stdio/SSE 协议。如果你用的 Agent 框架不支持 MCP，可以用 `boss schema` 命令直接生成对应格式：
+
+```bash
+# OpenAI Functions / Tools API（GPT-4 / GPT-5）
+boss schema --format openai-tools
+
+# Anthropic Tool Use（Claude API 直连）
+boss schema --format anthropic-tools
+```
+
+然后把 stdout 的 `data.tools` 数组直接喂给对应 SDK 即可。
 
 ## 贡献
 

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -2,6 +2,86 @@ import click
 
 from boss_agent_cli.output import emit_success
 
+# 类型转换：native schema → JSON Schema 基础类型
+_JSON_SCHEMA_TYPE_MAP = {
+	"string": "string",
+	"int": "integer",
+	"integer": "integer",
+	"bool": "boolean",
+	"boolean": "boolean",
+	"float": "number",
+	"number": "number",
+}
+
+
+def _option_to_json_schema_property(opt_spec: dict) -> dict:
+	"""把 native option 转成单个 JSON Schema 属性。"""
+	native_type = opt_spec.get("type", "string")
+	prop: dict = {"type": _JSON_SCHEMA_TYPE_MAP.get(native_type, "string")}
+	desc = opt_spec.get("description")
+	if desc:
+		prop["description"] = desc
+	default = opt_spec.get("default")
+	if default is not None:
+		prop["default"] = default
+	return prop
+
+
+def _command_to_json_schema(cmd_name: str, cmd_spec: dict) -> dict:
+	"""把 native 命令描述转成 OpenAI Tools / Anthropic Tool Use 共用的 JSON Schema。"""
+	properties: dict = {}
+	required: list[str] = []
+
+	for arg in cmd_spec.get("args", []):
+		arg_name = arg["name"]
+		properties[arg_name] = {
+			"type": "string",
+			"description": arg.get("description", ""),
+		}
+		if arg.get("required"):
+			required.append(arg_name)
+
+	for opt_key, opt_spec in cmd_spec.get("options", {}).items():
+		# 去掉短/长选项前缀，保留长选项作为参数名
+		primary_name = opt_key.split(",")[-1].strip().lstrip("-").replace("-", "_")
+		properties[primary_name] = _option_to_json_schema_property(opt_spec)
+
+	schema: dict = {
+		"type": "object",
+		"properties": properties,
+	}
+	if required:
+		schema["required"] = required
+	return schema
+
+
+def _format_openai_tools(data: dict) -> list[dict]:
+	"""OpenAI Functions / Tools API 格式。"""
+	tools = []
+	for cmd_name, cmd_spec in data["commands"].items():
+		tools.append({
+			"type": "function",
+			"function": {
+				"name": f"boss_{cmd_name.replace('-', '_')}",
+				"description": cmd_spec.get("description", ""),
+				"parameters": _command_to_json_schema(cmd_name, cmd_spec),
+			},
+		})
+	return tools
+
+
+def _format_anthropic_tools(data: dict) -> list[dict]:
+	"""Anthropic Tool Use 格式。"""
+	tools = []
+	for cmd_name, cmd_spec in data["commands"].items():
+		tools.append({
+			"name": f"boss_{cmd_name.replace('-', '_')}",
+			"description": cmd_spec.get("description", ""),
+			"input_schema": _command_to_json_schema(cmd_name, cmd_spec),
+		})
+	return tools
+
+
 SCHEMA_DATA = {
 	"name": "boss-agent-cli",
 	"description": "BOSS直聘求职工具。32 个命令覆盖搜索、筛选、打招呼、沟通、流水线、简历优化全流程。",
@@ -572,6 +652,18 @@ SCHEMA_DATA = {
 
 
 @click.command("schema")
-def schema_cmd():
+@click.option(
+	"--format", "output_format",
+	type=click.Choice(["native", "openai-tools", "anthropic-tools"]),
+	default="native",
+	help="输出格式：native（本项目信封）/ openai-tools（OpenAI Functions & Tools API）/ anthropic-tools（Claude Tool Use API）",
+)
+def schema_cmd(output_format):
 	"""返回工具完整能力描述的 JSON"""
+	if output_format == "openai-tools":
+		emit_success("schema", {"format": "openai-tools", "tools": _format_openai_tools(SCHEMA_DATA)})
+		return
+	if output_format == "anthropic-tools":
+		emit_success("schema", {"format": "anthropic-tools", "tools": _format_anthropic_tools(SCHEMA_DATA)})
+		return
 	emit_success("schema", SCHEMA_DATA)

--- a/tests/test_schema_formats.py
+++ b/tests/test_schema_formats.py
@@ -1,0 +1,132 @@
+"""Tests for boss schema --format 扩展（openai-tools / anthropic-tools）。"""
+
+import json
+
+from click.testing import CliRunner
+
+from boss_agent_cli.commands.schema import (
+	_command_to_json_schema,
+	_format_anthropic_tools,
+	_format_openai_tools,
+	SCHEMA_DATA,
+)
+from boss_agent_cli.main import cli
+
+
+def test_native_format_is_default():
+	"""默认 --format 应等同于 native（原行为）。"""
+	runner = CliRunner()
+	result = runner.invoke(cli, ["schema"])
+	assert result.exit_code == 0
+	data = json.loads(result.output)["data"]
+	assert "commands" in data
+	assert "error_codes" in data
+	assert "format" not in data  # native 格式不带 format 字段
+
+
+def test_openai_tools_format():
+	"""--format openai-tools 输出符合 OpenAI Tools API 结构。"""
+	runner = CliRunner()
+	result = runner.invoke(cli, ["schema", "--format", "openai-tools"])
+	assert result.exit_code == 0
+	data = json.loads(result.output)["data"]
+	assert data["format"] == "openai-tools"
+	tools = data["tools"]
+	assert len(tools) == len(SCHEMA_DATA["commands"])
+	for tool in tools:
+		assert tool["type"] == "function"
+		assert "function" in tool
+		fn = tool["function"]
+		assert fn["name"].startswith("boss_")
+		assert fn["description"]
+		assert fn["parameters"]["type"] == "object"
+		assert "properties" in fn["parameters"]
+
+
+def test_anthropic_tools_format():
+	"""--format anthropic-tools 输出符合 Claude Tool Use API 结构。"""
+	runner = CliRunner()
+	result = runner.invoke(cli, ["schema", "--format", "anthropic-tools"])
+	assert result.exit_code == 0
+	data = json.loads(result.output)["data"]
+	assert data["format"] == "anthropic-tools"
+	tools = data["tools"]
+	assert len(tools) == len(SCHEMA_DATA["commands"])
+	for tool in tools:
+		assert tool["name"].startswith("boss_")
+		assert tool["description"]
+		assert tool["input_schema"]["type"] == "object"
+
+
+def test_openai_and_anthropic_share_parameters_schema():
+	"""两种格式参数 schema 应一致（只是外层包装不同）。"""
+	oai = _format_openai_tools(SCHEMA_DATA)
+	anth = _format_anthropic_tools(SCHEMA_DATA)
+
+	oai_search = next(t["function"]["parameters"] for t in oai if t["function"]["name"] == "boss_search")
+	anth_search = next(t["input_schema"] for t in anth if t["name"] == "boss_search")
+	assert oai_search == anth_search
+
+
+def test_command_to_json_schema_required_args():
+	"""required=True 的参数应出现在 required 数组中。"""
+	cmd_spec = {
+		"args": [
+			{"name": "query", "required": True, "description": "关键词"},
+			{"name": "opt", "required": False, "description": "可选"},
+		],
+		"options": {},
+	}
+	schema = _command_to_json_schema("test", cmd_spec)
+	assert "query" in schema["properties"]
+	assert "opt" in schema["properties"]
+	assert schema["required"] == ["query"]
+
+
+def test_command_to_json_schema_type_mapping():
+	"""native 类型应映射到 JSON Schema 类型（int → integer, bool → boolean）。"""
+	cmd_spec = {
+		"args": [],
+		"options": {
+			"--days": {"type": "int", "default": 30, "description": "天数"},
+			"--dry-run": {"type": "bool", "default": False, "description": "预览"},
+			"--name": {"type": "string", "default": None, "description": "名称"},
+		},
+	}
+	schema = _command_to_json_schema("test", cmd_spec)
+	assert schema["properties"]["days"]["type"] == "integer"
+	assert schema["properties"]["days"]["default"] == 30
+	assert schema["properties"]["dry_run"]["type"] == "boolean"
+	assert schema["properties"]["name"]["type"] == "string"
+
+
+def test_command_name_dash_to_underscore():
+	"""带横线的命令名（如 batch-greet）应转成下划线。"""
+	oai = _format_openai_tools(SCHEMA_DATA)
+	names = {t["function"]["name"] for t in oai}
+	assert "boss_batch_greet" in names
+	assert "boss_follow_up" in names
+	assert "boss_chat_summary" in names
+
+
+def test_invalid_format_raises():
+	"""非法 --format 应被 Click 拦截。"""
+	runner = CliRunner()
+	result = runner.invoke(cli, ["schema", "--format", "xml"])
+	assert result.exit_code != 0
+
+
+def test_openai_tools_output_ready_for_openai_sdk():
+	"""OpenAI Tools 输出应能直接传给 openai SDK 的 tools 参数（结构校验）。"""
+	oai = _format_openai_tools(SCHEMA_DATA)
+	for tool in oai:
+		# 必需字段：type, function.name, function.description, function.parameters
+		assert set(tool.keys()) == {"type", "function"}
+		fn = tool["function"]
+		assert "name" in fn and "description" in fn and "parameters" in fn
+		# parameters 必须是合法 JSON Schema
+		params = fn["parameters"]
+		assert params["type"] == "object"
+		for prop_name, prop_spec in params.get("properties", {}).items():
+			assert "type" in prop_spec
+			assert prop_spec["type"] in {"string", "integer", "boolean", "number", "array", "object"}


### PR DESCRIPTION
## 关联 Issue

Closes #49

## Summary

让 `boss schema` 支持一键导出两种主流大模型工具定义格式，免除 Agent 开发者手写转换适配。

- `boss schema --format openai-tools` → OpenAI Functions / Tools API（\`type: \"function\"\` 包裹）
- `boss schema --format anthropic-tools` → Claude Tool Use API（扁平结构）
- `boss schema --format native`（默认，原行为不变）

## 变更类型

- [x] feat: 新功能

## Breaking Change

- [x] 本 PR **不包含** 破坏性变更（默认 format=native 保持旧行为）

## 技术细节

- **类型映射**：`int → integer`、`bool → boolean`、`string → string`，基础覆盖三种 API 要求的 JSON Schema
- **命名规范化**：`batch-greet → boss_batch_greet`（API 要求下划线）
- **参数 schema 共用**：OpenAI 和 Anthropic 共享同一个 `_command_to_json_schema()` 函数，只是外层包装不同
- **输出示例**：

\`\`\`python
# 直接喂给 openai SDK
from openai import OpenAI
import subprocess, json

tools = json.loads(
    subprocess.run(["boss", "schema", "--format", "openai-tools"],
                   capture_output=True, text=True).stdout
)["data"]["tools"]

client.chat.completions.create(model="gpt-4o", messages=[...], tools=tools)
\`\`\`

## Test plan

- [x] \`uv run pytest tests/ -q\` 701 → 710 passed（+9 新测试）
- [x] \`uv run ruff check src/ tests/\` 通过
- [x] Smoke 测试两种格式：\`boss schema --format openai-tools\` / \`--format anthropic-tools\` 均输出合法 JSON
- [x] 测试强制约束 \`parameters.type == \"object\"\` 及 \`properties.*.type\" \in {string, integer, boolean, number, array, object}\`

## 文档与契约

- [x] 已更新 \`src/boss_agent_cli/commands/schema.py\`（注册 --format 选项）
- [x] 已更新 \`mcp-server/README.md\`（新增"其他 Agent 宿主接入"章节引流）
- [x] 已更新 \`CHANGELOG.md\` Unreleased