### PR TITLE
feat: 严格类型检查白名单扩至十七个

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,12 @@ module = [
 	"boss_agent_cli.search_filters",
 	"boss_agent_cli.resume.models",
 	"boss_agent_cli.resume.store",
+	"boss_agent_cli.commands.cities",
+	"boss_agent_cli.commands.chat_utils",
+	"boss_agent_cli.commands.history",
+	"boss_agent_cli.commands.login",
+	"boss_agent_cli.commands.logout",
+	"boss_agent_cli.commands.recommend",
 ]
 disallow_untyped_defs = true
 disallow_any_generics = true

--- a/src/boss_agent_cli/commands/cities.py
+++ b/src/boss_agent_cli/commands/cities.py
@@ -6,7 +6,7 @@ from boss_agent_cli.display import handle_output, render_string_grid
 
 @click.command("cities")
 @click.pass_context
-def cities_cmd(ctx):
+def cities_cmd(ctx: click.Context) -> None:
 	"""列出所有支持的城市"""
 	cities = sorted(CITY_CODES.keys())
 	handle_output(

--- a/src/boss_agent_cli/commands/history.py
+++ b/src/boss_agent_cli/commands/history.py
@@ -10,7 +10,7 @@ from boss_agent_cli.display import handle_auth_errors, handle_output, render_job
 @click.option("--page", default=1, help="页码")
 @click.pass_context
 @handle_auth_errors("history")
-def history_cmd(ctx, page):
+def history_cmd(ctx: click.Context, page: int) -> None:
 	"""查看最近浏览过的职位"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]

--- a/src/boss_agent_cli/commands/login.py
+++ b/src/boss_agent_cli/commands/login.py
@@ -9,7 +9,7 @@ from boss_agent_cli.output import emit_error, emit_success
 @click.option("--cookie-source", default=None, help="指定浏览器提取 Cookie（如 chrome/firefox/edge），不指定则自动检测")
 @click.option("--cdp", is_flag=True, default=False, help="强制 CDP 模式（跳过 Cookie 提取，CDP 不可用直接报错）")
 @click.pass_context
-def login_cmd(ctx, timeout, cookie_source, cdp):
+def login_cmd(ctx: click.Context, timeout: int, cookie_source: str | None, cdp: bool) -> None:
 	"""登录 BOSS 直聘（三级降级：Cookie 提取 → CDP 自动探测 → patchright 扫码）"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]

--- a/src/boss_agent_cli/commands/logout.py
+++ b/src/boss_agent_cli/commands/logout.py
@@ -6,7 +6,7 @@ from boss_agent_cli.output import emit_error, emit_success
 
 @click.command("logout")
 @click.pass_context
-def logout_cmd(ctx):
+def logout_cmd(ctx: click.Context) -> None:
 	"""退出登录，清除本地保存的登录态"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]

--- a/src/boss_agent_cli/commands/recommend.py
+++ b/src/boss_agent_cli/commands/recommend.py
@@ -14,7 +14,7 @@ from boss_agent_cli.match_score import score_job_dict
 @click.option("--with-score", is_flag=True, default=False, help="附加匹配分和原因")
 @click.pass_context
 @handle_auth_errors("recommend")
-def recommend_cmd(ctx, page, with_score):
+def recommend_cmd(ctx: click.Context, page: int, with_score: bool) -> None:
 	"""基于简历的个性化职位推荐"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]

--- a/src/boss_agent_cli/display.py
+++ b/src/boss_agent_cli/display.py
@@ -270,7 +270,7 @@ def render_export_summary(data: dict) -> None:
 # ── Auth error decorator ─────────────────────────────────────────────
 
 
-def handle_auth_errors(command_name: str):
+def handle_auth_errors(command_name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
 	"""装饰器：统一处理 AuthRequired / TokenRefreshFailed / Exception 三层捕获。
 
 	用法:
@@ -280,9 +280,9 @@ def handle_auth_errors(command_name: str):
 	"""
 	from functools import wraps
 
-	def decorator(func):
+	def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
 		@wraps(func)
-		def wrapper(ctx, *args, **kwargs):
+		def wrapper(ctx: Any, *args: Any, **kwargs: Any) -> Any:
 			from boss_agent_cli.api.client import AccountRiskError
 			from boss_agent_cli.auth.manager import AuthRequired, TokenRefreshFailed
 			try:


### PR DESCRIPTION
## Summary

ROADMAP v2.0「架构演进」mypy 严格化连续第三轮推进。白名单从 **11 个扩到 17 个**，首次覆盖 CLI 命令层。

## 本轮新增

| 模块 | 角色 | 覆盖率 |
|------|------|-------|
| `commands/cities` | 城市列表查询 | 100% |
| `commands/chat_utils` | Chat 共享常量和工具函数 | 100% |
| `commands/history` | 浏览历史 | 100%（注解补全后） |
| `commands/login` | 登录命令 | 100% |
| `commands/logout` | 退出登录 | 100% |
| `commands/recommend` | 个性化推荐 | 100% |

## 关键改动

### CLI 命令函数类型注解
所有命令函数签名从 `def cmd(ctx, ...)` 升级为 `def cmd(ctx: click.Context, ...) -> None`，参数类型按 click.option 配置精确标注。

### `handle_auth_errors` 装饰器类型注解（display.py）
这个装饰器被 11+ 个命令使用，此前因无类型注解**污染所有被装饰函数**，导致它们无法通过 mypy --strict。本次补全：
```python
def handle_auth_errors(command_name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
	def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
		@wraps(func)
		def wrapper(ctx: Any, *args: Any, **kwargs: Any) -> Any:
			...
```

这个改动解锁了下一批命令模块（pipeline/digest/greet/apply 等）进入严格白名单的可能性。

## 底层逻辑

第一轮（#86/#88）建基线 → 第二轮（#92）纯函数 → 第三轮（本 PR）装饰器 + CLI 命令。每轮都是"修一个系统级阻塞点 + 带一批模块进严格"。下一轮可以啃 pipeline / digest_cmd / interviews 等剩余命令。

## Test plan

- [x] `uv run mypy src/boss_agent_cli` → **Success: no issues found in 75 source files**
- [x] `uv run pytest tests/ -q` **927 passed** 无回归
- [x] `uv run ruff check src/ tests/ mcp-server/` 全绿
- [x] 6 个新模块单独跑 `mypy --strict` 独立通过