### PR TITLE
chore: 发布版本 1.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ## [Unreleased]
 
+## [1.8.7] - 2026-04-20
+
+### Changed
+- **严格类型检查白名单扩至 11 个模块**（#97）— 新增 `chat_summary` / `search_filters` / `resume/models` / `resume/store`，所有这些模块现在强制 `disallow_untyped_defs` + `disallow_any_generics` + `warn_return_any`
+- 所有白名单模块的裸 `dict` / `list` 补上泛型参数
+- `search_filters._check_details_parallel` 修正 `welfare_conditions` 参数类型为 `list[tuple[str, list[str]]]`
+
+### Added
+- Issue #96「Bridge 协议 HTTP/WS → gRPC 升级调研」— 按多平台适配器（#90）的调研先行模式，为 v2.0 架构演进剩余一项锁定调研清单
+
 ## [1.8.6] - 2026-04-20
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "boss-agent-cli"
-version = "1.8.6"
+version = "1.8.7"
 description = "AI Agent 专用的 BOSS 直聘求职 CLI 工具"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/boss_agent_cli/__init__.py
+++ b/src/boss_agent_cli/__init__.py
@@ -17,7 +17,7 @@ from boss_agent_cli.auth.manager import AuthManager, AuthRequired, TokenRefreshF
 from boss_agent_cli.cache.store import CacheStore
 from boss_agent_cli.resume.models import ResumeData, ResumeFile
 
-__version__ = "1.8.6"
+__version__ = "1.8.7"
 
 __all__ = [
 	# 版本

--- a/uv.lock
+++ b/uv.lock
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "boss-agent-cli"
-version = "1.8.6"
+version = "1.8.7"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },


### PR DESCRIPTION
## Summary

版本 1.8.6 → 1.8.7（patch release），聚合 PR #97 mypy 严格白名单扩展 + Issue #96 Bridge gRPC 调研任务书。

## 核心变更
- 严格类型模块白名单 7 → 11 个（#97）
- Bridge gRPC 调研 issue #96 建立

## 发布流程
```bash
git checkout master && git pull
git tag v1.8.7 && git push origin v1.8.7
```

## Test plan
- [x] 全量 927 passed
- [x] `uv run mypy src/boss_agent_cli` → 0 errors（11 严格模块）