### PR TITLE
chore: 发布版本 1.8.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## [Unreleased]
 
+## [1.8.8] - 2026-04-20
+
+### Changed
+- **严格类型检查白名单扩至 17 个模块**（#99）— 首次覆盖 CLI 命令层：`commands/cities` / `commands/chat_utils` / `commands/history` / `commands/login` / `commands/logout` / `commands/recommend`
+- `display.handle_auth_errors` 装饰器补全类型注解，解锁下游 11+ 个命令的严格化路径
+- 所有目标命令的 `def cmd(ctx, ...)` 签名升级为 `def cmd(ctx: click.Context, ...) -> None`
+
 ## [1.8.7] - 2026-04-20
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "boss-agent-cli"
-version = "1.8.7"
+version = "1.8.8"
 description = "AI Agent 专用的 BOSS 直聘求职 CLI 工具"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/boss_agent_cli/__init__.py
+++ b/src/boss_agent_cli/__init__.py
@@ -17,7 +17,7 @@ from boss_agent_cli.auth.manager import AuthManager, AuthRequired, TokenRefreshF
 from boss_agent_cli.cache.store import CacheStore
 from boss_agent_cli.resume.models import ResumeData, ResumeFile
 
-__version__ = "1.8.7"
+__version__ = "1.8.8"
 
 __all__ = [
 	# 版本

--- a/uv.lock
+++ b/uv.lock
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "boss-agent-cli"
-version = "1.8.7"
+version = "1.8.8"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },


### PR DESCRIPTION
## Summary

版本 1.8.7 → 1.8.8（patch release），聚合 PR #99 严格类型白名单首次覆盖 CLI 命令层。

## 核心变更
- 严格类型模块 11 → 17 个（首次覆盖 CLI 命令层）
- `handle_auth_errors` 装饰器类型注解补全

## 发布流程
```bash
git checkout master && git pull
git tag v1.8.8 && git push origin v1.8.8
```

## Test plan
- [x] 全量 927 passed
- [x] mypy → 0 errors（17 严格模块）