### PR TITLE
feat: 平台抽象扩展与批量命令迁移

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@
 ## [Unreleased]
 
 ### Added
-- **`boss batch-greet` 迁移到 Platform**（Week 1c 第 3 个命令）— 从 `BossClient` 直用切换到 `get_platform_instance(ctx, auth)`，内部 `client.search_jobs` / `client.greet` 改为 `platform.search_jobs` / `platform.greet`。删除 `greet.py` 对 `BossClient` 的直接引用。
+- **Platform ABC 扩展 9 个 P0+ 方法**（Issue #129 Week 1c 第 4 轮）— 补齐 BossClient 实际公开面所需的：`resume_baseinfo` / `resume_expect` / `deliver_list` / `job_card` / `interview_data` / `chat_history` / `friend_label` / `exchange_contact`。BossPlatform 全部透传给底层 `BossClient`；ZhilianPlatform 未覆盖走基类默认 `NotImplementedError`。
+- **5 个命令迁移到 Platform** — `interviews` / `detail` / `show` / `me` / `recommend` 从 `with BossClient(...)` 切换到 `with get_platform_instance(ctx, auth) as platform:`。
+- 迁移后 Platform 已覆盖 **8 个命令**（greet / apply / batch-greet / interviews / detail / show / me / recommend）。
 
 ### Changed
-- `tests/test_greet_extended.py` / `test_greet_detail_extended.py` / `test_commands.py` 共 10 处 mock patch 位置从 `commands.greet.BossClient` 切到 `commands.greet.get_platform_instance`。
+- 相关测试文件 mock 位点从 `commands.X.BossClient` 切到 `commands.X.get_platform_instance`（`test_new_commands.py` / `test_commands.py` / `test_coverage_second_sprint.py` / `test_greet_detail_extended.py`）。
+- detail.py 内部辅助函数 `_detail_via_httpx` / `_detail_via_browser` 形参类型从 `BossClient` 改为 `Platform`。
+- me.py 保留 `from boss_agent_cli.api.client import AuthError` 仅做异常类型绑定，不再直接 instantiate `BossClient`。
 
 ### Added
 - **ZhilianPlatform stub**（Issue #129 Week 1d · 抽象自证）— `src/boss_agent_cli/platforms/zhilian.py` 新增智联招聘 stub 实现：

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -394,3 +394,4 @@ boss logout       -> 退出登录
 | 2026-04-21 | Platform CLI | 新增 --platform 全局选项与 get_platform_instance 辅助函数，schema 输出增加 current_platform / supported_platforms 字段，config.json 支持 platform 字段，测试 956→966，mypy 严格模块 69→70 |
 | 2026-04-21 | Platform 迁移 | greet 和 apply 命令从 BossClient 直用切换到 get_platform_instance，Platform ABC 补齐 with 上下文管理器（__enter__/__exit__/close），测试 966→971 |
 | 2026-04-21 | Platform 自证 | 新增 ZhilianPlatform stub 注册到 Platform 注册表，包络适配按 zhaopin.md 调研完整实现，P0/P1/P2 抛 NotImplementedError 待 Week 2 真实现，测试 971→998 |
+| 2026-04-21 | Platform ABC 扩展 | Platform ABC 补齐 9 个 P0+ 方法（resume_baseinfo/resume_expect/deliver_list/job_card/interview_data/chat_history/friend_label/exchange_contact），BossPlatform 全部透传；interviews/detail/show/me/recommend 共 5 个命令迁移到 Platform 接口 |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,7 +40,7 @@
 - [ ] 多平台支持：拉勾 / 智联 / 猎聘适配器 — API 调研已全部完成（Issue #90 已闭环 · [docs/research/platforms/](docs/research/platforms/)），结论：**智联为 v2.0 优先接入候选**（2-3 周），拉勾和猎聘不建议接入
   - [x] Week 1a：Platform ABC 骨架 + BossPlatform adapter（#129，零行为变化）
   - [x] Week 1b：`--platform` 全局 CLI 选项 + `get_platform_instance` helper + schema 暴露 current_platform
-  - [ ] Week 1c：逐步迁移 30+ 命令到 Platform 接口调用（已迁移 2 个：greet / apply）
+  - [ ] Week 1c：逐步迁移 30+ 命令到 Platform 接口调用（已迁移 8 个：greet / apply / batch-greet / interviews / detail / show / me / recommend）
   - [x] Week 1d：ZhilianPlatform stub 接入注册表（抽象自证，包络适配完整实现，P0/P1/P2 暂 NotImplementedError）
   - [ ] Week 2：ZhilianPlatform 只读实现（search / detail / recommend / user_info）
   - [ ] Week 3：ZhilianPlatform 写操作（greet / apply）+ 文档 + MCP 适配

--- a/src/boss_agent_cli/commands/detail.py
+++ b/src/boss_agent_cli/commands/detail.py
@@ -3,10 +3,11 @@ from typing import Any
 
 import click
 
-from boss_agent_cli.api.client import BossClient
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.cache.store import CacheStore
+from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_job_detail
+from boss_agent_cli.platforms import Platform
 
 
 @click.command("detail")
@@ -19,11 +20,9 @@ def detail_cmd(ctx: click.Context, security_id: str, lid: str, job_id: str) -> N
 	"""查看职位完整信息（职位描述、地址、招聘者信息）"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	delay = ctx.obj["delay"]
-	cdp_url = ctx.obj.get("cdp_url")
 
 	auth = AuthManager(data_dir, logger=logger)
-	with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
+	with get_platform_instance(ctx, auth) as platform:
 		# 优先走 httpx 快速通道：显式传入 > 缓存查找 > 降级浏览器通道
 		if not job_id:
 			with CacheStore(data_dir / "cache" / "boss_agent.db") as cache:
@@ -34,12 +33,12 @@ def detail_cmd(ctx: click.Context, security_id: str, lid: str, job_id: str) -> N
 		result = None
 		if job_id:
 			try:
-				result = _detail_via_httpx(client, security_id, job_id, data_dir)
+				result = _detail_via_httpx(platform, security_id, job_id, data_dir)
 			except Exception as e:
 				logger.info(f"httpx 快速通道失败（{e}），降级到浏览器通道")
 				result = None
 		if result is None:
-			result = _detail_via_browser(client, security_id, lid, data_dir)
+			result = _detail_via_browser(platform, security_id, lid, data_dir)
 
 	if result is None:
 		handle_error_output(
@@ -54,9 +53,9 @@ def detail_cmd(ctx: click.Context, security_id: str, lid: str, job_id: str) -> N
 	handle_output(ctx, "detail", result, render=render_job_detail, hints=hints)
 
 
-def _detail_via_httpx(client: BossClient, security_id: str, job_id: str, data_dir: Path) -> dict[str, Any] | None:
+def _detail_via_httpx(platform: Platform, security_id: str, job_id: str, data_dir: Path) -> dict[str, Any] | None:
 	"""快速通道：通过 httpx 获取职位详情（不需要浏览器）"""
-	raw = client.job_detail(job_id)
+	raw = platform.job_detail(job_id)
 	zp = raw.get("zpData", {})
 	job_info = zp.get("jobInfo", {})
 	boss_info = zp.get("bossInfo", {})
@@ -87,9 +86,9 @@ def _detail_via_httpx(client: BossClient, security_id: str, job_id: str, data_di
 	}
 
 
-def _detail_via_browser(client: BossClient, security_id: str, lid: str, data_dir: Path) -> dict[str, Any] | None:
+def _detail_via_browser(platform: Platform, security_id: str, lid: str, data_dir: Path) -> dict[str, Any] | None:
 	"""兜底通道：通过浏览器 job_card 获取职位详情"""
-	raw = client.job_card(security_id, lid)
+	raw = platform.job_card(security_id, lid)
 	card = raw.get("zpData", {}).get("jobCard", {})
 	if not card:
 		return None

--- a/src/boss_agent_cli/commands/interviews.py
+++ b/src/boss_agent_cli/commands/interviews.py
@@ -1,7 +1,7 @@
 import click
 
-from boss_agent_cli.api.client import BossClient
 from boss_agent_cli.auth.manager import AuthManager
+from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_simple_list
 from typing import Any
 
@@ -13,8 +13,6 @@ def interviews_cmd(ctx: click.Context) -> None:
 	"""查看面试邀请列表"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	delay = ctx.obj["delay"]
-	cdp_url = ctx.obj.get("cdp_url")
 	auth = AuthManager(data_dir, logger=logger)
 
 	token = auth.check_status()
@@ -27,8 +25,8 @@ def interviews_cmd(ctx: click.Context) -> None:
 		)
 		return
 
-	with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
-		raw = client.interview_data()
+	with get_platform_instance(ctx, auth) as platform:
+		raw = platform.interview_data()
 		interview_list = raw.get("zpData", {}).get("interviewList", [])
 
 	items = [

--- a/src/boss_agent_cli/commands/me.py
+++ b/src/boss_agent_cli/commands/me.py
@@ -1,7 +1,8 @@
 import click
 
-from boss_agent_cli.api.client import AuthError, BossClient
+from boss_agent_cli.api.client import AuthError
 from boss_agent_cli.auth.manager import AuthManager, AuthRequired, TokenRefreshFailed
+from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import handle_error_output, handle_output, render_sectioned_record
 
 
@@ -13,13 +14,11 @@ from boss_agent_cli.display import handle_error_output, handle_output, render_se
 def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 	"""获取当前登录用户的个人信息、简历、求职期望、投递记录"""
 	data_dir = ctx.obj["data_dir"]
-	delay = ctx.obj["delay"]
-	cdp_url = ctx.obj.get("cdp_url")
 	logger = ctx.obj.get("logger")
 
 	try:
 		auth = AuthManager(data_dir, logger=logger)
-		with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
+		with get_platform_instance(ctx, auth) as platform:
 			result = {}
 
 			sections = [section] if section else ["user", "resume", "expect", "deliver"]
@@ -27,7 +26,7 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 			if "user" in sections:
 				if logger:
 					logger.info("获取用户基本信息...")
-				resp = client.user_info()
+				resp = platform.user_info()
 				zp_data = resp.get("zpData", {})
 				result["user"] = {
 					"name": zp_data.get("name", ""),
@@ -40,21 +39,21 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 			if "resume" in sections:
 				if logger:
 					logger.info("获取简历基本信息...")
-				resp = client.resume_baseinfo()
+				resp = platform.resume_baseinfo()
 				zp_data = resp.get("zpData", {})
 				result["resume"] = zp_data
 
 			if "expect" in sections:
 				if logger:
 					logger.info("获取求职期望...")
-				resp = client.resume_expect()
+				resp = platform.resume_expect()
 				zp_data = resp.get("zpData", {})
 				result["expect"] = zp_data
 
 			if "deliver" in sections:
 				if logger:
 					logger.info("获取投递记录...")
-				resp = client.deliver_list(page=deliver_page)
+				resp = platform.deliver_list(page=deliver_page)
 				zp_data = resp.get("zpData", {})
 				result["deliver"] = zp_data
 

--- a/src/boss_agent_cli/commands/recommend.py
+++ b/src/boss_agent_cli/commands/recommend.py
@@ -1,9 +1,9 @@
 import click
 
-from boss_agent_cli.api.client import BossClient
 from boss_agent_cli.api.models import JobItem
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.cache.store import CacheStore
+from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import handle_output, render_job_table, handle_auth_errors
 from boss_agent_cli.index_cache import try_save_index
 from boss_agent_cli.match_score import score_job_dict
@@ -18,15 +18,13 @@ def recommend_cmd(ctx: click.Context, page: int, with_score: bool) -> None:
 	"""基于简历的个性化职位推荐"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	delay = ctx.obj["delay"]
-	cdp_url = ctx.obj.get("cdp_url")
 
 	auth = AuthManager(data_dir, logger=logger)
-	with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
+	with get_platform_instance(ctx, auth) as platform:
 		with CacheStore(data_dir / "cache" / "boss_agent.db") as cache:
-			expect_data = client.resume_expect().get("zpData", {}) if with_score else None
+			expect_data = platform.resume_expect().get("zpData", {}) if with_score else None
 
-			raw = client.recommend_jobs(page=page)
+			raw = platform.recommend_jobs(page=page)
 			zp_data = raw.get("zpData", {})
 			job_list = zp_data.get("jobList", [])
 

--- a/src/boss_agent_cli/commands/show.py
+++ b/src/boss_agent_cli/commands/show.py
@@ -1,8 +1,8 @@
 import click
 
-from boss_agent_cli.api.client import BossClient
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.cache.store import CacheStore
+from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_job_detail
 from boss_agent_cli.index_cache import get_index_info, get_job_by_index
 
@@ -15,8 +15,6 @@ def show_cmd(ctx: click.Context, index: int) -> None:
 	"""按编号查看搜索/推荐结果中的职位详情（如 boss show 3）"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	delay = ctx.obj["delay"]
-	cdp_url = ctx.obj.get("cdp_url")
 
 	# 从索引缓存获取职位信息
 	job = get_job_by_index(data_dir, index)
@@ -46,8 +44,8 @@ def show_cmd(ctx: click.Context, index: int) -> None:
 		return
 
 	auth = AuthManager(data_dir, logger=logger)
-	with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
-		raw = client.job_card(security_id)
+	with get_platform_instance(ctx, auth) as platform:
+		raw = platform.job_card(security_id)
 
 	card = raw.get("zpData", {}).get("jobCard", {})
 	if not card:

--- a/src/boss_agent_cli/platforms/base.py
+++ b/src/boss_agent_cli/platforms/base.py
@@ -101,6 +101,46 @@ class Platform(ABC):
 	def user_info(self) -> dict[str, Any]:
 		"""获取当前用户信息。"""
 
+	# ── 简历 / 投递（P0+，平台不支持时抛 NotImplementedError）──
+
+	def resume_baseinfo(self) -> dict[str, Any]:
+		"""获取简历基本信息。"""
+		raise NotImplementedError(f"{self.name} platform does not implement resume_baseinfo")
+
+	def resume_expect(self) -> dict[str, Any]:
+		"""获取求职期望。"""
+		raise NotImplementedError(f"{self.name} platform does not implement resume_expect")
+
+	def deliver_list(self, page: int = 1) -> dict[str, Any]:
+		"""获取投递记录。"""
+		raise NotImplementedError(f"{self.name} platform does not implement deliver_list")
+
+	# ── 职位卡片（详情降级通道）──
+
+	def job_card(self, security_id: str, lid: str = "") -> dict[str, Any]:
+		"""职位卡片（用于详情页降级）。"""
+		raise NotImplementedError(f"{self.name} platform does not implement job_card")
+
+	# ── 面试 ──
+
+	def interview_data(self) -> dict[str, Any]:
+		"""获取面试邀请列表。"""
+		raise NotImplementedError(f"{self.name} platform does not implement interview_data")
+
+	# ── 沟通扩展 ──
+
+	def chat_history(self, gid: str, security_id: str, page: int = 1, count: int = 20) -> dict[str, Any]:
+		"""查看与某联系人的聊天消息历史。"""
+		raise NotImplementedError(f"{self.name} platform does not implement chat_history")
+
+	def friend_label(self, friend_id: str, label_id: int, friend_source: int = 0, remove: bool = False) -> dict[str, Any]:
+		"""给联系人加/删标签。"""
+		raise NotImplementedError(f"{self.name} platform does not implement friend_label")
+
+	def exchange_contact(self, security_id: str, uid: str, friend_name: str, exchange_type: int = 1) -> dict[str, Any]:
+		"""请求交换联系方式（手机 / 微信）。"""
+		raise NotImplementedError(f"{self.name} platform does not implement exchange_contact")
+
 	def greet(self, security_id: str, job_id: str, message: str = "") -> dict[str, Any]:
 		"""打招呼。平台不支持时抛 NotImplementedError。"""
 		raise NotImplementedError(f"{self.name} platform does not implement greet")

--- a/src/boss_agent_cli/platforms/zhipin.py
+++ b/src/boss_agent_cli/platforms/zhipin.py
@@ -76,3 +76,29 @@ class BossPlatform(Platform):
 
 	def friend_list(self, page: int = 1) -> dict[str, Any]:
 		return self._client.friend_list(page)
+
+	# ── P0+ 扩展方法（BossClient 全部支持）───────────────
+
+	def resume_baseinfo(self) -> dict[str, Any]:
+		return self._client.resume_baseinfo()
+
+	def resume_expect(self) -> dict[str, Any]:
+		return self._client.resume_expect()
+
+	def deliver_list(self, page: int = 1) -> dict[str, Any]:
+		return self._client.deliver_list(page=page)
+
+	def job_card(self, security_id: str, lid: str = "") -> dict[str, Any]:
+		return self._client.job_card(security_id, lid)
+
+	def interview_data(self) -> dict[str, Any]:
+		return self._client.interview_data()
+
+	def chat_history(self, gid: str, security_id: str, page: int = 1, count: int = 20) -> dict[str, Any]:
+		return self._client.chat_history(gid, security_id, page=page, count=count)
+
+	def friend_label(self, friend_id: str, label_id: int, friend_source: int = 0, remove: bool = False) -> dict[str, Any]:
+		return self._client.friend_label(friend_id, label_id, friend_source, remove=remove)
+
+	def exchange_contact(self, security_id: str, uid: str, friend_name: str, exchange_type: int = 1) -> dict[str, Any]:
+		return self._client.exchange_contact(security_id, uid, friend_name, exchange_type=exchange_type)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -219,7 +219,7 @@ def test_doctor_with_partial_token_quality_warn(mock_auth_cls, mock_probe_cdp, m
 
 
 @patch("boss_agent_cli.commands.recommend.CacheStore")
-@patch("boss_agent_cli.commands.recommend.BossClient")
+@patch("boss_agent_cli.commands.recommend.get_platform_instance")
 @patch("boss_agent_cli.commands.recommend.AuthManager")
 def test_recommend_success(mock_auth_cls, mock_client_cls, mock_cache_cls):
 	mock_cache = _ctx_mock(mock_cache_cls)
@@ -263,7 +263,7 @@ def test_recommend_success(mock_auth_cls, mock_client_cls, mock_cache_cls):
 
 
 @patch("boss_agent_cli.commands.recommend.CacheStore")
-@patch("boss_agent_cli.commands.recommend.BossClient")
+@patch("boss_agent_cli.commands.recommend.get_platform_instance")
 @patch("boss_agent_cli.commands.recommend.AuthManager")
 def test_recommend_with_score(mock_auth_cls, mock_client_cls, mock_cache_cls):
 	mock_cache = _ctx_mock(mock_cache_cls)
@@ -352,7 +352,7 @@ def test_search_with_score(mock_client_cls, mock_auth_cls, mock_cache_cls, mock_
 
 @patch("boss_agent_cli.index_cache.save_index", side_effect=PermissionError("readonly"))
 @patch("boss_agent_cli.commands.recommend.CacheStore")
-@patch("boss_agent_cli.commands.recommend.BossClient")
+@patch("boss_agent_cli.commands.recommend.get_platform_instance")
 @patch("boss_agent_cli.commands.recommend.AuthManager")
 def test_recommend_ignores_index_cache_write_failure(mock_auth_cls, mock_client_cls, mock_cache_cls, mock_save_index):
 	mock_cache = _ctx_mock(mock_cache_cls)

--- a/tests/test_coverage_second_sprint.py
+++ b/tests/test_coverage_second_sprint.py
@@ -66,7 +66,7 @@ def test_show_missing_security_id(mock_get_job):
 	assert "security_id" in parsed["error"]["message"]
 
 
-@patch("boss_agent_cli.commands.show.BossClient")
+@patch("boss_agent_cli.commands.show.get_platform_instance")
 @patch("boss_agent_cli.commands.show.AuthManager")
 @patch("boss_agent_cli.commands.show.get_job_by_index")
 def test_show_job_card_empty_returns_not_found(mock_get_job, mock_auth_cls, mock_client_cls):
@@ -118,7 +118,7 @@ def test_mark_security_id_not_found_in_friend_list(mock_auth_cls, mock_client_cl
 # ── me 异常分支 ──────────────────────────────────────────
 
 
-@patch("boss_agent_cli.commands.me.BossClient")
+@patch("boss_agent_cli.commands.me.get_platform_instance")
 @patch("boss_agent_cli.commands.me.AuthManager")
 def test_me_auth_required(mock_auth_cls, mock_client_cls):
 	from boss_agent_cli.auth.manager import AuthRequired
@@ -129,7 +129,7 @@ def test_me_auth_required(mock_auth_cls, mock_client_cls):
 	assert parsed["error"]["code"] == "AUTH_REQUIRED"
 
 
-@patch("boss_agent_cli.commands.me.BossClient")
+@patch("boss_agent_cli.commands.me.get_platform_instance")
 @patch("boss_agent_cli.commands.me.AuthManager")
 def test_me_auth_error(mock_auth_cls, mock_client_cls):
 	from boss_agent_cli.api.client import AuthError
@@ -140,7 +140,7 @@ def test_me_auth_error(mock_auth_cls, mock_client_cls):
 	assert parsed["error"]["code"] == "AUTH_EXPIRED"
 
 
-@patch("boss_agent_cli.commands.me.BossClient")
+@patch("boss_agent_cli.commands.me.get_platform_instance")
 @patch("boss_agent_cli.commands.me.AuthManager")
 def test_me_generic_exception(mock_auth_cls, mock_client_cls):
 	mock_client_cls.side_effect = RuntimeError("boom")

--- a/tests/test_greet_detail_extended.py
+++ b/tests/test_greet_detail_extended.py
@@ -162,7 +162,7 @@ def test_batch_greet_respects_count_limit(tmp_path):
 
 _DETAIL_PATCHES = {
 	"auth": "boss_agent_cli.commands.detail.AuthManager",
-	"client": "boss_agent_cli.commands.detail.BossClient",
+	"client": "boss_agent_cli.commands.detail.get_platform_instance",
 	"cache": "boss_agent_cli.commands.detail.CacheStore",
 }
 

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -141,7 +141,7 @@ def test_exchange_wechat(mock_auth_cls, mock_client_cls):
 
 
 @patch("boss_agent_cli.commands.detail.CacheStore")
-@patch("boss_agent_cli.commands.detail.BossClient")
+@patch("boss_agent_cli.commands.detail.get_platform_instance")
 @patch("boss_agent_cli.commands.detail.AuthManager")
 def test_detail_with_job_id(mock_auth_cls, mock_client_cls, mock_cache_cls):
 	mock_cache = _ctx_mock(mock_cache_cls)
@@ -186,7 +186,7 @@ def test_detail_with_job_id(mock_auth_cls, mock_client_cls, mock_cache_cls):
 # ── me ───────────────────────────────────────────────────────────────
 
 
-@patch("boss_agent_cli.commands.me.BossClient")
+@patch("boss_agent_cli.commands.me.get_platform_instance")
 @patch("boss_agent_cli.commands.me.AuthManager")
 def test_me_basic(mock_auth_cls, mock_client_cls):
 	mock_client = _ctx_mock(mock_client_cls)
@@ -249,7 +249,7 @@ def test_history_uses_client_context_manager(mock_auth_cls, mock_client_cls):
 # ── interviews ───────────────────────────────────────────────────────
 
 
-@patch("boss_agent_cli.commands.interviews.BossClient")
+@patch("boss_agent_cli.commands.interviews.get_platform_instance")
 @patch("boss_agent_cli.commands.interviews.AuthManager")
 def test_interviews_success(mock_auth_cls, mock_client_cls):
 	mock_client = _ctx_mock(mock_client_cls)
@@ -265,7 +265,7 @@ def test_interviews_success(mock_auth_cls, mock_client_cls):
 
 
 @patch("boss_agent_cli.commands.detail.CacheStore")
-@patch("boss_agent_cli.commands.detail.BossClient")
+@patch("boss_agent_cli.commands.detail.get_platform_instance")
 @patch("boss_agent_cli.commands.detail.AuthManager")
 def test_detail_uses_client_context_manager(mock_auth_cls, mock_client_cls, mock_cache_cls):
 	mock_cache = _ctx_mock(mock_cache_cls)
@@ -289,7 +289,7 @@ def test_detail_uses_client_context_manager(mock_auth_cls, mock_client_cls, mock
 
 
 @patch("boss_agent_cli.commands.detail.CacheStore")
-@patch("boss_agent_cli.commands.detail.BossClient")
+@patch("boss_agent_cli.commands.detail.get_platform_instance")
 @patch("boss_agent_cli.commands.detail.AuthManager")
 def test_detail_httpx_fallback_to_browser_on_auth_error(mock_auth_cls, mock_client_cls, mock_cache_cls):
 	"""httpx 快速通道因 AuthError 失败时，应降级到浏览器通道而非直接报错"""
@@ -330,7 +330,7 @@ def test_detail_httpx_fallback_to_browser_on_auth_error(mock_auth_cls, mock_clie
 
 
 @patch("boss_agent_cli.commands.detail.CacheStore")
-@patch("boss_agent_cli.commands.detail.BossClient")
+@patch("boss_agent_cli.commands.detail.get_platform_instance")
 @patch("boss_agent_cli.commands.detail.AuthManager")
 def test_detail_httpx_fallback_to_browser_on_none(mock_auth_cls, mock_client_cls, mock_cache_cls):
 	"""httpx 快速通道返回空 jobInfo 时，应降级到浏览器通道"""
@@ -368,7 +368,7 @@ def test_detail_httpx_fallback_to_browser_on_none(mock_auth_cls, mock_client_cls
 
 @patch("boss_agent_cli.commands.show.CacheStore")
 @patch("boss_agent_cli.commands.show.get_job_by_index")
-@patch("boss_agent_cli.commands.show.BossClient")
+@patch("boss_agent_cli.commands.show.get_platform_instance")
 @patch("boss_agent_cli.commands.show.AuthManager")
 def test_show_uses_client_context_manager(mock_auth_cls, mock_client_cls, mock_get_job_by_index, mock_cache_cls):
 	mock_get_job_by_index.return_value = {"security_id": "sec_001"}
@@ -397,7 +397,7 @@ def test_show_uses_client_context_manager(mock_auth_cls, mock_client_cls, mock_g
 	instance.__exit__.assert_called_once()
 
 
-@patch("boss_agent_cli.commands.interviews.BossClient")
+@patch("boss_agent_cli.commands.interviews.get_platform_instance")
 @patch("boss_agent_cli.commands.interviews.AuthManager")
 def test_interviews_uses_client_context_manager(mock_auth_cls, mock_client_cls):
 	mock_auth_cls.return_value.check_status.return_value = {"cookies": {"wt2": "ok"}}


### PR DESCRIPTION
## 背景

Issue #129 Week 1c 第 4 轮批量迁移。Platform ABC 补齐 BossClient 实际公开面所需的 9 个方法，同时 5 个命令升级到 Platform 接口。

## 变更

### Platform ABC 扩展（9 个方法）

简历/投递：
- `resume_baseinfo()` — 简历基本信息
- `resume_expect()` — 求职期望
- `deliver_list(page=1)` — 投递记录

职位卡片：
- `job_card(security_id, lid="")` — 详情页降级通道

面试：
- `interview_data()` — 面试邀请列表

沟通扩展：
- `chat_history(gid, security_id, page=1, count=20)` — 聊天消息历史
- `friend_label(friend_id, label_id, friend_source=0, remove=False)` — 联系人打标
- `exchange_contact(security_id, uid, friend_name, exchange_type=1)` — 交换联系方式

所有方法在基类以 `NotImplementedError(f"{self.name} platform does not implement X")` 形式给出默认实现，平台不支持时有清晰错误消息。

### 命令迁移（5 个）

从 `with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:` 切换到 `with get_platform_instance(ctx, auth) as platform:`：

- `interviews` — `interview_data`
- `detail` — `job_detail` + `job_card`
- `show` — `job_card`
- `me` — `user_info` + `resume_baseinfo` + `resume_expect` + `deliver_list`
- `recommend` — `recommend_jobs` + `resume_expect`

累计 Platform 已覆盖 **8 个命令**（前序 greet / apply / batch-greet + 本轮 5 个）。

### BossPlatform 适配

所有新方法在 BossPlatform 直接透传给底层 BossClient，零行为变化：

```python
def resume_baseinfo(self) -> dict[str, Any]:
    return self._client.resume_baseinfo()
# ... 其他 8 个同理
```

### 测试

- 相关 mock 位点从 `commands.X.BossClient` → `commands.X.get_platform_instance`
- 涉及 `test_new_commands.py` / `test_commands.py` / `test_coverage_second_sprint.py` / `test_greet_detail_extended.py`

## 验证

\`\`\`
$ uv run pytest tests/ -q
998 passed in 33.79s

$ uv run mypy src/boss_agent_cli
Success: no issues found in 80 source files
\`\`\`

- 全量 998 测试通过（零新增，零回归）
- mypy strict 0 错误
- 零命令行为变化（纯委托式重构）

## 非目标

- 剩余 6 个命令（chatmsg / chat / mark / exchange / pipeline / digest / search）留给下一个 PR
- search.py 因 run_search_pipeline 间接耦合暂不迁移
- 版本号维持 1.9.1，待 Week 1c 完全收口后统一 bump 1.10.0