### PR TITLE
feat: 严格类型检查白名单扩至五十六个

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,11 @@ module = [
 	"boss_agent_cli.resume.export",
 	"boss_agent_cli.auth.token_store",
 	"boss_agent_cli.auth.cookie_extract",
+	"boss_agent_cli.api.models",
+	"boss_agent_cli.api.throttle",
+	"boss_agent_cli.api.endpoints",
+	"boss_agent_cli.api.endpoints_loader",
+	"boss_agent_cli.commands.stats",
 ]
 disallow_untyped_defs = true
 disallow_any_generics = true

--- a/src/boss_agent_cli/api/endpoints_loader.py
+++ b/src/boss_agent_cli/api/endpoints_loader.py
@@ -27,7 +27,8 @@ class BossApiSpec:
 def _load_yaml() -> dict[str, Any]:
 	"""Load boss.yaml from package resources."""
 	ref = importlib.resources.files("boss_agent_cli.api").joinpath("boss.yaml")
-	return yaml.safe_load(ref.read_text(encoding="utf-8"))
+	result: dict[str, Any] = yaml.safe_load(ref.read_text(encoding="utf-8"))
+	return result
 
 
 def load_boss_api_spec() -> BossApiSpec:

--- a/src/boss_agent_cli/api/models.py
+++ b/src/boss_agent_cli/api/models.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from typing import Any
 
 
 @dataclass
@@ -23,7 +24,7 @@ class JobItem:
 	greeted: bool = False
 
 	@classmethod
-	def from_api(cls, raw: dict) -> "JobItem":
+	def from_api(cls, raw: dict[str, Any]) -> "JobItem":
 		return cls(
 			job_id=raw.get("encryptJobId", ""),
 			title=raw.get("jobName", ""),
@@ -44,7 +45,7 @@ class JobItem:
 			security_id=raw.get("securityId", ""),
 		)
 
-	def to_dict(self) -> dict:
+	def to_dict(self) -> dict[str, Any]:
 		return {
 			"job_id": self.job_id,
 			"title": self.title,
@@ -81,11 +82,11 @@ class JobDetail:
 	boss_title: str
 	boss_active: str
 	security_id: str
-	company_info: dict = field(default_factory=dict)
+	company_info: dict[str, Any] = field(default_factory=dict)
 	greeted: bool = False
 
 	@classmethod
-	def from_api(cls, raw: dict) -> "JobDetail":
+	def from_api(cls, raw: dict[str, Any]) -> "JobDetail":
 		job_info = raw.get("jobInfo", {})
 		boss_info = raw.get("bossInfo", {})
 		brand_info = raw.get("brandComInfo", {})
@@ -109,7 +110,7 @@ class JobDetail:
 			},
 		)
 
-	def to_dict(self) -> dict:
+	def to_dict(self) -> dict[str, Any]:
 		return {
 			"job_id": self.job_id,
 			"title": self.title,

--- a/src/boss_agent_cli/api/throttle.py
+++ b/src/boss_agent_cli/api/throttle.py
@@ -10,12 +10,12 @@ from collections import deque
 class RequestThrottle:
 	"""Rate limiter with Gaussian-distributed delays and burst detection."""
 
-	def __init__(self, delay: tuple[float, float] = (1.5, 3.0)):
+	def __init__(self, delay: tuple[float, float] = (1.5, 3.0)) -> None:
 		self._delay = delay
 		self._last_request_time = 0.0
 		self._recent_times: deque[float] = deque(maxlen=12)
 
-	def wait(self):
+	def wait(self) -> None:
 		"""Block until it's safe to send the next request."""
 		elapsed = time.time() - self._last_request_time
 		mean = sum(self._delay) / 2
@@ -31,7 +31,7 @@ class RequestThrottle:
 		if total > 0:
 			time.sleep(total)
 
-	def mark(self):
+	def mark(self) -> None:
 		"""Record that a request was just sent."""
 		now = time.time()
 		self._last_request_time = now

--- a/src/boss_agent_cli/commands/stats.py
+++ b/src/boss_agent_cli/commands/stats.py
@@ -11,6 +11,7 @@ import sqlite3
 import sys
 import time
 from pathlib import Path
+from typing import Any
 
 import click
 
@@ -19,16 +20,18 @@ from boss_agent_cli.display import handle_output
 
 def _safe_count(conn: sqlite3.Connection, table: str) -> int:
 	try:
-		return conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+		result: int = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+		return result
 	except sqlite3.OperationalError:
 		return 0
 
 
 def _count_since(conn: sqlite3.Connection, table: str, column: str, since: float) -> int:
 	try:
-		return conn.execute(
+		result: int = conn.execute(
 			f"SELECT COUNT(*) FROM {table} WHERE {column} >= ?", (since,)
 		).fetchone()[0]
+		return result
 	except sqlite3.OperationalError:
 		return 0
 
@@ -39,7 +42,7 @@ def _ratio(numer: int, denom: int) -> float:
 	return round(numer / denom, 4)
 
 
-def _collect_stats(db_path: Path, days: int) -> dict:
+def _collect_stats(db_path: Path, days: int) -> dict[str, Any]:
 	"""从 SQLite 收集漏斗数据，返回结构化 dict。"""
 	if not db_path.exists():
 		return {
@@ -84,7 +87,7 @@ def _collect_stats(db_path: Path, days: int) -> dict:
 	}
 
 
-def _build_hints(data: dict) -> list[str]:
+def _build_hints(data: dict[str, Any]) -> list[str]:
 	hints: list[str] = []
 	funnel = data.get("funnel", {})
 	greeted_total = funnel.get("greeted", 0)
@@ -101,7 +104,7 @@ def _build_hints(data: dict) -> list[str]:
 	return hints
 
 
-def _render_html(data: dict) -> str:
+def _render_html(data: dict[str, Any]) -> str:
 	"""渲染自包含交互式 HTML 报表（纯 CSS + SVG，无外部依赖）。"""
 	funnel = data.get("funnel", {})
 	window = data.get("window", {})
@@ -303,7 +306,7 @@ footer a {{ color: var(--accent); text-decoration: none; }}
 	help="HTML 输出路径（仅 --format html 时有效，未指定时写到 stdout）",
 )
 @click.pass_context
-def stats_cmd(ctx, days, output_format, output_path):
+def stats_cmd(ctx: click.Context, days: int, output_format: str, output_path: Path | None) -> None:
 	"""投递转化漏斗统计（只读聚合）"""
 	data_dir: Path = ctx.obj["data_dir"]
 	db_path = data_dir / "cache" / "boss_agent.db"


### PR DESCRIPTION
## Summary

mypy 严格化第十轮，白名单 51 → **56**。本轮纳入 api/* 和 stats 5 模块，cache/store（17 error）留下一轮专攻。

## 新增 5 个

| 模块 | 关键改动 |
|------|---------|
| `api/models` | `JobItem.from_api` / `to_dict` / `JobDetail.*` 全部补 `dict[str, Any]` |
| `api/throttle` | `wait` / `mark` / `__init__` 补 `-> None` |
| `api/endpoints` | 0 error，直接入白名单 |
| `api/endpoints_loader` | `_load_yaml` 用 typed 中间变量避免 `no-any-return` |
| `commands/stats` | `_safe_count` / `_count_since` 用 typed 中间变量 + `stats_cmd` 精确签名 |

## Test plan
- [x] `uv run mypy src/boss_agent_cli` → 0 errors（56 严格模块）
- [x] `uv run pytest tests/ -q` 927 passed 无回归
- [x] `uv run ruff check src/ tests/ mcp-server/` 全绿