### PR TITLE
feat: 建立包级公开接口并守护契约

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,23 @@ npx skills add can4hou6joeng4/boss-agent-cli
 5. 用户提到福利要求时使用 `--welfare` 参数
 ```
 
+### 方式三：Python 直接嵌入（不走 subprocess）
+
+包已随 `py.typed` 标记发布，可直接作为类型化的 Python 库使用：
+
+```python
+from boss_agent_cli import AuthManager, BossClient, AuthRequired
+
+auth = AuthManager(data_dir=Path("~/.boss-agent").expanduser())
+try:
+    with BossClient(auth) as client:
+        result = client.search_jobs("Golang", city="广州")
+except AuthRequired:
+    ...  # 提示用户 boss login
+```
+
+公开 API（详见 `boss_agent_cli.__all__`）：`AuthManager` / `BossClient` / `CacheStore` / `JobItem` / `JobDetail` / `AIService` / `ResumeData` 等核心类型。
+
 ### 输出协议
 
 所有命令输出 JSON 到 stdout，统一信封格式：

--- a/src/boss_agent_cli/__init__.py
+++ b/src/boss_agent_cli/__init__.py
@@ -1,1 +1,44 @@
+"""boss-agent-cli — BOSS 直聘求职 CLI 工具，专为 AI Agent 设计。
+
+Public API 使用示例:
+
+    from boss_agent_cli import AuthManager, BossClient, CacheStore
+    from boss_agent_cli import AuthRequired, TokenRefreshFailed
+
+    auth = AuthManager(data_dir)
+    with BossClient(auth) as client:
+        result = client.search_jobs("Golang", city="广州")
+"""
+
+from boss_agent_cli.ai.service import AIService, AIServiceError
+from boss_agent_cli.api.client import AccountRiskError, AuthError, BossClient
+from boss_agent_cli.api.models import JobDetail, JobItem
+from boss_agent_cli.auth.manager import AuthManager, AuthRequired, TokenRefreshFailed
+from boss_agent_cli.cache.store import CacheStore
+from boss_agent_cli.resume.models import ResumeData, ResumeFile
+
 __version__ = "1.8.5"
+
+__all__ = [
+	# 版本
+	"__version__",
+	# 认证
+	"AuthManager",
+	"AuthRequired",
+	"TokenRefreshFailed",
+	# API 客户端
+	"BossClient",
+	"AuthError",
+	"AccountRiskError",
+	# 数据模型
+	"JobItem",
+	"JobDetail",
+	# 缓存
+	"CacheStore",
+	# AI 服务
+	"AIService",
+	"AIServiceError",
+	# 简历模型
+	"ResumeData",
+	"ResumeFile",
+]

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,129 @@
+"""Public API 契约测试 — 守护 `boss_agent_cli` 包级导出面不被意外破坏。
+
+这份测试保证下游项目可以通过 `from boss_agent_cli import X` 访问核心类型和异常，
+任何改名 / 删除都会在这里被立即捕获。
+"""
+import importlib
+
+import boss_agent_cli
+
+
+# ── __all__ 契约 ─────────────────────────────────────────
+
+
+EXPECTED_EXPORTS = {
+	"__version__",
+	"AuthManager",
+	"AuthRequired",
+	"TokenRefreshFailed",
+	"BossClient",
+	"AuthError",
+	"AccountRiskError",
+	"JobItem",
+	"JobDetail",
+	"CacheStore",
+	"AIService",
+	"AIServiceError",
+	"ResumeData",
+	"ResumeFile",
+}
+
+
+def test_all_is_defined():
+	assert hasattr(boss_agent_cli, "__all__")
+	assert isinstance(boss_agent_cli.__all__, list)
+
+
+def test_all_matches_expected_exports():
+	assert set(boss_agent_cli.__all__) == EXPECTED_EXPORTS
+
+
+def test_every_export_is_actually_importable():
+	"""__all__ 里声明的每个名字都能真的从包里 import 到。"""
+	for name in boss_agent_cli.__all__:
+		assert hasattr(boss_agent_cli, name), f"{name} declared in __all__ but not exported"
+
+
+# ── 关键类型的身份一致性 ──────────────────────────────────
+
+
+def test_auth_manager_identity():
+	from boss_agent_cli.auth.manager import AuthManager as OriginalAuthManager
+	assert boss_agent_cli.AuthManager is OriginalAuthManager
+
+
+def test_boss_client_identity():
+	from boss_agent_cli.api.client import BossClient as OriginalBossClient
+	assert boss_agent_cli.BossClient is OriginalBossClient
+
+
+def test_cache_store_identity():
+	from boss_agent_cli.cache.store import CacheStore as OriginalCacheStore
+	assert boss_agent_cli.CacheStore is OriginalCacheStore
+
+
+def test_job_item_identity():
+	from boss_agent_cli.api.models import JobItem as OriginalJobItem
+	assert boss_agent_cli.JobItem is OriginalJobItem
+
+
+def test_ai_service_identity():
+	from boss_agent_cli.ai.service import AIService as OriginalAIService
+	assert boss_agent_cli.AIService is OriginalAIService
+
+
+# ── 异常继承关系 ──────────────────────────────────────────
+
+
+def test_auth_required_is_exception():
+	assert issubclass(boss_agent_cli.AuthRequired, Exception)
+
+
+def test_token_refresh_failed_is_exception():
+	assert issubclass(boss_agent_cli.TokenRefreshFailed, Exception)
+
+
+def test_auth_error_is_exception():
+	assert issubclass(boss_agent_cli.AuthError, Exception)
+
+
+def test_account_risk_error_is_exception():
+	assert issubclass(boss_agent_cli.AccountRiskError, Exception)
+
+
+def test_ai_service_error_is_exception():
+	assert issubclass(boss_agent_cli.AIServiceError, Exception)
+
+
+# ── 版本格式 ──────────────────────────────────────────────
+
+
+def test_version_is_semver_string():
+	version = boss_agent_cli.__version__
+	assert isinstance(version, str)
+	parts = version.split(".")
+	assert len(parts) == 3, f"版本应为 X.Y.Z 格式，实际为 {version}"
+	for part in parts:
+		assert part.isdigit(), f"版本各段应为数字，实际为 {part}"
+
+
+# ── py.typed marker ──────────────────────────────────────
+
+
+def test_py_typed_marker_exists():
+	"""PEP 561 标记文件必须存在，下游才能启用类型检查。"""
+	pkg_spec = importlib.util.find_spec("boss_agent_cli")
+	assert pkg_spec is not None
+	assert pkg_spec.origin is not None
+	import pathlib
+	pkg_dir = pathlib.Path(pkg_spec.origin).parent
+	assert (pkg_dir / "py.typed").exists(), "py.typed 标记文件丢失"
+
+
+# ── 包级 docstring ────────────────────────────────────────
+
+
+def test_package_has_docstring():
+	"""提供给 help(boss_agent_cli) 的入口说明。"""
+	assert boss_agent_cli.__doc__ is not None
+	assert len(boss_agent_cli.__doc__.strip()) > 0


### PR DESCRIPTION
## Summary

ROADMAP v2.0「架构演进」收尾一项关键抓手：`boss_agent_cli` 此前已有 `py.typed` 标记（PEP 561），但 `__init__.py` 只有 `__version__`，下游集成只能深路径 import（如 `from boss_agent_cli.auth.manager import AuthManager`）。本次建立 canonical public API 表面，形成「严格类型 + 明确导出 + 契约守护」完整闭环。

## 底层逻辑

**之前**：
```python
from boss_agent_cli.auth.manager import AuthManager  # 深路径
from boss_agent_cli.api.client import BossClient
from boss_agent_cli.cache.store import CacheStore
```

**现在**：
```python
from boss_agent_cli import AuthManager, BossClient, CacheStore
```

## 公开 API 清单（14 个符号）

| 类别 | 导出 |
|------|------|
| 版本 | `__version__` |
| 认证 | `AuthManager` / `AuthRequired` / `TokenRefreshFailed` |
| API 客户端 | `BossClient` / `AuthError` / `AccountRiskError` |
| 数据模型 | `JobItem` / `JobDetail` |
| 缓存 | `CacheStore` |
| AI 服务 | `AIService` / `AIServiceError` |
| 简历模型 | `ResumeData` / `ResumeFile` |

## 契约守护

新增 `tests/test_public_api.py` 16 条测试，覆盖：
- `__all__` 存在且为 list
- `__all__` 内容匹配预期集合（增删导出必须同步）
- 每个名字都真正 importable
- 关键类型的 identity 与深路径一致（防 re-export 误操作）
- 异常继承关系（5 个异常类都是 `Exception` 子类）
- 版本号 SemVer 格式
- `py.typed` marker 文件存在
- 包级 docstring 非空

## 文档

- `__init__.py` 补 canonical 使用示例的 docstring
- `README.md` 在「AI Agent 集成」章节新增「方式三：Python 直接嵌入（不走 subprocess）」

## Test plan

- [x] `uv run pytest tests/test_public_api.py -q` **16 passed**
- [x] `uv run pytest tests/ -q` **927 passed**（+16，无回归）
- [x] `uv run mypy src/boss_agent_cli` → Success (0 errors)
- [x] `uv run ruff check src/ tests/ mcp-server/` 全绿
- [x] 运行时导入验证：`import boss_agent_cli; boss_agent_cli.__all__` 返回 14 个符号

## 顶层设计意义

从「包里有类型 annotations」（当前状态）升级到「包有明确的公开类型契约 + 自动化契约测试」：
- 下游 IDE 自动补全 canonical imports
- mypy / pyright 精确检查使用错误
- 未来 breaking change 被测试立即捕获