### PR TITLE
feat: 严格类型检查白名单扩至五十一个

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,14 @@ module = [
 	"boss_agent_cli.commands.config_cmd",
 	"boss_agent_cli.commands.ai_cmd",
 	"boss_agent_cli.commands.resume_cmd",
+	"boss_agent_cli.main",
+	"boss_agent_cli.ai.config",
+	"boss_agent_cli.ai.service",
+	"boss_agent_cli.ai.prompts",
+	"boss_agent_cli.resume.templates",
+	"boss_agent_cli.resume.export",
+	"boss_agent_cli.auth.token_store",
+	"boss_agent_cli.auth.cookie_extract",
 ]
 disallow_untyped_defs = true
 disallow_any_generics = true

--- a/src/boss_agent_cli/ai/config.py
+++ b/src/boss_agent_cli/ai/config.py
@@ -10,6 +10,7 @@ import os
 import platform
 from base64 import urlsafe_b64encode
 from pathlib import Path
+from typing import Any
 
 from cryptography.fernet import Fernet, InvalidToken
 from cryptography.hazmat.primitives import hashes
@@ -26,7 +27,7 @@ PROVIDER_BASE_URLS: dict[str, str | None] = {
 	"custom": None,
 }
 
-_DEFAULT_CONFIG: dict = {
+_DEFAULT_CONFIG: dict[str, Any] = {
 	"ai_provider": None,
 	"ai_model": None,
 	"ai_base_url": None,
@@ -97,7 +98,7 @@ class AIConfigStore:
 			return None
 		return plaintext.decode("utf-8")
 
-	def save_config(self, **kwargs) -> None:
+	def save_config(self, **kwargs: Any) -> None:
 		"""Save configuration, merging with existing values."""
 		current = self.load_config()
 		current.update(kwargs)
@@ -106,7 +107,7 @@ class AIConfigStore:
 			encoding="utf-8",
 		)
 
-	def load_config(self) -> dict:
+	def load_config(self) -> dict[str, Any]:
 		"""Load configuration with defaults for missing keys."""
 		config = dict(_DEFAULT_CONFIG)
 		if self._config_path.exists():
@@ -120,8 +121,9 @@ class AIConfigStore:
 	def get_base_url(self) -> str | None:
 		"""Get the API base URL: user config takes priority, then provider lookup."""
 		config = self.load_config()
-		if config.get("ai_base_url"):
-			return config["ai_base_url"]
+		base_url = config.get("ai_base_url")
+		if base_url:
+			return str(base_url)
 		provider = config.get("ai_provider")
 		if provider and provider in PROVIDER_BASE_URLS:
 			return PROVIDER_BASE_URLS[provider]

--- a/src/boss_agent_cli/ai/service.py
+++ b/src/boss_agent_cli/ai/service.py
@@ -3,6 +3,8 @@
 Provides a simple interface for chat completions with error handling.
 """
 
+from typing import Any, cast
+
 import httpx
 
 
@@ -34,7 +36,7 @@ class AIService:
 
 	def chat(
 		self,
-		messages: list[dict],
+		messages: list[dict[str, Any]],
 		*,
 		temperature: float | None = None,
 		max_tokens: int | None = None,
@@ -77,6 +79,6 @@ class AIService:
 
 		try:
 			data = response.json()
-			return data["choices"][0]["message"]["content"]
+			return cast("str", data["choices"][0]["message"]["content"])
 		except (KeyError, IndexError, TypeError) as exc:
 			raise AIServiceError(f"响应格式异常: {exc}") from exc

--- a/src/boss_agent_cli/auth/cookie_extract.py
+++ b/src/boss_agent_cli/auth/cookie_extract.py
@@ -1,7 +1,8 @@
 import sys
+from typing import Any, Callable
 
 
-def extract_cookies(source: str | None = None) -> dict | None:
+def extract_cookies(source: str | None = None) -> dict[str, Any] | None:
 	"""
 	从本地浏览器提取 zhipin.com 的 Cookie。
 	source: 指定浏览器名（如 "chrome"），None 则自动检测。
@@ -40,7 +41,7 @@ def extract_cookies(source: str | None = None) -> dict | None:
 	return None
 
 
-def _try_extract(loader) -> dict | None:
+def _try_extract(loader: Callable[..., Any]) -> dict[str, Any] | None:
 	"""尝试从单个浏览器提取 zhipin.com cookies"""
 	try:
 		cj = loader(domain_name=".zhipin.com")

--- a/src/boss_agent_cli/auth/token_store.py
+++ b/src/boss_agent_cli/auth/token_store.py
@@ -8,6 +8,7 @@ import time
 from base64 import urlsafe_b64encode
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Any, Iterator, cast
 
 from cryptography.fernet import Fernet, InvalidToken
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
@@ -87,13 +88,13 @@ class TokenStore:
 		key = kdf.derive(machine_id.encode())
 		return urlsafe_b64encode(key)
 
-	def save(self, token_data: dict) -> None:
+	def save(self, token_data: dict[str, Any]) -> None:
 		fernet = Fernet(self._derive_key())
 		plaintext = json.dumps(token_data, ensure_ascii=False).encode()
 		encrypted = fernet.encrypt(plaintext)
 		self._session_path.write_bytes(encrypted)
 
-	def load(self) -> dict | None:
+	def load(self) -> dict[str, Any] | None:
 		if not self._session_path.exists():
 			return None
 		fernet = Fernet(self._derive_key())
@@ -102,14 +103,14 @@ class TokenStore:
 			plaintext = fernet.decrypt(encrypted)
 		except (InvalidToken, ValueError):
 			return None
-		return json.loads(plaintext)
+		return cast("dict[str, Any]", json.loads(plaintext))
 
 	def clear(self) -> None:
 		"""删除 session.enc 文件（保留 salt 供下次登录复用）"""
 		self._session_path.unlink(missing_ok=True)
 
 	@contextmanager
-	def refresh_lock(self):
+	def refresh_lock(self) -> Iterator[None]:
 		"""原子文件锁：使用 O_CREAT|O_EXCL 避免 TOCTOU 竞态条件。"""
 		deadline = time.time() + _LOCK_TIMEOUT
 		fd = None

--- a/src/boss_agent_cli/main.py
+++ b/src/boss_agent_cli/main.py
@@ -17,14 +17,14 @@ from boss_agent_cli.output import Logger
 @click.option("--log-level", default=None, type=click.Choice(["error", "warning", "info", "debug"]))
 @click.option("--json/--no-json", "json_output", default=False, help="强制 JSON 输出（即使在终端中）")
 @click.pass_context
-def cli(ctx, data_dir, delay, cdp_url, log_level, json_output):
+def cli(ctx: click.Context, data_dir: str, delay: str | None, cdp_url: str | None, log_level: str | None, json_output: bool) -> None:
 	ctx.ensure_object(dict)
-	data_dir = Path(data_dir).expanduser()
-	data_dir.mkdir(parents=True, exist_ok=True)
-	ctx.obj["data_dir"] = data_dir
+	resolved_dir = Path(data_dir).expanduser()
+	resolved_dir.mkdir(parents=True, exist_ok=True)
+	ctx.obj["data_dir"] = resolved_dir
 	ctx.obj["json_output"] = json_output
 
-	cfg = load_config(data_dir / "config.json")
+	cfg = load_config(resolved_dir / "config.json")
 
 	if delay:
 		low, high = delay.split("-")

--- a/src/boss_agent_cli/resume/templates.py
+++ b/src/boss_agent_cli/resume/templates.py
@@ -5,6 +5,7 @@ optimized for A4 printing and PDF export.
 """
 
 import html
+from typing import Any
 
 from boss_agent_cli.resume.models import ResumeData
 
@@ -49,7 +50,7 @@ def _render_job_intention(resume: ResumeData) -> str:
 </div>"""
 
 
-def _render_row(row: dict) -> str:
+def _render_row(row: dict[str, Any]) -> str:
 	"""Render a single module row (richtext or tags)."""
 	row_type = row.get("type", "")
 	if row_type == "tags":


### PR DESCRIPTION
## Summary

mypy 严格化第九轮，白名单 43 → **51**，新增 8 个非 CLI 模块。剩余主要是 `api/*` / `auth/manager` / `auth/browser` / `bridge/*` / `cache/store` 等深度依赖运行时的模块。

## 本轮新增 8 个

| 模块 | 说明 |
|------|------|
| `ai/config` | AI 服务配置 + Fernet 加密 |
| `ai/service` | OpenAI 兼容 API 客户端 |
| `ai/prompts` | Prompt 模板（纯常量） |
| `resume/templates` | HTML 模板渲染 |
| `resume/export` | 多格式导出入口 |
| `auth/token_store` | Fernet 加密 Token 持久化 + 文件锁 |
| `auth/cookie_extract` | browser-cookie3 提取 |
| `main` | CLI 入口 |

## 关键改动

- `token_store.load()` / `ai/service.chat()` / `ai_cmd._call_ai` 使用 `cast()` 精确声明 JSON 解析返回类型，避免 `no-any-return`
- `token_store.refresh_lock` 补 `Iterator[None]` 返回类型（contextmanager 泛型）
- `cookie_extract._try_extract(loader: Callable[..., Any])` 精确参数签名
- `main.cli` 使用局部变量 `resolved_dir` 替代重新赋值 `data_dir` 避免 `str → Path` 类型冲突
- `ai/config.get_base_url` 显式 `str()` 包装以通过 `warn_return_any`

## Test plan
- [x] `uv run mypy src/boss_agent_cli` → 0 errors（51 严格模块）
- [x] `uv run pytest tests/ -q` 927 passed 无回归
- [x] `uv run ruff check src/ tests/ mcp-server/` 全绿