### PR TITLE
fix: 清零类型检查基线并切换为阻塞门禁

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,7 @@ jobs:
 
   typecheck:
     runs-on: ubuntu-latest
-    # 静态类型检查：目前以 baseline 形式非阻塞运行，逐模块收敛
-    continue-on-error: true
+    # 静态类型检查：baseline 已清零，切为 blocking
     steps:
       - uses: actions/checkout@v6
 
@@ -98,6 +97,5 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
-      - name: Run mypy (non-blocking baseline)
+      - name: Run mypy
         run: uv run mypy src/boss_agent_cli
-        continue-on-error: true

--- a/CONTRIBUTING.en.md
+++ b/CONTRIBUTING.en.md
@@ -20,7 +20,7 @@ Python **≥ 3.10** is required. We use [`uv`](https://github.com/astral-sh/uv) 
 
 - **Indentation:** tabs (not spaces) — enforced by `ruff format`
 - **Python version:** 3.10+, use `X | Y` union syntax (no `Optional[X]`)
-- **Type checking:** `uv run mypy src/boss_agent_cli` — strict modules are enforced, baseline errors in legacy code are non-blocking for now
+- **Type checking:** `uv run mypy src/boss_agent_cli` — enforced as a blocking CI gate. All new code must pass mypy.
 - **Commit messages:** `type: 中文描述` — the description is written in Chinese even if the code/comments are in English. Valid types: `feat / fix / refactor / docs / test / chore / perf / ci`
   - ✅ `feat: 新增配置管理命令`
   - ❌ `feat: add config command`  (English description)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ uv run pre-commit install
 - 缩进使用 **tab**
 - Python >= 3.10（使用 `X | Y` 联合类型）
 - commit message：`type: 中文描述`（feat / fix / refactor / docs / test / chore）
-- 类型检查（建议本地跑）：`uv run mypy src/boss_agent_cli`（CI 以 baseline 非阻塞运行）
+- 类型检查：`uv run mypy src/boss_agent_cli`（CI 阻塞式门禁，新代码必须零 mypy 错误）
 
 ## 提交流程
 

--- a/src/boss_agent_cli/api/browser_client.py
+++ b/src/boss_agent_cli/api/browser_client.py
@@ -9,6 +9,7 @@ Supports two modes:
 """
 import sys
 from pathlib import Path
+from typing import Any
 
 from patchright.sync_api import sync_playwright
 
@@ -38,10 +39,11 @@ class BrowserSession:
 
 	def __init__(self, cookies: dict, user_agent: str, *, delay: tuple[float, float] = (1.5, 3.0), cdp_url: str | None = None, logger=None):
 		self._throttle = RequestThrottle(delay)
-		self._pw = None
-		self._browser = None
-		self._context = None
-		self._page = None
+		# patchright / BridgeClient 运行时创建；注解为 Any 让 mypy 对外部依赖放行
+		self._pw: Any = None
+		self._browser: Any = None
+		self._context: Any = None
+		self._page: Any = None
 		self._cookies = cookies
 		self._user_agent = user_agent
 		self._started = False
@@ -49,7 +51,7 @@ class BrowserSession:
 		self._is_cdp = False
 		self._own_context = False  # 是否由我们创建的 context（需要在 close 时清理）
 		self._logger = logger
-		self._bridge_client = None
+		self._bridge_client: Any = None
 		self._is_bridge = False
 
 	def _log(self, message: str) -> None:

--- a/src/boss_agent_cli/auth/manager.py
+++ b/src/boss_agent_cli/auth/manager.py
@@ -43,6 +43,7 @@ class AuthManager:
 			force_cdp: 为 True 时跳过 Cookie 提取，CDP 不可用直接报错。
 		"""
 		method = "未知"
+		token: dict | None = None
 
 		if force_cdp:
 			# --cdp 强制模式：跳过 Cookie，CDP 不可用直接抛异常

--- a/src/boss_agent_cli/bridge/daemon.py
+++ b/src/boss_agent_cli/bridge/daemon.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import Any
 
 _PID_FILE = Path.home() / ".boss-agent" / "bridge" / "daemon.pid"
 _LOG_FILE = Path.home() / ".boss-agent" / "bridge" / "daemon.log"
@@ -77,7 +78,7 @@ def start_daemon_background() -> int | None:
 	_ensure_dirs()
 
 	# 跨平台后台启动：用 subprocess.Popen 替代 os.fork
-	kwargs = {}
+	kwargs: dict[str, Any] = {}
 	if sys.platform == "win32":
 		# Windows: DETACHED_PROCESS 标志
 		kwargs["creationflags"] = subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP

--- a/src/boss_agent_cli/commands/chat_utils.py
+++ b/src/boss_agent_cli/commands/chat_utils.py
@@ -1,7 +1,7 @@
 """Chat 共享常量和安全工具函数。"""
 
-# relationType 映射：API 返回值 → 可读标签
-RELATION_LABELS = {1: "对方主动", 2: "我主动", 3: "投递"}
+# relationType 映射：API 返回值 → 可读标签（key 类型放宽为 object，兼容 API 返回 None/未知值走 default）
+RELATION_LABELS: dict[object, str] = {1: "对方主动", 2: "我主动", 3: "投递"}
 FROM_FILTER = {"boss": 1, "me": 2}
 MSG_STATUS_LABELS = {1: "未读", 2: "已读"}
 

--- a/src/boss_agent_cli/resume/models.py
+++ b/src/boss_agent_cli/resume/models.py
@@ -209,8 +209,8 @@ def resume_to_text(resume: ResumeData) -> str:
 
 	if resume.job_intention is not None:
 		lines.append(resume.job_intention.title)
-		for item in resume.job_intention.items:
-			lines.append(f"{item.label}: {item.value}")
+		for ji_item in resume.job_intention.items:
+			lines.append(f"{ji_item.label}: {ji_item.value}")
 		lines.append("")
 
 	for mod in resume.modules:


### PR DESCRIPTION
## Summary

ROADMAP v2.0「架构演进」分区进一步收敛：上一版（#86）以 12 个 baseline error 非阻塞接入 mypy，本版把它们全部修复，切 `typecheck` CI job 为阻塞式门禁。**新代码从此必须零 mypy 错误才能合入 master。**

## 修复明细（12 errors → 0）

| 位置 | 问题类型 | 修复方式 |
|------|---------|---------|
| `api/browser_client.py` × 8 | 类属性初始化为 None 但后续赋非 None 触发 attr-defined | 给 `_pw` / `_browser` / `_context` / `_page` / `_bridge_client` 加 `: Any = None` 注解，交由运行时 patchright 推断 |
| `auth/manager.py:58` | `token: dict` 被赋值 `dict \| None` | 在 login 方法开头显式声明 `token: dict \| None = None` |
| `bridge/daemon.py:89` | Popen `**kwargs` dict 类型太窄导致 no-overload | 给 `kwargs` 加 `dict[str, Any]` 注解 |
| `commands/chat_utils.py:4`（通过 `pipeline_state.py:41`） | `RELATION_LABELS.get(API 返回值)` key 类型不匹配 | 把 `RELATION_LABELS` 类型放宽为 `dict[object, str]`，API 返回 None/未知值走 default |
| `resume/models.py:212` | for 循环变量 `item` 覆盖前面不同类型 | 重命名为 `ji_item` 避免类型混淆 |

## CI 变更

`typecheck` job 去掉 `continue-on-error: true`（job 级 + step 级），变为真正阻塞。mypy 报错从"可见性"升级为"必须修"。

## 文档

- `CONTRIBUTING.md` / `CONTRIBUTING.en.md` 更新 mypy 说明文案：从「non-blocking baseline」改为「blocking gate」

## Test plan

- [x] `uv run mypy src/boss_agent_cli` → **Success: no issues found in 75 source files**
- [x] `uv run pytest tests/ -q` **911 passed** 无回归
- [x] `uv run ruff check src/ tests/ mcp-server/` 全绿
- [x] 运行时行为未变：所有类型修改都是注解层面，不涉及业务逻辑

## 后续 Roadmap

- 逐步给 CLI 命令层 30+ 文件补全类型注解（当前用 `check_untyped_defs=false` 宽松通过）
- 把严格模块白名单从 3 个扩到 20+
- 最终目标：`--strict` 全局