### PR TITLE
chore: 发布版本 1.8.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ## [Unreleased]
 
+## [1.8.18] - 2026-04-20
+
+### Changed
+- **严格类型检查覆盖 api/client 核心请求客户端**（#119）— 37 error → 0，白名单 60 → 61
+- 用 `TYPE_CHECKING` 避免 BrowserSession / AuthManager 循环导入
+- `_request` / `_browser_request` 返回值用 `cast` 修 no-any-return
+- `__exit__` 精确 `TracebackType` 签名
+- 连锁修复 `commands/exchange.py` 类型传播问题
+
+### 里程碑
+- api/ 层覆盖达 6/7（剩 api/browser_client，patchright 外部依赖最重）
+- 严格模块累计 61 / 75（81%）
+
 ## [1.8.17] - 2026-04-20
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "boss-agent-cli"
-version = "1.8.17"
+version = "1.8.18"
 description = "AI Agent 专用的 BOSS 直聘求职 CLI 工具"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/boss_agent_cli/__init__.py
+++ b/src/boss_agent_cli/__init__.py
@@ -17,7 +17,7 @@ from boss_agent_cli.auth.manager import AuthManager, AuthRequired, TokenRefreshF
 from boss_agent_cli.cache.store import CacheStore
 from boss_agent_cli.resume.models import ResumeData, ResumeFile
 
-__version__ = "1.8.17"
+__version__ = "1.8.18"
 
 __all__ = [
 	# 版本

--- a/uv.lock
+++ b/uv.lock
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "boss-agent-cli"
-version = "1.8.17"
+version = "1.8.18"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },


### PR DESCRIPTION
版本 1.8.17 → 1.8.18：api/client 严格化（#119 R13）。严格模块达 61/75（81%）。