### PR TITLE
feat: 严格类型检查白名单扩至六十个

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,10 @@ module = [
 	"boss_agent_cli.api.endpoints",
 	"boss_agent_cli.api.endpoints_loader",
 	"boss_agent_cli.commands.stats",
+	"boss_agent_cli.commands.chat_summary",
 	"boss_agent_cli.cache.store",
+	"boss_agent_cli.auth.manager",
+	"boss_agent_cli.auth.qr_login",
 ]
 disallow_untyped_defs = true
 disallow_any_generics = true

--- a/src/boss_agent_cli/auth/manager.py
+++ b/src/boss_agent_cli/auth/manager.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Any
 
 from boss_agent_cli.auth.browser import login_via_browser, login_via_cdp, probe_cdp, refresh_stoken, refresh_stoken_via_cdp
 from boss_agent_cli.auth.cookie_extract import extract_cookies
@@ -16,12 +17,12 @@ class TokenRefreshFailed(Exception):
 
 
 class AuthManager:
-	def __init__(self, data_dir: Path, *, logger: Logger | None = None):
+	def __init__(self, data_dir: Path, *, logger: Logger | None = None) -> None:
 		self._store = TokenStore(data_dir / "auth")
-		self._token: dict | None = None
+		self._token: dict[str, Any] | None = None
 		self._logger = logger or Logger()
 
-	def get_token(self) -> dict:
+	def get_token(self) -> dict[str, Any]:
 		if self._token is not None:
 			return self._token
 		self._token = self._store.load()
@@ -36,14 +37,14 @@ class AuthManager:
 		cookie_source: str | None = None,
 		cdp_url: str | None = None,
 		force_cdp: bool = False,
-	) -> dict:
+	) -> dict[str, Any]:
 		"""三级降级登录：Cookie 提取 → CDP 自动探测 → patchright 扫码。
 
 		Args:
 			force_cdp: 为 True 时跳过 Cookie 提取，CDP 不可用直接报错。
 		"""
 		method = "未知"
-		token: dict | None = None
+		token: dict[str, Any] | None = None
 
 		if force_cdp:
 			# --cdp 强制模式：跳过 Cookie，CDP 不可用直接抛异常
@@ -99,7 +100,7 @@ class AuthManager:
 		self._token = token
 		return {**token, "_method": method}
 
-	def _verify_cookie(self, token: dict) -> bool:
+	def _verify_cookie(self, token: dict[str, Any]) -> bool:
 		"""验证 Cookie 是否有效（不依赖 stoken，直接用 Cookie 请求用户信息）"""
 		try:
 			import httpx
@@ -116,7 +117,7 @@ class AuthManager:
 				timeout=10,
 			)
 			data = resp.json()
-			return data.get("code") == 0
+			return bool(data.get("code") == 0)
 		except (httpx.HTTPError, ValueError, KeyError):
 			return False
 
@@ -143,7 +144,7 @@ class AuthManager:
 			except Exception as e:
 				raise TokenRefreshFailed(f"Token 刷新失败: {e}") from e
 
-	def check_status(self) -> dict | None:
+	def check_status(self) -> dict[str, Any] | None:
 		return self._store.load()
 
 	def logout(self) -> None:

--- a/src/boss_agent_cli/auth/qr_login.py
+++ b/src/boss_agent_cli/auth/qr_login.py
@@ -3,6 +3,7 @@
 Flow: randkey → getqrcode → poll scan → scanLogin/dispatcher → extract cookies.
 """
 import sys
+from typing import Any
 import time
 
 import httpx
@@ -13,7 +14,7 @@ _POLL_INTERVAL = 2
 _DEFAULT_TIMEOUT = 120
 
 
-def qr_login_httpx(*, timeout: int = _DEFAULT_TIMEOUT) -> dict:
+def qr_login_httpx(*, timeout: int = _DEFAULT_TIMEOUT) -> dict[str, Any]:
 	"""Execute QR login flow via httpx only.
 
 	Returns token dict: {"cookies": {...}, "stoken": "", "user_agent": ua}

--- a/src/boss_agent_cli/commands/chat_summary.py
+++ b/src/boss_agent_cli/commands/chat_summary.py
@@ -12,7 +12,7 @@ from boss_agent_cli.display import handle_auth_errors, handle_error_output, hand
 @click.option("--count", default=20, help="每页消息数量")
 @click.pass_context
 @handle_auth_errors("chat-summary")
-def chat_summary_cmd(ctx, security_id, page, count):
+def chat_summary_cmd(ctx: click.Context, security_id: str, page: int, count: int) -> None:
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
 	delay = ctx.obj["delay"]


### PR DESCRIPTION
## Summary

mypy R12：白名单 57 → **60**，新增 `auth/manager` / `auth/qr_login` / `commands/chat_summary`。

## 新增 3 个

| 模块 | 关键改动 |
|------|---------|
| `auth/manager` | `_token: dict[str, Any] \| None` + `get_token/login/check_status/_verify_cookie` 全量 `dict[str, Any]`；`_verify_cookie` 返回 `bool(data.get("code") == 0)` 修复 no-any-return |
| `auth/qr_login` | `qr_login_httpx` 返回 `dict[str, Any]` |
| `commands/chat_summary` | 命令签名 `ctx: click.Context, security_id/page/count` 精确类型 |

## Test plan
- [x] mypy → 0 errors（60 严格模块）
- [x] 927 passed 无回归
- [x] ruff 全绿