### PR TITLE
feat: 严格类型检查白名单扩至三十八个

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,12 @@ module = [
 	"boss_agent_cli.commands.chat_snapshot",
 	"boss_agent_cli.commands.preset",
 	"boss_agent_cli.commands.watch",
+	"boss_agent_cli.commands.search",
+	"boss_agent_cli.commands.greet",
+	"boss_agent_cli.commands.chat",
+	"boss_agent_cli.commands.detail",
+	"boss_agent_cli.commands.doctor",
+	"boss_agent_cli.commands.export",
 ]
 disallow_untyped_defs = true
 disallow_any_generics = true

--- a/src/boss_agent_cli/commands/chat.py
+++ b/src/boss_agent_cli/commands/chat.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+from typing import Any
 
 import click
 
@@ -34,7 +35,7 @@ _escape_md_cell = escape_md_cell
 	help="输出文件路径（不指定则自动保存到配置的 export_dir）")
 @click.pass_context
 @handle_auth_errors("chat")
-def chat_cmd(ctx, page, from_who, days, export_fmt, output_path):
+def chat_cmd(ctx: click.Context, page: int, from_who: str | None, days: int | None, export_fmt: str | None, output_path: str | None) -> None:
 	"""查看沟通列表（支持按发起方、时间筛选，支持导出）"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
@@ -162,7 +163,7 @@ def chat_cmd(ctx, page, from_who, days, export_fmt, output_path):
 		if days is not None:
 			title += f"（最近 {days} 天）"
 
-		def _render(data):
+		def _render(data: list[dict[str, Any]]) -> None:
 			render_simple_list(
 				data,
 				title,

--- a/src/boss_agent_cli/commands/detail.py
+++ b/src/boss_agent_cli/commands/detail.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+from typing import Any
+
 import click
 
 from boss_agent_cli.api.client import BossClient
@@ -12,7 +15,7 @@ from boss_agent_cli.display import handle_auth_errors, handle_error_output, hand
 @click.option("--job-id", default="", help="职位加密 ID（提供时走 httpx 快速通道，跳过浏览器）")
 @click.pass_context
 @handle_auth_errors("detail")
-def detail_cmd(ctx, security_id, lid, job_id):
+def detail_cmd(ctx: click.Context, security_id: str, lid: str, job_id: str) -> None:
 	"""查看职位完整信息（职位描述、地址、招聘者信息）"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
@@ -51,7 +54,7 @@ def detail_cmd(ctx, security_id, lid, job_id):
 	handle_output(ctx, "detail", result, render=render_job_detail, hints=hints)
 
 
-def _detail_via_httpx(client, security_id, job_id, data_dir):
+def _detail_via_httpx(client: BossClient, security_id: str, job_id: str, data_dir: Path) -> dict[str, Any] | None:
 	"""快速通道：通过 httpx 获取职位详情（不需要浏览器）"""
 	raw = client.job_detail(job_id)
 	zp = raw.get("zpData", {})
@@ -84,7 +87,7 @@ def _detail_via_httpx(client, security_id, job_id, data_dir):
 	}
 
 
-def _detail_via_browser(client, security_id, lid, data_dir):
+def _detail_via_browser(client: BossClient, security_id: str, lid: str, data_dir: Path) -> dict[str, Any] | None:
 	"""兜底通道：通过浏览器 job_card 获取职位详情"""
 	raw = client.job_card(security_id, lid)
 	card = raw.get("zpData", {}).get("jobCard", {})

--- a/src/boss_agent_cli/commands/doctor.py
+++ b/src/boss_agent_cli/commands/doctor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
+from typing import Any
 
 import click
 import httpx
@@ -14,15 +15,15 @@ from boss_agent_cli.display import handle_output, render_simple_list
 
 @click.command("doctor")
 @click.pass_context
-def doctor_cmd(ctx):
+def doctor_cmd(ctx: click.Context) -> None:
 	"""诊断本地运行环境、依赖和登录条件。"""
 	data_dir = ctx.obj["data_dir"]
 	auth = AuthManager(data_dir)
 	cdp_url = ctx.obj.get("cdp_url")
 
-	checks: list[dict] = []
+	checks: list[dict[str, Any]] = []
 
-	def add_check(name: str, status: str, detail: str, hint: str = ""):
+	def add_check(name: str, status: str, detail: str, hint: str | None = "") -> None:
 		checks.append({
 			"name": name,
 			"status": status,
@@ -54,7 +55,7 @@ def doctor_cmd(ctx):
 		Path.home() / ".cache" / "ms-playwright",
 		Path.home() / "Library" / "Caches" / "ms-playwright",
 	]
-	chromium_candidates = []
+	chromium_candidates: list[Path] = []
 	for base in patchright_browser_dirs:
 		if base.exists():
 			chromium_candidates.extend(base.glob("chromium-*"))

--- a/src/boss_agent_cli/commands/export.py
+++ b/src/boss_agent_cli/commands/export.py
@@ -1,6 +1,7 @@
 import csv
 import html as _html
 import json
+from typing import Any
 
 import click
 
@@ -19,7 +20,7 @@ from boss_agent_cli.display import handle_auth_errors, handle_output, render_exp
 @click.option("--output", "-o", default=None, help="输出文件路径（不指定则输出到 stdout JSON 信封）")
 @click.pass_context
 @handle_auth_errors("export")
-def export_cmd(ctx, query, city, salary, count, fmt, output):
+def export_cmd(ctx: click.Context, query: str, city: str | None, salary: str | None, count: int, fmt: str, output: str | None) -> None:
 	"""导出搜索结果为 CSV 或 JSON 文件"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
@@ -28,7 +29,7 @@ def export_cmd(ctx, query, city, salary, count, fmt, output):
 
 	auth = AuthManager(data_dir, logger=logger)
 	with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
-		all_items = []
+		all_items: list[dict[str, Any]] = []
 		page = 1
 		max_pages = (count + 14) // 15  # 每页约 15 条
 
@@ -85,7 +86,7 @@ def export_cmd(ctx, query, city, salary, count, fmt, output):
 			)
 
 
-def _write_to_file(items: list[dict], fmt: str, path: str):
+def _write_to_file(items: list[dict[str, Any]], fmt: str, path: str) -> None:
 	if fmt == "json":
 		with open(path, "w", encoding="utf-8") as f:
 			json.dump(items, f, ensure_ascii=False, indent=2)
@@ -120,7 +121,7 @@ def _sanitize_csv_cell(value: str) -> str:
 	return value
 
 
-def _write_html(items: list[dict], path: str):
+def _write_html(items: list[dict[str, Any]], path: str) -> None:
 	"""将搜索结果导出为 HTML 表格。"""
 	esc = _html.escape
 	if not items:

--- a/src/boss_agent_cli/commands/greet.py
+++ b/src/boss_agent_cli/commands/greet.py
@@ -28,7 +28,7 @@ from boss_agent_cli.display import (
 @click.option("--message", default="", help="自定义打招呼消息")
 @click.pass_context
 @handle_auth_errors("greet")
-def greet_cmd(ctx, security_id, job_id, message):
+def greet_cmd(ctx: click.Context, security_id: str, job_id: str, message: str) -> None:
 	"""向指定招聘者打招呼"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
@@ -109,7 +109,7 @@ def greet_cmd(ctx, security_id, job_id, message):
 @click.option("--dry-run", is_flag=True, default=False, help="仅模拟执行，不实际打招呼")
 @click.pass_context
 @handle_auth_errors("batch-greet")
-def batch_greet_cmd(ctx, query, city, salary, experience, education, industry, scale, stage, job_type, count, dry_run):
+def batch_greet_cmd(ctx: click.Context, query: str, city: str | None, salary: str | None, experience: str | None, education: str | None, industry: str | None, scale: str | None, stage: str | None, job_type: str | None, count: int, dry_run: bool) -> None:
 	"""搜索后批量打招呼（上限 10）"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]

--- a/src/boss_agent_cli/commands/search.py
+++ b/src/boss_agent_cli/commands/search.py
@@ -39,7 +39,7 @@ from boss_agent_cli.search_filters import (
 @click.option("--with-score", is_flag=True, default=False, help="附加匹配分和原因")
 @click.pass_context
 @handle_auth_errors("search")
-def search_cmd(ctx, query, preset, city, salary, experience, education, industry, scale, stage, job_type, welfare, page, no_cache, with_score):
+def search_cmd(ctx: click.Context, query: str, preset: str | None, city: str | None, salary: str | None, experience: str | None, education: str | None, industry: str | None, scale: str | None, stage: str | None, job_type: str | None, welfare: str | None, page: int, no_cache: bool, with_score: bool) -> None:
 	"""按关键词和筛选条件搜索职位列表"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]


### PR DESCRIPTION
## Summary

mypy 严格化连续第六轮，白名单 32 → **38**，CLI 命令层覆盖达 **84% (27/32)**。

## 本轮新增 6 个命令

| 模块 | 说明 |
|------|------|
| `commands/search` | 搜索（复杂参数组合） |
| `commands/greet` | 打招呼 + 批量打招呼 |
| `commands/chat` | 沟通列表 + 多格式导出 |
| `commands/detail` | 职位详情（httpx / browser 双通道） |
| `commands/doctor` | 环境诊断 |
| `commands/export` | 导出 CSV/JSON/HTML |

## 代码修复

- 所有命令签名升级为 `def cmd(ctx: click.Context, ...) -> None` + 具体参数类型
- `detail._detail_via_httpx` / `_detail_via_browser` 精确标注 `BossClient`/`str`/`Path` 参数
- `doctor.add_check` 的 `hint` 参数支持 `str | None`
- `doctor.chromium_candidates` 显式声明 `list[Path]`
- `export.all_items` 显式声明 `list[dict[str, Any]]`
- `export._write_to_file` / `_write_html` 补返回类型和泛型

## Test plan

- [x] `uv run mypy src/boss_agent_cli` → 0 errors
- [x] `uv run pytest tests/ -q` 927 passed 无回归
- [x] `uv run ruff check src/ tests/ mcp-server/` 全绿