### PR TITLE
feat: 严格类型检查覆盖所有业务模块

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,10 @@ module = [
 	"boss_agent_cli.auth.manager",
 	"boss_agent_cli.auth.qr_login",
 	"boss_agent_cli.api.client",
+	"boss_agent_cli.api.browser_client",
+	"boss_agent_cli.auth.browser",
+	"boss_agent_cli.bridge.client",
+	"boss_agent_cli.bridge.daemon",
 ]
 disallow_untyped_defs = true
 disallow_any_generics = true

--- a/src/boss_agent_cli/api/browser_client.py
+++ b/src/boss_agent_cli/api/browser_client.py
@@ -9,7 +9,8 @@ Supports two modes:
 """
 import sys
 from pathlib import Path
-from typing import Any
+from types import TracebackType
+from typing import Any, cast
 
 from patchright.sync_api import sync_playwright
 
@@ -37,7 +38,7 @@ class BrowserSession:
 	Tries CDP connection to user's Chrome first; falls back to headless patchright.
 	"""
 
-	def __init__(self, cookies: dict, user_agent: str, *, delay: tuple[float, float] = (1.5, 3.0), cdp_url: str | None = None, logger=None):
+	def __init__(self, cookies: dict[str, Any], user_agent: str, *, delay: tuple[float, float] = (1.5, 3.0), cdp_url: str | None = None, logger: Any = None) -> None:
 		self._throttle = RequestThrottle(delay)
 		# patchright / BridgeClient 运行时创建；注解为 Any 让 mypy 对外部依赖放行
 		self._pw: Any = None
@@ -61,7 +62,7 @@ class BrowserSession:
 		else:
 			print(message, file=sys.stderr)
 
-	def _ensure_started(self):
+	def _ensure_started(self) -> None:
 		if self._started:
 			return
 
@@ -176,7 +177,7 @@ class BrowserSession:
 		import httpx
 		try:
 			resp = httpx.get(f"{http_url}/json/version", timeout=_CDP_PROBE_TIMEOUT)
-			return resp.json().get("webSocketDebuggerUrl")
+			return cast("str | None", resp.json().get("webSocketDebuggerUrl"))
 		except (httpx.HTTPError, ValueError, KeyError):
 			return None
 
@@ -196,7 +197,7 @@ class BrowserSession:
 					continue
 		return None
 
-	def _start_headless(self):
+	def _start_headless(self) -> None:
 		"""Fallback: launch headless patchright Chromium."""
 		self._browser = self._pw.chromium.launch(headless=True)
 		self._context = self._browser.new_context(
@@ -219,7 +220,7 @@ class BrowserSession:
 
 	# ── Core request via browser fetch() ─────────────────────────────
 
-	def request(self, method: str, url: str, *, params: dict | None = None, data: dict | None = None) -> dict:
+	def request(self, method: str, url: str, *, params: dict[str, Any] | None = None, data: dict[str, Any] | None = None) -> dict[str, Any]:
 		self._ensure_started()
 		self._throttle.wait()
 
@@ -238,7 +239,7 @@ class BrowserSession:
 				referer=referer,
 			)
 			self._throttle.mark()
-			return result
+			return cast("dict[str, Any]", result)
 
 		# Playwright 模式（CDP 或 headless）
 		result = self._page.evaluate("""
@@ -281,7 +282,7 @@ class BrowserSession:
 		""", {"method": method, "url": url, "params": params or {}, "data": data, "referer": referer})
 
 		self._throttle.mark()
-		return result
+		return cast("dict[str, Any]", result)
 
 	# ── Lifecycle ────────────────────────────────────────────────────
 
@@ -320,8 +321,13 @@ class BrowserSession:
 			self._pw.stop()
 		self._started = False
 
-	def __enter__(self):
+	def __enter__(self) -> "BrowserSession":
 		return self
 
-	def __exit__(self, *args):
+	def __exit__(
+		self,
+		exc_type: type[BaseException] | None,
+		exc_val: BaseException | None,
+		exc_tb: TracebackType | None,
+	) -> None:
 		self.close()

--- a/src/boss_agent_cli/api/client.py
+++ b/src/boss_agent_cli/api/client.py
@@ -170,7 +170,7 @@ class BossClient:
 				f"建议：以 --remote-debugging-port=9222 启动 Chrome 后重试（CDP 模式可规避风控检测）",
 				is_cdp=is_cdp,
 			)
-		return cast("dict[str, Any]", result)
+		return result
 
 	# ── Public API ───────────────────────────────────────────────────
 	# High-risk: search, recommend, greet, job_card → browser channel

--- a/src/boss_agent_cli/auth/browser.py
+++ b/src/boss_agent_cli/auth/browser.py
@@ -1,5 +1,6 @@
 import sys
 import time
+from typing import Any, cast
 
 from patchright.sync_api import sync_playwright
 
@@ -20,12 +21,12 @@ def probe_cdp(cdp_url: str | None = None) -> str | None:
 	base = cdp_url or _DEFAULT_CDP_URL
 	try:
 		resp = httpx.get(f"{base}/json/version", timeout=_CDP_PROBE_TIMEOUT)
-		return resp.json().get("webSocketDebuggerUrl")
+		return cast("str | None", resp.json().get("webSocketDebuggerUrl"))
 	except (httpx.HTTPError, ValueError, KeyError):
 		return None
 
 
-def login_via_cdp(*, cdp_url: str | None = None, timeout: int = 120) -> dict:
+def login_via_cdp(*, cdp_url: str | None = None, timeout: int = 120) -> dict[str, Any]:
 	"""
 	通过 CDP 连接用户 Chrome 扫码登录。
 	返回 token dict，失败抛异常。
@@ -73,7 +74,7 @@ def login_via_cdp(*, cdp_url: str | None = None, timeout: int = 120) -> dict:
 	return {"cookies": all_cookies, "stoken": "", "user_agent": ua}
 
 
-def login_via_browser(*, timeout: int = 120) -> dict:
+def login_via_browser(*, timeout: int = 120) -> dict[str, Any]:
 	"""
 	使用 patchright（Playwright 反检测 fork）打开登录页。
 	双重检测登录成功：监听 API 响应 + 轮询 wt2 cookie。
@@ -94,7 +95,7 @@ def login_via_browser(*, timeout: int = 120) -> dict:
 		# 双重检测：API 响应 或 wt2 cookie 出现，任一触发即认为登录成功
 		login_detected = False
 
-		def _on_response(response):
+		def _on_response(response: Any) -> None:
 			nonlocal login_detected
 			url = response.url
 			if (url.startswith("https://www.zhipin.com/wapi/zppassport/qrcode/loginConfirm")
@@ -167,7 +168,7 @@ def refresh_stoken_via_cdp(cdp_url: str | None = None) -> str:
 	return stoken
 
 
-def refresh_stoken(cookies: dict, user_agent: str) -> str:
+def refresh_stoken(cookies: dict[str, Any], user_agent: str) -> str:
 	"""通过 headless patchright 刷新 stoken（兜底方案）。"""
 	with sync_playwright() as p:
 		browser = p.chromium.launch(headless=True)
@@ -185,7 +186,7 @@ def refresh_stoken(cookies: dict, user_agent: str) -> str:
 	return stoken
 
 
-def _extract_stoken(page) -> str:
+def _extract_stoken(page: Any) -> str:
 	try:
 		stoken = page.evaluate("""
 			() => {
@@ -195,6 +196,6 @@ def _extract_stoken(page) -> str:
 		""")
 		if not stoken:
 			stoken = page.evaluate("() => window.__zp_stoken__ || ''")
-		return stoken
+		return cast("str", stoken)
 	except Exception:
 		return ""

--- a/src/boss_agent_cli/bridge/client.py
+++ b/src/boss_agent_cli/bridge/client.py
@@ -2,6 +2,7 @@
 
 import json
 import time
+from typing import Any, cast
 
 import httpx
 
@@ -39,7 +40,7 @@ class BridgeClient:
 		except (httpx.HTTPError, OSError):
 			return False
 
-	def status(self) -> dict | None:
+	def status(self) -> dict[str, Any] | None:
 		"""获取 daemon 状态。"""
 		try:
 			resp = httpx.get(
@@ -47,7 +48,7 @@ class BridgeClient:
 				timeout=2.0,
 			)
 			if resp.status_code == 200:
-				return resp.json()
+				return cast("dict[str, Any]", resp.json())
 			return None
 		except (httpx.HTTPError, ValueError, OSError):
 			return None
@@ -57,7 +58,7 @@ class BridgeClient:
 		st = self.status()
 		return st is not None and st.get("extensionConnected", False)
 
-	def send_command(self, action: str, **kwargs) -> BridgeResult:
+	def send_command(self, action: str, **kwargs: Any) -> BridgeResult:
 		"""发送命令到扩展，自动重试。"""
 		last_error = ""
 
@@ -105,21 +106,21 @@ class BridgeClient:
 
 	# ── 高级 API ─────────────────────────────────────────────────
 
-	def evaluate(self, code: str, *, workspace: str = "boss") -> dict:
+	def evaluate(self, code: str, *, workspace: str = "boss") -> dict[str, Any]:
 		"""在页面上下文中执行 JS，返回结果。"""
 		result = self.send_command("exec", code=code, workspace=workspace)
 		if not result.ok:
 			raise RuntimeError(f"Bridge evaluate 失败: {result.error}")
 		return result.data if isinstance(result.data, dict) else {"result": result.data}
 
-	def navigate(self, url: str, *, workspace: str = "boss") -> dict:
+	def navigate(self, url: str, *, workspace: str = "boss") -> dict[str, Any]:
 		"""导航到指定 URL。"""
 		result = self.send_command("navigate", url=url, workspace=workspace)
 		if not result.ok:
 			raise RuntimeError(f"Bridge navigate 失败: {result.error}")
 		return result.data if isinstance(result.data, dict) else {}
 
-	def get_cookies(self, domain: str) -> list[dict]:
+	def get_cookies(self, domain: str) -> list[dict[str, Any]]:
 		"""获取指定域名的 Cookie。"""
 		result = self.send_command("cookies", domain=domain)
 		if not result.ok:
@@ -130,7 +131,7 @@ class BridgeClient:
 		"""关闭 automation window。"""
 		self.send_command("close-window", workspace=workspace)
 
-	def fetch_json(self, url: str, *, method: str = "GET", data: dict | None = None, referer: str = "", workspace: str = "boss") -> dict:
+	def fetch_json(self, url: str, *, method: str = "GET", data: dict[str, Any] | None = None, referer: str = "", workspace: str = "boss") -> dict[str, Any]:
 		"""通过浏览器 fetch() 发起 API 请求，返回 JSON。"""
 		if method == "GET":
 			js = f"""

--- a/src/boss_agent_cli/bridge/daemon.py
+++ b/src/boss_agent_cli/bridge/daemon.py
@@ -20,7 +20,7 @@ _PID_FILE = Path.home() / ".boss-agent" / "bridge" / "daemon.pid"
 _LOG_FILE = Path.home() / ".boss-agent" / "bridge" / "daemon.log"
 
 
-def _ensure_dirs():
+def _ensure_dirs() -> None:
 	_PID_FILE.parent.mkdir(parents=True, exist_ok=True)
 
 
@@ -106,7 +106,7 @@ def start_daemon_background() -> int | None:
 	return proc.pid
 
 
-async def _run_daemon():
+async def _run_daemon() -> None:
 	"""daemon 主循环：统一 aiohttp HTTP + WebSocket 服务。"""
 	from aiohttp import web
 
@@ -116,19 +116,19 @@ async def _run_daemon():
 	)
 
 	start_time = time.time()
-	ext_ws = None
-	ext_version = None
+	ext_ws: Any = None
+	ext_version: str | None = None
 	last_activity = time.time()
-	pending_commands: dict[str, asyncio.Future] = {}
+	pending_commands: dict[str, "asyncio.Future[Any]"] = {}
 
 	# ── HTTP handlers ─────────────────────────────────────────────
 
-	async def handle_ping(request):
+	async def handle_ping(request: Any) -> Any:
 		nonlocal last_activity
 		last_activity = time.time()
 		return web.json_response({"ok": True})
 
-	async def handle_status(request):
+	async def handle_status(request: Any) -> Any:
 		nonlocal last_activity
 		last_activity = time.time()
 		return web.json_response({
@@ -139,7 +139,7 @@ async def _run_daemon():
 			"uptime": int(time.time() - start_time),
 		})
 
-	async def handle_command(request):
+	async def handle_command(request: Any) -> Any:
 		nonlocal last_activity
 		last_activity = time.time()
 
@@ -180,7 +180,7 @@ async def _run_daemon():
 
 	# ── WebSocket handler（Chrome 扩展连接） ──────────────────────
 
-	async def ws_handler(request):
+	async def ws_handler(request: Any) -> Any:
 		nonlocal ext_ws, ext_version
 		ws = web.WebSocketResponse()
 		await ws.prepare(request)


### PR DESCRIPTION
## Summary

mypy 严格化 **R14（收官轮）**：白名单 61 → **66**，业务代码全量严格化 **100% (66/66) 🎯**

## 本轮新增 5 个（本会话唯一 5 模块 PR）

| 模块 | 难点 | 关键改动 |
|------|------|---------|
| `bridge/client` | httpx + dict 泛型 | `status()` 用 cast、`send_command` 的 kwargs 精确签名 |
| `bridge/daemon` | aiohttp 异步、嵌套闭包 | 所有 `async def handle_*(request: Any) -> Any`、`asyncio.Future[Any]` 精确泛型 |
| `auth/browser` | patchright 外部依赖 | `_on_response(response: Any)`、`_extract_stoken(page: Any)`、stoken 返回 cast |
| `api/browser_client` | patchright + 混合 Bridge/CDP 通道 | `__exit__` 用 `TracebackType`、`request` 返回 `cast("dict[str, Any]", ...)` |
| `api/client`（redundant-cast 修复） | 全局严格后 cast 变冗余 | 移除一处 redundant cast |

## 里程碑 🎯

**从 R1（#86）到 R14（本 PR），14 轮连续推进，严格模块 0 → 66**：

| 批次 | PR | 里程碑 |
|------|-----|--------|
| R1-R3 | #86/#88/#92/#99 | 建基线 + 装饰器解锁 + 首批 CLI 进严 |
| R4-R8 | #101/#103/#105/#107/#109 | CLI 命令层 100%（32/32） |
| R9-R11 | #111/#113/#115 | api/* + cache/* + 工具层 |
| R12-R13 | #117/#119 | auth/manager + api/client |
| **R14（本 PR）** | — | **patchright / aiohttp 深水区拿下，100% 业务代码严格化** |

## Test plan
- [x] `uv run mypy src/boss_agent_cli` → **Success: no issues found in 75 source files**
- [x] `uv run pytest tests/ -q` **927 passed** 无回归
- [x] `uv run ruff check src/ tests/ mcp-server/` 全绿