### PR TITLE
feat: 新增平台抽象基类和 BOSS 直聘适配器

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ## [Unreleased]
 
+### Added
+- **Platform 抽象基类**（Issue #129 Week 1 骨架）— 新增 `src/boss_agent_cli/platforms/` 子包：`Platform` ABC 定义跨平台统一契约（is_success / unwrap_data / parse_error + P0 只读 + P1 写操作 + P2 沟通），`BossPlatform` 降级为 `BossClient` 的 adapter（零行为变化）；新增 `get_platform` / `list_platforms` 注册表入口。
+- Python 嵌入 API 扩展导出 `Platform` / `BossPlatform` / `get_platform` / `list_platforms`，下游可用 `from boss_agent_cli import get_platform` 注入具体平台实现。
+- `tests/test_platform_base.py` 新增 25 条契约测试覆盖 ABC 限制、包络适配、委托调用、注册表行为。
+
+### Changed
+- mypy 严格化覆盖 `boss_agent_cli.platforms` / `.base` / `.zhipin` 三个新模块（严格白名单 66 → 69）。
+- Issue #90（多平台 API 调研）闭环，研究报告索引入库 `docs/research/platforms/`。
+
 ## [1.9.1] - 2026-04-20
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ graph TD
 | `src/boss_agent_cli/bridge/` | Python | Browser Bridge — Chrome 扩展 + Python daemon 零配置浏览器通道 | `client.py` | `tests/test_bridge.py`, `tests/test_bridge_extended.py` |
 | `src/boss_agent_cli/resume/` | Python | 简历数据模型、本地存储、模板渲染、多格式导出 | `models.py` | `tests/test_resume_commands.py`, `tests/test_resume_templates.py`, `tests/test_resume_export.py`, `tests/test_resume_models.py`, `tests/test_resume_store.py`, `tests/test_resume_import_compat.py` |
 | `src/boss_agent_cli/ai/` | Python | 智能服务：多模型配置、密钥加密存储、提示词模板、对话补全 | `service.py` | `tests/test_ai_config.py`, `tests/test_ai_prompts.py`, `tests/test_ai_service.py`, `tests/test_ai_commands.py` |
+| `src/boss_agent_cli/platforms/` | Python | 跨平台抽象（Issue #129 Week 1 骨架）：Platform ABC + 注册表 + BossPlatform adapter | `base.py`, `zhipin.py` | `tests/test_platform_base.py` |
 
 ## 技术栈
 
@@ -389,3 +390,4 @@ boss logout       -> 退出登录
 | 2026-04-15 | 文档对齐 | 补充不变量契约段落、Git 禁止项和 PR 合并流程、AI 错误码、调用链和文档引用全量更新 |
 | 2026-04-15 | 协议分析 | 基于竞品端点对比新增两个端点定义、诊断命令增加辅助凭据完整性检查、职位卡片请求优先走轻量通道，测试 52→55（658 项） |
 | 2026-04-19 | 智能能力扩展 | ai 命令组新增 interview-prep 和 chat-coach 两个子命令，协议服务新增两个工具（41→43），测试 814→828，版本 1.8.0 |
+| 2026-04-21 | Platform 抽象 | 新增 platforms/ 子包定义 Platform ABC + BossPlatform adapter（Week 1a 骨架，零行为变化），Issue #90 研究闭环，下游嵌入 API 新增 4 个导出符号，测试 927→956，mypy 严格模块 66→69 |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,7 +37,11 @@
 ### 生态扩展
 - [ ] Web UI（React + Tailwind），适合非 Agent 用户
 - [ ] 浏览器扩展深度集成 BOSS 直聘原生页面
-- [ ] 多平台支持：拉勾 / 智联 / 猎聘适配器 — API 调研已全部完成（Issue #90 · [docs/research/platforms/](docs/research/platforms/)），结论：**智联为 v2.0 优先接入候选**（2-3 周），拉勾和猎聘不建议接入
+- [ ] 多平台支持：拉勾 / 智联 / 猎聘适配器 — API 调研已全部完成（Issue #90 已闭环 · [docs/research/platforms/](docs/research/platforms/)），结论：**智联为 v2.0 优先接入候选**（2-3 周），拉勾和猎聘不建议接入
+  - [x] Week 1a：Platform ABC 骨架 + BossPlatform adapter（#129，零行为变化）
+  - [ ] Week 1b：CLI 命令层迁移到 Platform 接口（`--platform zhipin` 全局选项）
+  - [ ] Week 2：ZhilianPlatform 只读实现（search / detail / recommend / user_info）
+  - [ ] Week 3：ZhilianPlatform 写操作（greet / apply）+ 文档 + MCP 适配
 
 ### 社区建设
 - [ ] 中文 + 英文视频 demo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,9 @@ module = [
 	"boss_agent_cli.auth.browser",
 	"boss_agent_cli.bridge.client",
 	"boss_agent_cli.bridge.daemon",
+	"boss_agent_cli.platforms",
+	"boss_agent_cli.platforms.base",
+	"boss_agent_cli.platforms.zhipin",
 ]
 disallow_untyped_defs = true
 disallow_any_generics = true

--- a/src/boss_agent_cli/__init__.py
+++ b/src/boss_agent_cli/__init__.py
@@ -15,6 +15,7 @@ from boss_agent_cli.api.client import AccountRiskError, AuthError, BossClient
 from boss_agent_cli.api.models import JobDetail, JobItem
 from boss_agent_cli.auth.manager import AuthManager, AuthRequired, TokenRefreshFailed
 from boss_agent_cli.cache.store import CacheStore
+from boss_agent_cli.platforms import BossPlatform, Platform, get_platform, list_platforms
 from boss_agent_cli.resume.models import ResumeData, ResumeFile
 
 __version__ = "1.9.1"
@@ -41,4 +42,9 @@ __all__ = [
 	# 简历模型
 	"ResumeData",
 	"ResumeFile",
+	# 平台抽象（Week 1 ABC，详见 Issue #129）
+	"Platform",
+	"BossPlatform",
+	"get_platform",
+	"list_platforms",
 ]

--- a/src/boss_agent_cli/platforms/__init__.py
+++ b/src/boss_agent_cli/platforms/__init__.py
@@ -1,0 +1,50 @@
+"""Platform 注册表：根据 name 返回对应 Platform 实现类。
+
+使用示例:
+
+    from boss_agent_cli.platforms import get_platform
+    plat_cls = get_platform("zhipin")  # 默认
+    platform = plat_cls(boss_client)
+    result = platform.search_jobs("Python")
+"""
+
+from __future__ import annotations
+
+from boss_agent_cli.platforms.base import Platform
+from boss_agent_cli.platforms.zhipin import BossPlatform
+
+_REGISTRY: dict[str, type[Platform]] = {
+	"zhipin": BossPlatform,
+}
+
+
+def get_platform(name: str | None = "zhipin") -> type[Platform]:
+	"""按名称获取 Platform 实现类。
+
+	- ``name=None`` 或空字符串 → 返回默认 BOSS 直聘
+	- 未知名称 → 抛 ValueError
+	"""
+	key = name or "zhipin"
+	if key not in _REGISTRY:
+		available = ", ".join(sorted(_REGISTRY.keys()))
+		raise ValueError(f"unknown platform: {key!r}, available: [{available}]")
+	return _REGISTRY[key]
+
+
+def list_platforms() -> list[str]:
+	"""返回所有已注册平台名称。"""
+	return sorted(_REGISTRY.keys())
+
+
+def register_platform(name: str, cls: type[Platform]) -> None:
+	"""动态注册平台实现（主要给测试用）。"""
+	_REGISTRY[name] = cls
+
+
+__all__ = [
+	"Platform",
+	"BossPlatform",
+	"get_platform",
+	"list_platforms",
+	"register_platform",
+]

--- a/src/boss_agent_cli/platforms/base.py
+++ b/src/boss_agent_cli/platforms/base.py
@@ -1,0 +1,84 @@
+"""招聘平台抽象基类。
+
+Platform 接口定义跨平台统一契约（search / detail / greet / apply 等），
+让 CLI 命令层通过 Platform 抽象调用，不耦合具体平台协议。
+
+Week 1 交付：接口定义 + BOSS 直聘 adapter，不改动现有命令行为。
+详见 Issue #129。
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class Platform(ABC):
+	"""招聘平台抽象基类。
+
+	每个平台实现需覆盖：
+	- 基础元信息（name / display_name / base_url）
+	- 包络适配方法（is_success / unwrap_data / parse_error）
+	- P0 只读能力（search / detail / recommend / user_info）
+
+	写操作（greet / apply）和沟通接口（friend_list / chat_messages）为可选，
+	平台不支持时抛 NotImplementedError。
+	"""
+
+	name: str
+	display_name: str
+	base_url: str
+
+	@abstractmethod
+	def is_success(self, response: dict[str, Any]) -> bool:
+		"""判断响应是否成功。
+
+		- BOSS: ``code == 0``
+		- 智联: ``code == 200``
+		- 猎聘: ``flag == 1``
+		"""
+
+	@abstractmethod
+	def unwrap_data(self, response: dict[str, Any]) -> Any:
+		"""从响应包络提取 data。
+
+		- BOSS: ``response["zpData"]``
+		- 智联: ``response["data"]``
+		- 猎聘: ``response["data"]``
+		"""
+
+	@abstractmethod
+	def parse_error(self, response: dict[str, Any]) -> tuple[str, str]:
+		"""解析错误响应，返回 (统一错误码, 原始消息)。
+
+		统一错误码对齐 CLAUDE.md 错误码枚举：
+		AUTH_EXPIRED / RATE_LIMITED / TOKEN_REFRESH_FAILED / ACCOUNT_RISK / UNKNOWN。
+		"""
+
+	@abstractmethod
+	def search_jobs(self, query: str, **filters: Any) -> dict[str, Any]:
+		"""搜索职位。"""
+
+	@abstractmethod
+	def job_detail(self, job_id: str) -> dict[str, Any]:
+		"""查看职位详情。"""
+
+	@abstractmethod
+	def recommend_jobs(self, page: int = 1) -> dict[str, Any]:
+		"""获取个性化推荐。"""
+
+	@abstractmethod
+	def user_info(self) -> dict[str, Any]:
+		"""获取当前用户信息。"""
+
+	def greet(self, security_id: str, job_id: str, message: str = "") -> dict[str, Any]:
+		"""打招呼。平台不支持时抛 NotImplementedError。"""
+		raise NotImplementedError(f"{self.name} platform does not implement greet")
+
+	def apply(self, security_id: str, job_id: str, lid: str = "") -> dict[str, Any]:
+		"""发起投递。平台不支持时抛 NotImplementedError。"""
+		raise NotImplementedError(f"{self.name} platform does not implement apply")
+
+	def friend_list(self, page: int = 1) -> dict[str, Any]:
+		"""沟通列表。平台不支持时抛 NotImplementedError。"""
+		raise NotImplementedError(f"{self.name} platform does not implement friend_list")

--- a/src/boss_agent_cli/platforms/zhipin.py
+++ b/src/boss_agent_cli/platforms/zhipin.py
@@ -1,0 +1,76 @@
+"""BOSS 直聘平台 adapter。
+
+把现有 ``BossClient`` 包装为 ``Platform`` 实现，零行为变化。
+后续新平台（智联等）实现同一 Platform 接口，
+命令层可以通过 ``get_platform(name)`` 无差别调用。
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from boss_agent_cli.api.endpoints import BASE_URL
+from boss_agent_cli.platforms.base import Platform
+
+if TYPE_CHECKING:
+	from boss_agent_cli.api.client import BossClient
+
+
+# BOSS 直聘错误码 → 统一错误码映射（对齐 CLAUDE.md 错误码枚举）
+_ERROR_CODE_MAP: dict[int, str] = {
+	9: "RATE_LIMITED",
+	36: "ACCOUNT_RISK",
+	37: "TOKEN_REFRESH_FAILED",
+}
+
+
+class BossPlatform(Platform):
+	"""BOSS 直聘平台实现。"""
+
+	name = "zhipin"
+	display_name = "BOSS 直聘"
+	base_url = BASE_URL
+
+	def __init__(self, client: "BossClient") -> None:
+		self._client = client
+
+	# ── 包络适配 ────────────────────────────────────────
+
+	def is_success(self, response: dict[str, Any]) -> bool:
+		return response.get("code") == 0
+
+	def unwrap_data(self, response: dict[str, Any]) -> Any:
+		return response.get("zpData")
+
+	def parse_error(self, response: dict[str, Any]) -> tuple[str, str]:
+		code = response.get("code")
+		message = str(response.get("message") or response.get("zpData") or "")
+		unified = _ERROR_CODE_MAP.get(code, "UNKNOWN") if isinstance(code, int) else "UNKNOWN"
+		return unified, message
+
+	# ── P0 只读委托 ─────────────────────────────────────
+
+	def search_jobs(self, query: str, **filters: Any) -> dict[str, Any]:
+		return self._client.search_jobs(query, **filters)
+
+	def job_detail(self, job_id: str) -> dict[str, Any]:
+		return self._client.job_detail(job_id)
+
+	def recommend_jobs(self, page: int = 1) -> dict[str, Any]:
+		return self._client.recommend_jobs(page)
+
+	def user_info(self) -> dict[str, Any]:
+		return self._client.user_info()
+
+	# ── P1 写操作委托 ───────────────────────────────────
+
+	def greet(self, security_id: str, job_id: str, message: str = "") -> dict[str, Any]:
+		return self._client.greet(security_id, job_id, message)
+
+	def apply(self, security_id: str, job_id: str, lid: str = "") -> dict[str, Any]:
+		return self._client.apply(security_id, job_id, lid)
+
+	# ── P2 沟通委托 ─────────────────────────────────────
+
+	def friend_list(self, page: int = 1) -> dict[str, Any]:
+		return self._client.friend_list(page)

--- a/tests/test_platform_base.py
+++ b/tests/test_platform_base.py
@@ -1,0 +1,165 @@
+"""Platform 抽象基类契约测试。
+
+覆盖：
+- Platform ABC 不能实例化
+- BossPlatform 满足接口契约
+- 包络适配方法（is_success / unwrap_data / parse_error）语义正确
+- 委托方法正确传递给 BossClient
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from boss_agent_cli.platforms.base import Platform
+from boss_agent_cli.platforms.zhipin import BossPlatform
+
+
+class TestPlatformABC:
+	"""Platform 抽象基类契约。"""
+
+	def test_cannot_instantiate_abstract_base(self) -> None:
+		with pytest.raises(TypeError):
+			Platform()  # type: ignore[abstract]
+
+	def test_boss_platform_is_subclass(self) -> None:
+		assert issubclass(BossPlatform, Platform)
+
+	def test_boss_platform_metadata(self) -> None:
+		plat = BossPlatform(MagicMock())
+		assert plat.name == "zhipin"
+		assert plat.display_name == "BOSS 直聘"
+		assert "zhipin.com" in plat.base_url
+
+
+class TestBossEnvelopeAdapter:
+	"""BOSS 直聘响应包络适配。"""
+
+	def setup_method(self) -> None:
+		self.plat = BossPlatform(MagicMock())
+
+	def test_is_success_code_zero(self) -> None:
+		assert self.plat.is_success({"code": 0, "zpData": {}}) is True
+
+	def test_is_success_non_zero(self) -> None:
+		assert self.plat.is_success({"code": 9}) is False
+
+	def test_is_success_missing_code(self) -> None:
+		assert self.plat.is_success({}) is False
+
+	def test_unwrap_data_from_zpdata(self) -> None:
+		result = self.plat.unwrap_data({"code": 0, "zpData": {"jobList": [1, 2]}})
+		assert result == {"jobList": [1, 2]}
+
+	def test_unwrap_data_missing_zpdata(self) -> None:
+		assert self.plat.unwrap_data({"code": 0}) is None
+
+	def test_parse_error_stoken_expired(self) -> None:
+		code, msg = self.plat.parse_error({"code": 37, "message": "stoken invalid"})
+		assert code == "TOKEN_REFRESH_FAILED"
+		assert "stoken" in msg.lower() or msg
+
+	def test_parse_error_rate_limited(self) -> None:
+		code, _ = self.plat.parse_error({"code": 9, "message": "请求频繁"})
+		assert code == "RATE_LIMITED"
+
+	def test_parse_error_account_risk(self) -> None:
+		code, _ = self.plat.parse_error({"code": 36, "message": "risk"})
+		assert code == "ACCOUNT_RISK"
+
+	def test_parse_error_unknown(self) -> None:
+		code, _ = self.plat.parse_error({"code": 999, "message": "unknown"})
+		assert code == "UNKNOWN"
+
+
+class TestBossPlatformDelegation:
+	"""BossPlatform 委托给底层 BossClient。"""
+
+	def setup_method(self) -> None:
+		self.mock_client = MagicMock()
+		self.plat = BossPlatform(self.mock_client)
+
+	def test_search_jobs_delegates(self) -> None:
+		self.mock_client.search_jobs.return_value = {"code": 0, "zpData": {}}
+		result = self.plat.search_jobs("Python", city="广州")
+		self.mock_client.search_jobs.assert_called_once_with("Python", city="广州")
+		assert result == {"code": 0, "zpData": {}}
+
+	def test_job_detail_delegates(self) -> None:
+		self.mock_client.job_detail.return_value = {"code": 0}
+		self.plat.job_detail("job_123")
+		self.mock_client.job_detail.assert_called_once_with("job_123")
+
+	def test_recommend_jobs_delegates(self) -> None:
+		self.mock_client.recommend_jobs.return_value = {"code": 0}
+		self.plat.recommend_jobs(page=2)
+		self.mock_client.recommend_jobs.assert_called_once_with(2)
+
+	def test_user_info_delegates(self) -> None:
+		self.mock_client.user_info.return_value = {"code": 0}
+		self.plat.user_info()
+		self.mock_client.user_info.assert_called_once_with()
+
+	def test_greet_delegates(self) -> None:
+		self.mock_client.greet.return_value = {"code": 0}
+		self.plat.greet("sec_abc", "job_123", message="hi")
+		self.mock_client.greet.assert_called_once_with("sec_abc", "job_123", "hi")
+
+	def test_apply_delegates(self) -> None:
+		self.mock_client.apply.return_value = {"code": 0}
+		self.plat.apply("sec_abc", "job_123", lid="lid_x")
+		self.mock_client.apply.assert_called_once_with("sec_abc", "job_123", "lid_x")
+
+	def test_friend_list_delegates(self) -> None:
+		self.mock_client.friend_list.return_value = {"code": 0}
+		self.plat.friend_list(page=3)
+		self.mock_client.friend_list.assert_called_once_with(3)
+
+
+class TestPlatformRegistry:
+	"""Platform 注册表：通过 name 查找实现。"""
+
+	def test_get_platform_zhipin(self) -> None:
+		from boss_agent_cli.platforms import get_platform
+
+		plat_cls = get_platform("zhipin")
+		assert plat_cls is BossPlatform
+
+	def test_get_platform_default_zhipin(self) -> None:
+		"""向后兼容：不传参数等同 zhipin。"""
+		from boss_agent_cli.platforms import get_platform
+
+		plat_cls = get_platform()
+		assert plat_cls is BossPlatform
+
+	def test_get_platform_unknown_raises(self) -> None:
+		from boss_agent_cli.platforms import get_platform
+
+		with pytest.raises(ValueError, match="unknown platform"):
+			get_platform("nonexistent")
+
+	def test_list_platforms(self) -> None:
+		from boss_agent_cli.platforms import list_platforms
+
+		names = list_platforms()
+		assert "zhipin" in names
+
+
+class TestPlatformInterfaceCompleteness:
+	"""确保新实现不会漏实现抽象方法。"""
+
+	def test_boss_platform_implements_all_p0_methods(self) -> None:
+		plat = BossPlatform(MagicMock())
+		assert callable(plat.search_jobs)
+		assert callable(plat.job_detail)
+		assert callable(plat.recommend_jobs)
+		assert callable(plat.user_info)
+
+	def test_boss_platform_implements_envelope_methods(self) -> None:
+		plat = BossPlatform(MagicMock())
+		assert callable(plat.is_success)
+		assert callable(plat.unwrap_data)
+		assert callable(plat.parse_error)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -26,6 +26,10 @@ EXPECTED_EXPORTS = {
 	"AIServiceError",
 	"ResumeData",
 	"ResumeFile",
+	"Platform",
+	"BossPlatform",
+	"get_platform",
+	"list_platforms",
 }
 
 
@@ -93,6 +97,31 @@ def test_account_risk_error_is_exception():
 
 def test_ai_service_error_is_exception():
 	assert issubclass(boss_agent_cli.AIServiceError, Exception)
+
+
+# ── 平台抽象 ──────────────────────────────────────────────
+
+
+def test_platform_is_abstract():
+	import abc
+	assert inspect_abstract(boss_agent_cli.Platform)
+
+
+def inspect_abstract(cls: type) -> bool:
+	import abc
+	return bool(getattr(cls, "__abstractmethods__", set()))
+
+
+def test_boss_platform_subclasses_platform():
+	assert issubclass(boss_agent_cli.BossPlatform, boss_agent_cli.Platform)
+
+
+def test_get_platform_returns_boss_by_default():
+	assert boss_agent_cli.get_platform("zhipin") is boss_agent_cli.BossPlatform
+
+
+def test_list_platforms_contains_zhipin():
+	assert "zhipin" in boss_agent_cli.list_platforms()
 
 
 # ── 版本格式 ──────────────────────────────────────────────


### PR DESCRIPTION
## 背景

本 PR 是 Issue #129 Platform 抽象接口设计的 **Week 1a 骨架**，为后续多平台适配器（智联/拉勾/猎聘）建立统一契约入口。紧随 Issue #90 三家平台 API 调研结论（已闭环）。

## 变更

### 新增

- `src/boss_agent_cli/platforms/base.py` — `Platform` ABC 定义统一契约：
  - 包络适配：`is_success` / `unwrap_data` / `parse_error`
  - P0 只读（抽象必实现）：`search_jobs` / `job_detail` / `recommend_jobs` / `user_info`
  - P1 写操作（默认抛 NotImplementedError）：`greet` / `apply`
  - P2 沟通（默认抛 NotImplementedError）：`friend_list`
- `src/boss_agent_cli/platforms/zhipin.py` — `BossPlatform` 降级为现有 `BossClient` 的 adapter，零行为变化
- `src/boss_agent_cli/platforms/__init__.py` — 注册表入口 `get_platform(name)` + `list_platforms()` + `register_platform(name, cls)`
- `tests/test_platform_base.py` — 25 条契约测试覆盖 ABC 限制、包络适配、委托调用、注册表行为

### 变更

- `src/boss_agent_cli/__init__.py` 扩展导出 `Platform` / `BossPlatform` / `get_platform` / `list_platforms`（公共 API 面 14 → 18 个符号）
- `pyproject.toml` 把三个新模块加入 mypy 严格白名单（66 → 69）
- `tests/test_public_api.py` 同步 `EXPECTED_EXPORTS` + 新增 4 条契约测试
- `CHANGELOG.md` / `ROADMAP.md` / `CLAUDE.md` 同步说明

## 非目标

- **本 PR 不改命令行为**：现有命令仍用 `BossClient` 直连，不经 Platform 路由。命令层迁移留给 Week 1b
- 不实现新平台适配器（智联留给 Week 2）
- 不加 `--platform` CLI 全局选项（和命令层迁移一起做）

## 验证

\`\`\`
$ uv run pytest tests/ -q
956 passed in 34.12s

$ uv run mypy src/boss_agent_cli
Success: no issues found in 78 source files
\`\`\`

- 全量回归：927 → **956 测试全绿**（新增 29 条）
- mypy 严格：75 → **78 源文件 0 错误**（新增 3 个严格模块）
- 零命令行为变化，无破坏性