### PR TITLE
refactor: 迁移打招呼与投递命令到平台抽象

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,13 @@
 ## [Unreleased]
 
 ### Added
-- **`--platform` 全局 CLI 选项**（Issue #129 Week 1b）— 默认 `zhipin`，未知平台抛 `click.BadParameter`（exit code 2）；`~/.boss-agent/config.json` 支持 `"platform": "zhipin"` 字段持久化
-- `boss schema` 输出新增 `current_platform` 和 `supported_platforms` 字段，Agent 可实时感知当前平台配置
-- `src/boss_agent_cli/commands/_platform.py` — `get_platform_instance(ctx, auth)` 辅助函数为后续命令层迁移铺路
-- `tests/test_platform_cli.py` 新增 10 条测试覆盖 CLI 选项、schema 字段、helper 行为
+- **Platform 命令层迁移（Issue #129 Week 1c，首批 2 个命令）** — `boss greet` 和 `boss apply` 从 `BossClient` 直用切换到 `get_platform_instance(ctx, auth)`，走统一 Platform 抽象。
+- **Platform ABC 支持 `with` 上下文管理器** — `__enter__` / `__exit__` / `close()` 委托给底层 client，资源释放语义无损。
+- `tests/test_platform_base.py` 新增 5 条 context manager 契约测试。
 
 ### Changed
-- `Platform` ABC 统一 `__init__(client: Any)` 签名，子类可窄化类型（`BossPlatform` 保留 `BossClient` 类型）
-- mypy 严格白名单扩到 70（新增 `commands._platform`）
+- `commands/greet.py` 和 `commands/apply.py` 去除 delay / cdp_url 从 ctx.obj 手动读取的样板代码，复用 helper 统一处理。
+- 测试 Mock 位置从 `commands.greet.BossClient` / `commands.apply.BossClient` 迁到 `commands.greet.get_platform_instance` / `commands.apply.get_platform_instance`。
 
 ## [1.9.1] - 2026-04-20
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,3 +392,4 @@ boss logout       -> 退出登录
 | 2026-04-19 | 智能能力扩展 | ai 命令组新增 interview-prep 和 chat-coach 两个子命令，协议服务新增两个工具（41→43），测试 814→828，版本 1.8.0 |
 | 2026-04-21 | Platform 抽象 | 新增 platforms/ 子包定义 Platform ABC + BossPlatform adapter（Week 1a 骨架，零行为变化），Issue #90 研究闭环，下游嵌入 API 新增 4 个导出符号，测试 927→956，mypy 严格模块 66→69 |
 | 2026-04-21 | Platform CLI | 新增 --platform 全局选项与 get_platform_instance 辅助函数，schema 输出增加 current_platform / supported_platforms 字段，config.json 支持 platform 字段，测试 956→966，mypy 严格模块 69→70 |
+| 2026-04-21 | Platform 迁移 | greet 和 apply 命令从 BossClient 直用切换到 get_platform_instance，Platform ABC 补齐 with 上下文管理器（__enter__/__exit__/close），测试 966→971 |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,7 +40,7 @@
 - [ ] 多平台支持：拉勾 / 智联 / 猎聘适配器 — API 调研已全部完成（Issue #90 已闭环 · [docs/research/platforms/](docs/research/platforms/)），结论：**智联为 v2.0 优先接入候选**（2-3 周），拉勾和猎聘不建议接入
   - [x] Week 1a：Platform ABC 骨架 + BossPlatform adapter（#129，零行为变化）
   - [x] Week 1b：`--platform` 全局 CLI 选项 + `get_platform_instance` helper + schema 暴露 current_platform
-  - [ ] Week 1c：逐步迁移 30+ 命令到 Platform 接口调用
+  - [ ] Week 1c：逐步迁移 30+ 命令到 Platform 接口调用（已迁移 2 个：greet / apply）
   - [ ] Week 2：ZhilianPlatform 只读实现（search / detail / recommend / user_info）
   - [ ] Week 3：ZhilianPlatform 写操作（greet / apply）+ 文档 + MCP 适配
 

--- a/src/boss_agent_cli/commands/apply.py
+++ b/src/boss_agent_cli/commands/apply.py
@@ -1,8 +1,8 @@
 import click
 
-from boss_agent_cli.api.client import BossClient
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.cache.store import CacheStore
+from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_message_panel
 
 
@@ -16,8 +16,6 @@ def apply_cmd(ctx: click.Context, security_id: str, job_id: str, lid: str) -> No
 	"""发起最小可用投递/立即沟通动作（当前复用立即沟通链路）。"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	delay = ctx.obj["delay"]
-	cdp_url = ctx.obj.get("cdp_url")
 
 	with CacheStore(data_dir / "cache" / "boss_agent.db") as cache:
 		if cache.is_applied(security_id, job_id):
@@ -31,8 +29,8 @@ def apply_cmd(ctx: click.Context, security_id: str, job_id: str, lid: str) -> No
 			return
 
 		auth = AuthManager(data_dir, logger=logger)
-		with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
-			resp = client.apply(security_id, job_id, lid=lid)
+		with get_platform_instance(ctx, auth) as platform:
+			resp = platform.apply(security_id, job_id, lid=lid)
 			if resp.get("code") not in (None, 0):
 				handle_error_output(
 					ctx,

--- a/src/boss_agent_cli/commands/greet.py
+++ b/src/boss_agent_cli/commands/greet.py
@@ -13,6 +13,7 @@ from boss_agent_cli.api.endpoints import (
 from boss_agent_cli.api.models import JobItem
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.cache.store import CacheStore
+from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import (
 	handle_auth_errors,
 	handle_error_output,
@@ -32,8 +33,6 @@ def greet_cmd(ctx: click.Context, security_id: str, job_id: str, message: str) -
 	"""向指定招聘者打招呼"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	delay = ctx.obj["delay"]
-	cdp_url = ctx.obj.get("cdp_url")
 
 	with CacheStore(data_dir / "cache" / "boss_agent.db") as cache:
 		if cache.is_greeted(security_id):
@@ -46,7 +45,7 @@ def greet_cmd(ctx: click.Context, security_id: str, job_id: str, message: str) -
 			return
 
 		auth = AuthManager(data_dir, logger=logger)
-		with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
+		with get_platform_instance(ctx, auth) as platform:
 			# greet_before hook — allows veto
 			hooks = ctx.obj.get("hooks")
 			if hooks:
@@ -64,7 +63,7 @@ def greet_cmd(ctx: click.Context, security_id: str, job_id: str, message: str) -
 					)
 					return
 
-			client.greet(security_id, job_id, message)
+			platform.greet(security_id, job_id, message)
 
 			cache.record_greet(security_id, job_id)
 

--- a/src/boss_agent_cli/platforms/base.py
+++ b/src/boss_agent_cli/platforms/base.py
@@ -10,6 +10,7 @@ Week 1 交付：接口定义 + BOSS 直聘 adapter，不改动现有命令行为
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from types import TracebackType
 from typing import Any
 
 
@@ -23,6 +24,9 @@ class Platform(ABC):
 
 	写操作（greet / apply）和沟通接口（friend_list / chat_messages）为可选，
 	平台不支持时抛 NotImplementedError。
+
+	资源管理：支持 ``with`` 上下文管理器语法，``__exit__`` 自动调用 ``close()``
+	释放底层 client 持有的 httpx / 浏览器资源。
 	"""
 
 	name: str
@@ -35,6 +39,25 @@ class Platform(ABC):
 		具体实现可以覆盖参数类型（如 ``BossPlatform`` 声明 ``BossClient``）。
 		"""
 		self._client: Any = client
+
+	# ── 资源生命周期 ───────────────────────────────────
+
+	def close(self) -> None:
+		"""释放底层资源。默认委托给 ``client.close()``（若存在）。"""
+		close_fn = getattr(self._client, "close", None)
+		if callable(close_fn):
+			close_fn()
+
+	def __enter__(self) -> "Platform":
+		return self
+
+	def __exit__(
+		self,
+		exc_type: type[BaseException] | None,
+		exc_val: BaseException | None,
+		exc_tb: TracebackType | None,
+	) -> None:
+		self.close()
 
 	@abstractmethod
 	def is_success(self, response: dict[str, Any]) -> bool:

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -13,14 +13,14 @@ def _ctx_mock(mock_cls):
 	return instance
 
 
-@patch("boss_agent_cli.commands.apply.BossClient")
+@patch("boss_agent_cli.commands.apply.get_platform_instance")
 @patch("boss_agent_cli.commands.apply.AuthManager")
 @patch("boss_agent_cli.commands.apply.CacheStore")
-def test_apply_success(mock_cache_cls, mock_auth_cls, mock_client_cls):
+def test_apply_success(mock_cache_cls, mock_auth_cls, mock_get_platform):
 	mock_cache = _ctx_mock(mock_cache_cls)
 	mock_cache.is_applied.return_value = False
-	mock_client = _ctx_mock(mock_client_cls)
-	mock_client.apply.return_value = {"code": 0, "zpData": {}}
+	mock_platform = _ctx_mock(mock_get_platform)
+	mock_platform.apply.return_value = {"code": 0, "zpData": {}}
 
 	runner = CliRunner()
 	result = runner.invoke(cli, ["--json", "apply", "sec_001", "job_001"])
@@ -33,10 +33,10 @@ def test_apply_success(mock_cache_cls, mock_auth_cls, mock_client_cls):
 	mock_cache.record_apply.assert_called_once_with("sec_001", "job_001")
 
 
-@patch("boss_agent_cli.commands.apply.BossClient")
+@patch("boss_agent_cli.commands.apply.get_platform_instance")
 @patch("boss_agent_cli.commands.apply.AuthManager")
 @patch("boss_agent_cli.commands.apply.CacheStore")
-def test_apply_duplicate_is_blocked(mock_cache_cls, mock_auth_cls, mock_client_cls):
+def test_apply_duplicate_is_blocked(mock_cache_cls, mock_auth_cls, mock_get_platform):
 	mock_cache = _ctx_mock(mock_cache_cls)
 	mock_cache.is_applied.return_value = True
 
@@ -47,14 +47,14 @@ def test_apply_duplicate_is_blocked(mock_cache_cls, mock_auth_cls, mock_client_c
 	assert parsed["error"]["code"] == "ALREADY_APPLIED"
 
 
-@patch("boss_agent_cli.commands.apply.BossClient")
+@patch("boss_agent_cli.commands.apply.get_platform_instance")
 @patch("boss_agent_cli.commands.apply.AuthManager")
 @patch("boss_agent_cli.commands.apply.CacheStore")
-def test_apply_failure_does_not_record_local_state(mock_cache_cls, mock_auth_cls, mock_client_cls):
+def test_apply_failure_does_not_record_local_state(mock_cache_cls, mock_auth_cls, mock_get_platform):
 	mock_cache = _ctx_mock(mock_cache_cls)
 	mock_cache.is_applied.return_value = False
-	mock_client = _ctx_mock(mock_client_cls)
-	mock_client.apply.return_value = {"code": 1, "message": "失败"}
+	mock_platform = _ctx_mock(mock_get_platform)
+	mock_platform.apply.return_value = {"code": 1, "message": "失败"}
 
 	runner = CliRunner()
 	result = runner.invoke(cli, ["apply", "sec_001", "job_001"])

--- a/tests/test_greet_detail_extended.py
+++ b/tests/test_greet_detail_extended.py
@@ -13,6 +13,7 @@ from boss_agent_cli.main import cli
 _PATCHES = {
 	"auth": "boss_agent_cli.commands.greet.AuthManager",
 	"client": "boss_agent_cli.commands.greet.BossClient",
+	"platform": "boss_agent_cli.commands.greet.get_platform_instance",
 	"cache": "boss_agent_cli.commands.greet.CacheStore",
 }
 
@@ -21,7 +22,7 @@ def _invoke_greet(*args, tmp_path, cache_greeted=False, greet_side_effect=None):
 	runner = CliRunner()
 	with (
 		patch(_PATCHES["auth"]),
-		patch(_PATCHES["client"]) as mock_client_cls,
+		patch(_PATCHES["platform"]) as mock_get_platform,
 		patch(_PATCHES["cache"]) as mock_cache_cls,
 	):
 		mock_cache = MagicMock()
@@ -29,16 +30,16 @@ def _invoke_greet(*args, tmp_path, cache_greeted=False, greet_side_effect=None):
 		mock_cache_cls.return_value.__enter__ = lambda s: mock_cache
 		mock_cache_cls.return_value.__exit__ = MagicMock(return_value=False)
 
-		mock_client = MagicMock()
+		mock_platform = MagicMock()
 		if greet_side_effect:
-			mock_client.greet.side_effect = greet_side_effect
-		mock_client_cls.return_value.__enter__ = lambda s: mock_client
-		mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+			mock_platform.greet.side_effect = greet_side_effect
+		mock_get_platform.return_value.__enter__ = lambda s: mock_platform
+		mock_get_platform.return_value.__exit__ = MagicMock(return_value=False)
 
 		cli_args = ["--data-dir", str(tmp_path), *args]
 		result = runner.invoke(cli, cli_args)
 	parsed = json.loads(result.output) if result.output.strip() else None
-	return result.exit_code, parsed, mock_cache, mock_client
+	return result.exit_code, parsed, mock_cache, mock_platform
 
 
 # ── greet 命令 ──────────────────────────────────────────────────────

--- a/tests/test_greet_extended.py
+++ b/tests/test_greet_extended.py
@@ -43,14 +43,14 @@ def _make_raw_job(name: str = "Go 开发", security_id: str = "sec_x") -> dict:
 # ── greet 成功路径 ─────────────────────────────────────────
 
 
-@patch("boss_agent_cli.commands.greet.BossClient")
+@patch("boss_agent_cli.commands.greet.get_platform_instance")
 @patch("boss_agent_cli.commands.greet.AuthManager")
 @patch("boss_agent_cli.commands.greet.CacheStore")
-def test_greet_success_renders_message_and_records_cache(mock_cache_cls, mock_auth_cls, mock_client_cls):
+def test_greet_success_renders_message_and_records_cache(mock_cache_cls, mock_auth_cls, mock_get_platform):
 	mock_cache = _ctx_mock(mock_cache_cls)
 	mock_cache.is_greeted.return_value = False
-	mock_client = _ctx_mock(mock_client_cls)
-	mock_client.greet.return_value = None
+	mock_platform = _ctx_mock(mock_get_platform)
+	mock_platform.greet.return_value = None
 
 	runner = CliRunner()
 	result = runner.invoke(cli, ["greet", "sec_001", "job_001"])
@@ -61,7 +61,7 @@ def test_greet_success_renders_message_and_records_cache(mock_cache_cls, mock_au
 	assert parsed["data"]["job_id"] == "job_001"
 	assert "打招呼成功" in parsed["data"]["message"]
 
-	mock_client.greet.assert_called_once_with("sec_001", "job_001", "")
+	mock_platform.greet.assert_called_once_with("sec_001", "job_001", "")
 	mock_cache.record_greet.assert_called_once_with("sec_001", "job_001")
 
 

--- a/tests/test_platform_base.py
+++ b/tests/test_platform_base.py
@@ -163,3 +163,41 @@ class TestPlatformInterfaceCompleteness:
 		assert callable(plat.is_success)
 		assert callable(plat.unwrap_data)
 		assert callable(plat.parse_error)
+
+
+class TestPlatformContextManager:
+	"""Platform 作为 with 上下文管理器释放底层资源。"""
+
+	def test_platform_supports_with_statement(self) -> None:
+		client = MagicMock()
+		plat = BossPlatform(client)
+		with plat as p:
+			assert p is plat
+		client.close.assert_called_once()
+
+	def test_close_calls_client_close(self) -> None:
+		client = MagicMock()
+		plat = BossPlatform(client)
+		plat.close()
+		client.close.assert_called_once()
+
+	def test_close_tolerates_missing_close(self) -> None:
+		"""底层 client 没有 close 方法时不抛错。"""
+		client_no_close = object()
+		plat = BossPlatform(client_no_close)  # type: ignore[arg-type]
+		plat.close()  # 不抛错
+
+	def test_exit_closes_on_exception(self) -> None:
+		"""with 块内抛异常时仍然关闭底层资源。"""
+		client = MagicMock()
+		plat = BossPlatform(client)
+		with pytest.raises(RuntimeError):
+			with plat:
+				raise RuntimeError("boom")
+		client.close.assert_called_once()
+
+	def test_enter_returns_self(self) -> None:
+		client = MagicMock()
+		plat = BossPlatform(client)
+		entered = plat.__enter__()
+		assert entered is plat


### PR DESCRIPTION
## 背景

Issue #129 Week 1c 首批命令迁移。在 PR #131（ABC 骨架）+ PR #132（CLI 选项 + helper）已就位的基础上，本 PR 把 **`boss greet`** 和 **`boss apply`** 两个命令从直接 `BossClient(...)` 切换到 `with get_platform_instance(ctx, auth) as platform:`。

这两个命令选作首批的原因：调用面最小（只用 `greet` / `apply` 各一次），Platform ABC 已完整覆盖，风险可控。

## 变更

### Changed

- `src/boss_agent_cli/commands/greet.py` `greet_cmd`：`with BossClient(...)` → `with get_platform_instance(ctx, auth) as platform:`，`client.greet(...)` → `platform.greet(...)`
- `src/boss_agent_cli/commands/apply.py` `apply_cmd`：同上
- 两个命令都减少了 `delay` / `cdp_url` 的手动读取样板代码（helper 内部处理）

### Added

- `src/boss_agent_cli/platforms/base.py` `Platform` ABC 补齐 **`with` 上下文管理器支持**：`__enter__` / `__exit__` / `close()` 委托给底层 client，资源释放语义与原 `BossClient` 一致
- `tests/test_platform_base.py` 新增 5 条 context manager 契约测试（enter 返回 self / exit 调用 close / 异常路径仍关闭 / 缺 close 方法不抛错）

### Tests

- `tests/test_apply.py` 三处 mock 位点切换 `commands.apply.BossClient` → `commands.apply.get_platform_instance`
- `tests/test_greet_extended.py` 单处同上
- `tests/test_greet_detail_extended.py` `_invoke_greet` helper 适配
- `batch_greet_cmd` 未迁移，相关 mock 保留不变

## 非目标

- `batch-greet` / `recommend` / `search` / `detail` 等其他命令未迁移（留给 Week 1c 后续批次）
- 不新增任何命令或功能

## 验证

\`\`\`
$ uv run pytest tests/ -q
971 passed in 33.79s

$ uv run mypy src/boss_agent_cli
Success: no issues found in 79 source files
\`\`\`

- 测试 966 → **971 通过**（+5 context manager 契约测试）
- mypy strict：0 错误
- 命令行为零变化（mock signature 与返回一致）