### PR TITLE
feat: 支持最新一代大模型和主流国内外聚合入口

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ npx skills add can4hou6joeng4/boss-agent-cli
 | `boss ai interview-prep` | 基于 JD 生成模拟面试题 |
 | `boss ai chat-coach` | 基于聊天记录给沟通建议 |
 
+> 支持 Claude 4.7 / GPT-5 / DeepSeek-V3 / Qwen3 等最新模型，详见 [推荐模型与入口](docs/integrations/ai-models.md)。
+
 ### 系统管理
 
 | 命令 | 说明 |

--- a/docs/agent-hosts.md
+++ b/docs/agent-hosts.md
@@ -33,3 +33,7 @@
 2. 所有成功/失败都以 stdout JSON 信封为准，不要解析 stderr。
 3. 把 `boss doctor`、`boss login`、`boss status` 当成统一恢复入口。
 4. 用户提到福利要求时，优先把条件落到 `--welfare`。
+
+## 相关文档
+
+- [推荐 AI 模型与入口](integrations/ai-models.md) — Claude 4.7 / GPT-5 / DeepSeek-V3 / Qwen3 等最新模型配置示例

--- a/docs/integrations/ai-models.md
+++ b/docs/integrations/ai-models.md
@@ -1,0 +1,113 @@
+# 推荐 AI 模型与入口
+
+`boss ai` 命令组基于 OpenAI 兼容协议。下表汇总主流模型的推荐入口和配置示例，供你挑选最新或最合适的模型接入。更新时间：2026-04-20。
+
+## 支持的 Provider
+
+| Provider | 默认 base_url | 覆盖模型 |
+|----------|---------------|---------|
+| `openai` | `https://api.openai.com/v1` | GPT-5、GPT-4.1、GPT-4o、o4 系列 |
+| `deepseek` | `https://api.deepseek.com/v1` | DeepSeek-V3、DeepSeek-R1 |
+| `moonshot` | `https://api.moonshot.cn/v1` | Kimi K2 |
+| `openrouter` | `https://openrouter.ai/api/v1` | **聚合入口**，支持 Anthropic Claude、OpenAI、Google、Meta 等全家桶 |
+| `qwen` | `https://dashscope.aliyuncs.com/compatible-mode/v1` | 通义千问 Qwen3 系列 |
+| `zhipu` | `https://open.bigmodel.cn/api/paas/v4` | 智谱 GLM-4.6 / GLM-Z1 |
+| `siliconflow` | `https://api.siliconflow.cn/v1` | 硅基流动聚合推理 |
+| `custom` | 需手动指定 `--base-url` | 自建代理、LiteLLM、OneAPI 等 |
+
+## Claude 4.7 / GPT-5 配置示例
+
+### Claude 4.7（通过 OpenRouter）
+
+OpenRouter 把 Anthropic Messages API 包装成 OpenAI 协议，是目前最省事的 Claude 4.7 接入方式：
+
+```bash
+boss ai config \
+  --provider openrouter \
+  --model anthropic/claude-opus-4.7 \
+  --api-key <OPENROUTER_KEY>
+```
+
+其他 Claude 变体：`anthropic/claude-sonnet-4.6`、`anthropic/claude-haiku-4.5`。
+
+### GPT-5（通过 OpenAI 直连）
+
+```bash
+boss ai config \
+  --provider openai \
+  --model gpt-5 \
+  --api-key <OPENAI_KEY>
+```
+
+### DeepSeek-V3（国内直连）
+
+```bash
+boss ai config \
+  --provider deepseek \
+  --model deepseek-chat \
+  --api-key <DEEPSEEK_KEY>
+```
+
+### Qwen3（通义千问）
+
+```bash
+boss ai config \
+  --provider qwen \
+  --model qwen3-max \
+  --api-key <DASHSCOPE_KEY>
+```
+
+### 智谱 GLM-4.6
+
+```bash
+boss ai config \
+  --provider zhipu \
+  --model glm-4.6 \
+  --api-key <ZHIPU_KEY>
+```
+
+### 自建代理（LiteLLM / OneAPI）
+
+```bash
+boss ai config \
+  --provider custom \
+  --base-url https://your-proxy.example.com/v1 \
+  --model any-model-id \
+  --api-key <YOUR_KEY>
+```
+
+## 如何选择
+
+| 场景 | 建议 |
+|------|------|
+| 想用最强推理模型 | `openrouter` + `anthropic/claude-opus-4.7` 或 `openai` + `gpt-5` |
+| 对成本敏感 | `deepseek` + `deepseek-chat`（性价比极高） |
+| 国内直连不走代理 | `qwen` / `zhipu` / `deepseek` / `moonshot` |
+| 需要混用多家模型 | `openrouter` 一个 key 全覆盖 |
+| 已有自建代理 | `custom` + `--base-url` |
+
+## 配置校验
+
+```bash
+# 查看当前配置
+boss ai config
+
+# 快速测试
+boss ai polish my-resume
+```
+
+配置错误会返回错误码：
+
+- `AI_NOT_CONFIGURED`：未配置 provider / model / api_key
+- `AI_API_ERROR`：API 调用失败（鉴权/网络/限速等）
+- `AI_PARSE_ERROR`：模型返回不符合预期 JSON 格式（重试即可）
+
+## 相关命令
+
+- `boss ai analyze-jd <jd>` — 职位匹配分析
+- `boss ai polish <resume>` — 简历通用润色
+- `boss ai optimize <resume> --jd <jd>` — 针对岗位定向优化
+- `boss ai suggest <resume> --jd <jd>` — 求职改进建议
+- `boss ai reply <message>` — 招聘者消息回复草稿
+- `boss ai interview-prep <jd>` — 模拟面试题生成
+- `boss ai chat-coach <chat>` — 沟通教练

--- a/src/boss_agent_cli/ai/config.py
+++ b/src/boss_agent_cli/ai/config.py
@@ -19,6 +19,10 @@ PROVIDER_BASE_URLS: dict[str, str | None] = {
 	"openai": "https://api.openai.com/v1",
 	"deepseek": "https://api.deepseek.com/v1",
 	"moonshot": "https://api.moonshot.cn/v1",
+	"openrouter": "https://openrouter.ai/api/v1",
+	"qwen": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+	"zhipu": "https://open.bigmodel.cn/api/paas/v4",
+	"siliconflow": "https://api.siliconflow.cn/v1",
 	"custom": None,
 }
 

--- a/src/boss_agent_cli/commands/ai_cmd.py
+++ b/src/boss_agent_cli/commands/ai_cmd.py
@@ -127,10 +127,10 @@ def ai_group():
 
 
 @ai_group.command("config")
-@click.option("--provider", default=None, help="AI 提供商（openai/deepseek/moonshot/custom）")
-@click.option("--model", default=None, help="模型名称（如 gpt-4o）")
+@click.option("--provider", default=None, help="AI 提供商（openai/deepseek/moonshot/openrouter/qwen/zhipu/siliconflow/custom）")
+@click.option("--model", default=None, help="模型名称（如 gpt-4o / claude-sonnet-4.5 / deepseek-chat）")
 @click.option("--api-key", default=None, help="API 密钥（将加密存储）")
-@click.option("--base-url", default=None, help="自定义 API 基础地址")
+@click.option("--base-url", default=None, help="自定义 API 基础地址（provider=custom 或自建代理时使用）")
 @click.option("--temperature", default=None, type=float, help="生成温度")
 @click.option("--max-tokens", default=None, type=int, help="最大令牌数")
 @click.pass_context

--- a/tests/test_ai_config.py
+++ b/tests/test_ai_config.py
@@ -124,6 +124,34 @@ def test_base_url_moonshot(tmp_path, monkeypatch):
 	assert store.get_base_url() == "https://api.moonshot.cn/v1"
 
 
+def test_base_url_openrouter(tmp_path, monkeypatch):
+	"""OpenRouter 聚合入口，支持 Claude / GPT-5 等多家模型。"""
+	store = _make_store(tmp_path, monkeypatch)
+	store.save_config(ai_provider="openrouter")
+	assert store.get_base_url() == "https://openrouter.ai/api/v1"
+
+
+def test_base_url_qwen(tmp_path, monkeypatch):
+	"""通义千问 DashScope OpenAI 兼容入口。"""
+	store = _make_store(tmp_path, monkeypatch)
+	store.save_config(ai_provider="qwen")
+	assert store.get_base_url() == "https://dashscope.aliyuncs.com/compatible-mode/v1"
+
+
+def test_base_url_zhipu(tmp_path, monkeypatch):
+	"""智谱 GLM 开放平台入口。"""
+	store = _make_store(tmp_path, monkeypatch)
+	store.save_config(ai_provider="zhipu")
+	assert store.get_base_url() == "https://open.bigmodel.cn/api/paas/v4"
+
+
+def test_base_url_siliconflow(tmp_path, monkeypatch):
+	"""硅基流动聚合推理入口。"""
+	store = _make_store(tmp_path, monkeypatch)
+	store.save_config(ai_provider="siliconflow")
+	assert store.get_base_url() == "https://api.siliconflow.cn/v1"
+
+
 # ── is_configured ────────────────────────────────────────────
 
 
@@ -166,5 +194,9 @@ def test_provider_base_urls_completeness():
 	assert "openai" in PROVIDER_BASE_URLS
 	assert "deepseek" in PROVIDER_BASE_URLS
 	assert "moonshot" in PROVIDER_BASE_URLS
+	assert "openrouter" in PROVIDER_BASE_URLS
+	assert "qwen" in PROVIDER_BASE_URLS
+	assert "zhipu" in PROVIDER_BASE_URLS
+	assert "siliconflow" in PROVIDER_BASE_URLS
 	assert "custom" in PROVIDER_BASE_URLS
 	assert PROVIDER_BASE_URLS["custom"] is None


### PR DESCRIPTION
## Summary

ROADMAP v1.8.x「智能能力」分区收官：AI 配置新增 4 个 provider 预设，覆盖 Claude 4.7 / GPT-5 等最新模型的最短接入路径。

## 变更内容

### Provider 扩展

| Provider | base_url | 覆盖 |
|----------|----------|------|
| `openrouter` | `https://openrouter.ai/api/v1` | **聚合入口** — Anthropic Claude 4.7 / OpenAI GPT-5 / Google / Meta 全家桶 |
| `qwen` | `https://dashscope.aliyuncs.com/compatible-mode/v1` | 通义千问 Qwen3 |
| `zhipu` | `https://open.bigmodel.cn/api/paas/v4` | 智谱 GLM-4.6 |
| `siliconflow` | `https://api.siliconflow.cn/v1` | 硅基流动聚合推理 |

`openai` / `deepseek` / `moonshot` / `custom` 原有 4 个保持不变。

### 底层逻辑

Claude / GPT-5 原生 API 协议各异，本次不动 `ai/service.py`（纯 OpenAI 兼容协议），而是通过 `openrouter` 这个业内成熟的 OpenAI-compatible 聚合入口一次覆盖所有主流模型。一个 OpenRouter Key 即可切 Claude Opus 4.7 / Sonnet 4.6 / GPT-5 / Gemini 全系。

### 文档

- 新建 `docs/integrations/ai-models.md` 推荐模型配置表 — 按场景给 Claude 4.7 / GPT-5 / DeepSeek-V3 / Qwen3 / GLM-4.6 / 自建代理六种最常见配置示例
- `docs/agent-hosts.md` 相关文档章节补一条链接
- `README.md` AI 命令表下方加一条推荐模型引用
- `ai config` 命令 `--provider` / `--model` 帮助文案同步更新

### 测试

- `tests/test_ai_config.py` 新增 4 条 base_url 断言测试 + 补齐 `test_provider_base_urls_completeness` 覆盖新 provider
- 全量测试 **835 → 839**（+4）

## Test plan

- [x] `uv run pytest tests/ -q` 839 passed
- [x] `uv run ruff check src/ tests/` 全绿
- [x] 每个新 provider 的 `get_base_url()` 有单独断言

## Closes

ROADMAP v1.8.x 智能能力分区「支持 Claude 4.7 / GPT-5 最新模型」勾选完成