### PR TITLE
refactor: 迁移沟通与漏斗命令到平台抽象

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,11 @@
 ## [Unreleased]
 
 ### Added
-- **Platform ABC 扩展 9 个 P0+ 方法**（Issue #129 Week 1c 第 4 轮）— 补齐 BossClient 实际公开面所需的：`resume_baseinfo` / `resume_expect` / `deliver_list` / `job_card` / `interview_data` / `chat_history` / `friend_label` / `exchange_contact`。BossPlatform 全部透传给底层 `BossClient`；ZhilianPlatform 未覆盖走基类默认 `NotImplementedError`。
-- **5 个命令迁移到 Platform** — `interviews` / `detail` / `show` / `me` / `recommend` 从 `with BossClient(...)` 切换到 `with get_platform_instance(ctx, auth) as platform:`。
-- 迁移后 Platform 已覆盖 **8 个命令**（greet / apply / batch-greet / interviews / detail / show / me / recommend）。
+- **Week 1c 命令层迁移收口**（Issue #129 Week 1c 第 5 轮）— 剩余 6 个需网络请求的命令全部迁移到 `get_platform_instance`：`chat` / `chatmsg` / `mark` / `exchange` / `pipeline` / `digest`（包括 `pipeline` 的内部 `_collect_pipeline_items` 辅助函数）。
+- 至此 Week 1c 目标达成：**14 个命令**（前序 8 个 + 本轮 6 个）已全部经 Platform 抽象调用。只有 `search` 因为 `run_search_pipeline` 间接耦合的 BossClient 签名留待独立重构 PR。
 
 ### Changed
-- 相关测试文件 mock 位点从 `commands.X.BossClient` 切到 `commands.X.get_platform_instance`（`test_new_commands.py` / `test_commands.py` / `test_coverage_second_sprint.py` / `test_greet_detail_extended.py`）。
-- detail.py 内部辅助函数 `_detail_via_httpx` / `_detail_via_browser` 形参类型从 `BossClient` 改为 `Platform`。
-- me.py 保留 `from boss_agent_cli.api.client import AuthError` 仅做异常类型绑定，不再直接 instantiate `BossClient`。
+- 相关测试文件 mock 位点从 `commands.X.BossClient` → `commands.X.get_platform_instance`（覆盖 `test_chatmsg_extended.py` / `test_commands.py` / `test_coverage_second_sprint.py` / `test_digest_command.py` / `test_new_commands.py` / `test_pipeline_commands.py` 共 6 个测试文件）。
 
 ### Added
 - **ZhilianPlatform stub**（Issue #129 Week 1d · 抽象自证）— `src/boss_agent_cli/platforms/zhilian.py` 新增智联招聘 stub 实现：

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -395,3 +395,4 @@ boss logout       -> 退出登录
 | 2026-04-21 | Platform 迁移 | greet 和 apply 命令从 BossClient 直用切换到 get_platform_instance，Platform ABC 补齐 with 上下文管理器（__enter__/__exit__/close），测试 966→971 |
 | 2026-04-21 | Platform 自证 | 新增 ZhilianPlatform stub 注册到 Platform 注册表，包络适配按 zhaopin.md 调研完整实现，P0/P1/P2 抛 NotImplementedError 待 Week 2 真实现，测试 971→998 |
 | 2026-04-21 | Platform ABC 扩展 | Platform ABC 补齐 9 个 P0+ 方法（resume_baseinfo/resume_expect/deliver_list/job_card/interview_data/chat_history/friend_label/exchange_contact），BossPlatform 全部透传；interviews/detail/show/me/recommend 共 5 个命令迁移到 Platform 接口 |
+| 2026-04-21 | Platform 迁移收口 | chat/chatmsg/mark/exchange/pipeline/digest 共 6 个命令迁移到 Platform（Week 1c 第 5 轮），累计 14 个命令已走 Platform 抽象 |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,7 +40,7 @@
 - [ ] 多平台支持：拉勾 / 智联 / 猎聘适配器 — API 调研已全部完成（Issue #90 已闭环 · [docs/research/platforms/](docs/research/platforms/)），结论：**智联为 v2.0 优先接入候选**（2-3 周），拉勾和猎聘不建议接入
   - [x] Week 1a：Platform ABC 骨架 + BossPlatform adapter（#129，零行为变化）
   - [x] Week 1b：`--platform` 全局 CLI 选项 + `get_platform_instance` helper + schema 暴露 current_platform
-  - [ ] Week 1c：逐步迁移 30+ 命令到 Platform 接口调用（已迁移 8 个：greet / apply / batch-greet / interviews / detail / show / me / recommend）
+  - [x] Week 1c：命令层批量迁移到 Platform 接口（已迁移 14 个，search 因间接耦合留待单独 PR）
   - [x] Week 1d：ZhilianPlatform stub 接入注册表（抽象自证，包络适配完整实现，P0/P1/P2 暂 NotImplementedError）
   - [ ] Week 2：ZhilianPlatform 只读实现（search / detail / recommend / user_info）
   - [ ] Week 3：ZhilianPlatform 写操作（greet / apply）+ 文档 + MCP 适配

--- a/src/boss_agent_cli/commands/chat.py
+++ b/src/boss_agent_cli/commands/chat.py
@@ -4,8 +4,8 @@ from typing import Any
 
 import click
 
-from boss_agent_cli.api.client import BossClient
 from boss_agent_cli.auth.manager import AuthManager
+from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.commands.chat_export import render_export
 from boss_agent_cli.commands.chat_snapshot import save_snapshot_and_diff, load_snapshot
 from boss_agent_cli.commands.chat_utils import (
@@ -39,8 +39,6 @@ def chat_cmd(ctx: click.Context, page: int, from_who: str | None, days: int | No
 	"""查看沟通列表（支持按发起方、时间筛选，支持导出）"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	delay = ctx.obj["delay"]
-	cdp_url = ctx.obj.get("cdp_url")
 	auth = AuthManager(data_dir, logger=logger)
 
 	token = auth.check_status()
@@ -53,8 +51,8 @@ def chat_cmd(ctx: click.Context, page: int, from_who: str | None, days: int | No
 		)
 		return
 
-	with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
-		resp = client.friend_list(page=page)
+	with get_platform_instance(ctx, auth) as platform:
+		resp = platform.friend_list(page=page)
 		zp_data = resp.get("zpData", {})
 		items = zp_data.get("result") or zp_data.get("friendList") or []
 

--- a/src/boss_agent_cli/commands/chatmsg.py
+++ b/src/boss_agent_cli/commands/chatmsg.py
@@ -3,8 +3,8 @@ from typing import Any
 
 import click
 
-from boss_agent_cli.api.client import BossClient
 from boss_agent_cli.auth.manager import AuthManager
+from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_simple_list
 
 _MSG_TYPE_MAP = {
@@ -23,12 +23,10 @@ def chatmsg_cmd(ctx: click.Context, security_id: str, page: int, count: int) -> 
 	"""查看与指定好友的聊天消息历史"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	delay = ctx.obj["delay"]
-	cdp_url = ctx.obj.get("cdp_url")
 	auth = AuthManager(data_dir, logger=logger)
 
-	with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
-		friends_resp = client.friend_list(page=1)
+	with get_platform_instance(ctx, auth) as platform:
+		friends_resp = platform.friend_list(page=1)
 		zp_data = friends_resp.get("zpData", {})
 		items = zp_data.get("result") or zp_data.get("friendList") or []
 
@@ -48,7 +46,7 @@ def chatmsg_cmd(ctx: click.Context, security_id: str, page: int, count: int) -> 
 			)
 			return
 
-		resp = client.chat_history(gid, security_id, page=page, count=count)
+		resp = platform.chat_history(gid, security_id, page=page, count=count)
 		msg_data = resp.get("zpData", {})
 		messages = msg_data.get("messages") or msg_data.get("historyMsgList") or []
 

--- a/src/boss_agent_cli/commands/digest.py
+++ b/src/boss_agent_cli/commands/digest.py
@@ -4,8 +4,8 @@ from pathlib import Path
 
 import click
 
-from boss_agent_cli.api.client import BossClient
 from boss_agent_cli.auth.manager import AuthManager
+from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.digest import build_digest, render_digest_markdown
 from boss_agent_cli.display import handle_auth_errors, handle_output, render_message_panel
 from boss_agent_cli.pipeline_state import build_pipeline_items, select_follow_up_candidates
@@ -31,14 +31,12 @@ from boss_agent_cli.pipeline_state import build_pipeline_items, select_follow_up
 def digest_cmd(ctx: click.Context, days_stale: int, now_ts_ms: int | None, output_format: str, output_path: Path | None) -> None:
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	delay = ctx.obj["delay"]
-	cdp_url = ctx.obj.get("cdp_url")
 	auth = AuthManager(data_dir, logger=logger)
 
-	with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
-		friend_resp = client.friend_list(page=1)
+	with get_platform_instance(ctx, auth) as platform:
+		friend_resp = platform.friend_list(page=1)
 		chat_items = friend_resp.get("zpData", {}).get("result") or friend_resp.get("zpData", {}).get("friendList") or []
-		interview_resp = client.interview_data()
+		interview_resp = platform.interview_data()
 		interview_items = interview_resp.get("zpData", {}).get("interviewList") or []
 
 	items = build_pipeline_items(

--- a/src/boss_agent_cli/commands/exchange.py
+++ b/src/boss_agent_cli/commands/exchange.py
@@ -1,7 +1,7 @@
 import click
 
-from boss_agent_cli.api.client import BossClient
 from boss_agent_cli.auth.manager import AuthManager
+from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_message_panel
 
 
@@ -14,15 +14,13 @@ def exchange_cmd(ctx: click.Context, security_id: str, exchange_type: str) -> No
 	"""请求交换联系方式（手机号或微信）"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	delay = ctx.obj["delay"]
-	cdp_url = ctx.obj.get("cdp_url")
 	auth = AuthManager(data_dir, logger=logger)
 
 	type_id = 2 if exchange_type == "wechat" else 1
 	type_label = "微信" if exchange_type == "wechat" else "手机号"
 
-	with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
-		friends_resp = client.friend_list(page=1)
+	with get_platform_instance(ctx, auth) as platform:
+		friends_resp = platform.friend_list(page=1)
 		zp_data = friends_resp.get("zpData", {})
 		items = zp_data.get("result") or zp_data.get("friendList") or []
 
@@ -41,7 +39,7 @@ def exchange_cmd(ctx: click.Context, security_id: str, exchange_type: str) -> No
 			)
 			return
 
-		client.exchange_contact(security_id, uid, friend_name, exchange_type=type_id)
+		platform.exchange_contact(security_id, uid, friend_name, exchange_type=type_id)
 
 		data = {
 			"security_id": security_id,

--- a/src/boss_agent_cli/commands/mark.py
+++ b/src/boss_agent_cli/commands/mark.py
@@ -1,7 +1,7 @@
 import click
 
-from boss_agent_cli.api.client import BossClient
 from boss_agent_cli.auth.manager import AuthManager
+from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_message_panel
 
 _LABEL_MAP = {
@@ -36,16 +36,14 @@ def mark_cmd(ctx: click.Context, security_id: str, label: str, remove: bool) -> 
 	"""给联系人添加/移除标签"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	delay = ctx.obj["delay"]
-	cdp_url = ctx.obj.get("cdp_url")
 	auth = AuthManager(data_dir, logger=logger)
 
 	label_id = _resolve_label(label)
 	label_name = _LABEL_NAMES.get(label_id, str(label_id))
 	action_text = "移除" if remove else "添加"
 
-	with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
-		friends_resp = client.friend_list(page=1)
+	with get_platform_instance(ctx, auth) as platform:
+		friends_resp = platform.friend_list(page=1)
 		zp_data = friends_resp.get("zpData", {})
 		items = zp_data.get("result") or zp_data.get("friendList") or []
 
@@ -66,7 +64,7 @@ def mark_cmd(ctx: click.Context, security_id: str, label: str, remove: bool) -> 
 			)
 			return
 
-		client.friend_label(friend_id, label_id, friend_source, remove=remove)
+		platform.friend_label(friend_id, label_id, friend_source, remove=remove)
 
 		data = {
 			"security_id": security_id,

--- a/src/boss_agent_cli/commands/pipeline.py
+++ b/src/boss_agent_cli/commands/pipeline.py
@@ -3,8 +3,8 @@ from typing import Any
 
 import click
 
-from boss_agent_cli.api.client import BossClient
 from boss_agent_cli.auth.manager import AuthManager
+from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import handle_auth_errors, handle_output, render_simple_list
 from boss_agent_cli.pipeline_state import build_pipeline_items, select_follow_up_candidates
 
@@ -12,14 +12,12 @@ from boss_agent_cli.pipeline_state import build_pipeline_items, select_follow_up
 def _collect_pipeline_items(ctx: click.Context, *, now_ts_ms: int | None, stale_days: int) -> list[dict[str, Any]]:
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	delay = ctx.obj["delay"]
-	cdp_url = ctx.obj.get("cdp_url")
 	auth = AuthManager(data_dir, logger=logger)
 
-	with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
-		friend_resp = client.friend_list(page=1)
+	with get_platform_instance(ctx, auth) as platform:
+		friend_resp = platform.friend_list(page=1)
 		chat_items = friend_resp.get("zpData", {}).get("result") or friend_resp.get("zpData", {}).get("friendList") or []
-		interview_resp = client.interview_data()
+		interview_resp = platform.interview_data()
 		interview_items = interview_resp.get("zpData", {}).get("interviewList") or []
 
 	return build_pipeline_items(

--- a/tests/test_chatmsg_extended.py
+++ b/tests/test_chatmsg_extended.py
@@ -33,7 +33,7 @@ def _make_friend(name="张HR", sid="sec_001", uid=12345):
 # ── 正常消息历史返回 ────────────────────────────────────────────────
 
 
-@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
 @patch("boss_agent_cli.commands.chatmsg.AuthManager")
 def test_chatmsg_returns_correct_messages(mock_auth_cls, mock_client_cls):
 	"""正常返回消息列表，包含正确的字段。
@@ -67,7 +67,7 @@ def test_chatmsg_returns_correct_messages(mock_auth_cls, mock_client_cls):
 	assert parsed["data"][2]["text"] == "方便聊聊吗"
 
 
-@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
 @patch("boss_agent_cli.commands.chatmsg.AuthManager")
 def test_chatmsg_message_fields_complete(mock_auth_cls, mock_client_cls):
 	"""返回的每条消息应包含 from/type/text/time 四个字段"""
@@ -90,7 +90,7 @@ def test_chatmsg_message_fields_complete(mock_auth_cls, mock_client_cls):
 	assert "time" in msg
 
 
-@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
 @patch("boss_agent_cli.commands.chatmsg.AuthManager")
 def test_chatmsg_hints_present(mock_auth_cls, mock_client_cls):
 	"""返回结果应包含 hints.next_actions"""
@@ -113,7 +113,7 @@ def test_chatmsg_hints_present(mock_auth_cls, mock_client_cls):
 # ── 空消息列表边界 ──────────────────────────────────────────────────
 
 
-@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
 @patch("boss_agent_cli.commands.chatmsg.AuthManager")
 def test_chatmsg_empty_messages(mock_auth_cls, mock_client_cls):
 	"""好友存在但消息列表为空时应返回空数组"""
@@ -130,7 +130,7 @@ def test_chatmsg_empty_messages(mock_auth_cls, mock_client_cls):
 	assert parsed["data"] == []
 
 
-@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
 @patch("boss_agent_cli.commands.chatmsg.AuthManager")
 def test_chatmsg_messages_key_missing(mock_auth_cls, mock_client_cls):
 	"""API 返回中缺少 messages 键时应安全降级为空列表"""
@@ -147,7 +147,7 @@ def test_chatmsg_messages_key_missing(mock_auth_cls, mock_client_cls):
 	assert parsed["data"] == []
 
 
-@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
 @patch("boss_agent_cli.commands.chatmsg.AuthManager")
 def test_chatmsg_uses_history_msg_list_fallback(mock_auth_cls, mock_client_cls):
 	"""API 返回 historyMsgList 而非 messages 时应正确解析"""
@@ -171,7 +171,7 @@ def test_chatmsg_uses_history_msg_list_fallback(mock_auth_cls, mock_client_cls):
 # ── 无效好友 ID 处理 ────────────────────────────────────────────────
 
 
-@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
 @patch("boss_agent_cli.commands.chatmsg.AuthManager")
 def test_chatmsg_invalid_security_id(mock_auth_cls, mock_client_cls):
 	"""不存在的 security_id 应返回 JOB_NOT_FOUND 错误"""
@@ -186,7 +186,7 @@ def test_chatmsg_invalid_security_id(mock_auth_cls, mock_client_cls):
 	assert "sec_nonexistent" in parsed["error"]["message"]
 
 
-@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
 @patch("boss_agent_cli.commands.chatmsg.AuthManager")
 def test_chatmsg_empty_friend_list(mock_auth_cls, mock_client_cls):
 	"""好友列表为空时应返回 JOB_NOT_FOUND"""
@@ -202,7 +202,7 @@ def test_chatmsg_empty_friend_list(mock_auth_cls, mock_client_cls):
 # ── 消息格式化逻辑 ─────────────────────────────────────────────────
 
 
-@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
 @patch("boss_agent_cli.commands.chatmsg.AuthManager")
 def test_chatmsg_message_type_mapping(mock_auth_cls, mock_client_cls):
 	"""消息类型应被正确映射为可读标签"""
@@ -230,7 +230,7 @@ def test_chatmsg_message_type_mapping(mock_auth_cls, mock_client_cls):
 	assert types[4] == "系统"
 
 
-@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
 @patch("boss_agent_cli.commands.chatmsg.AuthManager")
 def test_chatmsg_unknown_message_type(mock_auth_cls, mock_client_cls):
 	"""未知消息类型应显示为 '其他(N)' 格式"""
@@ -249,7 +249,7 @@ def test_chatmsg_unknown_message_type(mock_auth_cls, mock_client_cls):
 	assert parsed["data"][0]["type"] == "其他(99)"
 
 
-@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
 @patch("boss_agent_cli.commands.chatmsg.AuthManager")
 def test_chatmsg_self_message_identified(mock_auth_cls, mock_client_cls):
 	"""自己发的消息 from 应显示为 '我'。
@@ -275,7 +275,7 @@ def test_chatmsg_self_message_identified(mock_auth_cls, mock_client_cls):
 	assert parsed["data"][1]["from"] == "张HR"
 
 
-@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
 @patch("boss_agent_cli.commands.chatmsg.AuthManager")
 def test_chatmsg_time_formatting(mock_auth_cls, mock_client_cls):
 	"""消息时间应被格式化为 MM-DD HH:MM 格式"""
@@ -299,7 +299,7 @@ def test_chatmsg_time_formatting(mock_auth_cls, mock_client_cls):
 	assert ":" in time_str
 
 
-@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
 @patch("boss_agent_cli.commands.chatmsg.AuthManager")
 def test_chatmsg_no_time_field(mock_auth_cls, mock_client_cls):
 	"""消息缺少 time 字段时应返回空字符串"""
@@ -318,7 +318,7 @@ def test_chatmsg_no_time_field(mock_auth_cls, mock_client_cls):
 	assert parsed["data"][0]["time"] == ""
 
 
-@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
 @patch("boss_agent_cli.commands.chatmsg.AuthManager")
 def test_chatmsg_text_fallback_to_body(mock_auth_cls, mock_client_cls):
 	"""text 为空时应从 body.text 取值"""
@@ -343,7 +343,7 @@ def test_chatmsg_text_fallback_to_body(mock_auth_cls, mock_client_cls):
 	assert parsed["data"][0]["text"] == "来自body的内容"
 
 
-@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
 @patch("boss_agent_cli.commands.chatmsg.AuthManager")
 def test_chatmsg_text_both_empty(mock_auth_cls, mock_client_cls):
 	"""text 和 body.text 都为空时应返回空字符串"""
@@ -371,7 +371,7 @@ def test_chatmsg_text_both_empty(mock_auth_cls, mock_client_cls):
 # ── 分页参数 ────────────────────────────────────────────────────────
 
 
-@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
 @patch("boss_agent_cli.commands.chatmsg.AuthManager")
 def test_chatmsg_page_and_count_params(mock_auth_cls, mock_client_cls):
 	"""--page 和 --count 参数应传递给 chat_history"""
@@ -391,7 +391,7 @@ def test_chatmsg_page_and_count_params(mock_auth_cls, mock_client_cls):
 # ── Context manager 验证 ──────────────────────────────────────────
 
 
-@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
 @patch("boss_agent_cli.commands.chatmsg.AuthManager")
 def test_chatmsg_uses_client_context_manager(mock_auth_cls, mock_client_cls):
 	"""应使用 BossClient 的 context manager"""

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -489,7 +489,7 @@ def _make_friend_item(name, brand, relation_type, last_ts):
 	}
 
 
-@patch("boss_agent_cli.commands.chat.BossClient")
+@patch("boss_agent_cli.commands.chat.get_platform_instance")
 @patch("boss_agent_cli.commands.chat.AuthManager")
 def test_chat_from_boss_filter(mock_auth_cls, mock_client_cls):
 	"""--from boss 只返回 relationType=1 的记录"""
@@ -515,7 +515,7 @@ def test_chat_from_boss_filter(mock_auth_cls, mock_client_cls):
 	assert all(f["initiated_by"] == "对方主动" for f in parsed["data"])
 
 
-@patch("boss_agent_cli.commands.chat.BossClient")
+@patch("boss_agent_cli.commands.chat.get_platform_instance")
 @patch("boss_agent_cli.commands.chat.AuthManager")
 def test_chat_days_filter(mock_auth_cls, mock_client_cls):
 	"""--days 3 只返回最近 3 天的记录"""
@@ -541,7 +541,7 @@ def test_chat_days_filter(mock_auth_cls, mock_client_cls):
 	assert parsed["data"][0]["brand_name"] == "阿里"
 
 
-@patch("boss_agent_cli.commands.chat.BossClient")
+@patch("boss_agent_cli.commands.chat.get_platform_instance")
 @patch("boss_agent_cli.commands.chat.AuthManager")
 def test_chat_combined_filter(mock_auth_cls, mock_client_cls):
 	"""--from boss --days 3 组合筛选"""
@@ -569,7 +569,7 @@ def test_chat_combined_filter(mock_auth_cls, mock_client_cls):
 	assert parsed["data"][0]["initiated_by"] == "对方主动"
 
 
-@patch("boss_agent_cli.commands.chat.BossClient")
+@patch("boss_agent_cli.commands.chat.get_platform_instance")
 @patch("boss_agent_cli.commands.chat.AuthManager")
 def test_chat_export_md(mock_auth_cls, mock_client_cls, tmp_path):
 	"""--export md 导出包含 security_id 和 diff 摘要"""
@@ -606,7 +606,7 @@ def test_chat_export_md(mock_auth_cls, mock_client_cls, tmp_path):
 	assert len(json_files) == 1
 
 
-@patch("boss_agent_cli.commands.chat.BossClient")
+@patch("boss_agent_cli.commands.chat.get_platform_instance")
 @patch("boss_agent_cli.commands.chat.AuthManager")
 def test_chat_export_csv(mock_auth_cls, mock_client_cls, tmp_path):
 	"""--export csv 导出 CSV 格式"""
@@ -634,7 +634,7 @@ def test_chat_export_csv(mock_auth_cls, mock_client_cls, tmp_path):
 	assert "张HR" in content
 
 
-@patch("boss_agent_cli.commands.chat.BossClient")
+@patch("boss_agent_cli.commands.chat.get_platform_instance")
 @patch("boss_agent_cli.commands.chat.AuthManager")
 def test_chat_export_json_default_path(mock_auth_cls, mock_client_cls, tmp_path):
 	"""--export json 不指定 -o 时自动保存到 export_dir"""
@@ -673,7 +673,7 @@ def test_chat_export_json_default_path(mock_auth_cls, mock_client_cls, tmp_path)
 	assert items[0]["security_id"] == "sec_张HR"
 
 
-@patch("boss_agent_cli.commands.chat.BossClient")
+@patch("boss_agent_cli.commands.chat.get_platform_instance")
 @patch("boss_agent_cli.commands.chat.AuthManager")
 def test_chat_snapshot_diff(mock_auth_cls, mock_client_cls, tmp_path):
 	"""第二次导出时 diff 能检测新增条目"""
@@ -738,7 +738,7 @@ def test_md_escape_pipe_and_newline():
 	assert _escape_md_cell("正常") == "正常"
 
 
-@patch("boss_agent_cli.commands.chat.BossClient")
+@patch("boss_agent_cli.commands.chat.get_platform_instance")
 @patch("boss_agent_cli.commands.chat.AuthManager")
 def test_chat_export_none_fields(mock_auth_cls, mock_client_cls, tmp_path):
 	"""API 返回 None 字段时不应 crash"""
@@ -772,7 +772,7 @@ def test_chat_export_none_fields(mock_auth_cls, mock_client_cls, tmp_path):
 	assert result.exit_code == 0
 
 
-@patch("boss_agent_cli.commands.chat.BossClient")
+@patch("boss_agent_cli.commands.chat.get_platform_instance")
 @patch("boss_agent_cli.commands.chat.AuthManager")
 def test_chat_export_unknown_relation_type(mock_auth_cls, mock_client_cls, tmp_path):
 	"""未知 relationType 应渲染到「未知」分组，不被丢弃"""
@@ -818,7 +818,7 @@ def test_snapshot_corrupted_structure(tmp_path):
 	assert result == [{"security_id": "ok"}]
 
 
-@patch("boss_agent_cli.commands.chat.BossClient")
+@patch("boss_agent_cli.commands.chat.get_platform_instance")
 @patch("boss_agent_cli.commands.chat.AuthManager")
 def test_chat_snapshot_page_merge(mock_auth_cls, mock_client_cls, tmp_path):
 	"""同天不同页的快照应合并，而非覆盖"""
@@ -861,7 +861,7 @@ def test_chat_snapshot_page_merge(mock_auth_cls, mock_client_cls, tmp_path):
 	assert "sec_P2_HR" in sids  # page 2 新增
 
 
-@patch("boss_agent_cli.commands.chat.BossClient")
+@patch("boss_agent_cli.commands.chat.get_platform_instance")
 @patch("boss_agent_cli.commands.chat.AuthManager")
 def test_chat_export_html(mock_auth_cls, mock_client_cls, tmp_path):
 	"""--export html 导出 HTML 格式，包含表格、分组和映射表"""
@@ -895,7 +895,7 @@ def test_chat_export_html(mock_auth_cls, mock_client_cls, tmp_path):
 	assert "<table>" in content
 
 
-@patch("boss_agent_cli.commands.chat.BossClient")
+@patch("boss_agent_cli.commands.chat.get_platform_instance")
 @patch("boss_agent_cli.commands.chat.AuthManager")
 def test_chat_export_html_xss_prevention(mock_auth_cls, mock_client_cls, tmp_path):
 	"""HTML 导出应转义特殊字符，防止 XSS"""

--- a/tests/test_coverage_second_sprint.py
+++ b/tests/test_coverage_second_sprint.py
@@ -102,7 +102,7 @@ def test_mark_resolve_label_unknown_raises():
 		_resolve_label("火星标签")
 
 
-@patch("boss_agent_cli.commands.mark.BossClient")
+@patch("boss_agent_cli.commands.mark.get_platform_instance")
 @patch("boss_agent_cli.commands.mark.AuthManager")
 def test_mark_security_id_not_found_in_friend_list(mock_auth_cls, mock_client_cls):
 	client = _ctx_mock(mock_client_cls)

--- a/tests/test_digest_command.py
+++ b/tests/test_digest_command.py
@@ -46,7 +46,7 @@ def _setup_digest_mocks(mock_client_cls):
 	return mock_client
 
 
-@patch("boss_agent_cli.commands.digest.BossClient")
+@patch("boss_agent_cli.commands.digest.get_platform_instance")
 @patch("boss_agent_cli.commands.digest.AuthManager")
 def test_digest_command_returns_structured_sections(mock_auth_cls, mock_client_cls):
 	_setup_digest_mocks(mock_client_cls)
@@ -71,7 +71,7 @@ def test_digest_is_exposed_in_schema():
 # ── --format md 支持 ────────────────────────────────────────
 
 
-@patch("boss_agent_cli.commands.digest.BossClient")
+@patch("boss_agent_cli.commands.digest.get_platform_instance")
 @patch("boss_agent_cli.commands.digest.AuthManager")
 def test_digest_format_md_writes_markdown_to_stdout(mock_auth_cls, mock_client_cls):
 	"""--format md 未指定 -o 时把 Markdown 写到 stdout，不套 JSON 信封"""
@@ -88,7 +88,7 @@ def test_digest_format_md_writes_markdown_to_stdout(mock_auth_cls, mock_client_c
 	assert not result.output.lstrip().startswith("{")
 
 
-@patch("boss_agent_cli.commands.digest.BossClient")
+@patch("boss_agent_cli.commands.digest.get_platform_instance")
 @patch("boss_agent_cli.commands.digest.AuthManager")
 def test_digest_format_md_with_output_path_writes_file(mock_auth_cls, mock_client_cls, tmp_path):
 	"""--format md -o <path> 写文件并返回 JSON 信封说明路径"""
@@ -111,7 +111,7 @@ def test_digest_format_md_with_output_path_writes_file(mock_auth_cls, mock_clien
 	assert "Go 开发" in content
 
 
-@patch("boss_agent_cli.commands.digest.BossClient")
+@patch("boss_agent_cli.commands.digest.get_platform_instance")
 @patch("boss_agent_cli.commands.digest.AuthManager")
 def test_digest_format_md_contains_interview_details(mock_auth_cls, mock_client_cls):
 	"""Markdown 中面试条目应含岗位名 / 公司 / 时间"""
@@ -124,7 +124,7 @@ def test_digest_format_md_contains_interview_details(mock_auth_cls, mock_client_
 	assert "2026-04-14" in result.output
 
 
-@patch("boss_agent_cli.commands.digest.BossClient")
+@patch("boss_agent_cli.commands.digest.get_platform_instance")
 @patch("boss_agent_cli.commands.digest.AuthManager")
 def test_digest_format_md_handles_empty_sections(mock_auth_cls, mock_client_cls):
 	"""没有任何数据时 md 应写友好占位符而非抛异常"""
@@ -140,7 +140,7 @@ def test_digest_format_md_handles_empty_sections(mock_auth_cls, mock_client_cls)
 	assert "暂无" in result.output or "无" in result.output
 
 
-@patch("boss_agent_cli.commands.digest.BossClient")
+@patch("boss_agent_cli.commands.digest.get_platform_instance")
 @patch("boss_agent_cli.commands.digest.AuthManager")
 def test_digest_format_json_default_unchanged(mock_auth_cls, mock_client_cls):
 	"""未指定 format 时保持原来的 JSON 信封行为不变"""

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -31,7 +31,7 @@ def _make_friend(name="张HR", sid="sec_001", uid=12345):
 # ── chatmsg ──────────────────────────────────────────────────────────
 
 
-@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
 @patch("boss_agent_cli.commands.chatmsg.AuthManager")
 def test_chatmsg_success(mock_auth_cls, mock_client_cls):
 	mock_client = _ctx_mock(mock_client_cls)
@@ -53,7 +53,7 @@ def test_chatmsg_success(mock_auth_cls, mock_client_cls):
 	assert parsed["data"][0]["text"] == "你好"
 
 
-@patch("boss_agent_cli.commands.chatmsg.BossClient")
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
 @patch("boss_agent_cli.commands.chatmsg.AuthManager")
 def test_chatmsg_not_found(mock_auth_cls, mock_client_cls):
 	mock_client = _ctx_mock(mock_client_cls)
@@ -68,7 +68,7 @@ def test_chatmsg_not_found(mock_auth_cls, mock_client_cls):
 # ── mark ─────────────────────────────────────────────────────────────
 
 
-@patch("boss_agent_cli.commands.mark.BossClient")
+@patch("boss_agent_cli.commands.mark.get_platform_instance")
 @patch("boss_agent_cli.commands.mark.AuthManager")
 def test_mark_add_label(mock_auth_cls, mock_client_cls):
 	mock_client = _ctx_mock(mock_client_cls)
@@ -82,7 +82,7 @@ def test_mark_add_label(mock_auth_cls, mock_client_cls):
 	assert "沟通中" in parsed["data"]["message"]
 
 
-@patch("boss_agent_cli.commands.mark.BossClient")
+@patch("boss_agent_cli.commands.mark.get_platform_instance")
 @patch("boss_agent_cli.commands.mark.AuthManager")
 def test_mark_remove_label(mock_auth_cls, mock_client_cls):
 	mock_client = _ctx_mock(mock_client_cls)
@@ -95,7 +95,7 @@ def test_mark_remove_label(mock_auth_cls, mock_client_cls):
 	assert parsed["data"]["action"] == "移除"
 
 
-@patch("boss_agent_cli.commands.mark.BossClient")
+@patch("boss_agent_cli.commands.mark.get_platform_instance")
 @patch("boss_agent_cli.commands.mark.AuthManager")
 def test_mark_not_found(mock_auth_cls, mock_client_cls):
 	mock_client = _ctx_mock(mock_client_cls)
@@ -110,7 +110,7 @@ def test_mark_not_found(mock_auth_cls, mock_client_cls):
 # ── exchange ─────────────────────────────────────────────────────────
 
 
-@patch("boss_agent_cli.commands.exchange.BossClient")
+@patch("boss_agent_cli.commands.exchange.get_platform_instance")
 @patch("boss_agent_cli.commands.exchange.AuthManager")
 def test_exchange_phone(mock_auth_cls, mock_client_cls):
 	mock_client = _ctx_mock(mock_client_cls)
@@ -124,7 +124,7 @@ def test_exchange_phone(mock_auth_cls, mock_client_cls):
 	assert "手机号" in parsed["data"]["message"]
 
 
-@patch("boss_agent_cli.commands.exchange.BossClient")
+@patch("boss_agent_cli.commands.exchange.get_platform_instance")
 @patch("boss_agent_cli.commands.exchange.AuthManager")
 def test_exchange_wechat(mock_auth_cls, mock_client_cls):
 	mock_client = _ctx_mock(mock_client_cls)

--- a/tests/test_pipeline_commands.py
+++ b/tests/test_pipeline_commands.py
@@ -51,7 +51,7 @@ def _interview_item():
 	}
 
 
-@patch("boss_agent_cli.commands.pipeline.BossClient")
+@patch("boss_agent_cli.commands.pipeline.get_platform_instance")
 @patch("boss_agent_cli.commands.pipeline.AuthManager")
 def test_pipeline_command_returns_aggregated_items(mock_auth_cls, mock_client_cls):
 	mock_client = _ctx_mock(mock_client_cls)
@@ -68,7 +68,7 @@ def test_pipeline_command_returns_aggregated_items(mock_auth_cls, mock_client_cl
 	assert "interview" in stages
 
 
-@patch("boss_agent_cli.commands.pipeline.BossClient")
+@patch("boss_agent_cli.commands.pipeline.get_platform_instance")
 @patch("boss_agent_cli.commands.pipeline.AuthManager")
 def test_follow_up_command_filters_actionable_items(mock_auth_cls, mock_client_cls):
 	mock_client = _ctx_mock(mock_client_cls)


### PR DESCRIPTION
## 背景

Issue #129 Week 1c 第 5 轮（收口轮）。将剩余所有直接使用 `BossClient` 的命令迁移到 `get_platform_instance`。

## 变更

### 命令迁移（6 个）

| 命令 | 使用的 Platform 方法 |
|------|--------------------|
| `chat` | `friend_list` |
| `chatmsg` | `friend_list` + `chat_history` |
| `mark` | `friend_list` + `friend_label` |
| `exchange` | `friend_list` + `exchange_contact` |
| `pipeline` / `follow-up` | `friend_list` + `interview_data`（辅助函数 `_collect_pipeline_items`） |
| `digest` | `friend_list` + `interview_data` |

迁移模板统一：`with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:` → `with get_platform_instance(ctx, auth) as platform:`，方法调用 `client.X(...)` → `platform.X(...)`。

### 累计 Week 1c 结果

| 轮次 | 命令 | 数量 |
|------|------|------|
| PR #133 | greet / apply | 2 |
| PR #135 | batch-greet | 1 |
| PR #136 | interviews / detail / show / me / recommend | 5 |
| 本 PR | chat / chatmsg / mark / exchange / pipeline / digest | 6 |
| **合计** | **14 个命令** | |

### 剩余工作

- **`search`**：通过 `run_search_pipeline(client, ...)` 间接使用 BossClient，需签名改造，留给独立 PR
- **静态命令**（login/logout/status/doctor/cities/history/watch/preset/shortlist/resume/ai/config/clean/export/schema 等）：本身不直接请求 BOSS API，无需迁移

### 测试

- 6 个测试文件 mock 位点同步更新

## 验证

\`\`\`
$ uv run pytest tests/ -q
998 passed in 33.62s

$ uv run mypy src/boss_agent_cli
Success: no issues found in 80 source files
\`\`\`

- 全量 998 测试通过（零新增，零回归）
- mypy strict 0 错误
- 零命令行为变化