### PR TITLE
feat: 严格类型检查覆盖全部命令行命令

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,8 @@ module = [
 	"boss_agent_cli.commands.schema",
 	"boss_agent_cli.commands.chat_export",
 	"boss_agent_cli.commands.config_cmd",
+	"boss_agent_cli.commands.ai_cmd",
+	"boss_agent_cli.commands.resume_cmd",
 ]
 disallow_untyped_defs = true
 disallow_any_generics = true

--- a/src/boss_agent_cli/cache/store.py
+++ b/src/boss_agent_cli/cache/store.py
@@ -379,7 +379,7 @@ class CacheStore:
 		self._conn.commit()
 		return cursor.rowcount > 0
 
-	def close(self):
+	def close(self) -> None:
 		self._conn.close()
 
 	def __enter__(self):

--- a/src/boss_agent_cli/commands/ai_cmd.py
+++ b/src/boss_agent_cli/commands/ai_cmd.py
@@ -5,6 +5,7 @@
 
 import json
 from pathlib import Path
+from typing import Any, cast
 
 import click
 
@@ -24,15 +25,15 @@ from boss_agent_cli.resume.models import resume_to_text
 from boss_agent_cli.resume.store import ResumeStore
 
 
-def _get_ai_config_store(ctx) -> AIConfigStore:
+def _get_ai_config_store(ctx: click.Context) -> AIConfigStore:
 	return AIConfigStore(ctx.obj["data_dir"])
 
 
-def _get_resume_store(ctx) -> ResumeStore:
+def _get_resume_store(ctx: click.Context) -> ResumeStore:
 	return ResumeStore(ctx.obj["data_dir"] / "resumes")
 
 
-def _create_ai_service(ctx) -> AIService | None:
+def _create_ai_service(ctx: click.Context) -> AIService | None:
 	"""从配置创建 AIService 实例，未配置时返回 None。"""
 	store = _get_ai_config_store(ctx)
 	if not store.is_configured():
@@ -51,7 +52,7 @@ def _create_ai_service(ctx) -> AIService | None:
 	)
 
 
-def _require_ai_service(ctx) -> AIService | None:
+def _require_ai_service(ctx: click.Context) -> AIService | None:
 	"""获取 AIService，未配置时输出错误信封并返回 None。"""
 	svc = _create_ai_service(ctx)
 	if svc is None:
@@ -67,7 +68,7 @@ def _require_ai_service(ctx) -> AIService | None:
 	return svc
 
 
-def _load_resume_text(ctx, resume_name: str) -> str | None:
+def _load_resume_text(ctx: click.Context, resume_name: str) -> str | None:
 	"""加载简历纯文本，不存在时输出错误。"""
 	store = _get_resume_store(ctx)
 	resume = store.get(resume_name)
@@ -82,7 +83,7 @@ def _load_resume_text(ctx, resume_name: str) -> str | None:
 	return resume_to_text(resume)
 
 
-def _call_ai(ctx, svc: AIService, prompt: str) -> dict | None:
+def _call_ai(ctx: click.Context, svc: AIService, prompt: str) -> dict[str, Any] | None:
 	"""调用 AI 并解析 JSON 结果，失败时输出错误信封。"""
 	try:
 		raw = svc.chat([
@@ -108,7 +109,7 @@ def _call_ai(ctx, svc: AIService, prompt: str) -> dict | None:
 		text = "\n".join(lines).strip()
 
 	try:
-		return json.loads(text)
+		return cast("dict[str, Any]", json.loads(text))
 	except json.JSONDecodeError:
 		handle_error_output(
 			ctx, "ai",
@@ -122,7 +123,7 @@ def _call_ai(ctx, svc: AIService, prompt: str) -> dict | None:
 
 
 @click.group("ai")
-def ai_group():
+def ai_group() -> None:
 	"""AI 简历优化。"""
 
 
@@ -134,7 +135,7 @@ def ai_group():
 @click.option("--temperature", default=None, type=float, help="生成温度")
 @click.option("--max-tokens", default=None, type=int, help="最大令牌数")
 @click.pass_context
-def ai_config_cmd(ctx, provider, model, api_key, base_url, temperature, max_tokens):
+def ai_config_cmd(ctx: click.Context, provider: str | None, model: str | None, api_key: str | None, base_url: str | None, temperature: float | None, max_tokens: int | None) -> None:
 	"""查看或设置 AI 服务配置"""
 	store = _get_ai_config_store(ctx)
 
@@ -153,7 +154,7 @@ def ai_config_cmd(ctx, provider, model, api_key, base_url, temperature, max_toke
 		return
 
 	# 有参数时更新配置
-	updates = {}
+	updates: dict[str, Any] = {}
 	if provider is not None:
 		updates["ai_provider"] = provider
 	if model is not None:
@@ -180,7 +181,7 @@ def ai_config_cmd(ctx, provider, model, api_key, base_url, temperature, max_toke
 @click.argument("jd_text")
 @click.option("--resume", "resume_name", required=True, help="对比的本地简历名称")
 @click.pass_context
-def ai_analyze_jd_cmd(ctx, jd_text, resume_name):
+def ai_analyze_jd_cmd(ctx: click.Context, jd_text: str, resume_name: str) -> None:
 	"""分析职位描述并评估简历匹配度
 
 	JD_TEXT 可以是职位描述文本，也可以是 @文件路径 读取文件内容。
@@ -219,7 +220,7 @@ def ai_analyze_jd_cmd(ctx, jd_text, resume_name):
 @ai_group.command("polish")
 @click.argument("resume_name")
 @click.pass_context
-def ai_polish_cmd(ctx, resume_name):
+def ai_polish_cmd(ctx: click.Context, resume_name: str) -> None:
 	"""通用简历润色优化"""
 	svc = _require_ai_service(ctx)
 	if svc is None:
@@ -244,7 +245,7 @@ def ai_polish_cmd(ctx, resume_name):
 @click.argument("resume_name")
 @click.option("--jd", "jd_text", required=True, help="目标职位描述文本或 @文件路径")
 @click.pass_context
-def ai_optimize_cmd(ctx, resume_name, jd_text):
+def ai_optimize_cmd(ctx: click.Context, resume_name: str, jd_text: str) -> None:
 	"""基于目标职位描述优化简历"""
 	svc = _require_ai_service(ctx)
 	if svc is None:
@@ -280,7 +281,7 @@ def ai_optimize_cmd(ctx, resume_name, jd_text):
 @click.argument("resume_name")
 @click.option("--jd", "jd_text", required=True, help="目标职位描述文本或 @文件路径")
 @click.pass_context
-def ai_suggest_cmd(ctx, resume_name, jd_text):
+def ai_suggest_cmd(ctx: click.Context, resume_name: str, jd_text: str) -> None:
 	"""基于目标职位描述给出改进建议（不修改简历）"""
 	svc = _require_ai_service(ctx)
 	if svc is None:
@@ -318,7 +319,7 @@ def ai_suggest_cmd(ctx, resume_name, jd_text):
 @click.option("--resume", "resume_name", default=None, help="参考简历名称（可选）")
 @click.option("--tone", default="简洁专业", type=click.Choice(["简洁专业", "热情积极", "谨慎确认"]), help="语气偏好")
 @click.pass_context
-def ai_reply_cmd(ctx, recruiter_message, context, resume_name, tone):
+def ai_reply_cmd(ctx: click.Context, recruiter_message: str, context: str, resume_name: str | None, tone: str) -> None:
 	"""基于招聘者消息生成回复草稿（2-3 条候选）
 
 	RECRUITER_MESSAGE 为招聘者发来的消息文本，或 @文件路径 读取文件内容。
@@ -370,7 +371,7 @@ def ai_reply_cmd(ctx, recruiter_message, context, resume_name, tone):
 @click.option("--resume", "resume_name", default=None, help="参考简历名称（可选，根据简历真实经历定制问题）")
 @click.option("--count", default=10, type=int, help="题量，默认 10")
 @click.pass_context
-def ai_interview_prep_cmd(ctx, jd_text, resume_name, count):
+def ai_interview_prep_cmd(ctx: click.Context, jd_text: str, resume_name: str | None, count: int) -> None:
 	"""基于目标职位生成模拟面试题
 
 	JD_TEXT 是目标职位描述文本，或 @文件路径 读取文件内容。
@@ -417,7 +418,7 @@ def ai_interview_prep_cmd(ctx, jd_text, resume_name, count):
 @click.option("--resume", "resume_name", default=None, help="参考简历名称（可选）")
 @click.option("--style", default="简洁专业", help="沟通风格偏好（如 简洁专业/积极主动/谨慎稳重）")
 @click.pass_context
-def ai_chat_coach_cmd(ctx, chat_text, resume_name, style):
+def ai_chat_coach_cmd(ctx: click.Context, chat_text: str, resume_name: str | None, style: str) -> None:
 	"""基于聊天记录给出沟通技巧诊断与下一步建议
 
 	CHAT_TEXT 是聊天记录文本，或 @文件路径 读取文件内容。

--- a/src/boss_agent_cli/commands/resume_cmd.py
+++ b/src/boss_agent_cli/commands/resume_cmd.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import Any
 
 import click
 
@@ -8,7 +9,7 @@ from boss_agent_cli.resume.models import ResumeData, PersonalInfoSection, resume
 from boss_agent_cli.resume.store import ResumeStore
 
 
-def _get_store(ctx) -> ResumeStore:
+def _get_store(ctx: click.Context) -> ResumeStore:
 	resumes_dir: Path = ctx.obj["data_dir"] / "resumes"
 	return ResumeStore(resumes_dir)
 
@@ -26,10 +27,10 @@ def _build_default_template(name: str) -> ResumeData:
 	)
 
 
-def _set_nested(data: dict, path: str, value: str) -> bool:
+def _set_nested(data: dict[str, Any], path: str, value: str) -> bool:
 	"""通过 . 分隔路径设置嵌套 dict 字段，返回是否成功"""
 	keys = path.split(".")
-	current = data
+	current: Any = data
 	for key in keys[:-1]:
 		if isinstance(current, dict) and key in current:
 			current = current[key]
@@ -42,9 +43,9 @@ def _set_nested(data: dict, path: str, value: str) -> bool:
 	return False
 
 
-def _flat_diff(left: dict, right: dict, prefix: str = "") -> list[dict]:
+def _flat_diff(left: dict[str, Any], right: dict[str, Any], prefix: str = "") -> list[dict[str, Any]]:
 	"""对比两个 dict 的差异，返回 [{field, left, right}, ...]"""
-	diffs: list[dict] = []
+	diffs: list[dict[str, Any]] = []
 	all_keys = sorted(set(list(left.keys()) + list(right.keys())))
 	for key in all_keys:
 		full_key = f"{prefix}.{key}" if prefix else key
@@ -61,7 +62,7 @@ def _flat_diff(left: dict, right: dict, prefix: str = "") -> list[dict]:
 
 
 @click.group("resume")
-def resume_group():
+def resume_group() -> None:
 	"""本地简历管理。"""
 
 
@@ -69,7 +70,7 @@ def resume_group():
 @click.option("--name", default=None, help="简历名称")
 @click.option("--template", default=None, help="模板名称（如 default）")
 @click.pass_context
-def resume_init_cmd(ctx, name, template):
+def resume_init_cmd(ctx: click.Context, name: str | None, template: str | None) -> None:
 	"""从默认模板初始化本地简历"""
 	store = _get_store(ctx)
 	if template is None:
@@ -97,7 +98,7 @@ def resume_init_cmd(ctx, name, template):
 
 @resume_group.command("list")
 @click.pass_context
-def resume_list_cmd(ctx):
+def resume_list_cmd(ctx: click.Context) -> None:
 	"""列出所有本地简历"""
 	store = _get_store(ctx)
 	items = store.list_all()
@@ -110,7 +111,7 @@ def resume_list_cmd(ctx):
 @resume_group.command("show")
 @click.argument("name")
 @click.pass_context
-def resume_show_cmd(ctx, name):
+def resume_show_cmd(ctx: click.Context, name: str) -> None:
 	"""查看简历详情"""
 	store = _get_store(ctx)
 	resume = store.get(name)
@@ -132,7 +133,7 @@ def resume_show_cmd(ctx, name):
 @click.option("--field", required=True, help="字段路径（如 title, personal_info.layout）")
 @click.option("--value", required=True, help="新值")
 @click.pass_context
-def resume_edit_cmd(ctx, name, field, value):
+def resume_edit_cmd(ctx: click.Context, name: str, field: str, value: str) -> None:
 	"""编辑简历字段"""
 	store = _get_store(ctx)
 	resume = store.get(name)
@@ -164,7 +165,7 @@ def resume_edit_cmd(ctx, name, field, value):
 @resume_group.command("delete")
 @click.argument("name")
 @click.pass_context
-def resume_delete_cmd(ctx, name):
+def resume_delete_cmd(ctx: click.Context, name: str) -> None:
 	"""删除简历"""
 	store = _get_store(ctx)
 	if not store.exists(name):
@@ -184,7 +185,7 @@ def resume_delete_cmd(ctx, name):
 @click.option("--format", "fmt", default="json", type=click.Choice(["pdf", "json", "html"]), help="导出格式")
 @click.option("-o", "--output", "output_path", default=None, help="输出文件路径")
 @click.pass_context
-def resume_export_cmd(ctx, name, fmt, output_path):
+def resume_export_cmd(ctx: click.Context, name: str, fmt: str, output_path: Path | None) -> None:
 	"""导出简历"""
 	store = _get_store(ctx)
 	if not store.exists(name):
@@ -198,7 +199,7 @@ def resume_export_cmd(ctx, name, fmt, output_path):
 			ctx.exit(1)
 			return
 		if output_path is None:
-			output_path = f"{name}.{fmt}"
+			output_path = Path(f"{name}.{fmt}")
 		out = Path(output_path)
 		try:
 			from boss_agent_cli.resume.export import export_html, export_pdf
@@ -235,7 +236,7 @@ def resume_export_cmd(ctx, name, fmt, output_path):
 @resume_group.command("import")
 @click.argument("file_path", type=click.Path())
 @click.pass_context
-def resume_import_cmd(ctx, file_path):
+def resume_import_cmd(ctx: click.Context, file_path: Path) -> None:
 	"""导入 JSON 简历"""
 	path = Path(file_path)
 	if not path.exists():
@@ -268,7 +269,7 @@ def resume_import_cmd(ctx, file_path):
 @click.argument("name")
 @click.argument("new_name")
 @click.pass_context
-def resume_clone_cmd(ctx, name, new_name):
+def resume_clone_cmd(ctx: click.Context, name: str, new_name: str) -> None:
 	"""复制简历为新版本"""
 	store = _get_store(ctx)
 	if not store.exists(name):
@@ -296,7 +297,7 @@ def resume_clone_cmd(ctx, name, new_name):
 @click.argument("name1")
 @click.argument("name2")
 @click.pass_context
-def resume_diff_cmd(ctx, name1, name2):
+def resume_diff_cmd(ctx: click.Context, name1: str, name2: str) -> None:
 	"""对比两份简历差异"""
 	store = _get_store(ctx)
 	r1 = store.get(name1)
@@ -326,7 +327,7 @@ def resume_diff_cmd(ctx, name1, name2):
 @click.option("--title", default="", help="职位名称")
 @click.option("--company", default="", help="公司名称")
 @click.pass_context
-def resume_link_cmd(ctx, name, security_id, job_id, title, company):
+def resume_link_cmd(ctx: click.Context, name: str, security_id: str, job_id: str, title: str, company: str) -> None:
 	"""关联简历与职位"""
 	store = _get_store(ctx)
 	if not store.exists(name):
@@ -347,7 +348,7 @@ def resume_link_cmd(ctx, name, security_id, job_id, title, company):
 @resume_group.command("applications")
 @click.argument("name")
 @click.pass_context
-def resume_applications_cmd(ctx, name):
+def resume_applications_cmd(ctx: click.Context, name: str) -> None:
 	"""查看简历关联的所有职位"""
 	store = _get_store(ctx)
 	if not store.exists(name):


### PR DESCRIPTION
## Summary

mypy 严格化第八轮：**CLI 命令层 100% 覆盖**（32/32）！新增 `ai_cmd` / `resume_cmd` 两个大模块，白名单 41 → **43**。

## 本轮新增

| 模块 | 原 error | 说明 |
|------|---------|------|
| `commands/ai_cmd` | 17 | 8 个子命令（config/analyze-jd/polish/optimize/suggest/reply/interview-prep/chat-coach） |
| `commands/resume_cmd` | 18 | 11 个子命令（init/list/show/edit/delete/export/import/clone/diff/link/applications） |

## 关键改动

- `ai_cmd`：`_call_ai` 使用 `cast("dict[str, Any]", json.loads(...))` 避免 no-any-return；`updates: dict[str, Any] = {}` 支持多类型值
- `resume_cmd`：`_set_nested` 的 `current` 变量声明为 `Any`（dict 嵌套导航）；`resume_export_cmd` 修正 output_path 默认值用 `Path(f"{name}.{fmt}")`
- `cache/store.CacheStore.close` 补 `-> None` 类型注解（被 resume_cmd 调用）
- 所有 22 个 AI/Resume 子命令签名升级为 `def cmd(ctx: click.Context, ...) -> None`

## 里程碑 🎯

**CLI 命令层严格化首次达到 100%（32/32）**！从 R3 `handle_auth_errors` 装饰器解锁开始，经过 6 轮（R3→R8）推进，每轮都不是堆积模块而是解决系统级障碍带一批进来：

| 轮次 | 严格模块数 | 里程碑 |
|------|-----------|--------|
| R3（#99）| 11 → 17 | handle_auth_errors 装饰器 + 6 个 CLI |
| R4（#101）| 17 → 24 | pipeline + digest + 5 个 CLI |
| R5（#103）| 24 → 32 | me + show + mark + 5 组管理类命令 |
| R6（#105）| 32 → 38 | search/greet/chat/detail/doctor/export 6 大命令 |
| R7（#107）| 38 → 41 | schema + chat_export + config_cmd |
| **R8（本 PR）** | 41 → **43** | **ai_cmd + resume_cmd（CLI 层收尾）** |

## Test plan

- [x] `uv run mypy src/boss_agent_cli` → 0 errors（43 严格模块）
- [x] `uv run pytest tests/ -q` 927 passed 无回归
- [x] `uv run ruff check src/ tests/ mcp-server/` 全绿