### PR TITLE
feat: 新增平台选项与辅助函数

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,14 @@
 ## [Unreleased]
 
 ### Added
-- **Platform 抽象基类**（Issue #129 Week 1 骨架）— 新增 `src/boss_agent_cli/platforms/` 子包：`Platform` ABC 定义跨平台统一契约（is_success / unwrap_data / parse_error + P0 只读 + P1 写操作 + P2 沟通），`BossPlatform` 降级为 `BossClient` 的 adapter（零行为变化）；新增 `get_platform` / `list_platforms` 注册表入口。
-- Python 嵌入 API 扩展导出 `Platform` / `BossPlatform` / `get_platform` / `list_platforms`，下游可用 `from boss_agent_cli import get_platform` 注入具体平台实现。
-- `tests/test_platform_base.py` 新增 25 条契约测试覆盖 ABC 限制、包络适配、委托调用、注册表行为。
+- **`--platform` 全局 CLI 选项**（Issue #129 Week 1b）— 默认 `zhipin`，未知平台抛 `click.BadParameter`（exit code 2）；`~/.boss-agent/config.json` 支持 `"platform": "zhipin"` 字段持久化
+- `boss schema` 输出新增 `current_platform` 和 `supported_platforms` 字段，Agent 可实时感知当前平台配置
+- `src/boss_agent_cli/commands/_platform.py` — `get_platform_instance(ctx, auth)` 辅助函数为后续命令层迁移铺路
+- `tests/test_platform_cli.py` 新增 10 条测试覆盖 CLI 选项、schema 字段、helper 行为
 
 ### Changed
-- mypy 严格化覆盖 `boss_agent_cli.platforms` / `.base` / `.zhipin` 三个新模块（严格白名单 66 → 69）。
-- Issue #90（多平台 API 调研）闭环，研究报告索引入库 `docs/research/platforms/`。
+- `Platform` ABC 统一 `__init__(client: Any)` 签名，子类可窄化类型（`BossPlatform` 保留 `BossClient` 类型）
+- mypy 严格白名单扩到 70（新增 `commands._platform`）
 
 ## [1.9.1] - 2026-04-20
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -391,3 +391,4 @@ boss logout       -> 退出登录
 | 2026-04-15 | 协议分析 | 基于竞品端点对比新增两个端点定义、诊断命令增加辅助凭据完整性检查、职位卡片请求优先走轻量通道，测试 52→55（658 项） |
 | 2026-04-19 | 智能能力扩展 | ai 命令组新增 interview-prep 和 chat-coach 两个子命令，协议服务新增两个工具（41→43），测试 814→828，版本 1.8.0 |
 | 2026-04-21 | Platform 抽象 | 新增 platforms/ 子包定义 Platform ABC + BossPlatform adapter（Week 1a 骨架，零行为变化），Issue #90 研究闭环，下游嵌入 API 新增 4 个导出符号，测试 927→956，mypy 严格模块 66→69 |
+| 2026-04-21 | Platform CLI | 新增 --platform 全局选项与 get_platform_instance 辅助函数，schema 输出增加 current_platform / supported_platforms 字段，config.json 支持 platform 字段，测试 956→966，mypy 严格模块 69→70 |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,7 +39,8 @@
 - [ ] 浏览器扩展深度集成 BOSS 直聘原生页面
 - [ ] 多平台支持：拉勾 / 智联 / 猎聘适配器 — API 调研已全部完成（Issue #90 已闭环 · [docs/research/platforms/](docs/research/platforms/)），结论：**智联为 v2.0 优先接入候选**（2-3 周），拉勾和猎聘不建议接入
   - [x] Week 1a：Platform ABC 骨架 + BossPlatform adapter（#129，零行为变化）
-  - [ ] Week 1b：CLI 命令层迁移到 Platform 接口（`--platform zhipin` 全局选项）
+  - [x] Week 1b：`--platform` 全局 CLI 选项 + `get_platform_instance` helper + schema 暴露 current_platform
+  - [ ] Week 1c：逐步迁移 30+ 命令到 Platform 接口调用
   - [ ] Week 2：ZhilianPlatform 只读实现（search / detail / recommend / user_info）
   - [ ] Week 3：ZhilianPlatform 写操作（greet / apply）+ 文档 + MCP 适配
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ module = [
 	"boss_agent_cli.platforms",
 	"boss_agent_cli.platforms.base",
 	"boss_agent_cli.platforms.zhipin",
+	"boss_agent_cli.commands._platform",
 ]
 disallow_untyped_defs = true
 disallow_any_generics = true

--- a/src/boss_agent_cli/commands/_platform.py
+++ b/src/boss_agent_cli/commands/_platform.py
@@ -1,0 +1,48 @@
+"""Platform 实例化辅助函数。
+
+命令层统一通过 ``get_platform_instance(ctx, auth)`` 拿到 Platform 实现，
+不直接依赖具体的 ``BossClient``，为多平台适配器铺路（Issue #129 Week 1b）。
+
+示例::
+
+    from boss_agent_cli.commands._platform import get_platform_instance
+
+    @click.command()
+    @click.pass_context
+    def cmd(ctx: click.Context) -> None:
+        auth = AuthManager(ctx.obj["data_dir"])
+        platform = get_platform_instance(ctx, auth)
+        result = platform.search_jobs("Python", city="广州")
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from boss_agent_cli.api.client import BossClient
+from boss_agent_cli.platforms import Platform, get_platform
+
+if TYPE_CHECKING:
+	import click
+
+	from boss_agent_cli.auth.manager import AuthManager
+
+
+def get_platform_instance(ctx: "click.Context", auth: "AuthManager") -> Platform:
+	"""根据 ctx.obj["platform"] 构造 Platform 实例。
+
+	- 读取 ``ctx.obj`` 中的 ``platform`` / ``delay`` / ``cdp_url`` 配置
+	- 未设 platform 时 fallback 到 "zhipin"
+	- 未知平台抛 ``ValueError``
+	"""
+	obj = ctx.obj or {}
+	name = obj.get("platform") or "zhipin"
+	plat_cls = get_platform(name)
+
+	delay = obj.get("delay", (1.5, 3.0))
+	cdp_url = obj.get("cdp_url")
+	client = BossClient(auth, delay=delay, cdp_url=cdp_url)
+	return plat_cls(client)
+
+
+__all__ = ["get_platform_instance"]

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -3,6 +3,7 @@ from typing import Any
 import click
 
 from boss_agent_cli.output import emit_success
+from boss_agent_cli.platforms import list_platforms
 
 # 类型转换：native schema → JSON Schema 基础类型
 _JSON_SCHEMA_TYPE_MAP = {
@@ -553,6 +554,12 @@ SCHEMA_DATA = {
 			"default": None,
 			"description": "Chrome CDP 调试地址（如 http://localhost:9222），启用后优先用用户 Chrome 发请求",
 		},
+		"--platform": {
+			"type": "string",
+			"default": "zhipin",
+			"description": "招聘平台适配器（当前仅 zhipin，其他平台通过 Platform ABC 后续接入）",
+			"choices": ["zhipin"],
+		},
 		"--json": {
 			"type": "bool",
 			"default": False,
@@ -664,12 +671,19 @@ SCHEMA_DATA = {
 	default="native",
 	help="输出格式：native（本项目信封）/ openai-tools（OpenAI Functions & Tools API）/ anthropic-tools（Claude Tool Use API）",
 )
-def schema_cmd(output_format: str) -> None:
+@click.pass_context
+def schema_cmd(ctx: click.Context, output_format: str) -> None:
 	"""返回工具完整能力描述的 JSON"""
+	# 动态注入当前会话的平台信息（Issue #129 Week 1b）
+	data = dict(SCHEMA_DATA)
+	current = (ctx.obj or {}).get("platform") or "zhipin"
+	data["current_platform"] = current
+	data["supported_platforms"] = list_platforms()
+
 	if output_format == "openai-tools":
-		emit_success("schema", {"format": "openai-tools", "tools": _format_openai_tools(SCHEMA_DATA)})
+		emit_success("schema", {"format": "openai-tools", "tools": _format_openai_tools(data)})
 		return
 	if output_format == "anthropic-tools":
-		emit_success("schema", {"format": "anthropic-tools", "tools": _format_anthropic_tools(SCHEMA_DATA)})
+		emit_success("schema", {"format": "anthropic-tools", "tools": _format_anthropic_tools(data)})
 		return
-	emit_success("schema", SCHEMA_DATA)
+	emit_success("schema", data)

--- a/src/boss_agent_cli/config.py
+++ b/src/boss_agent_cli/config.py
@@ -14,6 +14,7 @@ DEFAULTS: dict[str, Any] = {
 	"export_dir": None,
 	"resume_default_template": "default",
 	"resume_export_format": "pdf",
+	"platform": "zhipin",
 }
 
 

--- a/src/boss_agent_cli/main.py
+++ b/src/boss_agent_cli/main.py
@@ -7,6 +7,7 @@ from boss_agent_cli.commands import schema, login, logout, status, doctor, searc
 from boss_agent_cli.config import load_config
 from boss_agent_cli.hooks import create_hook_bus
 from boss_agent_cli.output import Logger
+from boss_agent_cli.platforms import list_platforms
 
 
 @click.group(context_settings={"allow_interspersed_args": False})
@@ -14,10 +15,11 @@ from boss_agent_cli.output import Logger
 @click.option("--data-dir", default="~/.boss-agent", help="数据存储目录")
 @click.option("--delay", default=None, help="请求间隔范围（秒），如 1.5-3.0")
 @click.option("--cdp-url", default=None, help="Chrome CDP 调试地址（如 http://localhost:9222），启用则优先用用户 Chrome")
+@click.option("--platform", "platform_name", default=None, help="指定招聘平台适配器（默认 zhipin，即 BOSS 直聘）")
 @click.option("--log-level", default=None, type=click.Choice(["error", "warning", "info", "debug"]))
 @click.option("--json/--no-json", "json_output", default=False, help="强制 JSON 输出（即使在终端中）")
 @click.pass_context
-def cli(ctx: click.Context, data_dir: str, delay: str | None, cdp_url: str | None, log_level: str | None, json_output: bool) -> None:
+def cli(ctx: click.Context, data_dir: str, delay: str | None, cdp_url: str | None, platform_name: str | None, log_level: str | None, json_output: bool) -> None:
 	ctx.ensure_object(dict)
 	resolved_dir = Path(data_dir).expanduser()
 	resolved_dir.mkdir(parents=True, exist_ok=True)
@@ -36,6 +38,16 @@ def cli(ctx: click.Context, data_dir: str, delay: str | None, cdp_url: str | Non
 	ctx.obj["log_level"] = level
 	ctx.obj["logger"] = Logger(level)
 	ctx.obj["cdp_url"] = cdp_url or cfg.get("cdp_url")
+
+	resolved_platform = platform_name or cfg.get("platform") or "zhipin"
+	available = list_platforms()
+	if resolved_platform not in available:
+		raise click.BadParameter(
+			f"unknown platform {resolved_platform!r}, supported: {', '.join(available)}",
+			param_hint="--platform",
+		)
+	ctx.obj["platform"] = resolved_platform
+
 	ctx.obj["config"] = cfg
 	ctx.obj["hooks"] = create_hook_bus()
 

--- a/src/boss_agent_cli/platforms/base.py
+++ b/src/boss_agent_cli/platforms/base.py
@@ -29,6 +29,13 @@ class Platform(ABC):
 	display_name: str
 	base_url: str
 
+	def __init__(self, client: Any) -> None:
+		"""ABC 构造签名：所有实现都接收一个平台专用 client。
+
+		具体实现可以覆盖参数类型（如 ``BossPlatform`` 声明 ``BossClient``）。
+		"""
+		self._client: Any = client
+
 	@abstractmethod
 	def is_success(self, response: dict[str, Any]) -> bool:
 		"""判断响应是否成功。

--- a/src/boss_agent_cli/platforms/zhipin.py
+++ b/src/boss_agent_cli/platforms/zhipin.py
@@ -32,7 +32,9 @@ class BossPlatform(Platform):
 	base_url = BASE_URL
 
 	def __init__(self, client: "BossClient") -> None:
-		self._client = client
+		super().__init__(client)
+		# 重新 bound 出类型化属性，下游 IDE 可以看到 BossClient 方法
+		self._client: "BossClient" = client
 
 	# ── 包络适配 ────────────────────────────────────────
 

--- a/tests/test_platform_cli.py
+++ b/tests/test_platform_cli.py
@@ -1,0 +1,122 @@
+"""CLI `--platform` 全局选项与 Platform 辅助函数测试。"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+	return CliRunner()
+
+
+class TestPlatformGlobalOption:
+	"""main.py 新增 --platform 全局选项。"""
+
+	def test_schema_exposes_supported_platforms(self, runner: CliRunner) -> None:
+		from boss_agent_cli.main import cli
+
+		result = runner.invoke(cli, ["schema"])
+		assert result.exit_code == 0
+		payload = json.loads(result.output)
+		meta = payload["data"]
+		assert "supported_platforms" in meta
+		assert "zhipin" in meta["supported_platforms"]
+		assert meta.get("current_platform") == "zhipin"
+
+	def test_schema_current_platform_reflects_option(self, runner: CliRunner) -> None:
+		from boss_agent_cli.main import cli
+
+		result = runner.invoke(cli, ["--platform", "zhipin", "schema"])
+		assert result.exit_code == 0
+		payload = json.loads(result.output)
+		assert payload["data"]["current_platform"] == "zhipin"
+
+	def test_unknown_platform_exits_with_error(self, runner: CliRunner) -> None:
+		from boss_agent_cli.main import cli
+
+		result = runner.invoke(cli, ["--platform", "nonexistent", "schema"])
+		assert result.exit_code != 0
+
+	def test_schema_exposes_platform_option_in_global(self, runner: CliRunner) -> None:
+		from boss_agent_cli.main import cli
+
+		result = runner.invoke(cli, ["schema"])
+		assert result.exit_code == 0
+		payload = json.loads(result.output)
+		global_opts = payload["data"]["global_options"]
+		assert "--platform" in global_opts
+
+
+class TestGetPlatformInstanceHelper:
+	"""get_platform_instance(ctx, auth) helper。"""
+
+	def test_helper_returns_boss_platform_by_default(self) -> None:
+		from boss_agent_cli.platforms import BossPlatform
+		from boss_agent_cli.commands._platform import get_platform_instance
+
+		ctx = MagicMock()
+		ctx.obj = {"platform": "zhipin", "data_dir": "/tmp/fake", "delay": (0.0, 0.0), "cdp_url": None}
+		auth = MagicMock()
+
+		with patch("boss_agent_cli.commands._platform.BossClient") as mock_client_cls:
+			plat = get_platform_instance(ctx, auth)
+			assert isinstance(plat, BossPlatform)
+			mock_client_cls.assert_called_once()
+
+	def test_helper_passes_delay_and_cdp_to_client(self) -> None:
+		from boss_agent_cli.commands._platform import get_platform_instance
+
+		ctx = MagicMock()
+		ctx.obj = {"platform": "zhipin", "delay": (2.0, 4.0), "cdp_url": "http://localhost:9222"}
+		auth = MagicMock()
+
+		with patch("boss_agent_cli.commands._platform.BossClient") as mock_client_cls:
+			get_platform_instance(ctx, auth)
+			mock_client_cls.assert_called_once_with(auth, delay=(2.0, 4.0), cdp_url="http://localhost:9222")
+
+	def test_helper_defaults_missing_platform_to_zhipin(self) -> None:
+		from boss_agent_cli.platforms import BossPlatform
+		from boss_agent_cli.commands._platform import get_platform_instance
+
+		ctx = MagicMock()
+		ctx.obj = {"delay": (0.0, 0.0)}
+		auth = MagicMock()
+
+		with patch("boss_agent_cli.commands._platform.BossClient"):
+			plat = get_platform_instance(ctx, auth)
+			assert isinstance(plat, BossPlatform)
+
+	def test_helper_raises_on_unknown_platform(self) -> None:
+		from boss_agent_cli.commands._platform import get_platform_instance
+
+		ctx = MagicMock()
+		ctx.obj = {"platform": "unknown", "delay": (0.0, 0.0)}
+		auth = MagicMock()
+
+		with pytest.raises(ValueError, match="unknown platform"):
+			get_platform_instance(ctx, auth)
+
+
+class TestConfigPlatformDefault:
+	"""config.json 新增 platform 字段默认值。"""
+
+	def test_defaults_has_platform_zhipin(self) -> None:
+		from boss_agent_cli.config import DEFAULTS
+
+		assert DEFAULTS.get("platform") == "zhipin"
+
+	def test_load_config_honors_user_platform(self, tmp_path: Any) -> None:
+		import json as _json
+
+		from boss_agent_cli.config import load_config
+
+		cfg_path = tmp_path / "config.json"
+		cfg_path.write_text(_json.dumps({"platform": "zhipin"}))
+		cfg = load_config(cfg_path)
+		assert cfg["platform"] == "zhipin"


### PR DESCRIPTION
## 背景

延续 PR #131（Platform ABC 骨架），本 PR 交付 Issue #129 Week 1b：CLI 面暴露 Platform 选择能力、为后续命令层迁移准备辅助函数。

## 变更

### Added

- **`--platform` 全局 CLI 选项**（`main.py`），默认 `zhipin`；未知平台抛 `click.BadParameter`，exit code 2
- **`~/.boss-agent/config.json`** 新增 `"platform"` 默认字段，与 CLI 选项互通，CLI 显式传参优先
- **`boss schema`** 输出新增两个字段：
  - `current_platform`：当前会话生效的平台（跟 `--platform` 或 `config.json` 联动）
  - `supported_platforms`：注册表中所有已知平台（目前仅 `zhipin`）
  - `global_options` 新增 `--platform` 描述
- **`src/boss_agent_cli/commands/_platform.py`**：`get_platform_instance(ctx, auth)` helper，统一构造 Platform 实例，封装 BossClient 实例化细节
- **`tests/test_platform_cli.py`**：10 条测试覆盖 CLI 选项注入、schema 字段、helper 行为、未知平台报错

### Changed

- `Platform` ABC 补齐 `__init__(client: Any)` 签名，子类覆盖时可窄化（`BossPlatform` 声明为 `BossClient`）
- mypy 严格白名单 69 → 70（新增 `commands._platform`）

## 非目标（留给 Week 1c）

- 现有 30+ 命令**仍直接用 `BossClient`**，不经 `get_platform_instance`。Week 1c 分批迁移
- 不新增其他平台适配器（Zhilian 留给 Week 2）

## 验证

\`\`\`
$ uv run pytest tests/ -q
966 passed in 33.45s

$ uv run mypy src/boss_agent_cli
Success: no issues found in 79 source files

$ uv run boss schema | python3 -c "import sys,json; d=json.loads(sys.stdin.read())['data']; print('current:', d['current_platform']); print('supported:', d['supported_platforms'])"
current: zhipin
supported: ['zhipin']

$ uv run boss --platform nonexistent schema; echo exit=$?
Error: Invalid value for --platform: unknown platform 'nonexistent', supported: zhipin
exit=2
\`\`\`

- 本地全量 966 测试全绿（+10 新增）
- mypy strict 0 错误（+1 严格模块）
- 零命令行为变化，无破坏性