### PR TITLE
docs: 新增两款智能体开发环境的集成接入示例

### DIFF
--- a/docs/agent-hosts.md
+++ b/docs/agent-hosts.md
@@ -14,6 +14,8 @@
 |---|---|---|
 | Codex | 在终端内直接做 Bash 编排和 JSON 解析 | [Codex](integrations/codex.md) |
 | Claude Code | 通过 skill / 规则文件接入求职动作 | [Claude Code](integrations/claude-code.md) |
+| Cursor | Composer Agent + MCP 或 `.cursor/rules` | [Cursor](integrations/cursor.md) |
+| Windsurf | Cascade Agent + MCP 或 `.windsurfrules` | [Windsurf](integrations/windsurf.md) |
 | Shell Agent | 任意支持 shell tool 的 Agent 框架或自建编排器 | [Shell Agent](integrations/shell-agent.md) |
 | Python SDK 直调 | 自建 Agent / LangGraph / 业务代码直接驱动 OpenAI 或 Claude SDK | [Python SDK](integrations/python-sdk.md) |
 
@@ -21,6 +23,7 @@
 
 - 如果 Agent 原生支持终端和多步工具调用，优先看 `Codex`
 - 如果你已经在用 skill 分发和规则驱动，优先看 `Claude Code`
+- 在 Cursor / Windsurf IDE 里工作，优先把 MCP 服务挂上（见各自文档的「方式一」）
 - 如果你有自己的 Agent 宿主或调度器，优先看 `Shell Agent`
 - 如果要在 Python 代码里直接驱动大模型做工具调用，优先看 `Python SDK 直调`
 

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -1,0 +1,99 @@
+# Cursor Integration Example
+
+适用版本：`boss-agent-cli` 当前 CLI 契约（2026-04-19）
+
+Cursor 是基于 VS Code 的 AI 优先 IDE，Composer 模式的 Agent 可以直接执行终端命令，0.42+ 还支持 MCP 协议接入。本指引给两种接入方式：MCP 原生接入（推荐）和 Shell 命令接入（兜底）。
+
+## 适用场景
+
+- 在 Cursor 里用 Composer Agent 推进完整求职链路
+- 希望 `boss` 命令以 MCP 工具形式暴露给 Cursor，而非依赖 terminal 脚本
+- 已经有 `.cursor/rules/` 规则体系，想追加 BOSS 直聘能力
+
+## 最小接入流程
+
+Cursor 支持两种接入方式，按需二选一。
+
+### 方式一：MCP 服务接入（推荐）
+
+在 Cursor 设置 → MCP 里添加一个 stdio 服务器，指向本仓库的 `mcp-server/server.py`：
+
+```json
+{
+  "mcpServers": {
+    "boss-agent-cli": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "/absolute/path/to/boss-agent-cli",
+        "run",
+        "python",
+        "mcp-server/server.py"
+      ]
+    }
+  }
+}
+```
+
+启用后 Composer 会自动看到 `boss_search` / `boss_detail` / `boss_greet` 等 43 个工具，直接在会话里调用即可。不需要额外粘贴 shell 命令。
+
+### 方式二：Shell 命令接入
+
+在 `.cursor/rules/boss-agent-cli.mdc` 里加入以下规则：
+
+```markdown
+---
+description: BOSS 直聘求职能力
+globs:
+alwaysApply: false
+---
+
+当用户要求搜索岗位 / 查看详情 / 打招呼 / 推进候选进度时：
+1. 先运行 `boss schema` 获取能力与参数
+2. 再运行 `boss status` 检查登录态
+3. 未登录时运行 `boss login`，提示用户扫码
+4. 搜索使用 `boss search <query> --city <city> --welfare <keywords>`
+5. 命中后用 `boss detail <security_id>` 看完整信息
+6. 执行动作用 `boss greet <security_id> <job_id>`
+7. 只读取 stdout JSON；`ok=false` 时读 `error.recovery_action`
+```
+
+最小命令链路：
+
+```bash
+boss schema
+boss status
+boss search "Golang" --city 广州 --welfare "双休,五险一金"
+boss detail <security_id>
+boss greet <security_id> <job_id>
+```
+
+## 解析字段
+
+- `ok`：判断命令是否成功
+- `data`：读取职位、详情或动作结果
+- `hints.next_actions`：决定下一条命令
+- `error.code`：做恢复分流
+- `error.recovery_action`：告诉 Agent 如何修复
+
+## 失败恢复
+
+推荐恢复顺序：
+
+```bash
+boss doctor
+boss status
+boss login
+```
+
+常见分流：
+
+- `AUTH_REQUIRED` / `AUTH_EXPIRED`：重新执行 `boss login`
+- `INVALID_PARAM`：回退到 `boss schema` 校验参数名
+- `RATE_LIMITED`：等待后重试，不要盲目连发 `boss greet`
+- `ACCOUNT_RISK`：启动 CDP Chrome（`boss-chrome` alias），再重试
+
+## 进阶
+
+- 把 `boss ai interview-prep <jd>` / `boss ai chat-coach <chat>` 接入 Composer，让 Cursor 承担简历匹配与沟通辅导
+- 用 `boss digest --format md -o daily.md` 生成每日摘要，Cursor 侧边栏打开预览即可

--- a/docs/integrations/windsurf.md
+++ b/docs/integrations/windsurf.md
@@ -1,0 +1,95 @@
+# Windsurf Integration Example
+
+适用版本：`boss-agent-cli` 当前 CLI 契约（2026-04-19）
+
+Windsurf 是 Codeium 发布的 agentic IDE，Cascade 面板是主力 Agent，支持 MCP 协议和项目级 `.windsurfrules`。本指引给两种接入方式：MCP 原生接入（推荐）和规则文件接入（兜底）。
+
+## 适用场景
+
+- 用 Cascade 跑完整求职链路，让 Agent 自主决定何时 search / detail / greet
+- 希望把 `boss` 能力以 MCP 工具形式注册，而非每次粘贴终端命令
+- 已有 `.windsurfrules` 项目规则，想追加 BOSS 直聘约束
+
+## 最小接入流程
+
+Windsurf 支持两种接入方式，按需二选一。
+
+### 方式一：MCP 服务接入（推荐）
+
+在 Windsurf 设置 → Cascade → MCP Servers 里添加：
+
+```json
+{
+  "mcpServers": {
+    "boss-agent-cli": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "/absolute/path/to/boss-agent-cli",
+        "run",
+        "python",
+        "mcp-server/server.py"
+      ]
+    }
+  }
+}
+```
+
+启用后 Cascade 会自动枚举 `boss_search` / `boss_detail` / `boss_greet` / `boss_ai_*` 等 43 个工具，无需额外提示词。
+
+### 方式二：.windsurfrules 规则接入
+
+在项目根目录 `.windsurfrules` 里追加：
+
+```markdown
+## BOSS 直聘求职能力
+
+当任务涉及搜索岗位、查看职位详情、打招呼或推进求职进度时：
+1. 先运行 `boss schema` 获取能力和参数
+2. 再运行 `boss status` 检查登录态
+3. 未登录时运行 `boss login`，提示用户完成扫码
+4. 搜索使用 `boss search`，优先带 `--welfare` 精准筛选
+5. 命中后用 `boss detail <security_id>` 看完整信息
+6. 执行动作用 `boss greet <security_id> <job_id>`
+7. 只消费 stdout JSON；`ok=false` 时读 `error.recovery_action` 做恢复决策
+```
+
+最小命令链路：
+
+```bash
+boss schema
+boss status
+boss search "Golang" --city 广州 --welfare "双休,五险一金"
+boss detail <security_id>
+boss greet <security_id> <job_id>
+```
+
+## 解析字段
+
+- `ok`：判断命令是否成功
+- `data`：读取职位、详情或动作结果
+- `hints.next_actions`：决定下一条命令
+- `error.code`：做恢复分流
+- `error.recovery_action`：告诉 Cascade 如何修复
+
+## 失败恢复
+
+推荐恢复顺序：
+
+```bash
+boss doctor
+boss status
+boss login
+```
+
+常见分流：
+
+- `AUTH_REQUIRED` / `AUTH_EXPIRED`：重新执行 `boss login`
+- `INVALID_PARAM`：回退到 `boss schema` 校验参数名
+- `RATE_LIMITED`：等待后重试，不要盲目连发 `boss greet`
+- `ACCOUNT_RISK`：启动 CDP Chrome（`boss-chrome` alias），再重试
+
+## 进阶
+
+- 把 `boss ai reply <message>` / `boss ai chat-coach <chat>` 接给 Cascade，让它在沟通过程中提供话术支持
+- 用 `boss digest --format md` 生成每日摘要，Cascade 预览面板直出飞书/邮件可用版

--- a/tests/test_agent_host_examples.py
+++ b/tests/test_agent_host_examples.py
@@ -7,6 +7,8 @@ INDEX_DOC = DOCS_ROOT / "agent-hosts.md"
 HOST_DOCS = {
 	"Codex": DOCS_ROOT / "integrations" / "codex.md",
 	"Claude Code": DOCS_ROOT / "integrations" / "claude-code.md",
+	"Cursor": DOCS_ROOT / "integrations" / "cursor.md",
+	"Windsurf": DOCS_ROOT / "integrations" / "windsurf.md",
 	"Shell Agent": DOCS_ROOT / "integrations" / "shell-agent.md",
 }
 REQUIRED_COMMANDS = [


### PR DESCRIPTION
## Summary

ROADMAP v1.8.x「Agent 集成」分区再进一步，补齐 Cursor 和 Windsurf 两款主流 IDE 的接入示例。每份文档同时给出 MCP 原生接入（推荐）和规则文件接入（兜底）两条路径，让用户按自己的环境二选一。

- `docs/integrations/cursor.md`：Composer Agent + MCP 或 `.cursor/rules`
- `docs/integrations/windsurf.md`：Cascade Agent + MCP 或 `.windsurfrules`
- `docs/agent-hosts.md` 宿主索引表补两条
- `tests/test_agent_host_examples.py` meta 测试覆盖新增示例，守护结构一致性

## Test plan

- [x] `uv run pytest tests/test_agent_host_examples.py -v` 3 passed
- [x] `uv run pytest tests/ -q` 828 passed 全量无回归
- [x] meta 测试校验每份示例含「适用场景 / 最小接入流程 / 失败恢复」段落和核心命令链

## Closes

ROADMAP v1.8.x Agent 集成分区「Codex / Cursor / Windsurf 专用接入示例」