### PR TITLE
fix: 修复浏览器未安装时自动检测提取 Cookie 崩溃的问题

### DIFF
--- a/src/boss_agent_cli/auth/cookie_extract.py
+++ b/src/boss_agent_cli/auth/cookie_extract.py
@@ -52,5 +52,5 @@ def _try_extract(loader) -> dict | None:
 			"user_agent": "",  # browser-cookie3 无法获取 UA，后续由 httpx 默认 UA 补充
 			"stoken": cookies.get("__zp_stoken__", ""),
 		}
-	except (OSError, KeyError, ValueError, PermissionError):
+	except Exception:
 		return None


### PR DESCRIPTION
## Summary

- `_try_extract` 的异常捕获范围从列举式改为 `Exception`
- 修复 `browser_cookie3` 对未安装浏览器抛出 `BrowserCookieError` 时自动检测循环崩溃的问题

## 复现场景

在没有安装 Edge 的 Linux 系统上运行 `boss doctor`，`extract_cookies` 在自动检测模式下尝试 Edge 时抛出 `BrowserCookieError`，该异常不在原有捕获列表中，导致整个命令崩溃退出。

## Test plan

- [ ] 在未安装 Edge 的 Linux 环境运行 `boss doctor`，确认不再崩溃
- [ ] 在安装了 Chrome 且已登录 Boss 直聘的环境中运行 `boss doctor`，确认 Cookie 提取正常
- [ ] `uv run pytest tests/ -q` 全部通过