### PR TITLE
feat: 严格类型检查白名单扩至四十一个

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,9 @@ module = [
 	"boss_agent_cli.commands.detail",
 	"boss_agent_cli.commands.doctor",
 	"boss_agent_cli.commands.export",
+	"boss_agent_cli.commands.schema",
+	"boss_agent_cli.commands.chat_export",
+	"boss_agent_cli.commands.config_cmd",
 ]
 disallow_untyped_defs = true
 disallow_any_generics = true

--- a/src/boss_agent_cli/commands/chat_export.py
+++ b/src/boss_agent_cli/commands/chat_export.py
@@ -5,20 +5,21 @@ import datetime
 import html as _html
 import io
 import json
+from typing import Any
 
 from boss_agent_cli.commands.chat_utils import sanitize_csv_cell, escape_md_cell, GROUP_ORDER
 
 
 def prepare_render_data(
-	friends: list[dict],
+	friends: list[dict[str, Any]],
 	from_who: str | None,
-	diff_result: dict,
-) -> dict:
+	diff_result: dict[str, Any],
+) -> dict[str, Any]:
 	"""公共数据准备：分组、统计、diff 标记、渲染顺序。供 MD/HTML 共用。"""
 	now_str = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
 
 	# 按 relationType 分组
-	groups: dict[str, list[dict]] = {}
+	groups: dict[str, list[dict[str, Any]]] = {}
 	for item in friends:
 		key = item.get("initiated_by", "未知")
 		groups.setdefault(key, []).append(item)
@@ -111,11 +112,11 @@ def prepare_render_data(
 
 
 def render_export(
-	friends: list[dict],
+	friends: list[dict[str, Any]],
 	fmt: str,
 	from_who: str | None,
 	days: int | None,
-	diff_result: dict,
+	diff_result: dict[str, Any],
 ) -> str:
 	"""将沟通列表渲染为指定格式的字符串。"""
 	if fmt == "json":
@@ -127,7 +128,7 @@ def render_export(
 	return _render_markdown(friends, from_who, days, diff_result)
 
 
-def _render_csv(friends: list[dict]) -> str:
+def _render_csv(friends: list[dict[str, Any]]) -> str:
 	"""渲染为 CSV 格式（含公式注入防护）。"""
 	if not friends:
 		return ""
@@ -146,10 +147,10 @@ def _render_csv(friends: list[dict]) -> str:
 
 
 def _render_markdown(
-	friends: list[dict],
+	friends: list[dict[str, Any]],
 	from_who: str | None,
 	days: int | None,
-	diff_result: dict,
+	diff_result: dict[str, Any],
 ) -> str:
 	"""渲染为分组 Markdown 格式，含摘要和 diff 标记。"""
 	rd = prepare_render_data(friends, from_who, diff_result)
@@ -218,10 +219,10 @@ def _render_markdown(
 
 
 def _render_html(
-	friends: list[dict],
+	friends: list[dict[str, Any]],
 	from_who: str | None,
 	days: int | None,
-	diff_result: dict,
+	diff_result: dict[str, Any],
 ) -> str:
 	"""渲染为 HTML 格式，含分组、diff 标记和 security_id 映射。"""
 	esc = _html.escape

--- a/src/boss_agent_cli/commands/config_cmd.py
+++ b/src/boss_agent_cli/commands/config_cmd.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
+from typing import Any
 
 import click
 
@@ -12,7 +14,7 @@ from boss_agent_cli.display import handle_output, render_simple_list
 
 @click.group("config", invoke_without_command=True)
 @click.pass_context
-def config_group(ctx):
+def config_group(ctx: click.Context) -> None:
 	"""查看和修改配置项。不带子命令时显示当前全部配置。"""
 	if ctx.invoked_subcommand is None:
 		ctx.invoke(config_list_cmd)
@@ -20,7 +22,7 @@ def config_group(ctx):
 
 @config_group.command("list")
 @click.pass_context
-def config_list_cmd(ctx):
+def config_list_cmd(ctx: click.Context) -> None:
 	"""显示当前全部配置。"""
 	cfg = ctx.obj["config"]
 	config_path = ctx.obj["data_dir"] / "config.json"
@@ -65,7 +67,7 @@ def config_list_cmd(ctx):
 @config_group.command("get")
 @click.argument("key")
 @click.pass_context
-def config_get_cmd(ctx, key):
+def config_get_cmd(ctx: click.Context, key: str) -> None:
 	"""查看单个配置项的值。"""
 	cfg = ctx.obj["config"]
 	if key not in DEFAULTS:
@@ -90,7 +92,7 @@ def config_get_cmd(ctx, key):
 @click.argument("key")
 @click.argument("value")
 @click.pass_context
-def config_set_cmd(ctx, key, value):
+def config_set_cmd(ctx: click.Context, key: str, value: str) -> None:
 	"""修改配置项。"""
 	if key not in DEFAULTS:
 		from boss_agent_cli.output import emit_error
@@ -116,7 +118,7 @@ def config_set_cmd(ctx, key, value):
 @config_group.command("reset")
 @click.argument("key")
 @click.pass_context
-def config_reset_cmd(ctx, key):
+def config_reset_cmd(ctx: click.Context, key: str) -> None:
 	"""将配置项恢复为默认值。"""
 	if key not in DEFAULTS:
 		from boss_agent_cli.output import emit_error
@@ -137,18 +139,19 @@ def config_reset_cmd(ctx, key):
 	handle_output(ctx, "config", data, render=lambda d: None)
 
 
-def _load_user_overrides(config_path) -> dict:
+def _load_user_overrides(config_path: Path) -> dict[str, Any]:
 	"""加载用户自定义配置（不含默认值）。"""
 	if config_path.exists():
 		try:
 			with open(config_path) as f:
-				return json.load(f)
+				result: dict[str, Any] = json.load(f)
+				return result
 		except (json.JSONDecodeError, OSError):
 			return {}
 	return {}
 
 
-def _save_user_overrides(config_path, user_cfg: dict):
+def _save_user_overrides(config_path: Path, user_cfg: dict[str, Any]) -> None:
 	"""保存用户配置到文件。"""
 	config_path.parent.mkdir(parents=True, exist_ok=True)
 	with open(config_path, "w", encoding="utf-8") as f:
@@ -156,7 +159,7 @@ def _save_user_overrides(config_path, user_cfg: dict):
 		f.write("\n")
 
 
-def _parse_value(raw: str, default):
+def _parse_value(raw: str, default: Any) -> Any:
 	"""根据默认值类型推断并转换输入值。"""
 	if default is None:
 		if raw.lower() in ("null", "none", ""):

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import click
 
 from boss_agent_cli.output import emit_success
@@ -14,10 +16,10 @@ _JSON_SCHEMA_TYPE_MAP = {
 }
 
 
-def _option_to_json_schema_property(opt_spec: dict) -> dict:
+def _option_to_json_schema_property(opt_spec: dict[str, Any]) -> dict[str, Any]:
 	"""把 native option 转成单个 JSON Schema 属性。"""
 	native_type = opt_spec.get("type", "string")
-	prop: dict = {"type": _JSON_SCHEMA_TYPE_MAP.get(native_type, "string")}
+	prop: dict[str, Any] = {"type": _JSON_SCHEMA_TYPE_MAP.get(native_type, "string")}
 	desc = opt_spec.get("description")
 	if desc:
 		prop["description"] = desc
@@ -27,9 +29,9 @@ def _option_to_json_schema_property(opt_spec: dict) -> dict:
 	return prop
 
 
-def _command_to_json_schema(cmd_name: str, cmd_spec: dict) -> dict:
+def _command_to_json_schema(cmd_name: str, cmd_spec: dict[str, Any]) -> dict[str, Any]:
 	"""把 native 命令描述转成 OpenAI Tools / Anthropic Tool Use 共用的 JSON Schema。"""
-	properties: dict = {}
+	properties: dict[str, Any] = {}
 	required: list[str] = []
 
 	for arg in cmd_spec.get("args", []):
@@ -46,7 +48,7 @@ def _command_to_json_schema(cmd_name: str, cmd_spec: dict) -> dict:
 		primary_name = opt_key.split(",")[-1].strip().lstrip("-").replace("-", "_")
 		properties[primary_name] = _option_to_json_schema_property(opt_spec)
 
-	schema: dict = {
+	schema: dict[str, Any] = {
 		"type": "object",
 		"properties": properties,
 	}
@@ -55,7 +57,7 @@ def _command_to_json_schema(cmd_name: str, cmd_spec: dict) -> dict:
 	return schema
 
 
-def _format_openai_tools(data: dict) -> list[dict]:
+def _format_openai_tools(data: dict[str, Any]) -> list[dict[str, Any]]:
 	"""OpenAI Functions / Tools API 格式。"""
 	tools = []
 	for cmd_name, cmd_spec in data["commands"].items():
@@ -70,7 +72,7 @@ def _format_openai_tools(data: dict) -> list[dict]:
 	return tools
 
 
-def _format_anthropic_tools(data: dict) -> list[dict]:
+def _format_anthropic_tools(data: dict[str, Any]) -> list[dict[str, Any]]:
 	"""Anthropic Tool Use 格式。"""
 	tools = []
 	for cmd_name, cmd_spec in data["commands"].items():
@@ -662,7 +664,7 @@ SCHEMA_DATA = {
 	default="native",
 	help="输出格式：native（本项目信封）/ openai-tools（OpenAI Functions & Tools API）/ anthropic-tools（Claude Tool Use API）",
 )
-def schema_cmd(output_format):
+def schema_cmd(output_format: str) -> None:
 	"""返回工具完整能力描述的 JSON"""
 	if output_format == "openai-tools":
 		emit_success("schema", {"format": "openai-tools", "tools": _format_openai_tools(SCHEMA_DATA)})


### PR DESCRIPTION
## Summary

mypy 严格化第七轮，白名单 38 → **41**，新增 `schema` / `chat_export` / `config_cmd`。剩余 `resume_cmd` / `ai_cmd` 两个大模块（17+18 error）留下一轮精修。

## 新增 3 个

| 模块 | 说明 |
|------|------|
| `commands/schema` | 32 命令能力自描述 + OpenAI/Anthropic tools 格式输出 |
| `commands/chat_export` | 沟通列表多格式渲染（MD/CSV/JSON/HTML） |
| `commands/config_cmd` | 配置管理（list/get/set/reset） |

## 关键改动
- schema 全量 `dict` 补泛型参数 `dict[str, Any]`
- chat_export 内部 `groups: dict[str, list[dict[str, Any]]]` 精确声明
- config_cmd 的 `_load_user_overrides` 返回用 typed 中间变量避免 `no-any-return`
- `_parse_value(default: Any) -> Any` 精确标注

## Test plan
- [x] `uv run mypy src/boss_agent_cli` → 0 errors（41 严格模块）
- [x] 927 passed 无回归