### PR TITLE
chore: 发布版本 1.8.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## [Unreleased]
 
+## [1.8.9] - 2026-04-20
+
+### Changed
+- **严格类型检查白名单扩至 24 个模块**（#101）— 本轮新增 CLI 命令层 7 个：`apply` / `chatmsg` / `digest` / `exchange` / `interviews` / `pipeline` / `status`
+- 所有 7 个命令签名升级为 `def cmd(ctx: click.Context, ...) -> None`
+- `pipeline._collect_pipeline_items` 返回类型精确标注为 `list[dict[str, Any]]`
+
 ## [1.8.8] - 2026-04-20
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "boss-agent-cli"
-version = "1.8.8"
+version = "1.8.9"
 description = "AI Agent 专用的 BOSS 直聘求职 CLI 工具"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/boss_agent_cli/__init__.py
+++ b/src/boss_agent_cli/__init__.py
@@ -17,7 +17,7 @@ from boss_agent_cli.auth.manager import AuthManager, AuthRequired, TokenRefreshF
 from boss_agent_cli.cache.store import CacheStore
 from boss_agent_cli.resume.models import ResumeData, ResumeFile
 
-__version__ = "1.8.8"
+__version__ = "1.8.9"
 
 __all__ = [
 	# 版本

--- a/uv.lock
+++ b/uv.lock
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "boss-agent-cli"
-version = "1.8.8"
+version = "1.8.9"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },


### PR DESCRIPTION
## Summary

版本 1.8.8 → 1.8.9，聚合 PR #101 严格类型白名单扩展。

## 核心变更
- 严格类型模块 17 → 24 个（CLI 命令层覆盖 13/32 = 40%）

## 发布流程
```bash
git checkout master && git pull
git tag v1.8.9 && git push origin v1.8.9
```

## Test plan
- [x] 全量 927 passed
- [x] mypy → 0 errors（24 严格模块）