### PR TITLE
chore: 发布版本 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,39 +4,52 @@
 
 ## [Unreleased]
 
-### Added
-- **Week 1c 命令层迁移收口**（Issue #129 Week 1c 第 5 轮）— 剩余 6 个需网络请求的命令全部迁移到 `get_platform_instance`：`chat` / `chatmsg` / `mark` / `exchange` / `pipeline` / `digest`（包括 `pipeline` 的内部 `_collect_pipeline_items` 辅助函数）。
-- 至此 Week 1c 目标达成：**14 个命令**（前序 8 个 + 本轮 6 个）已全部经 Platform 抽象调用。只有 `search` 因为 `run_search_pipeline` 间接耦合的 BossClient 签名留待独立重构 PR。
+## [1.10.0] - 2026-04-21
 
-### Changed
-- 相关测试文件 mock 位点从 `commands.X.BossClient` → `commands.X.get_platform_instance`（覆盖 `test_chatmsg_extended.py` / `test_commands.py` / `test_coverage_second_sprint.py` / `test_digest_command.py` / `test_new_commands.py` / `test_pipeline_commands.py` 共 6 个测试文件）。
+### 🎯 核心里程碑：Platform 抽象架构落地（Issue #129 Week 1 全量收口）
 
-### Added
-- **ZhilianPlatform stub**（Issue #129 Week 1d · 抽象自证）— `src/boss_agent_cli/platforms/zhilian.py` 新增智联招聘 stub 实现：
-  - 元信息：`name="zhilian"` / `display_name="智联招聘"` / `base_url="https://m.zhaopin.com"`
-  - 包络适配按 [zhaopin.md](docs/research/platforms/zhaopin.md) §4 调研结果完整实现（`is_success` 检 `code==200` · `unwrap_data` 取 `data` key · `parse_error` 映射 401/403/429）
-  - P0/P1/P2 方法抛 `NotImplementedError("Week 2 待实现")`，Week 2 替换为真实现
-- `boss --platform zhilian` CLI 选项正式接入，`schema` 输出 `supported_platforms` 包含 `zhilian`
-- Python 嵌入 API 导出 `ZhilianPlatform`，下游可提前查看类型签名
-- `tests/test_zhilian_stub.py` 新增 **27 条契约测试**覆盖元信息 / 包络适配 / stub 行为 / CLI 集成
+从 v1.9.1 到 v1.10.0，本版本沿着 C → A → B 三阶段路线把 Platform 抽象从"只有骨架"推到"两个平台注册 + 14 个命令走抽象"的稳定状态，为 v2.0 多平台（智联真实现）打平底盘。
 
-### Changed
-- Platform 注册表从单一 `{"zhipin": BossPlatform}` 扩展为 `{"zhipin": BossPlatform, "zhilian": ZhilianPlatform}`
-- mypy 严格白名单扩到 71（新增 `platforms.zhilian`）
-- `tests/test_public_api.py` 同步 `EXPECTED_EXPORTS` 加入 `ZhilianPlatform`
-- schema `--platform` 描述更新为 "zhipin 生产可用；zhilian stub Week 2 真实现"
+#### Platform ABC 完整设计（PR #131 / #132 / #133 / #136）
+- `src/boss_agent_cli/platforms/` 新子包定义 Platform ABC + 注册表 + BossPlatform adapter
+- P0 只读（`search_jobs` / `job_detail` / `recommend_jobs` / `user_info`）+ P1 写操作（`greet` / `apply`）+ P2 沟通（`friend_list`）
+- ABC 扩展 P0+：`resume_baseinfo` / `resume_expect` / `deliver_list` / `job_card` / `interview_data` / `chat_history` / `friend_label` / `exchange_contact`
+- ABC 统一 `__init__(client: Any)` 签名 + `with` 上下文管理器（`__enter__` / `__exit__` / `close()`）
+- `Platform` / `BossPlatform` / `ZhilianPlatform` / `get_platform` / `list_platforms` 导出到 `from boss_agent_cli import ...` 公共 API 面
 
-### 底层逻辑
-Platform 抽象只有一个实现（zhipin）时**抽象设计是否正确尚未被证伪**。本轮加入 Zhilian stub 强制第二平台走完整注册 / CLI / schema / with 上下文流程，发现任何设计缺陷前置暴露（事实：全通过，抽象设计对齐 zhaopin.md §7 差异矩阵）。
+#### CLI 与注册表（PR #132 / #134）
+- `--platform` 全局 CLI 选项（默认 `zhipin`），未知平台 exit code 2
+- `~/.boss-agent/config.json` 支持 `"platform": "zhipin"` 字段持久化
+- `boss schema` 输出 `current_platform` + `supported_platforms`
+- Zhilian stub 接入注册表，`boss --platform zhilian schema` 端到端可用
 
-### Added
-- **Platform 命令层迁移（Issue #129 Week 1c，首批 2 个命令）** — `boss greet` 和 `boss apply` 从 `BossClient` 直用切换到 `get_platform_instance(ctx, auth)`，走统一 Platform 抽象。
-- **Platform ABC 支持 `with` 上下文管理器** — `__enter__` / `__exit__` / `close()` 委托给底层 client，资源释放语义无损。
-- `tests/test_platform_base.py` 新增 5 条 context manager 契约测试。
+#### 命令层迁移（PR #133 / #135 / #136 / #137，共 14 个命令）
+| 命令 | PR | 使用的 Platform 方法 |
+|------|-----|--------------------|
+| `greet` / `apply` | #133 | `greet` / `apply` |
+| `batch-greet` | #135 | `search_jobs` + `greet` |
+| `interviews` / `detail` / `show` / `me` / `recommend` | #136 | P0 + P0+ 方法 |
+| `chat` / `chatmsg` / `mark` / `exchange` / `pipeline` / `digest` | #137 | `friend_list` / `chat_history` / `friend_label` / `exchange_contact` / `interview_data` |
 
-### Changed
-- `commands/greet.py` 和 `commands/apply.py` 去除 delay / cdp_url 从 ctx.obj 手动读取的样板代码，复用 helper 统一处理。
-- 测试 Mock 位置从 `commands.greet.BossClient` / `commands.apply.BossClient` 迁到 `commands.greet.get_platform_instance` / `commands.apply.get_platform_instance`。
+唯一留待独立 PR 的是 `search`，因为通过 `run_search_pipeline(client, ...)` 间接耦合 BossClient 签名需单独重构。
+
+#### ZhilianPlatform 自证（PR #134）
+- `src/boss_agent_cli/platforms/zhilian.py` — 智联招聘 stub 实现
+- 包络适配按 [zhaopin.md](docs/research/platforms/zhaopin.md) §4 完整实现（`code==200` / `data` key / 401+403+429 映射）
+- P0/P1/P2 方法抛 `NotImplementedError("Week 2 待实现")`
+- 27 条契约测试覆盖元信息 / 包络适配 / stub 行为 / CLI 集成
+
+#### Research 闭环
+- Issue #90 关闭（拉勾 + 智联 + 猎聘 API 调研全部归档到 `docs/research/platforms/`）
+
+### Tests & Quality
+- 测试 927 → **998**（+71 新增：25 platform ABC + 27 zhilian + 10 CLI + 5 context manager + 4 contract）
+- mypy 严格模块 66 → **71**（新增 4 个 platforms 子模块 + `commands._platform`）
+- mypy `--strict` 0 错误 / 80 源文件全覆盖
+- 7 PR 连合（#131/#132/#133/#134/#135/#136/#137），全部 CI 7/7 绿
+
+### Breaking Changes
+**无**。命令行为、信封格式、错误码枚举、CLI 接口全部向后兼容。Platform 抽象为纯重构，新增能力均在基类默认 `NotImplementedError` 形式下兼容老代码。
 
 ## [1.9.1] - 2026-04-20
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "boss-agent-cli"
-version = "1.9.1"
+version = "1.10.0"
 description = "AI Agent 专用的 BOSS 直聘求职 CLI 工具"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/boss_agent_cli/__init__.py
+++ b/src/boss_agent_cli/__init__.py
@@ -18,7 +18,7 @@ from boss_agent_cli.cache.store import CacheStore
 from boss_agent_cli.platforms import BossPlatform, Platform, ZhilianPlatform, get_platform, list_platforms
 from boss_agent_cli.resume.models import ResumeData, ResumeFile
 
-__version__ = "1.9.1"
+__version__ = "1.10.0"
 
 __all__ = [
 	# 版本

--- a/uv.lock
+++ b/uv.lock
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "boss-agent-cli"
-version = "1.9.1"
+version = "1.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },


### PR DESCRIPTION
## 版本标记：Platform 抽象架构落地

从 v1.9.1 → v1.10.0，按 SemVer minor 版升号，标记 Platform 抽象从"骨架"到"14 命令走抽象 + 2 平台注册"的里程碑节点。

## 变更

- `pyproject.toml`：1.9.1 → 1.10.0
- `src/boss_agent_cli/__init__.py::__version__`：同步
- `CHANGELOG.md`：[Unreleased] → [1.10.0] - 2026-04-21，完整记录 7 个 PR（#131-#137）的交付

## 七 PR 合流汇总

| PR | 内容 |
|-----|------|
| #131 | Platform ABC + BossPlatform adapter 骨架 |
| #132 | --platform CLI 选项 + get_platform_instance helper |
| #133 | greet / apply 首批迁移 + Platform with 上下文 |
| #134 | ZhilianPlatform stub（抽象自证，27 契约测试）|
| #135 | batch-greet 迁移 |
| #136 | ABC 扩展 9 个 P0+ 方法 + 5 命令迁移 |
| #137 | 剩余 6 命令迁移（Week 1c 收口）|

## 验证

\`\`\`
$ uv run python -c "import boss_agent_cli; print(boss_agent_cli.__version__)"
1.10.0

$ uv run boss --version
boss, version 1.10.0

$ uv run pytest tests/ -q
998 passed in 33.15s

$ uv run mypy src/boss_agent_cli
Success: no issues found in 80 source files
\`\`\`

## Breaking Changes

**无**。信封格式、错误码、CLI 接口、Python 嵌入 API 全部向后兼容。

## 发布后续

合并后建议创建 GitHub Release v1.10.0，发 PyPI 包同步。