### PR TITLE
chore: 发布版本 1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ## [Unreleased]
 
+## [1.9.1] - 2026-04-20
+
+### Changed
+- **🎯 mypy 严格模式全量接入达成 100%**（#124）— 本轮收尾 4 个 patchright / aiohttp 外部依赖深水区（`api/browser_client` / `auth/browser` / `bridge/client` / `bridge/daemon`），白名单 61 → **66（业务代码 100%）**
+- ROADMAP v2.0「架构演进」分区 2/3 完成（mypy 严格化 ✅、类型 stubs 导出 ✅）
+- 所有业务模块强制 `disallow_untyped_defs + disallow_any_generics + warn_return_any`
+
+### 里程碑
+从 R1（#86）到 R14（#124），14 轮连续推进，严格模块 0 → 66。CI `typecheck` job 阻塞式，新代码零容忍。
+
 ## [1.9.0] - 2026-04-20
 
 ### Summary

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,7 +30,7 @@
 ## 🔮 中期（v2.0）
 
 ### 架构演进
-- [ ] mypy 严格模式全量接入 — **81% 已完成**（61/75 严格化，CLI 命令层 100%、api/* 6/7、auth/* 4/5、cache/ 1/1）。剩余 4 个 patchright/aiohttp 外部依赖模块。
+- [x] mypy 严格模式全量接入 — **100% 完成**（66/66 业务模块全部 `disallow_untyped_defs + disallow_any_generics + warn_return_any` 严格化，v1.9.1）
 - [x] 类型签名导出到 `stubs/`，供下游 IDE 使用（v1.8.6，py.typed + canonical `__all__` + 16 条契约测试）
 - [ ] Bridge 协议从 HTTP/WS 升级为 gRPC — 先做调研（Issue #96）再启动实现
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "boss-agent-cli"
-version = "1.9.0"
+version = "1.9.1"
 description = "AI Agent 专用的 BOSS 直聘求职 CLI 工具"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/boss_agent_cli/__init__.py
+++ b/src/boss_agent_cli/__init__.py
@@ -17,7 +17,7 @@ from boss_agent_cli.auth.manager import AuthManager, AuthRequired, TokenRefreshF
 from boss_agent_cli.cache.store import CacheStore
 from boss_agent_cli.resume.models import ResumeData, ResumeFile
 
-__version__ = "1.9.0"
+__version__ = "1.9.1"
 
 __all__ = [
 	# 版本

--- a/uv.lock
+++ b/uv.lock
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "boss-agent-cli"
-version = "1.9.0"
+version = "1.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },


### PR DESCRIPTION
## Summary

🎯 里程碑发布：mypy 严格类型检查覆盖 **100% 业务模块**（66/66）。

## 核心变更
- #124 严格化收尾 patchright / aiohttp 深水区 4 模块
- ROADMAP v2.0「mypy 严格模式全量接入」✅
- CHANGELOG 记录 14 轮推进里程碑

## 发布流程
```bash
git checkout master && git pull
git tag v1.9.1 && git push origin v1.9.1
```

## Test plan
- [x] mypy → 0 errors（全 75 source files 严格通过）
- [x] 927 passed 无回归