### PR TITLE
docs: 更新社区投稿真实状态与渠道约束

### DIFF
--- a/docs/awesome-submissions.md
+++ b/docs/awesome-submissions.md
@@ -88,12 +88,29 @@
 5. "MIT License，本地加密存储，数据不出机"
 6. "mypy 严格化 81%，927 测试，下游 Python 嵌入零学习成本"
 
-## 实际投稿记录
+## 实际投稿记录 & 渠道约束（2026-04-20 复盘）
 
-| 日期 | 列表 | 状态 |
-|------|------|------|
-| 2026-04-17 | awesome-mcp-servers (#4992) | 等待审核 |
-| TBD | awesome-claude-code | 待投递 |
-| TBD | awesome-agents | 待投递 |
+| 列表 | 日期 | PR/Issue | 状态 | 接续动作 |
+|------|------|---------|------|---------|
+| [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) | 2026-04-17 | PR #4992 | ⏳ 机器人要求先注册 [Glama.ai](https://glama.ai/mcp/servers) | **阻塞**：需在 Glama.ai 提交 MCP server → 通过 server introspection check → 加 `[![...](...badges/score.svg)](...)` 徽章到 PR → 重新 push |
+| [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code) | — | — | ⚠️ 渠道限制 | **必须通过 Web UI issue 表单**（`/issues/new?template=recommend-resource.yml`），**禁止 gh CLI**（违规会被封禁，见 docs/CONTRIBUTING.md 明文警告） |
+| [awesome-agents (kyrolabs)](https://github.com/kyrolabs/awesome-agents) | — | — | ⚠️ 星数门槛 | 规则明确：brand new repo without demonstrated traction 自动拒绝。当前 19 star 低于阈值，建议达 50+ 后再投 |
+| [awesome-ai-tools (mahseema)](https://github.com/mahseema/awesome-ai-tools) | — | — | 🟢 可投 | 无明确门槛，可考虑投稿 Agents & Automation 分区 |
+| ~~awesome-python-cli (shinokada)~~ | — | — | ❌ 仓库不存在 | 404，从投稿列表移除 |
 
-> 策略：达到 30+ stars 后再集中批量投稿，减少"brand new repo"被拒概率（awesome-agents 明确拒绝无历史仓库）。
+### 接续路径
+
+1. **短期**（本会话或下次）：给 [awesome-mcp-servers PR #4992](https://github.com/punkpeye/awesome-mcp-servers/pull/4992) 解锁——到 glama.ai 注册 MCP server，通过 introspection check，回填徽章
+2. **中期**（star ≥ 30 后）：集中批量投稿其他 awesome 列表
+3. **长期**（star ≥ 50 后）：awesome-agents (kyrolabs) 满足 demonstrated traction
+
+### 投稿渠道约束快查表
+
+| 渠道 | 可用 gh CLI？ | 特殊前置 |
+|------|------------|---------|
+| awesome-mcp-servers | ✅ | Glama.ai 注册 + 徽章 |
+| awesome-claude-code | ❌ 只能 Web UI 表单 | — |
+| awesome-agents (kyrolabs) | ✅ | 明示 traction（star ≥ 50 建议） |
+| awesome-ai-tools | ✅ | 无明示 |
+
+> 策略总结：**不强投**——对于设有 traction 门槛或非 CLI 渠道的列表，宁可推迟到条件满足，避免无效 PR 浪费维护者时间。核心阻塞是 PR #4992 的 Glama.ai 注册动作，这是下次会话应优先推进的外部动作。


### PR DESCRIPTION
## Summary

P2「awesome 实际投稿」的真实盘点结果。原素材文档是「TBD 待投递」乐观表述，实际动手时发现三大渠道均有约束——本 PR 把真实阻塞落到文档里，给接续人清晰路径。

## 关键发现

| 渠道 | 真实状态 |
|------|---------|
| awesome-mcp-servers PR #4992 | ⏳ **已投但阻塞**：机器人要求先注册 [Glama.ai](https://glama.ai/mcp/servers)，通过 server introspection check，拿 Glama 徽章后重新 push |
| awesome-claude-code | ⚠️ **渠道限制**：必须通过 Web UI issue 表单，gh CLI 会被封禁（docs/CONTRIBUTING.md 明文警告） |
| awesome-agents (kyrolabs) | ⚠️ **星数门槛**：明确拒绝 brand new repo，19 star 低于阈值 |
| awesome-python-cli | ❌ **仓库不存在**：从列表移除 |

## 更新内容

- 「实际投稿记录」改为**真实投稿状态表**（含 PR/Issue 链接、阻塞说明、接续动作）
- 新增「接续路径」章节：短中长期投稿动作分层
- 新增「投稿渠道约束快查表」：可用 gh CLI？/ 特殊前置
- 策略总结：**不强投**原则，避免无效 PR

## 核心价值

1. **避免下次会话重复踩坑**：明确每个渠道的约束
2. **明确关键阻塞**：PR #4992 的 Glama.ai 注册是下次外部动作的关键路径
3. **合规性**：awesome-claude-code 禁止 CLI 投稿是重要合规信息，文档化后避免违规

## Test plan

- [x] 纯文档改动，无代码影响
- [x] 所有 GitHub API 验证均已执行（PR #4992 状态、各仓库 star 数、awesome-python-cli 404）
- [x] 渠道约束引用自各仓库的 CONTRIBUTING.md 原文