### PR TITLE
docs: 英文版补齐 LINUX DO 友链对齐中文

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased]
 
+### Added
+- 英文版 README 新增「👭 Related Communities」分区，对齐中文版的 LINUX DO 友链认可
+
 ## [1.7.1] - 2026-04-17
 
 ### Added

--- a/README.en.md
+++ b/README.en.md
@@ -320,3 +320,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). TL;DR: fork → `feat/xxx` branch → wr
 ## 📄 License
 
 MIT © [can4hou6joeng4](https://github.com/can4hou6joeng4)
+
+## 👭 Related Communities
+
+- [LINUX DO - a new community for tech enthusiasts](https://linux.do/)


### PR DESCRIPTION
master 上已有中文 README 的 LINUX DO 友链（commit 31b358a），本 PR 将英文版 README.en.md 末尾对齐补上 "Related Communities" 分区，并同步 CHANGELOG Unreleased。

## 参考

- 社区规范：https://linux.do/t/topic/1776670
- 样板：https://github.com/undsky/RuoYi-SpringBoot3-Pro README 末尾的友情链接

## Test plan

- [x] 纯文档变更，全量 710 passed 不变
- [x] ruff check 通过