### PR TITLE
feat: 日报命令新增 Markdown 格式输出

### DIFF
--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -220,11 +220,13 @@ TOOLS = [
 	),
 	Tool(
 		name="boss_digest",
-		description="汇总新增职位、待跟进会话和面试项的只读日报",
+		description="汇总新增职位、待跟进会话和面试项的只读日报（支持 md 输出便于邮件/飞书直发）",
 		inputSchema={
 			"type": "object",
 			"properties": {
 				"days_stale": {"type": "integer", "description": "超过 N 天未推进视为待跟进", "default": 3},
+				"format": {"type": "string", "description": "输出格式", "enum": ["json", "md"], "default": "json"},
+				"output": {"type": "string", "description": "Markdown 输出路径（仅 format=md 时生效）"},
 			},
 			"required": [],
 		},
@@ -593,6 +595,10 @@ def _build_args(tool_name: str, arguments: dict) -> list[str]:
 		args = [name]
 		if "days_stale" in arguments:
 			args.extend(["--days-stale", str(arguments["days_stale"])])
+		if arguments.get("format"):
+			args.extend(["--format", arguments["format"]])
+		if arguments.get("output"):
+			args.extend(["-o", arguments["output"]])
 		return args
 
 	if name == "stats":

--- a/src/boss_agent_cli/commands/digest.py
+++ b/src/boss_agent_cli/commands/digest.py
@@ -1,10 +1,12 @@
+import sys
 import time
+from pathlib import Path
 
 import click
 
 from boss_agent_cli.api.client import BossClient
 from boss_agent_cli.auth.manager import AuthManager
-from boss_agent_cli.digest import build_digest
+from boss_agent_cli.digest import build_digest, render_digest_markdown
 from boss_agent_cli.display import handle_auth_errors, handle_output, render_message_panel
 from boss_agent_cli.pipeline_state import build_pipeline_items, select_follow_up_candidates
 
@@ -12,9 +14,21 @@ from boss_agent_cli.pipeline_state import build_pipeline_items, select_follow_up
 @click.command("digest")
 @click.option("--days-stale", default=3, type=int, help="超过 N 天未推进则视为 follow_up")
 @click.option("--now-ts-ms", default=None, type=int, help="测试用：覆盖当前时间戳（毫秒）")
+@click.option(
+	"--format", "output_format",
+	type=click.Choice(["json", "md"]),
+	default="json",
+	help="输出格式（json 走 JSON 信封；md 生成可直接发邮件/飞书的 Markdown）",
+)
+@click.option(
+	"-o", "--output", "output_path",
+	type=click.Path(dir_okay=False, writable=True, path_type=Path),
+	default=None,
+	help="Markdown 输出路径（仅 --format md 时有效，未指定时写到 stdout）",
+)
 @click.pass_context
 @handle_auth_errors("digest")
-def digest_cmd(ctx, days_stale, now_ts_ms):
+def digest_cmd(ctx, days_stale, now_ts_ms, output_format, output_path):
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
 	delay = ctx.obj["delay"]
@@ -41,6 +55,21 @@ def digest_cmd(ctx, days_stale, now_ts_ms):
 		follow_ups=follow_ups,
 		interviews=[item for item in items if item.get("source") == "interview"],
 	)
+
+	if output_format == "md":
+		md_text = render_digest_markdown(data)
+		if output_path:
+			output_path.write_text(md_text, encoding="utf-8")
+			handle_output(
+				ctx,
+				"digest",
+				{"format": "md", "path": str(output_path), "bytes": len(md_text.encode("utf-8"))},
+				hints={"next_actions": [f"open {output_path}", "cat 或邮件客户端直接发送"]},
+			)
+		else:
+			sys.stdout.write(md_text)
+			sys.stdout.flush()
+		return
 
 	handle_output(
 		ctx,

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -458,10 +458,12 @@ SCHEMA_DATA = {
 			"options": {},
 		},
 		"digest": {
-			"description": "汇总新增职位、待跟进会话和面试项的只读日报",
+			"description": "汇总新增职位、待跟进会话和面试项的只读日报（支持 JSON / Markdown 两种输出）",
 			"args": [],
 			"options": {
 				"--days-stale": {"type": "int", "default": 3, "description": "超过 N 天未推进则视为 follow_up"},
+				"--format": {"type": "string", "default": "json", "description": "输出格式（json 信封 / md 可直发邮件飞书）"},
+				"-o, --output": {"type": "string", "default": None, "description": "Markdown 输出路径（仅 --format md 时有效）"},
 			},
 		},
 		"config": {

--- a/src/boss_agent_cli/digest.py
+++ b/src/boss_agent_cli/digest.py
@@ -1,3 +1,6 @@
+import time
+
+
 def build_digest(*, new_matches: list[dict], follow_ups: list[dict], interviews: list[dict]) -> dict:
 	return {
 		"new_match_count": len(new_matches),
@@ -8,3 +11,133 @@ def build_digest(*, new_matches: list[dict], follow_ups: list[dict], interviews:
 		"interviews": interviews,
 		"summary": f"{len(new_matches)} new matches, {len(follow_ups)} follow-ups, {len(interviews)} interviews",
 	}
+
+
+def _escape_md_cell(text: object) -> str:
+	"""Markdown 表格单元格内的 | 和换行转义，防止破坏表格结构。"""
+	s = "" if text is None else str(text)
+	return s.replace("|", "\\|").replace("\n", " ").replace("\r", " ")
+
+
+def _fmt_follow_up(item: dict) -> str:
+	company = _escape_md_cell(item.get("company") or "-")
+	title = _escape_md_cell(item.get("title") or "-")
+	stage = _escape_md_cell(item.get("stage") or "")
+	relation = _escape_md_cell(item.get("relation") or "")
+	unread = item.get("unread") or 0
+	last_msg = _escape_md_cell(item.get("last_msg") or "")
+	last_time = _escape_md_cell(item.get("last_time") or "")
+	reason = _escape_md_cell(item.get("reason") or "")
+	header_parts = [f"**{company}**"]
+	if title and title != "-":
+		header_parts.append(f"· {title}")
+	if relation:
+		header_parts.append(f"· {relation}")
+	if stage:
+		header_parts.append(f"· 阶段：{stage}")
+	if unread:
+		header_parts.append(f"· 未读 {unread}")
+	if last_time:
+		header_parts.append(f"· {last_time}")
+	line = "- " + " ".join(header_parts)
+	if reason:
+		line += f"\n  原因：{reason}"
+	if last_msg and last_msg != "-":
+		line += f"\n  > {last_msg}"
+	return line
+
+
+def _fmt_new_match(item: dict) -> str:
+	company = _escape_md_cell(item.get("company") or "-")
+	title = _escape_md_cell(item.get("title") or "-")
+	relation = _escape_md_cell(item.get("relation") or "")
+	unread = item.get("unread") or 0
+	last_msg = _escape_md_cell(item.get("last_msg") or "")
+	last_time = _escape_md_cell(item.get("last_time") or "")
+	header = f"**{company}**"
+	if title and title != "-":
+		header += f" · {title}"
+	if relation:
+		header += f" · {relation}"
+	if unread:
+		header += f" · 未读 {unread}"
+	if last_time:
+		header += f" · {last_time}"
+	line = f"- {header}"
+	if last_msg and last_msg != "-":
+		line += f"\n  > {last_msg}"
+	return line
+
+
+def _fmt_interview(item: dict) -> str:
+	company = _escape_md_cell(item.get("company") or "-")
+	title = _escape_md_cell(item.get("title") or "-")
+	interview_time = _escape_md_cell(item.get("last_time") or "")
+	status = _escape_md_cell(item.get("last_msg") or "")
+	parts = [f"**{title}**"]
+	if company and company != "-":
+		parts.append(f"（{company}）")
+	if interview_time:
+		parts.append(f"· {interview_time}")
+	if status and status != "-":
+		parts.append(f"· {status}")
+	return "- " + " ".join(parts)
+
+
+def render_digest_markdown(data: dict, *, generated_at: str | None = None) -> str:
+	"""把 build_digest 产出的结构化数据渲染为 Markdown 文本，可直接发邮件/飞书。"""
+	if generated_at is None:
+		generated_at = time.strftime("%Y-%m-%d %H:%M:%S")
+
+	new_matches = data.get("new_matches") or []
+	follow_ups = data.get("follow_ups") or []
+	interviews = data.get("interviews") or []
+
+	lines: list[str] = []
+	lines.append("# 每日求职摘要")
+	lines.append("")
+	lines.append(f"_生成时间：{generated_at}_")
+	lines.append("")
+
+	lines.append("## 核心指标")
+	lines.append("")
+	lines.append("| 维度 | 数量 |")
+	lines.append("|------|------|")
+	lines.append(f"| 新匹配（待回复） | {len(new_matches)} |")
+	lines.append(f"| 待跟进 | {len(follow_ups)} |")
+	lines.append(f"| 面试 | {len(interviews)} |")
+	lines.append("")
+
+	lines.append("## 新匹配")
+	lines.append("")
+	if not new_matches:
+		lines.append("_暂无新匹配_")
+	else:
+		for item in new_matches:
+			lines.append(_fmt_new_match(item))
+	lines.append("")
+
+	lines.append("## 待跟进")
+	lines.append("")
+	if not follow_ups:
+		lines.append("_暂无待跟进_")
+	else:
+		for item in follow_ups:
+			lines.append(_fmt_follow_up(item))
+	lines.append("")
+
+	lines.append("## 面试")
+	lines.append("")
+	if not interviews:
+		lines.append("_暂无面试_")
+	else:
+		for item in interviews:
+			lines.append(_fmt_interview(item))
+	lines.append("")
+
+	lines.append("---")
+	lines.append("")
+	lines.append("_由 `boss digest --format md` 生成 · [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli)_")
+	lines.append("")
+
+	return "\n".join(lines)

--- a/tests/test_digest_command.py
+++ b/tests/test_digest_command.py
@@ -13,9 +13,8 @@ def _ctx_mock(mock_cls):
 	return instance
 
 
-@patch("boss_agent_cli.commands.digest.BossClient")
-@patch("boss_agent_cli.commands.digest.AuthManager")
-def test_digest_command_returns_structured_sections(mock_auth_cls, mock_client_cls):
+def _setup_digest_mocks(mock_client_cls):
+	"""统一 mock 返回值，供多个测试复用。"""
 	mock_client = _ctx_mock(mock_client_cls)
 	mock_client.friend_list.return_value = {
 		"zpData": {
@@ -44,6 +43,13 @@ def test_digest_command_returns_structured_sections(mock_auth_cls, mock_client_c
 			],
 		},
 	}
+	return mock_client
+
+
+@patch("boss_agent_cli.commands.digest.BossClient")
+@patch("boss_agent_cli.commands.digest.AuthManager")
+def test_digest_command_returns_structured_sections(mock_auth_cls, mock_client_cls):
+	_setup_digest_mocks(mock_client_cls)
 
 	runner = CliRunner()
 	result = runner.invoke(cli, ["--json", "digest"])
@@ -60,3 +66,89 @@ def test_digest_is_exposed_in_schema():
 	assert result.exit_code == 0
 	parsed = json.loads(result.output)
 	assert "digest" in parsed["data"]["commands"]
+
+
+# ── --format md 支持 ────────────────────────────────────────
+
+
+@patch("boss_agent_cli.commands.digest.BossClient")
+@patch("boss_agent_cli.commands.digest.AuthManager")
+def test_digest_format_md_writes_markdown_to_stdout(mock_auth_cls, mock_client_cls):
+	"""--format md 未指定 -o 时把 Markdown 写到 stdout，不套 JSON 信封"""
+	_setup_digest_mocks(mock_client_cls)
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["digest", "--format", "md"])
+	assert result.exit_code == 0
+	assert "# 每日求职摘要" in result.output
+	assert "## 核心指标" in result.output
+	assert "## 待跟进" in result.output
+	assert "## 面试" in result.output
+	# 不是 JSON 信封
+	assert not result.output.lstrip().startswith("{")
+
+
+@patch("boss_agent_cli.commands.digest.BossClient")
+@patch("boss_agent_cli.commands.digest.AuthManager")
+def test_digest_format_md_with_output_path_writes_file(mock_auth_cls, mock_client_cls, tmp_path):
+	"""--format md -o <path> 写文件并返回 JSON 信封说明路径"""
+	_setup_digest_mocks(mock_client_cls)
+
+	out = tmp_path / "digest.md"
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "digest", "--format", "md", "-o", str(out)])
+	assert result.exit_code == 0
+
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["format"] == "md"
+	assert parsed["data"]["path"] == str(out)
+	assert parsed["data"]["bytes"] > 0
+
+	content = out.read_text(encoding="utf-8")
+	assert content.startswith("# 每日求职摘要")
+	assert "TestCo" in content
+	assert "Go 开发" in content
+
+
+@patch("boss_agent_cli.commands.digest.BossClient")
+@patch("boss_agent_cli.commands.digest.AuthManager")
+def test_digest_format_md_contains_interview_details(mock_auth_cls, mock_client_cls):
+	"""Markdown 中面试条目应含岗位名 / 公司 / 时间"""
+	_setup_digest_mocks(mock_client_cls)
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["digest", "--format", "md"])
+	assert "Go 开发" in result.output
+	assert "TestCo" in result.output
+	assert "2026-04-14" in result.output
+
+
+@patch("boss_agent_cli.commands.digest.BossClient")
+@patch("boss_agent_cli.commands.digest.AuthManager")
+def test_digest_format_md_handles_empty_sections(mock_auth_cls, mock_client_cls):
+	"""没有任何数据时 md 应写友好占位符而非抛异常"""
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = {"zpData": {"result": []}}
+	mock_client.interview_data.return_value = {"zpData": {"interviewList": []}}
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["digest", "--format", "md"])
+	assert result.exit_code == 0
+	assert "# 每日求职摘要" in result.output
+	# 空段落应有明确占位而非空白
+	assert "暂无" in result.output or "无" in result.output
+
+
+@patch("boss_agent_cli.commands.digest.BossClient")
+@patch("boss_agent_cli.commands.digest.AuthManager")
+def test_digest_format_json_default_unchanged(mock_auth_cls, mock_client_cls):
+	"""未指定 format 时保持原来的 JSON 信封行为不变"""
+	_setup_digest_mocks(mock_client_cls)
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "digest"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert "new_match_count" in parsed["data"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -257,6 +257,16 @@ def test_build_args_digest():
 	assert args == ["digest", "--days-stale", "5"]
 
 
+def test_build_args_digest_format_md():
+	args = _build_args("boss_digest", {"format": "md"})
+	assert args == ["digest", "--format", "md"]
+
+
+def test_build_args_digest_format_md_with_output():
+	args = _build_args("boss_digest", {"format": "md", "output": "/tmp/d.md"})
+	assert args == ["digest", "--format", "md", "-o", "/tmp/d.md"]
+
+
 def test_build_args_config_list():
 	assert _build_args("boss_config", {"action": "list"}) == ["config", "list"]
 


### PR DESCRIPTION
## Summary

ROADMAP v1.8.x「数据可视化」分区收尾。`boss digest` 新增 `--format md` 和 `-o` 选项，产出可直接贴邮件/飞书的 Markdown 日报，无需二次加工。

- `boss digest --format md`：把日报渲染成 Markdown 输出到 stdout
- `boss digest --format md -o report.md`：写入文件并返回 JSON 信封说明路径和字节数
- `--format json`（默认）保持原有 JSON 信封行为不变，不影响现有 Agent 链路
- Markdown 包含核心指标表、新匹配 / 待跟进 / 面试三段落，空段落写「暂无」占位而非抛异常
- 渲染器做了表格内 `|` 和换行转义防止破坏表格结构
- 协议服务 `boss_digest` 工具同步新增 `format` / `output` 参数

## Test plan

- [x] `uv run ruff check src/ tests/ mcp-server/` 全绿
- [x] `uv run pytest tests/ -q` 835 passed（828 → 835，+7）
- [x] 新增测试覆盖：md 输出到 stdout、md 写文件、面试条目字段渲染、空数据占位符、默认 json 行为回归
- [x] MCP `_build_args` `format` 和 `output` 参数覆盖

## Closes

ROADMAP v1.8.x 数据可视化分区最后一项