### PR TITLE
chore: 发布版本 1.8.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## [Unreleased]
 
+## [1.8.10] - 2026-04-20
+
+### Changed
+- **严格类型检查白名单扩至 32 个模块**（#103）— 新增 8 个 CLI 命令：`me` / `show` / `mark` / `clean` / `shortlist` / `chat_snapshot` / `preset` / `watch`
+- CLI 命令层严格覆盖率从 40% (13/32) 提升至 **66% (21/32)**
+- `preset` / `watch` 的参数构造器给 10 个参数逐个精确标注 `str | None`
+- `chat_snapshot` 使用 `boss_agent_cli.output.Logger` 替代裸 `logger` 参数
+
 ## [1.8.9] - 2026-04-20
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "boss-agent-cli"
-version = "1.8.9"
+version = "1.8.10"
 description = "AI Agent 专用的 BOSS 直聘求职 CLI 工具"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/boss_agent_cli/__init__.py
+++ b/src/boss_agent_cli/__init__.py
@@ -17,7 +17,7 @@ from boss_agent_cli.auth.manager import AuthManager, AuthRequired, TokenRefreshF
 from boss_agent_cli.cache.store import CacheStore
 from boss_agent_cli.resume.models import ResumeData, ResumeFile
 
-__version__ = "1.8.9"
+__version__ = "1.8.10"
 
 __all__ = [
 	# 版本

--- a/uv.lock
+++ b/uv.lock
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "boss-agent-cli"
-version = "1.8.9"
+version = "1.8.10"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },


### PR DESCRIPTION
## Summary
版本 1.8.9 → 1.8.10，聚合 PR #103 mypy 严格化第五轮。

## 核心变更
- 严格类型白名单 24 → 32（CLI 命令层 21/32 = 66%）

## Test plan
- [x] 全量 927 passed
- [x] mypy → 0 errors