### PR TITLE
feat: 扩展严格类型检查模块白名单至七个

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,8 +85,14 @@ module = [
 	"boss_agent_cli.output",
 	"boss_agent_cli.config",
 	"boss_agent_cli.hooks",
+	"boss_agent_cli.digest",
+	"boss_agent_cli.match_score",
+	"boss_agent_cli.pipeline_state",
+	"boss_agent_cli.index_cache",
 ]
 disallow_untyped_defs = true
+disallow_any_generics = true
+warn_return_any = true
 
 [dependency-groups]
 dev = [

--- a/src/boss_agent_cli/config.py
+++ b/src/boss_agent_cli/config.py
@@ -1,7 +1,8 @@
 import json
 from pathlib import Path
+from typing import Any
 
-DEFAULTS = {
+DEFAULTS: dict[str, Any] = {
 	"default_city": None,
 	"default_salary": None,
 	"request_delay": [1.5, 3.0],
@@ -16,7 +17,7 @@ DEFAULTS = {
 }
 
 
-def load_config(config_path: Path | None) -> dict:
+def load_config(config_path: Path | None) -> dict[str, Any]:
 	cfg = dict(DEFAULTS)
 	if config_path and config_path.exists():
 		with open(config_path) as f:

--- a/src/boss_agent_cli/digest.py
+++ b/src/boss_agent_cli/digest.py
@@ -1,7 +1,8 @@
 import time
+from typing import Any
 
 
-def build_digest(*, new_matches: list[dict], follow_ups: list[dict], interviews: list[dict]) -> dict:
+def build_digest(*, new_matches: list[dict[str, Any]], follow_ups: list[dict[str, Any]], interviews: list[dict[str, Any]]) -> dict[str, Any]:
 	return {
 		"new_match_count": len(new_matches),
 		"follow_up_count": len(follow_ups),
@@ -19,7 +20,7 @@ def _escape_md_cell(text: object) -> str:
 	return s.replace("|", "\\|").replace("\n", " ").replace("\r", " ")
 
 
-def _fmt_follow_up(item: dict) -> str:
+def _fmt_follow_up(item: dict[str, Any]) -> str:
 	company = _escape_md_cell(item.get("company") or "-")
 	title = _escape_md_cell(item.get("title") or "-")
 	stage = _escape_md_cell(item.get("stage") or "")
@@ -47,7 +48,7 @@ def _fmt_follow_up(item: dict) -> str:
 	return line
 
 
-def _fmt_new_match(item: dict) -> str:
+def _fmt_new_match(item: dict[str, Any]) -> str:
 	company = _escape_md_cell(item.get("company") or "-")
 	title = _escape_md_cell(item.get("title") or "-")
 	relation = _escape_md_cell(item.get("relation") or "")
@@ -69,7 +70,7 @@ def _fmt_new_match(item: dict) -> str:
 	return line
 
 
-def _fmt_interview(item: dict) -> str:
+def _fmt_interview(item: dict[str, Any]) -> str:
 	company = _escape_md_cell(item.get("company") or "-")
 	title = _escape_md_cell(item.get("title") or "-")
 	interview_time = _escape_md_cell(item.get("last_time") or "")
@@ -84,7 +85,7 @@ def _fmt_interview(item: dict) -> str:
 	return "- " + " ".join(parts)
 
 
-def render_digest_markdown(data: dict, *, generated_at: str | None = None) -> str:
+def render_digest_markdown(data: dict[str, Any], *, generated_at: str | None = None) -> str:
 	"""把 build_digest 产出的结构化数据渲染为 Markdown 文本，可直接发邮件/飞书。"""
 	if generated_at is None:
 		generated_at = time.strftime("%Y-%m-%d %H:%M:%S")

--- a/src/boss_agent_cli/hooks.py
+++ b/src/boss_agent_cli/hooks.py
@@ -6,10 +6,10 @@ Two hook types:
 """
 import sys
 from dataclasses import dataclass, field
-from typing import Callable
+from typing import Any, Callable
 
-Handler = Callable[[dict], None]
-BailHandler = Callable[[dict], str | bool | None]
+Handler = Callable[[dict[str, Any]], None]
+BailHandler = Callable[[dict[str, Any]], str | bool | None]
 
 
 class SyncHook:
@@ -21,7 +21,7 @@ class SyncHook:
 	def tap(self, name: str, handler: Handler) -> None:
 		self._handlers.append((name, handler))
 
-	def call(self, payload: dict) -> None:
+	def call(self, payload: dict[str, Any]) -> None:
 		for name, handler in self._handlers:
 			try:
 				handler(payload)
@@ -38,7 +38,7 @@ class BailHook:
 	def tap(self, name: str, handler: BailHandler) -> None:
 		self._handlers.append((name, handler))
 
-	def call(self, payload: dict) -> str | bool | None:
+	def call(self, payload: dict[str, Any]) -> str | bool | None:
 		for name, handler in self._handlers:
 			result = handler(payload)
 			if result:

--- a/src/boss_agent_cli/index_cache.py
+++ b/src/boss_agent_cli/index_cache.py
@@ -4,6 +4,9 @@
 import json
 import time
 from pathlib import Path
+from typing import Any, cast
+
+from boss_agent_cli.output import Logger
 
 _CACHE_FILE = "index_cache.json"
 
@@ -12,7 +15,7 @@ def _cache_path(data_dir: Path) -> Path:
 	return data_dir / "cache" / _CACHE_FILE
 
 
-def save_index(data_dir: Path, jobs: list[dict], source: str = "search") -> None:
+def save_index(data_dir: Path, jobs: list[dict[str, Any]], source: str = "search") -> None:
 	"""保存搜索/推荐结果到索引缓存。"""
 	entries = []
 	for job in jobs:
@@ -40,7 +43,7 @@ def save_index(data_dir: Path, jobs: list[dict], source: str = "search") -> None
 	path.write_text(json.dumps(cache_data, ensure_ascii=False, indent=2), encoding="utf-8")
 
 
-def try_save_index(data_dir: Path, jobs: list[dict], *, source: str = "search", logger=None) -> bool:
+def try_save_index(data_dir: Path, jobs: list[dict[str, Any]], *, source: str = "search", logger: Logger | None = None) -> bool:
 	"""Best-effort 保存索引缓存，失败时记录 warning，不影响主命令成功返回。"""
 	try:
 		save_index(data_dir, jobs, source=source)
@@ -51,7 +54,7 @@ def try_save_index(data_dir: Path, jobs: list[dict], *, source: str = "search", 
 		return False
 
 
-def get_job_by_index(data_dir: Path, index: int) -> dict | None:
+def get_job_by_index(data_dir: Path, index: int) -> dict[str, Any] | None:
 	"""按 1-based 编号获取缓存的职位信息。"""
 	path = _cache_path(data_dir)
 	if not path.exists():
@@ -66,10 +69,10 @@ def get_job_by_index(data_dir: Path, index: int) -> dict | None:
 	if index < 1 or index > len(jobs):
 		return None
 
-	return jobs[index - 1]
+	return cast("dict[str, Any]", jobs[index - 1])
 
 
-def get_index_info(data_dir: Path) -> dict:
+def get_index_info(data_dir: Path) -> dict[str, Any]:
 	"""获取缓存元信息（来源、数量、保存时间）。"""
 	path = _cache_path(data_dir)
 	if not path.exists():

--- a/src/boss_agent_cli/match_score.py
+++ b/src/boss_agent_cli/match_score.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from boss_agent_cli.api.models import JobItem
 from boss_agent_cli.search_filters import (
 	SearchFilterCriteria,
@@ -7,7 +9,7 @@ from boss_agent_cli.search_filters import (
 )
 
 
-def _extract_expect_preferences(expect_data: dict | None) -> dict:
+def _extract_expect_preferences(expect_data: dict[str, Any] | None) -> dict[str, Any]:
 	if not expect_data:
 		return {}
 	return {
@@ -31,7 +33,7 @@ def _score_salary(candidate: str, required: str | None, match_reasons: list[str]
 	return 0
 
 
-def score_job_item(job: JobItem, *, criteria: SearchFilterCriteria | None, expect_data: dict | None) -> dict:
+def score_job_item(job: JobItem, *, criteria: SearchFilterCriteria | None, expect_data: dict[str, Any] | None) -> dict[str, Any]:
 	preferences = _extract_expect_preferences(expect_data)
 	match_reasons: list[str] = []
 	mismatch_reasons: list[str] = []
@@ -82,7 +84,7 @@ def score_job_item(job: JobItem, *, criteria: SearchFilterCriteria | None, expec
 	}
 
 
-def score_job_dict(item: dict, *, criteria: SearchFilterCriteria | None, expect_data: dict | None) -> dict:
+def score_job_dict(item: dict[str, Any], *, criteria: SearchFilterCriteria | None, expect_data: dict[str, Any] | None) -> dict[str, Any]:
 	job = JobItem(
 		job_id=item.get("job_id", ""),
 		title=item.get("title", ""),

--- a/src/boss_agent_cli/output.py
+++ b/src/boss_agent_cli/output.py
@@ -9,8 +9,8 @@ def envelope_success(
 	command: str,
 	data: Any,
 	*,
-	pagination: dict | None = None,
-	hints: dict | None = None,
+	pagination: dict[str, Any] | None = None,
+	hints: dict[str, Any] | None = None,
 ) -> str:
 	return json.dumps(
 		{
@@ -33,7 +33,7 @@ def envelope_error(
 	message: str,
 	recoverable: bool = False,
 	recovery_action: str | None = None,
-	hints: dict | None = None,
+	hints: dict[str, Any] | None = None,
 ) -> str:
 	return json.dumps(
 		{

--- a/src/boss_agent_cli/pipeline_state.py
+++ b/src/boss_agent_cli/pipeline_state.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Any
 
 from boss_agent_cli.commands.chat_utils import RELATION_LABELS
 
@@ -13,7 +14,7 @@ def _ts_to_label(ts_ms: int) -> str:
 	return dt.strftime("%m-%d %H:%M")
 
 
-def _chat_stage(item: dict, *, now_ts_ms: int, stale_days: int) -> str:
+def _chat_stage(item: dict[str, Any], *, now_ts_ms: int, stale_days: int) -> str:
 	unread = item.get("unreadMsgCount") or 0
 	relation_type = item.get("relationType")
 	last_ts = item.get("lastTS") or 0
@@ -26,8 +27,8 @@ def _chat_stage(item: dict, *, now_ts_ms: int, stale_days: int) -> str:
 	return "chatting"
 
 
-def build_pipeline_items(*, chat_items: list[dict], interview_items: list[dict], now_ts_ms: int, stale_days: int = 3) -> list[dict]:
-	items = []
+def build_pipeline_items(*, chat_items: list[dict[str, Any]], interview_items: list[dict[str, Any]], now_ts_ms: int, stale_days: int = 3) -> list[dict[str, Any]]:
+	items: list[dict[str, Any]] = []
 
 	for raw in chat_items:
 		items.append(
@@ -67,5 +68,5 @@ def build_pipeline_items(*, chat_items: list[dict], interview_items: list[dict],
 	return sorted(items, key=lambda item: (priority.get(item["stage"], 99), item["company"], item["title"]))
 
 
-def select_follow_up_candidates(items: list[dict]) -> list[dict]:
+def select_follow_up_candidates(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
 	return [item for item in items if item.get("stage") in _FOLLOW_UP_STATES]


### PR DESCRIPTION
## Summary

ROADMAP v2.0「架构演进」继续收敛 mypy 严格化覆盖。严格类型模块白名单从 **3 个扩到 7 个**，新增 4 个 100% 覆盖率的纯函数模块进入 `--strict` 级别的类型保护。

## 白名单变更

| 模块 | 覆盖率 | 角色 |
|------|--------|------|
| `output` | 100% | 基础 JSON 信封封装 |
| `config` | 100% | 配置加载 |
| `hooks` | 100% | 事件钩子系统 |
| **`digest`** 🆕 | 100% | 日报数据聚合 + Markdown 渲染 |
| **`match_score`** 🆕 | 100% | 职位匹配评分 |
| **`pipeline_state`** 🆕 | 100% | 候选进度状态机 |
| **`index_cache`** 🆕 | 95% | 搜索结果索引缓存 |

启用的严格选项（`[[tool.mypy.overrides]]`）：
- `disallow_untyped_defs = true` — 禁止无类型注解函数
- `disallow_any_generics = true` — 禁止裸 `dict` / `list`（必须 `dict[K, V]`）
- `warn_return_any = true` — 返回 Any 时警告

## 代码修复

- 所有白名单模块的裸 `dict` / `list` 都补上泛型参数（大多数改为 `dict[str, Any]`）
- `index_cache.py` 的 `try_save_index` 补 `logger: Logger | None` 精确类型
- `index_cache.get_job_by_index` 对 `cache_data.get("jobs")` 的结果加 `cast` 避免 warn_return_any

## 底层逻辑

严格类型不是一次性切全局，而是**逐模块冷启动**。先从 100% 覆盖率的纯函数模块做起——这些模块最好修、最好维护，一旦进入白名单后续改动自动享受 mypy 保护。

## Test plan

- [x] `uv run mypy src/boss_agent_cli` → **Success: no issues found in 75 source files**
- [x] `uv run pytest tests/ -q` **911 passed** 无回归
- [x] `uv run ruff check src/ tests/ mcp-server/` 全绿
- [x] 新增 4 个模块均通过 `mypy --strict` 单独检查

## 后续 Roadmap

- 逐步把 commands 层补全类型后纳入严格白名单
- 最终目标：`[tool.mypy]` 全局 `strict = true`