### PR TITLE
refactor: 迁移批量打招呼命令到平台抽象

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 ## [Unreleased]
 
 ### Added
+- **`boss batch-greet` 迁移到 Platform**（Week 1c 第 3 个命令）— 从 `BossClient` 直用切换到 `get_platform_instance(ctx, auth)`，内部 `client.search_jobs` / `client.greet` 改为 `platform.search_jobs` / `platform.greet`。删除 `greet.py` 对 `BossClient` 的直接引用。
+
+### Changed
+- `tests/test_greet_extended.py` / `test_greet_detail_extended.py` / `test_commands.py` 共 10 处 mock patch 位置从 `commands.greet.BossClient` 切到 `commands.greet.get_platform_instance`。
+
+### Added
 - **ZhilianPlatform stub**（Issue #129 Week 1d · 抽象自证）— `src/boss_agent_cli/platforms/zhilian.py` 新增智联招聘 stub 实现：
   - 元信息：`name="zhilian"` / `display_name="智联招聘"` / `base_url="https://m.zhaopin.com"`
   - 包络适配按 [zhaopin.md](docs/research/platforms/zhaopin.md) §4 调研结果完整实现（`is_success` 检 `code==200` · `unwrap_data` 取 `data` key · `parse_error` 映射 401/403/429）

--- a/src/boss_agent_cli/commands/greet.py
+++ b/src/boss_agent_cli/commands/greet.py
@@ -3,7 +3,6 @@ import time
 
 import click
 
-from boss_agent_cli.api.client import BossClient
 from boss_agent_cli.api.endpoints import (
 	INDUSTRY_CODES,
 	JOB_TYPE_CODES,
@@ -112,15 +111,13 @@ def batch_greet_cmd(ctx: click.Context, query: str, city: str | None, salary: st
 	"""搜索后批量打招呼（上限 10）"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	delay = ctx.obj["delay"]
-	cdp_url = ctx.obj.get("cdp_url")
 
 	count = min(count, 10)
 
 	with CacheStore(data_dir / "cache" / "boss_agent.db") as cache:
 		auth = AuthManager(data_dir, logger=logger)
-		with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
-			raw = client.search_jobs(
+		with get_platform_instance(ctx, auth) as platform:
+			raw = platform.search_jobs(
 				query, city=city, salary=salary, experience=experience,
 				education=education, industry=industry, scale=scale,
 				stage=stage, job_type=job_type,
@@ -157,7 +154,7 @@ def batch_greet_cmd(ctx: click.Context, query: str, city: str | None, salary: st
 
 				while retry_count <= 1:
 					try:
-						client.greet(item.security_id, item.job_id)
+						platform.greet(item.security_id, item.job_id)
 						cache.record_greet(item.security_id, item.job_id)
 						results.append({
 							"security_id": item.security_id,

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -86,7 +86,7 @@ def test_search_invalid_city(mock_client_cls, mock_auth_cls, mock_cache_cls):
 	assert parsed["error"]["code"] == "INVALID_PARAM"
 
 
-@patch("boss_agent_cli.commands.greet.BossClient")
+@patch("boss_agent_cli.commands.greet.get_platform_instance")
 @patch("boss_agent_cli.commands.greet.AuthManager")
 @patch("boss_agent_cli.commands.greet.CacheStore")
 def test_greet_already_greeted(mock_cache_cls, mock_auth_cls, mock_client_cls):
@@ -100,7 +100,7 @@ def test_greet_already_greeted(mock_cache_cls, mock_auth_cls, mock_client_cls):
 
 
 @patch("boss_agent_cli.commands.greet.time")
-@patch("boss_agent_cli.commands.greet.BossClient")
+@patch("boss_agent_cli.commands.greet.get_platform_instance")
 @patch("boss_agent_cli.commands.greet.AuthManager")
 @patch("boss_agent_cli.commands.greet.CacheStore")
 def test_batch_greet_dry_run(mock_cache_cls, mock_auth_cls, mock_client_cls, mock_time):

--- a/tests/test_greet_detail_extended.py
+++ b/tests/test_greet_detail_extended.py
@@ -12,7 +12,7 @@ from boss_agent_cli.main import cli
 
 _PATCHES = {
 	"auth": "boss_agent_cli.commands.greet.AuthManager",
-	"client": "boss_agent_cli.commands.greet.BossClient",
+	"client": "boss_agent_cli.commands.greet.get_platform_instance",
 	"platform": "boss_agent_cli.commands.greet.get_platform_instance",
 	"cache": "boss_agent_cli.commands.greet.CacheStore",
 }

--- a/tests/test_greet_extended.py
+++ b/tests/test_greet_extended.py
@@ -73,7 +73,7 @@ def test_greet_success_renders_message_and_records_cache(mock_cache_cls, mock_au
 
 
 @patch("boss_agent_cli.commands.greet.time")
-@patch("boss_agent_cli.commands.greet.BossClient")
+@patch("boss_agent_cli.commands.greet.get_platform_instance")
 @patch("boss_agent_cli.commands.greet.AuthManager")
 @patch("boss_agent_cli.commands.greet.CacheStore")
 def test_batch_greet_success_all(mock_cache_cls, mock_auth_cls, mock_client_cls, mock_time):
@@ -101,7 +101,7 @@ def test_batch_greet_success_all(mock_cache_cls, mock_auth_cls, mock_client_cls,
 
 
 @patch("boss_agent_cli.commands.greet.time")
-@patch("boss_agent_cli.commands.greet.BossClient")
+@patch("boss_agent_cli.commands.greet.get_platform_instance")
 @patch("boss_agent_cli.commands.greet.AuthManager")
 @patch("boss_agent_cli.commands.greet.CacheStore")
 def test_batch_greet_rate_limited_stops_remaining(mock_cache_cls, mock_auth_cls, mock_client_cls, mock_time):
@@ -134,7 +134,7 @@ def test_batch_greet_rate_limited_stops_remaining(mock_cache_cls, mock_auth_cls,
 
 
 @patch("boss_agent_cli.commands.greet.time")
-@patch("boss_agent_cli.commands.greet.BossClient")
+@patch("boss_agent_cli.commands.greet.get_platform_instance")
 @patch("boss_agent_cli.commands.greet.AuthManager")
 @patch("boss_agent_cli.commands.greet.CacheStore")
 def test_batch_greet_greet_limit_stops_remaining(mock_cache_cls, mock_auth_cls, mock_client_cls, mock_time):
@@ -157,7 +157,7 @@ def test_batch_greet_greet_limit_stops_remaining(mock_cache_cls, mock_auth_cls, 
 
 
 @patch("boss_agent_cli.commands.greet.time")
-@patch("boss_agent_cli.commands.greet.BossClient")
+@patch("boss_agent_cli.commands.greet.get_platform_instance")
 @patch("boss_agent_cli.commands.greet.AuthManager")
 @patch("boss_agent_cli.commands.greet.CacheStore")
 def test_batch_greet_network_error_retries_once_then_skips(mock_cache_cls, mock_auth_cls, mock_client_cls, mock_time):
@@ -194,7 +194,7 @@ def test_batch_greet_network_error_retries_once_then_skips(mock_cache_cls, mock_
 
 
 @patch("boss_agent_cli.commands.greet.time")
-@patch("boss_agent_cli.commands.greet.BossClient")
+@patch("boss_agent_cli.commands.greet.get_platform_instance")
 @patch("boss_agent_cli.commands.greet.AuthManager")
 @patch("boss_agent_cli.commands.greet.CacheStore")
 def test_batch_greet_network_error_first_retry_succeeds(mock_cache_cls, mock_auth_cls, mock_client_cls, mock_time):
@@ -226,7 +226,7 @@ def test_batch_greet_network_error_first_retry_succeeds(mock_cache_cls, mock_aut
 
 
 @patch("boss_agent_cli.commands.greet.time")
-@patch("boss_agent_cli.commands.greet.BossClient")
+@patch("boss_agent_cli.commands.greet.get_platform_instance")
 @patch("boss_agent_cli.commands.greet.AuthManager")
 @patch("boss_agent_cli.commands.greet.CacheStore")
 def test_batch_greet_skips_already_greeted(mock_cache_cls, mock_auth_cls, mock_client_cls, mock_time):
@@ -252,7 +252,7 @@ def test_batch_greet_skips_already_greeted(mock_cache_cls, mock_auth_cls, mock_c
 
 
 @patch("boss_agent_cli.commands.greet.time")
-@patch("boss_agent_cli.commands.greet.BossClient")
+@patch("boss_agent_cli.commands.greet.get_platform_instance")
 @patch("boss_agent_cli.commands.greet.AuthManager")
 @patch("boss_agent_cli.commands.greet.CacheStore")
 def test_batch_greet_respects_count_cap(mock_cache_cls, mock_auth_cls, mock_client_cls, mock_time):


### PR DESCRIPTION
## 背景

Issue #129 Week 1c 第 3 个命令迁移。本 PR 把 `boss batch-greet` 从 `BossClient` 直用切换到 `get_platform_instance`，与前序 PR #133（greet / apply）保持一致模式。

## 变更

### Changed

- `src/boss_agent_cli/commands/greet.py`：
  - `batch_greet_cmd` 从 `with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:` 切换到 `with get_platform_instance(ctx, auth) as platform:`
  - 内部 `client.search_jobs(...)` / `client.greet(...)` 改为 `platform.search_jobs(...)` / `platform.greet(...)`
  - 删除 `BossClient` 导入（greet.py 内已无直接引用）
  - 去除 delay / cdp_url 样板代码

### Tests

- `tests/test_greet_extended.py` 8 处 `@patch("commands.greet.BossClient")` → `@patch("commands.greet.get_platform_instance")`
- `tests/test_greet_detail_extended.py` 1 处 `_PATCHES` 字典更新
- `tests/test_commands.py` 2 处 mock 位置同步

## 验证

\`\`\`
$ uv run pytest tests/ -q
998 passed in 35.41s

$ uv run mypy src/boss_agent_cli
Success: no issues found in 80 source files
\`\`\`

- 全量 998 测试通过（零新增）
- mypy strict 0 错误
- 零命令行为变化

## 非目标

- detail / recommend / search 命令等未迁移（依赖 ABC 扩展，留给下一个 PR）