### PR TITLE
feat: 扩展严格类型检查模块白名单至十一个

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,10 @@ module = [
 	"boss_agent_cli.match_score",
 	"boss_agent_cli.pipeline_state",
 	"boss_agent_cli.index_cache",
+	"boss_agent_cli.chat_summary",
+	"boss_agent_cli.search_filters",
+	"boss_agent_cli.resume.models",
+	"boss_agent_cli.resume.store",
 ]
 disallow_untyped_defs = true
 disallow_any_generics = true

--- a/src/boss_agent_cli/chat_summary.py
+++ b/src/boss_agent_cli/chat_summary.py
@@ -1,4 +1,7 @@
-def summarize_messages(messages: list[dict], *, friend_uid: str) -> dict:
+from typing import Any
+
+
+def summarize_messages(messages: list[dict[str, Any]], *, friend_uid: str) -> dict[str, Any]:
 	stage = "new"
 	pending_action = "review"
 	key_facts: list[str] = []

--- a/src/boss_agent_cli/resume/models.py
+++ b/src/boss_agent_cli/resume/models.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Any
 
 
 @dataclass
@@ -62,7 +63,7 @@ class ResumeModule:
 	id: str
 	title: str
 	icon: str = ""
-	rows: list[dict] = field(default_factory=list)
+	rows: list[dict[str, Any]] = field(default_factory=list)
 
 
 @dataclass
@@ -79,7 +80,7 @@ class ResumeData:
 	created_at: str = ""
 	updated_at: str = ""
 
-	def __post_init__(self):
+	def __post_init__(self) -> None:
 		now = datetime.now().isoformat()
 		if not self.created_at:
 			self.created_at = now
@@ -93,7 +94,7 @@ class ResumeFile:
 
 	version: str = "1.0"
 	data: ResumeData | None = None
-	metadata: dict = field(
+	metadata: dict[str, Any] = field(
 		default_factory=lambda: {
 			"exported_at": "",
 			"app_version": "",
@@ -102,9 +103,9 @@ class ResumeFile:
 	)
 
 
-def resume_to_dict(resume: ResumeData) -> dict:
+def resume_to_dict(resume: ResumeData) -> dict[str, Any]:
 	"""将 ResumeData 转为可 JSON 序列化的 dict"""
-	d: dict = {
+	d: dict[str, Any] = {
 		"name": resume.name,
 		"title": resume.title,
 		"center_title": resume.center_title,
@@ -139,7 +140,7 @@ def resume_to_dict(resume: ResumeData) -> dict:
 	return d
 
 
-def dict_to_resume(data: dict) -> ResumeData:
+def dict_to_resume(data: dict[str, Any]) -> ResumeData:
 	"""从 dict 恢复 ResumeData（处理嵌套对象）"""
 	pi_data = data.get("personal_info") or data.get("personalInfoSection") or {}
 	pi_items = [

--- a/src/boss_agent_cli/resume/store.py
+++ b/src/boss_agent_cli/resume/store.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 from boss_agent_cli.resume.models import ResumeData, ResumeFile, dict_to_resume, resume_to_dict
 
@@ -20,9 +21,9 @@ class ResumeStore:
 	def _path_for(self, name: str) -> Path:
 		return self._dir / f"{_safe_filename(name)}.json"
 
-	def list_all(self) -> list[dict]:
+	def list_all(self) -> list[dict[str, Any]]:
 		"""列出所有简历摘要（name, title, updated_at）"""
-		results: list[dict] = []
+		results: list[dict[str, Any]] = []
 		for path in sorted(self._dir.glob("*.json")):
 			try:
 				raw = json.loads(path.read_text(encoding="utf-8"))

--- a/src/boss_agent_cli/search_filters.py
+++ b/src/boss_agent_cli/search_filters.py
@@ -5,6 +5,7 @@ Centralizes filtering logic shared by search, batch-greet, and export commands.
 import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
+from typing import Any
 
 from boss_agent_cli.api.models import JobItem
 
@@ -111,7 +112,7 @@ class SearchPipelineStats:
 
 @dataclass
 class SearchPipelineResult:
-	items: list[dict] = field(default_factory=list)
+	items: list[dict[str, Any]] = field(default_factory=list)
 	has_more: bool = False
 	total: int | None = None
 	last_page: int = 0
@@ -120,7 +121,7 @@ class SearchPipelineResult:
 
 # ── List-page prefilter ─────────────────────────────────────────────
 
-def prefilter_job(raw_item: dict, criteria: SearchFilterCriteria) -> tuple[bool, list[str]]:
+def prefilter_job(raw_item: dict[str, Any], criteria: SearchFilterCriteria) -> tuple[bool, list[str]]:
 	"""Fast prefilter using list-page fields only. Returns (pass, rejection_reasons)."""
 	reasons: list[str] = []
 
@@ -183,7 +184,7 @@ def match_all_welfare(
 	return results
 
 
-def _fetch_and_check(client, welfare_conditions, raw_item) -> dict | None:
+def _fetch_and_check(client: Any, welfare_conditions: list[tuple[str, list[str]]], raw_item: dict[str, Any]) -> dict[str, Any] | None:
 	"""Single job: fetch detail + welfare match. 不访问 cache（线程安全）。"""
 	welfare_list = raw_item.get("welfareList", [])
 	try:
@@ -204,7 +205,14 @@ def _fetch_and_check(client, welfare_conditions, raw_item) -> dict | None:
 	return None
 
 
-def _check_details_parallel(client, cache, logger, welfare_conditions, items, matched):
+def _check_details_parallel(
+	client: Any,
+	cache: Any,
+	logger: Any,
+	welfare_conditions: list[tuple[str, list[str]]],
+	items: list[dict[str, Any]],
+	matched: list[dict[str, Any]],
+) -> None:
 	"""Parallel detail check, append matched to list. cache 操作在主线程完成。"""
 	with ThreadPoolExecutor(max_workers=_WELFARE_WORKERS) as pool:
 		futures = {
@@ -233,9 +241,9 @@ def _check_details_parallel(client, cache, logger, welfare_conditions, items, ma
 # ── Main pipeline ───────────────────────────────────────────────────
 
 def run_search_pipeline(
-	client,
-	cache,
-	logger,
+	client: Any,
+	cache: Any,
+	logger: Any,
 	*,
 	criteria: SearchFilterCriteria,
 	start_page: int = 1,
@@ -246,7 +254,7 @@ def run_search_pipeline(
 ) -> SearchPipelineResult:
 	"""Run the full search pipeline: API search → list prefilter → welfare detail fallback."""
 	stats = SearchPipelineStats()
-	matched: list[dict] = []
+	matched: list[dict[str, Any]] = []
 	current_page = start_page
 	last_page_scanned = 0
 	has_more = False


### PR DESCRIPTION
## Summary

ROADMAP v2.0「架构演进」继续收敛 mypy 严格化。严格类型模块白名单从 **7 个扩到 11 个**，新增 4 个模块进入 `--strict` 级别保护。

## 白名单变更

| 模块 | 状态 |
|------|------|
| output | 已严格 |
| config | 已严格 |
| hooks | 已严格 |
| digest | 已严格 |
| match_score | 已严格 |
| pipeline_state | 已严格 |
| index_cache | 已严格 |
| **chat_summary** 🆕 | 聊天消息结构化摘要 |
| **search_filters** 🆕 | 搜索结果预过滤 + 并行详情检查 |
| **resume/models** 🆕 | 简历数据模型 |
| **resume/store** 🆕 | 简历本地存储 |

## 代码修复

- 所有目标模块的裸 `dict` / `list` 补上泛型参数（统一 `dict[str, Any]`）
- `search_filters._check_details_parallel` 修正 welfare_conditions 参数类型（实际为 `list[tuple[str, list[str]]]` 而非 `list[str]`）
- `resume/models.ResumeData.__post_init__` 补 `-> None` 注解
- `search_filters._fetch_and_check` / `_check_details_parallel` / `run_search_pipeline` 给 BossClient / CacheStore / Logger 协作参数加 `Any` 类型

## 底层逻辑

严格类型不是一次切全局，而是**逐模块冷启动**。本轮覆盖的 4 个模块都是：
- 覆盖率 ≥ 94%（resume/store 94%，其他 100%）
- 纯函数或简单状态持有者
- 不涉及外部 I/O mock 复杂度

下一步：推进 commands 层的简单命令（如 cities / schema / history / show 等）进入严格白名单。

## Test plan

- [x] `uv run mypy src/boss_agent_cli` → **Success: no issues found in 75 source files**
- [x] `uv run pytest tests/ -q` **927 passed** 无回归
- [x] `uv run ruff check src/ tests/ mcp-server/` 全绿
- [x] 单独跑 `mypy --strict` 验证 4 个新模块各自独立通过

## 关联

v2.0 架构演进剩余：Bridge gRPC 调研（#96 新开）