### PR TITLE
chore: 发布版本 1.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ## [Unreleased]
 
+## [1.8.6] - 2026-04-20
+
+### Added
+- **包级公开接口**（#94）— `boss_agent_cli.__all__` 导出 14 个核心符号（AuthManager / BossClient / CacheStore / JobItem / JobDetail / AIService / ResumeData 等），下游项目可直接 `from boss_agent_cli import X` 使用，不再需要深路径 import
+- `tests/test_public_api.py` 16 条契约测试守护 public API（identity 一致性 / 异常继承 / SemVer 版本格式 / py.typed marker 存在）
+- `README.md` 新增「方式三：Python 直接嵌入」章节，给出 canonical 使用示例
+
+### Changed
+- `src/boss_agent_cli/__init__.py` 补完整 docstring 说明包的公开 API 契约
+
 ## [1.8.5] - 2026-04-20
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "boss-agent-cli"
-version = "1.8.5"
+version = "1.8.6"
 description = "AI Agent 专用的 BOSS 直聘求职 CLI 工具"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/boss_agent_cli/__init__.py
+++ b/src/boss_agent_cli/__init__.py
@@ -17,7 +17,7 @@ from boss_agent_cli.auth.manager import AuthManager, AuthRequired, TokenRefreshF
 from boss_agent_cli.cache.store import CacheStore
 from boss_agent_cli.resume.models import ResumeData, ResumeFile
 
-__version__ = "1.8.5"
+__version__ = "1.8.6"
 
 __all__ = [
 	# 版本

--- a/uv.lock
+++ b/uv.lock
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "boss-agent-cli"
-version = "1.8.5"
+version = "1.8.6"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },


### PR DESCRIPTION
## Summary

版本 1.8.5 → 1.8.6（patch release），聚合 PR #94「包级公开接口 + 契约测试」。

## 核心变更
- 建立 canonical public API（14 个核心符号）
- 16 条契约测试守护 API 稳定性
- README 新增「Python 直接嵌入」章节

## 发布流程
```bash
git checkout master && git pull
git tag v1.8.6 && git push origin v1.8.6
```

## Test plan
- [x] 全量 927 passed
- [x] `uv run mypy src/boss_agent_cli` → 0 errors
- [x] `import boss_agent_cli` 导出 14 个 canonical 符号