### PR TITLE
chore: 忽略本地社区发帖草稿

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ GEMINI.md
 coverage.xml
 coverage.json
 htmlcov/
+
+# 本地专属的社区发帖草稿（未公开前保留在本地）
+docs/blog/linuxdo-promo.md


### PR DESCRIPTION
## Summary

把 `docs/blog/linuxdo-promo.md` 纳入 `.gitignore`，使本地社区发帖草稿不会被误推送到远程。其他 `docs/blog/` 下已提交的落地故事文档（`zh-launch-story.md` / `en-launch-story.md`）继续正常追踪，不受影响。

## 底层逻辑

精准忽略单个文件而非整个目录，保持 blog 目录内已有公开文档的追踪状态。

## Test plan

- [x] `git status` 确认 untracked 文件不再出现
- [x] 其他 `docs/blog/*` 文件仍然处于追踪状态