### PR TITLE
feat: 严格类型检查白名单扩至三十二个

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,14 @@ module = [
 	"boss_agent_cli.commands.interviews",
 	"boss_agent_cli.commands.pipeline",
 	"boss_agent_cli.commands.status",
+	"boss_agent_cli.commands.me",
+	"boss_agent_cli.commands.show",
+	"boss_agent_cli.commands.mark",
+	"boss_agent_cli.commands.clean",
+	"boss_agent_cli.commands.shortlist",
+	"boss_agent_cli.commands.chat_snapshot",
+	"boss_agent_cli.commands.preset",
+	"boss_agent_cli.commands.watch",
 ]
 disallow_untyped_defs = true
 disallow_any_generics = true

--- a/src/boss_agent_cli/commands/chat_snapshot.py
+++ b/src/boss_agent_cli/commands/chat_snapshot.py
@@ -3,11 +3,14 @@
 import datetime
 import json
 import os
+from typing import Any
+
+from boss_agent_cli.output import Logger
 
 
 def save_snapshot_and_diff(
-	snapshot_dir: str, friends: list[dict], logger
-) -> dict:
+	snapshot_dir: str, friends: list[dict[str, Any]], logger: Logger
+) -> dict[str, Any]:
 	"""保存当日 JSON 快照（按 security_id 合并）并与上次对比。"""
 	os.makedirs(snapshot_dir, exist_ok=True)
 	today = datetime.date.today().isoformat()
@@ -73,7 +76,7 @@ def save_snapshot_and_diff(
 	}
 
 
-def load_snapshot(path: str, logger) -> list[dict] | None:
+def load_snapshot(path: str, logger: Logger) -> list[dict[str, Any]] | None:
 	"""加载并校验快照文件，返回 None 表示不可用。"""
 	try:
 		with open(path, encoding="utf-8") as f:

--- a/src/boss_agent_cli/commands/clean.py
+++ b/src/boss_agent_cli/commands/clean.py
@@ -16,7 +16,7 @@ from boss_agent_cli.display import handle_output
 @click.option("--all", "clean_all", is_flag=True, default=False, help="清理全部缓存（包括未过期的搜索缓存和打招呼记录）")
 @click.option("--days", default=30, help="清理超过指定天数的快照和导出文件")
 @click.pass_context
-def clean_cmd(ctx, dry_run, clean_all, days):
+def clean_cmd(ctx: click.Context, dry_run: bool, clean_all: bool, days: int) -> None:
 	"""清理过期缓存和临时文件。"""
 	data_dir = ctx.obj["data_dir"]
 	results = []
@@ -59,7 +59,7 @@ def clean_cmd(ctx, dry_run, clean_all, days):
 		"total_bytes_freed_display": _format_size(total_freed),
 	}
 
-	hints = {"next_actions": []}
+	hints: dict[str, list[str]] = {"next_actions": []}
 	if dry_run:
 		hints["next_actions"].append("boss clean — 执行实际清理")
 	else:

--- a/src/boss_agent_cli/commands/mark.py
+++ b/src/boss_agent_cli/commands/mark.py
@@ -32,7 +32,7 @@ def _resolve_label(label_input: str) -> int:
 @click.option("--remove", is_flag=True, default=False, help="移除标签（默认为添加）")
 @click.pass_context
 @handle_auth_errors("mark")
-def mark_cmd(ctx, security_id, label, remove):
+def mark_cmd(ctx: click.Context, security_id: str, label: str, remove: bool) -> None:
 	"""给联系人添加/移除标签"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]

--- a/src/boss_agent_cli/commands/me.py
+++ b/src/boss_agent_cli/commands/me.py
@@ -10,7 +10,7 @@ from boss_agent_cli.display import handle_error_output, handle_output, render_se
 	help="只获取指定部分（不指定则获取全部）")
 @click.option("--deliver-page", default=1, type=int, help="投递记录页码")
 @click.pass_context
-def me_cmd(ctx, section, deliver_page):
+def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 	"""获取当前登录用户的个人信息、简历、求职期望、投递记录"""
 	data_dir = ctx.obj["data_dir"]
 	delay = ctx.obj["delay"]

--- a/src/boss_agent_cli/commands/preset.py
+++ b/src/boss_agent_cli/commands/preset.py
@@ -11,7 +11,18 @@ from boss_agent_cli.cache.store import CacheStore
 from boss_agent_cli.display import handle_error_output, handle_output
 
 
-def _build_params(query, city, salary, experience, education, industry, scale, stage, job_type, welfare) -> dict:
+def _build_params(
+	query: str,
+	city: str | None,
+	salary: str | None,
+	experience: str | None,
+	education: str | None,
+	industry: str | None,
+	scale: str | None,
+	stage: str | None,
+	job_type: str | None,
+	welfare: str | None,
+) -> dict[str, str | None]:
 	return {
 		"query": query,
 		"city": city,
@@ -27,7 +38,7 @@ def _build_params(query, city, salary, experience, education, industry, scale, s
 
 
 @click.group("preset")
-def preset_group():
+def preset_group() -> None:
 	"""管理可复用搜索预设。"""
 
 
@@ -44,7 +55,20 @@ def preset_group():
 @click.option("--job-type", default=None, type=click.Choice(list(JOB_TYPE_CODES.keys()), case_sensitive=False), help="职位类型")
 @click.option("--welfare", default=None, help="福利筛选")
 @click.pass_context
-def preset_add_cmd(ctx, name, query, city, salary, experience, education, industry, scale, stage, job_type, welfare):
+def preset_add_cmd(
+	ctx: click.Context,
+	name: str,
+	query: str,
+	city: str | None,
+	salary: str | None,
+	experience: str | None,
+	education: str | None,
+	industry: str | None,
+	scale: str | None,
+	stage: str | None,
+	job_type: str | None,
+	welfare: str | None,
+) -> None:
 	if city and city not in CITY_CODES:
 		handle_error_output(ctx, "preset", code="INVALID_PARAM", message=f"未知城市: {city}")
 		return
@@ -62,7 +86,7 @@ def preset_add_cmd(ctx, name, query, city, salary, experience, education, indust
 
 @preset_group.command("list")
 @click.pass_context
-def preset_list_cmd(ctx):
+def preset_list_cmd(ctx: click.Context) -> None:
 	with CacheStore(ctx.obj["data_dir"] / "cache" / "boss_agent.db") as cache:
 		items = cache.list_saved_searches()
 	handle_output(
@@ -76,7 +100,7 @@ def preset_list_cmd(ctx):
 @preset_group.command("remove")
 @click.argument("name")
 @click.pass_context
-def preset_remove_cmd(ctx, name):
+def preset_remove_cmd(ctx: click.Context, name: str) -> None:
 	with CacheStore(ctx.obj["data_dir"] / "cache" / "boss_agent.db") as cache:
 		removed = cache.delete_saved_search(name)
 	handle_output(ctx, "preset", {"action": "remove", "name": name, "removed": removed})

--- a/src/boss_agent_cli/commands/shortlist.py
+++ b/src/boss_agent_cli/commands/shortlist.py
@@ -5,7 +5,7 @@ from boss_agent_cli.display import handle_output, render_simple_list
 
 
 @click.group("shortlist")
-def shortlist_group():
+def shortlist_group() -> None:
 	"""管理职位候选池。"""
 
 
@@ -18,7 +18,7 @@ def shortlist_group():
 @click.option("--salary", default="", help="薪资")
 @click.option("--source", default="manual", help="来源，如 search/recommend/show/manual")
 @click.pass_context
-def shortlist_add_cmd(ctx, security_id, job_id, title, company, city, salary, source):
+def shortlist_add_cmd(ctx: click.Context, security_id: str, job_id: str, title: str, company: str, city: str, salary: str, source: str) -> None:
 	with CacheStore(ctx.obj["data_dir"] / "cache" / "boss_agent.db") as cache:
 		cache.add_shortlist(
 			{
@@ -50,7 +50,7 @@ def shortlist_add_cmd(ctx, security_id, job_id, title, company, city, salary, so
 
 @shortlist_group.command("list")
 @click.pass_context
-def shortlist_list_cmd(ctx):
+def shortlist_list_cmd(ctx: click.Context) -> None:
 	with CacheStore(ctx.obj["data_dir"] / "cache" / "boss_agent.db") as cache:
 		items = cache.list_shortlist()
 	handle_output(
@@ -76,7 +76,7 @@ def shortlist_list_cmd(ctx):
 @click.argument("security_id")
 @click.argument("job_id")
 @click.pass_context
-def shortlist_remove_cmd(ctx, security_id, job_id):
+def shortlist_remove_cmd(ctx: click.Context, security_id: str, job_id: str) -> None:
 	with CacheStore(ctx.obj["data_dir"] / "cache" / "boss_agent.db") as cache:
 		removed = cache.remove_shortlist(security_id, job_id)
 	handle_output(

--- a/src/boss_agent_cli/commands/show.py
+++ b/src/boss_agent_cli/commands/show.py
@@ -11,7 +11,7 @@ from boss_agent_cli.index_cache import get_index_info, get_job_by_index
 @click.argument("index", type=int)
 @click.pass_context
 @handle_auth_errors("show")
-def show_cmd(ctx, index):
+def show_cmd(ctx: click.Context, index: int) -> None:
 	"""按编号查看搜索/推荐结果中的职位详情（如 boss show 3）"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]

--- a/src/boss_agent_cli/commands/watch.py
+++ b/src/boss_agent_cli/commands/watch.py
@@ -14,7 +14,18 @@ from boss_agent_cli.display import handle_auth_errors, handle_error_output, hand
 from boss_agent_cli.search_filters import SearchFilterCriteria, resolve_welfare_keywords, run_search_pipeline
 
 
-def _parse_watch_filters(query, city, salary, experience, education, industry, scale, stage, job_type, welfare) -> tuple[dict, list[tuple[str, list[str]]] | None]:
+def _parse_watch_filters(
+	query: str,
+	city: str | None,
+	salary: str | None,
+	experience: str | None,
+	education: str | None,
+	industry: str | None,
+	scale: str | None,
+	stage: str | None,
+	job_type: str | None,
+	welfare: str | None,
+) -> tuple[dict[str, str | None], list[tuple[str, list[str]]] | None]:
 	params = {
 		"query": query,
 		"city": city,
@@ -35,7 +46,7 @@ def _parse_watch_filters(query, city, salary, experience, education, industry, s
 
 
 @click.group("watch")
-def watch_group():
+def watch_group() -> None:
 	"""保存搜索条件并执行增量监控。"""
 
 
@@ -52,7 +63,20 @@ def watch_group():
 @click.option("--job-type", default=None, type=click.Choice(list(JOB_TYPE_CODES.keys()), case_sensitive=False), help="职位类型")
 @click.option("--welfare", default=None, help="福利筛选")
 @click.pass_context
-def watch_add_cmd(ctx, name, query, city, salary, experience, education, industry, scale, stage, job_type, welfare):
+def watch_add_cmd(
+	ctx: click.Context,
+	name: str,
+	query: str,
+	city: str | None,
+	salary: str | None,
+	experience: str | None,
+	education: str | None,
+	industry: str | None,
+	scale: str | None,
+	stage: str | None,
+	job_type: str | None,
+	welfare: str | None,
+) -> None:
 	if city and city not in CITY_CODES:
 		handle_error_output(ctx, "watch", code="INVALID_PARAM", message=f"未知城市: {city}")
 		return
@@ -69,7 +93,7 @@ def watch_add_cmd(ctx, name, query, city, salary, experience, education, industr
 
 @watch_group.command("list")
 @click.pass_context
-def watch_list_cmd(ctx):
+def watch_list_cmd(ctx: click.Context) -> None:
 	with CacheStore(ctx.obj["data_dir"] / "cache" / "boss_agent.db") as cache:
 		items = cache.list_saved_searches()
 	handle_output(ctx, "watch", items, hints={"next_actions": ["boss watch run <name>", "boss watch remove <name>"]})
@@ -78,7 +102,7 @@ def watch_list_cmd(ctx):
 @watch_group.command("remove")
 @click.argument("name")
 @click.pass_context
-def watch_remove_cmd(ctx, name):
+def watch_remove_cmd(ctx: click.Context, name: str) -> None:
 	with CacheStore(ctx.obj["data_dir"] / "cache" / "boss_agent.db") as cache:
 		removed = cache.delete_saved_search(name)
 	handle_output(ctx, "watch", {"action": "remove", "name": name, "removed": removed})
@@ -88,7 +112,7 @@ def watch_remove_cmd(ctx, name):
 @click.argument("name")
 @click.pass_context
 @handle_auth_errors("watch")
-def watch_run_cmd(ctx, name):
+def watch_run_cmd(ctx: click.Context, name: str) -> None:
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
 	delay = ctx.obj["delay"]


### PR DESCRIPTION
## Summary

mypy 严格化连续第五轮，白名单 24 → **32**，CLI 命令层覆盖 13/32 → **21/32 (66%)**。

## 本轮新增 8 个模块

| 模块 | 说明 |
|------|------|
| `commands/me` | 用户信息 |
| `commands/show` | 按编号查看 |
| `commands/mark` | 联系人标签 |
| `commands/clean` | 清理缓存 |
| `commands/shortlist` | 候选池（3 个子命令） |
| `commands/chat_snapshot` | JSON 快照 + diff |
| `commands/preset` | 搜索预设（3 个子命令） |
| `commands/watch` | 增量监控（4 个子命令） |

## 代码修复

- 所有命令函数签名升级为 `def cmd(ctx: click.Context, ...) -> None`
- `preset._build_params` / `watch._parse_watch_filters` 给 10 个参数逐个精确标注 `str | None` 类型
- `chat_snapshot` 导入 `boss_agent_cli.output.Logger` 替代裸 `logger` 参数
- `clean.hints` 变量声明为 `dict[str, list[str]]`

## Test plan

- [x] `uv run mypy src/boss_agent_cli` → Success (0 errors, 32 严格模块)
- [x] `uv run pytest tests/ -q` **927 passed** 无回归
- [x] `uv run ruff check src/ tests/ mcp-server/` 全绿