### PR TITLE
feat: 新增智联招聘平台自证接入

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@
 ## [Unreleased]
 
 ### Added
+- **ZhilianPlatform stub**（Issue #129 Week 1d · 抽象自证）— `src/boss_agent_cli/platforms/zhilian.py` 新增智联招聘 stub 实现：
+  - 元信息：`name="zhilian"` / `display_name="智联招聘"` / `base_url="https://m.zhaopin.com"`
+  - 包络适配按 [zhaopin.md](docs/research/platforms/zhaopin.md) §4 调研结果完整实现（`is_success` 检 `code==200` · `unwrap_data` 取 `data` key · `parse_error` 映射 401/403/429）
+  - P0/P1/P2 方法抛 `NotImplementedError("Week 2 待实现")`，Week 2 替换为真实现
+- `boss --platform zhilian` CLI 选项正式接入，`schema` 输出 `supported_platforms` 包含 `zhilian`
+- Python 嵌入 API 导出 `ZhilianPlatform`，下游可提前查看类型签名
+- `tests/test_zhilian_stub.py` 新增 **27 条契约测试**覆盖元信息 / 包络适配 / stub 行为 / CLI 集成
+
+### Changed
+- Platform 注册表从单一 `{"zhipin": BossPlatform}` 扩展为 `{"zhipin": BossPlatform, "zhilian": ZhilianPlatform}`
+- mypy 严格白名单扩到 71（新增 `platforms.zhilian`）
+- `tests/test_public_api.py` 同步 `EXPECTED_EXPORTS` 加入 `ZhilianPlatform`
+- schema `--platform` 描述更新为 "zhipin 生产可用；zhilian stub Week 2 真实现"
+
+### 底层逻辑
+Platform 抽象只有一个实现（zhipin）时**抽象设计是否正确尚未被证伪**。本轮加入 Zhilian stub 强制第二平台走完整注册 / CLI / schema / with 上下文流程，发现任何设计缺陷前置暴露（事实：全通过，抽象设计对齐 zhaopin.md §7 差异矩阵）。
+
+### Added
 - **Platform 命令层迁移（Issue #129 Week 1c，首批 2 个命令）** — `boss greet` 和 `boss apply` 从 `BossClient` 直用切换到 `get_platform_instance(ctx, auth)`，走统一 Platform 抽象。
 - **Platform ABC 支持 `with` 上下文管理器** — `__enter__` / `__exit__` / `close()` 委托给底层 client，资源释放语义无损。
 - `tests/test_platform_base.py` 新增 5 条 context manager 契约测试。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -393,3 +393,4 @@ boss logout       -> 退出登录
 | 2026-04-21 | Platform 抽象 | 新增 platforms/ 子包定义 Platform ABC + BossPlatform adapter（Week 1a 骨架，零行为变化），Issue #90 研究闭环，下游嵌入 API 新增 4 个导出符号，测试 927→956，mypy 严格模块 66→69 |
 | 2026-04-21 | Platform CLI | 新增 --platform 全局选项与 get_platform_instance 辅助函数，schema 输出增加 current_platform / supported_platforms 字段，config.json 支持 platform 字段，测试 956→966，mypy 严格模块 69→70 |
 | 2026-04-21 | Platform 迁移 | greet 和 apply 命令从 BossClient 直用切换到 get_platform_instance，Platform ABC 补齐 with 上下文管理器（__enter__/__exit__/close），测试 966→971 |
+| 2026-04-21 | Platform 自证 | 新增 ZhilianPlatform stub 注册到 Platform 注册表，包络适配按 zhaopin.md 调研完整实现，P0/P1/P2 抛 NotImplementedError 待 Week 2 真实现，测试 971→998 |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,6 +41,7 @@
   - [x] Week 1a：Platform ABC 骨架 + BossPlatform adapter（#129，零行为变化）
   - [x] Week 1b：`--platform` 全局 CLI 选项 + `get_platform_instance` helper + schema 暴露 current_platform
   - [ ] Week 1c：逐步迁移 30+ 命令到 Platform 接口调用（已迁移 2 个：greet / apply）
+  - [x] Week 1d：ZhilianPlatform stub 接入注册表（抽象自证，包络适配完整实现，P0/P1/P2 暂 NotImplementedError）
   - [ ] Week 2：ZhilianPlatform 只读实现（search / detail / recommend / user_info）
   - [ ] Week 3：ZhilianPlatform 写操作（greet / apply）+ 文档 + MCP 适配
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ module = [
 	"boss_agent_cli.platforms",
 	"boss_agent_cli.platforms.base",
 	"boss_agent_cli.platforms.zhipin",
+	"boss_agent_cli.platforms.zhilian",
 	"boss_agent_cli.commands._platform",
 ]
 disallow_untyped_defs = true

--- a/src/boss_agent_cli/__init__.py
+++ b/src/boss_agent_cli/__init__.py
@@ -15,7 +15,7 @@ from boss_agent_cli.api.client import AccountRiskError, AuthError, BossClient
 from boss_agent_cli.api.models import JobDetail, JobItem
 from boss_agent_cli.auth.manager import AuthManager, AuthRequired, TokenRefreshFailed
 from boss_agent_cli.cache.store import CacheStore
-from boss_agent_cli.platforms import BossPlatform, Platform, get_platform, list_platforms
+from boss_agent_cli.platforms import BossPlatform, Platform, ZhilianPlatform, get_platform, list_platforms
 from boss_agent_cli.resume.models import ResumeData, ResumeFile
 
 __version__ = "1.9.1"
@@ -45,6 +45,7 @@ __all__ = [
 	# 平台抽象（Week 1 ABC，详见 Issue #129）
 	"Platform",
 	"BossPlatform",
+	"ZhilianPlatform",
 	"get_platform",
 	"list_platforms",
 ]

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -557,8 +557,8 @@ SCHEMA_DATA = {
 		"--platform": {
 			"type": "string",
 			"default": "zhipin",
-			"description": "招聘平台适配器（当前仅 zhipin，其他平台通过 Platform ABC 后续接入）",
-			"choices": ["zhipin"],
+			"description": "招聘平台适配器（zhipin=BOSS 直聘生产可用；zhilian=智联招聘 stub，Week 2 真实现）",
+			"choices": ["zhipin", "zhilian"],
 		},
 		"--json": {
 			"type": "bool",

--- a/src/boss_agent_cli/platforms/__init__.py
+++ b/src/boss_agent_cli/platforms/__init__.py
@@ -11,10 +11,12 @@
 from __future__ import annotations
 
 from boss_agent_cli.platforms.base import Platform
+from boss_agent_cli.platforms.zhilian import ZhilianPlatform
 from boss_agent_cli.platforms.zhipin import BossPlatform
 
 _REGISTRY: dict[str, type[Platform]] = {
 	"zhipin": BossPlatform,
+	"zhilian": ZhilianPlatform,
 }
 
 
@@ -44,6 +46,7 @@ def register_platform(name: str, cls: type[Platform]) -> None:
 __all__ = [
 	"Platform",
 	"BossPlatform",
+	"ZhilianPlatform",
 	"get_platform",
 	"list_platforms",
 	"register_platform",

--- a/src/boss_agent_cli/platforms/zhilian.py
+++ b/src/boss_agent_cli/platforms/zhilian.py
@@ -1,0 +1,78 @@
+"""智联招聘平台 stub 实现。
+
+**当前状态：Week 1d 自证 stub** — 包络适配方法按 zhaopin.md 调研给出真实逻辑，
+P0/P1/P2 抽象方法暂抛 `NotImplementedError("Week 2 待实现")`，
+让 Platform 抽象在两个平台上都可编译 / 注册 / schema 可见。
+
+**Week 2 TODO**（Issue #129 Week 2）：
+- 实现 ZhilianClient（基于 BrowserSession / Bridge 通道）
+- 实现 search_jobs / job_detail / recommend_jobs / user_info 只读方法
+- 基于调研 [docs/research/platforms/zhaopin.md](../../docs/research/platforms/zhaopin.md)
+
+协议核心差异（对比 BOSS 直聘）：
+- 成功码：`code == 200`（BOSS 是 `code == 0`）
+- 数据包络：`response["data"]`（BOSS 是 `response["zpData"]`）
+- 错误码：401 未授权 / 403 风控 / 429 限流（BOSS 用 code 9/36/37）
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from boss_agent_cli.platforms.base import Platform
+
+if TYPE_CHECKING:
+	# Week 2 引入 ZhilianClient；当前 stub 无依赖
+	pass
+
+
+# 智联错误码 → 统一错误码映射（对齐 CLAUDE.md 错误码枚举）
+_ERROR_CODE_MAP: dict[int, str] = {
+	401: "AUTH_EXPIRED",
+	403: "ACCOUNT_RISK",
+	429: "RATE_LIMITED",
+}
+
+# Week 2 时会替换为真实实现
+_NOT_YET_MSG = "Zhilian Week 2 待实现，当前为注册自证 stub，详见 Issue #129"
+
+
+class ZhilianPlatform(Platform):
+	"""智联招聘平台实现（当前为 Week 1d 自证 stub）。"""
+
+	name = "zhilian"
+	display_name = "智联招聘"
+	base_url = "https://m.zhaopin.com"
+
+	def __init__(self, client: Any) -> None:
+		super().__init__(client)
+
+	# ── 包络适配（Week 1d 已按 zhaopin.md 调研完成）──
+
+	def is_success(self, response: dict[str, Any]) -> bool:
+		return response.get("code") == 200
+
+	def unwrap_data(self, response: dict[str, Any]) -> Any:
+		return response.get("data")
+
+	def parse_error(self, response: dict[str, Any]) -> tuple[str, str]:
+		code = response.get("code")
+		message = str(response.get("message") or "")
+		unified = _ERROR_CODE_MAP.get(code, "UNKNOWN") if isinstance(code, int) else "UNKNOWN"
+		return unified, message
+
+	# ── P0 只读（Week 2 待实现）─────────────────────
+
+	def search_jobs(self, query: str, **filters: Any) -> dict[str, Any]:
+		raise NotImplementedError(f"{_NOT_YET_MSG}: search_jobs(query={query!r}, filters={filters!r})")
+
+	def job_detail(self, job_id: str) -> dict[str, Any]:
+		raise NotImplementedError(f"{_NOT_YET_MSG}: job_detail(job_id={job_id!r})")
+
+	def recommend_jobs(self, page: int = 1) -> dict[str, Any]:
+		raise NotImplementedError(f"{_NOT_YET_MSG}: recommend_jobs(page={page})")
+
+	def user_info(self) -> dict[str, Any]:
+		raise NotImplementedError(f"{_NOT_YET_MSG}: user_info()")
+
+	# greet / apply / friend_list 沿用 Platform 基类的 NotImplementedError 默认

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -28,6 +28,7 @@ EXPECTED_EXPORTS = {
 	"ResumeFile",
 	"Platform",
 	"BossPlatform",
+	"ZhilianPlatform",
 	"get_platform",
 	"list_platforms",
 }

--- a/tests/test_zhilian_stub.py
+++ b/tests/test_zhilian_stub.py
@@ -1,0 +1,171 @@
+"""ZhilianPlatform stub 契约测试。
+
+Zhilian 在 Week 1d 以 stub 形态接入 Platform 注册表，P0/P1/P2 方法暂抛 NotImplementedError，
+但 is_success / unwrap_data / parse_error 按智联真实协议返回正确值，
+验证 Platform 抽象设计对第二平台也自洽（Issue #129 Week 1d 自证）。
+
+Week 2 会把 stub 替换为真实实现。
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from boss_agent_cli.platforms import BossPlatform, Platform, get_platform, list_platforms
+from boss_agent_cli.platforms.zhilian import ZhilianPlatform
+
+
+class TestZhilianRegistration:
+	"""Zhilian 已注册到 Platform 注册表。"""
+
+	def test_list_platforms_contains_zhilian(self) -> None:
+		assert "zhilian" in list_platforms()
+
+	def test_list_platforms_still_contains_zhipin(self) -> None:
+		assert "zhipin" in list_platforms()
+
+	def test_get_platform_returns_zhilian_class(self) -> None:
+		assert get_platform("zhilian") is ZhilianPlatform
+
+	def test_zhilian_subclasses_platform(self) -> None:
+		assert issubclass(ZhilianPlatform, Platform)
+
+	def test_zhilian_is_distinct_from_boss(self) -> None:
+		assert ZhilianPlatform is not BossPlatform
+
+
+class TestZhilianMetadata:
+	"""Zhilian 基础元信息（对齐 docs/research/platforms/zhaopin.md）。"""
+
+	def setup_method(self) -> None:
+		self.plat = ZhilianPlatform(MagicMock())
+
+	def test_name_is_zhilian(self) -> None:
+		assert self.plat.name == "zhilian"
+
+	def test_display_name_is_chinese(self) -> None:
+		assert self.plat.display_name == "智联招聘"
+
+	def test_base_url_points_to_zhaopin(self) -> None:
+		assert "zhaopin.com" in self.plat.base_url
+
+
+class TestZhilianEnvelopeAdapter:
+	"""Zhilian 响应包络适配（基于 zhaopin.md §4）。"""
+
+	def setup_method(self) -> None:
+		self.plat = ZhilianPlatform(MagicMock())
+
+	def test_is_success_code_200(self) -> None:
+		"""智联成功是 code == 200，区别于 BOSS 的 code == 0。"""
+		assert self.plat.is_success({"code": 200, "data": {}}) is True
+
+	def test_is_success_non_200(self) -> None:
+		assert self.plat.is_success({"code": 401}) is False
+
+	def test_is_success_missing_code(self) -> None:
+		assert self.plat.is_success({}) is False
+
+	def test_unwrap_data_from_data_key(self) -> None:
+		"""智联数据在 data key，区别于 BOSS 的 zpData。"""
+		result = self.plat.unwrap_data({"code": 200, "data": {"list": [1, 2]}})
+		assert result == {"list": [1, 2]}
+
+	def test_unwrap_data_missing(self) -> None:
+		assert self.plat.unwrap_data({"code": 200}) is None
+
+	def test_parse_error_unauthorized(self) -> None:
+		"""智联 401 → AUTH_EXPIRED / AUTH_REQUIRED。"""
+		code, _ = self.plat.parse_error({"code": 401, "message": "unauthorized"})
+		assert code in ("AUTH_EXPIRED", "AUTH_REQUIRED")
+
+	def test_parse_error_forbidden_as_risk(self) -> None:
+		"""智联 403 → ACCOUNT_RISK。"""
+		code, _ = self.plat.parse_error({"code": 403, "message": "forbidden"})
+		assert code == "ACCOUNT_RISK"
+
+	def test_parse_error_rate_limited(self) -> None:
+		"""智联 429 → RATE_LIMITED。"""
+		code, _ = self.plat.parse_error({"code": 429, "message": "too many"})
+		assert code == "RATE_LIMITED"
+
+	def test_parse_error_unknown(self) -> None:
+		code, _ = self.plat.parse_error({"code": 999, "message": "whatever"})
+		assert code == "UNKNOWN"
+
+
+class TestZhilianStubBehavior:
+	"""Stub 方法在 Week 2 之前应抛 NotImplementedError 附友好提示。"""
+
+	def setup_method(self) -> None:
+		self.plat = ZhilianPlatform(MagicMock())
+
+	def test_search_jobs_not_implemented(self) -> None:
+		with pytest.raises(NotImplementedError, match="Week 2"):
+			self.plat.search_jobs("Python")
+
+	def test_job_detail_not_implemented(self) -> None:
+		with pytest.raises(NotImplementedError, match="Week 2"):
+			self.plat.job_detail("abc")
+
+	def test_recommend_jobs_not_implemented(self) -> None:
+		with pytest.raises(NotImplementedError, match="Week 2"):
+			self.plat.recommend_jobs()
+
+	def test_user_info_not_implemented(self) -> None:
+		with pytest.raises(NotImplementedError, match="Week 2"):
+			self.plat.user_info()
+
+	def test_greet_not_implemented_defaults_from_base(self) -> None:
+		"""Platform 基类 greet 抛 NotImplementedError，Zhilian stub 沿用。"""
+		with pytest.raises(NotImplementedError):
+			self.plat.greet("sid", "jid")
+
+	def test_apply_not_implemented_defaults_from_base(self) -> None:
+		with pytest.raises(NotImplementedError):
+			self.plat.apply("sid", "jid")
+
+	def test_stub_can_enter_with_context(self) -> None:
+		"""with 上下文即使 P0 方法抛错也能正常关闭（客户端是 MagicMock）。"""
+		mock_client = MagicMock()
+		plat = ZhilianPlatform(mock_client)
+		with plat:
+			pass
+		mock_client.close.assert_called_once()
+
+
+class TestZhilianCliIntegration:
+	"""CLI 集成：--platform zhilian schema 可用且暴露正确字段。"""
+
+	def test_zhilian_accepted_as_platform_option(self) -> None:
+		from boss_agent_cli.main import cli
+
+		runner = CliRunner()
+		result = runner.invoke(cli, ["--platform", "zhilian", "schema"])
+		assert result.exit_code == 0
+		payload = json.loads(result.output)
+		assert payload["data"]["current_platform"] == "zhilian"
+
+	def test_schema_supported_platforms_includes_zhilian(self) -> None:
+		from boss_agent_cli.main import cli
+
+		runner = CliRunner()
+		result = runner.invoke(cli, ["schema"])
+		assert result.exit_code == 0
+		payload = json.loads(result.output)
+		assert "zhilian" in payload["data"]["supported_platforms"]
+
+	def test_schema_platform_choice_updated(self) -> None:
+		"""schema 的 --platform 选项 choices 应包含 zhilian。"""
+		from boss_agent_cli.main import cli
+
+		runner = CliRunner()
+		result = runner.invoke(cli, ["schema"])
+		assert result.exit_code == 0
+		payload = json.loads(result.output)
+		platform_opt = payload["data"]["global_options"]["--platform"]
+		assert "zhilian" in platform_opt.get("choices", [])


### PR DESCRIPTION
## 背景

Issue #129 Week 1d 自证任务。Platform 抽象在只有一个实现（zhipin）时"设计是否正确"尚未被证伪。本 PR 加入 Zhilian stub 强制抽象跑完整"注册 / CLI / schema / with 上下文 / 包络适配"全流程，在 Week 2 投入真实现之前暴露任何设计缺陷。

事实：**全通过**。抽象设计对齐 [zhaopin.md §7 差异矩阵](docs/research/platforms/zhaopin.md)。

## 变更

### Added

- **`src/boss_agent_cli/platforms/zhilian.py`** — `ZhilianPlatform` stub：
  - 元信息：`name="zhilian"` / `display_name="智联招聘"` / `base_url="https://m.zhaopin.com"`
  - 包络适配按 zhaopin.md §4 **完整实现**：
    - `is_success`：`code == 200`（BOSS 是 `code == 0`）
    - `unwrap_data`：`data` key（BOSS 是 `zpData`）
    - `parse_error`：401→AUTH_EXPIRED / 403→ACCOUNT_RISK / 429→RATE_LIMITED
  - P0/P1/P2 抽象方法抛 `NotImplementedError("Week 2 待实现，当前为注册自证 stub")`，Week 2 替换
- **`tests/test_zhilian_stub.py`**：27 条契约测试覆盖
  - Platform 注册表（4 条）
  - 元信息（3 条）
  - 包络适配（10 条）
  - Stub 行为（7 条，包括 with 上下文异常安全）
  - CLI 集成（3 条，`boss --platform zhilian schema` 端到端）

### Changed

- `src/boss_agent_cli/platforms/__init__.py` 注册表扩为 `{"zhipin": BossPlatform, "zhilian": ZhilianPlatform}`
- `src/boss_agent_cli/commands/schema.py` 的 `--platform` choices 更新为 `["zhipin", "zhilian"]`，描述说明两者状态
- `src/boss_agent_cli/__init__.py` 导出 `ZhilianPlatform`（下游可提前查签名）
- `tests/test_public_api.py` `EXPECTED_EXPORTS` 加 `ZhilianPlatform`
- mypy 严格白名单扩到 71（`platforms.zhilian`）

## 非目标

- **不实现**任何 P0/P1/P2 方法（Week 2 做）
- 不做 ZhilianClient（等 Week 2 接入真实 API）
- 不做命令路由升级（已迁移命令能路由，未迁移命令不影响）

## 验证

\`\`\`
$ uv run pytest tests/ -q
998 passed in 32.99s

$ uv run mypy src/boss_agent_cli
Success: no issues found in 80 source files

$ uv run boss --platform zhilian schema | python3 -c "import sys,json; d=json.loads(sys.stdin.read())['data']; print('current:', d['current_platform']); print('supported:', d['supported_platforms'])"
current: zhilian
supported: ['zhilian', 'zhipin']

$ uv run boss --platform zhilian greet sid1 jid1
{"ok": false, "command": "greet", "error": {"message": "greet 失败: zhilian platform does not implement greet", ...}}
\`\`\`

- 测试 971 → **998 通过**（+27 zhilian 契约测试）
- mypy strict 0 错误（+1 严格模块）
- CLI 端到端：`--platform zhilian schema` OK、已迁移命令路由到 Zhilian 抛 NotImplementedError 消息
- 零已有命令行为变化