### PR TITLE
refactor: 完成命令层全量平台抽象迁移

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## [Unreleased]
 
+### Added
+- **Week 1c 100% 完成** — 剩余 6 个命令迁移到 Platform 抽象：`search` / `export` / `chat_summary` / `history` / `status` / `watch`。`run_search_pipeline` 接受 `client: Any` 保持兼容，直接传 Platform 实例。
+- Platform ABC 新增 `job_history(page=1)` 方法（history 命令所需）。
+- 至此 `commands/` 目录下除 `_platform.py`（桥接层）外**无任何命令直接引用 BossClient**。
+
+### Changed
+- 相关测试 mock 位点从 `commands.X.BossClient` → `commands.X.get_platform_instance`。
+
 ## [1.10.0] - 2026-04-21
 
 ### 🎯 核心里程碑：Platform 抽象架构落地（Issue #129 Week 1 全量收口）

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,7 +40,7 @@
 - [ ] 多平台支持：拉勾 / 智联 / 猎聘适配器 — API 调研已全部完成（Issue #90 已闭环 · [docs/research/platforms/](docs/research/platforms/)），结论：**智联为 v2.0 优先接入候选**（2-3 周），拉勾和猎聘不建议接入
   - [x] Week 1a：Platform ABC 骨架 + BossPlatform adapter（#129，零行为变化）
   - [x] Week 1b：`--platform` 全局 CLI 选项 + `get_platform_instance` helper + schema 暴露 current_platform
-  - [x] Week 1c：命令层批量迁移到 Platform 接口（已迁移 14 个，search 因间接耦合留待单独 PR）
+  - [x] Week 1c：命令层全量迁移到 Platform 接口（**20 个命令**：greet / apply / batch-greet / interviews / detail / show / me / recommend / chat / chatmsg / mark / exchange / pipeline / digest / search / export / chat_summary / history / status / watch）
   - [x] Week 1d：ZhilianPlatform stub 接入注册表（抽象自证，包络适配完整实现，P0/P1/P2 暂 NotImplementedError）
   - [ ] Week 2：ZhilianPlatform 只读实现（search / detail / recommend / user_info）
   - [ ] Week 3：ZhilianPlatform 写操作（greet / apply）+ 文档 + MCP 适配

--- a/src/boss_agent_cli/commands/chat_summary.py
+++ b/src/boss_agent_cli/commands/chat_summary.py
@@ -1,8 +1,8 @@
 import click
 
-from boss_agent_cli.api.client import BossClient
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.chat_summary import summarize_messages
+from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_message_panel
 
 
@@ -15,12 +15,10 @@ from boss_agent_cli.display import handle_auth_errors, handle_error_output, hand
 def chat_summary_cmd(ctx: click.Context, security_id: str, page: int, count: int) -> None:
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	delay = ctx.obj["delay"]
-	cdp_url = ctx.obj.get("cdp_url")
 	auth = AuthManager(data_dir, logger=logger)
 
-	with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
-		friends_resp = client.friend_list(page=1)
+	with get_platform_instance(ctx, auth) as platform:
+		friends_resp = platform.friend_list(page=1)
 		items = friends_resp.get("zpData", {}).get("result") or friends_resp.get("zpData", {}).get("friendList") or []
 
 		gid = None
@@ -40,7 +38,7 @@ def chat_summary_cmd(ctx: click.Context, security_id: str, page: int, count: int
 			)
 			return
 
-		resp = client.chat_history(gid, security_id, page=page, count=count)
+		resp = platform.chat_history(gid, security_id, page=page, count=count)
 		messages = resp.get("zpData", {}).get("messages") or resp.get("zpData", {}).get("historyMsgList") or []
 		summary = summarize_messages(messages, friend_uid=gid)
 

--- a/src/boss_agent_cli/commands/export.py
+++ b/src/boss_agent_cli/commands/export.py
@@ -5,9 +5,9 @@ from typing import Any
 
 import click
 
-from boss_agent_cli.api.client import BossClient
 from boss_agent_cli.api.models import JobItem
 from boss_agent_cli.auth.manager import AuthManager
+from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import handle_auth_errors, handle_output, render_export_summary, render_job_table
 
 
@@ -24,18 +24,16 @@ def export_cmd(ctx: click.Context, query: str, city: str | None, salary: str | N
 	"""导出搜索结果为 CSV 或 JSON 文件"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	delay = ctx.obj["delay"]
-	cdp_url = ctx.obj.get("cdp_url")
 
 	auth = AuthManager(data_dir, logger=logger)
-	with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
+	with get_platform_instance(ctx, auth) as platform:
 		all_items: list[dict[str, Any]] = []
 		page = 1
 		max_pages = (count + 14) // 15  # 每页约 15 条
 
 		while len(all_items) < count and page <= max_pages:
 			logger.info(f"正在获取第 {page} 页...")
-			raw = client.search_jobs(query, city=city, salary=salary, page=page)
+			raw = platform.search_jobs(query, city=city, salary=salary, page=page)
 			zp_data = raw.get("zpData", {})
 			job_list = zp_data.get("jobList", [])
 			if not job_list:

--- a/src/boss_agent_cli/commands/history.py
+++ b/src/boss_agent_cli/commands/history.py
@@ -1,8 +1,8 @@
 import click
 
-from boss_agent_cli.api.client import BossClient
 from boss_agent_cli.api.models import JobItem
 from boss_agent_cli.auth.manager import AuthManager
+from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import handle_auth_errors, handle_output, render_job_table
 
 
@@ -14,12 +14,10 @@ def history_cmd(ctx: click.Context, page: int) -> None:
 	"""查看最近浏览过的职位"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	delay = ctx.obj["delay"]
-	cdp_url = ctx.obj.get("cdp_url")
 
 	auth = AuthManager(data_dir, logger=logger)
-	with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
-		raw = client.job_history(page)
+	with get_platform_instance(ctx, auth) as platform:
+		raw = platform.job_history(page)
 		zp_data = raw.get("zpData", {})
 		job_list = zp_data.get("jobList", [])
 

--- a/src/boss_agent_cli/commands/search.py
+++ b/src/boss_agent_cli/commands/search.py
@@ -2,7 +2,6 @@ import json
 
 import click
 
-from boss_agent_cli.api.client import BossClient
 from boss_agent_cli.api.endpoints import (
 	CITY_CODES,
 	INDUSTRY_CODES,
@@ -12,6 +11,7 @@ from boss_agent_cli.api.endpoints import (
 )
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.cache.store import CacheStore
+from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_job_table
 from boss_agent_cli.index_cache import try_save_index
 from boss_agent_cli.match_score import score_job_dict
@@ -43,8 +43,6 @@ def search_cmd(ctx: click.Context, query: str, preset: str | None, city: str | N
 	"""按关键词和筛选条件搜索职位列表"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	delay = ctx.obj["delay"]
-	cdp_url = ctx.obj.get("cdp_url")
 
 	if preset:
 		with CacheStore(data_dir / "cache" / "boss_agent.db") as cache:
@@ -110,10 +108,10 @@ def search_cmd(ctx: click.Context, query: str, preset: str | None, city: str | N
 				return
 
 		auth = AuthManager(data_dir, logger=logger)
-		with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
+		with get_platform_instance(ctx, auth) as platform:
 			max_pages = 5 if welfare_conditions else 1
 			pipeline_result = run_search_pipeline(
-				client, cache, logger,
+				platform, cache, logger,
 				criteria=criteria,
 				start_page=page,
 				max_pages=max_pages,

--- a/src/boss_agent_cli/commands/status.py
+++ b/src/boss_agent_cli/commands/status.py
@@ -1,7 +1,7 @@
 import click
 
-from boss_agent_cli.api.client import BossClient
 from boss_agent_cli.auth.manager import AuthManager
+from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_status
 
 
@@ -12,8 +12,6 @@ def status_cmd(ctx: click.Context) -> None:
 	"""检查当前登录态"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	delay = ctx.obj["delay"]
-	cdp_url = ctx.obj.get("cdp_url")
 	auth = AuthManager(data_dir, logger=logger)
 
 	token = auth.check_status()
@@ -26,8 +24,8 @@ def status_cmd(ctx: click.Context) -> None:
 		)
 		return
 
-	with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
-		info = client.user_info()
+	with get_platform_instance(ctx, auth) as platform:
+		info = platform.user_info()
 		user_name = info.get("zpData", {}).get("name", "未知用户")
 		data = {
 			"logged_in": True,

--- a/src/boss_agent_cli/commands/watch.py
+++ b/src/boss_agent_cli/commands/watch.py
@@ -1,6 +1,5 @@
 import click
 
-from boss_agent_cli.api.client import BossClient
 from boss_agent_cli.api.endpoints import (
 	CITY_CODES,
 	INDUSTRY_CODES,
@@ -10,6 +9,7 @@ from boss_agent_cli.api.endpoints import (
 )
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.cache.store import CacheStore
+from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output
 from boss_agent_cli.search_filters import SearchFilterCriteria, resolve_welfare_keywords, run_search_pipeline
 
@@ -115,8 +115,6 @@ def watch_remove_cmd(ctx: click.Context, name: str) -> None:
 def watch_run_cmd(ctx: click.Context, name: str) -> None:
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	delay = ctx.obj["delay"]
-	cdp_url = ctx.obj.get("cdp_url")
 
 	with CacheStore(data_dir / "cache" / "boss_agent.db") as cache:
 		record = cache.get_saved_search(name)
@@ -150,9 +148,9 @@ def watch_run_cmd(ctx: click.Context, name: str) -> None:
 			job_type=params.get("job_type"),
 		)
 		auth = AuthManager(data_dir, logger=logger)
-		with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
+		with get_platform_instance(ctx, auth) as platform:
 			pipeline_result = run_search_pipeline(
-				client,
+				platform,
 				cache,
 				logger,
 				criteria=criteria,

--- a/src/boss_agent_cli/platforms/base.py
+++ b/src/boss_agent_cli/platforms/base.py
@@ -141,6 +141,10 @@ class Platform(ABC):
 		"""请求交换联系方式（手机 / 微信）。"""
 		raise NotImplementedError(f"{self.name} platform does not implement exchange_contact")
 
+	def job_history(self, page: int = 1) -> dict[str, Any]:
+		"""浏览历史。"""
+		raise NotImplementedError(f"{self.name} platform does not implement job_history")
+
 	def greet(self, security_id: str, job_id: str, message: str = "") -> dict[str, Any]:
 		"""打招呼。平台不支持时抛 NotImplementedError。"""
 		raise NotImplementedError(f"{self.name} platform does not implement greet")

--- a/src/boss_agent_cli/platforms/zhipin.py
+++ b/src/boss_agent_cli/platforms/zhipin.py
@@ -102,3 +102,6 @@ class BossPlatform(Platform):
 
 	def exchange_contact(self, security_id: str, uid: str, friend_name: str, exchange_type: int = 1) -> dict[str, Any]:
 		return self._client.exchange_contact(security_id, uid, friend_name, exchange_type=exchange_type)
+
+	def job_history(self, page: int = 1) -> dict[str, Any]:
+		return self._client.job_history(page)

--- a/tests/test_chat_summary_command.py
+++ b/tests/test_chat_summary_command.py
@@ -34,7 +34,7 @@ def _friend():
 	}
 
 
-@patch("boss_agent_cli.commands.chat_summary.BossClient")
+@patch("boss_agent_cli.commands.chat_summary.get_platform_instance")
 @patch("boss_agent_cli.commands.chat_summary.AuthManager")
 def test_chat_summary_command_success(mock_auth_cls, mock_client_cls):
 	mock_client = _ctx_mock(mock_client_cls)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -39,7 +39,7 @@ def test_status_not_logged_in(mock_auth_cls):
 	assert parsed["error"]["code"] == "AUTH_REQUIRED"
 
 
-@patch("boss_agent_cli.commands.status.BossClient")
+@patch("boss_agent_cli.commands.status.get_platform_instance")
 @patch("boss_agent_cli.commands.status.AuthManager")
 def test_status_logged_in_happy_path(mock_auth_cls, mock_client_cls):
 	"""登录成功路径：check_status 返回 token，user_info 返回名字"""
@@ -58,7 +58,7 @@ def test_status_logged_in_happy_path(mock_auth_cls, mock_client_cls):
 	assert parsed["data"]["user_name"] == "张三"
 
 
-@patch("boss_agent_cli.commands.status.BossClient")
+@patch("boss_agent_cli.commands.status.get_platform_instance")
 @patch("boss_agent_cli.commands.status.AuthManager")
 def test_status_logged_in_unknown_user(mock_auth_cls, mock_client_cls):
 	"""user_info 缺失 name 字段时应回退到默认占位"""
@@ -77,7 +77,7 @@ def test_status_logged_in_unknown_user(mock_auth_cls, mock_client_cls):
 
 @patch("boss_agent_cli.commands.search.CacheStore")
 @patch("boss_agent_cli.commands.search.AuthManager")
-@patch("boss_agent_cli.commands.search.BossClient")
+@patch("boss_agent_cli.commands.search.get_platform_instance")
 def test_search_invalid_city(mock_client_cls, mock_auth_cls, mock_cache_cls):
 	runner = CliRunner()
 	result = runner.invoke(cli, ["search", "golang", "--city", "火星"])
@@ -307,7 +307,7 @@ def test_recommend_with_score(mock_auth_cls, mock_client_cls, mock_cache_cls):
 @patch("boss_agent_cli.commands.search.run_search_pipeline")
 @patch("boss_agent_cli.commands.search.CacheStore")
 @patch("boss_agent_cli.commands.search.AuthManager")
-@patch("boss_agent_cli.commands.search.BossClient")
+@patch("boss_agent_cli.commands.search.get_platform_instance")
 def test_search_with_score(mock_client_cls, mock_auth_cls, mock_cache_cls, mock_pipeline):
 	mock_cache = _ctx_mock(mock_cache_cls)
 	mock_cache.get_search.return_value = None
@@ -396,7 +396,7 @@ def test_recommend_ignores_index_cache_write_failure(mock_auth_cls, mock_client_
 @patch("boss_agent_cli.commands.search.run_search_pipeline")
 @patch("boss_agent_cli.commands.search.CacheStore")
 @patch("boss_agent_cli.commands.search.AuthManager")
-@patch("boss_agent_cli.commands.search.BossClient")
+@patch("boss_agent_cli.commands.search.get_platform_instance")
 def test_search_ignores_index_cache_write_failure(mock_client_cls, mock_auth_cls, mock_cache_cls, mock_pipeline, mock_save_index):
 	mock_cache = _ctx_mock(mock_cache_cls)
 	mock_cache.get_search.return_value = None
@@ -430,7 +430,7 @@ def test_search_ignores_index_cache_write_failure(mock_client_cls, mock_auth_cls
 	mock_save_index.assert_called_once()
 
 
-@patch("boss_agent_cli.commands.export.BossClient")
+@patch("boss_agent_cli.commands.export.get_platform_instance")
 @patch("boss_agent_cli.commands.export.AuthManager")
 def test_export_to_stdout(mock_auth_cls, mock_client_cls):
 	mock_client =	_ctx_mock(mock_client_cls)
@@ -928,7 +928,7 @@ def test_chat_export_html_xss_prevention(mock_auth_cls, mock_client_cls, tmp_pat
 @patch("boss_agent_cli.commands.search.run_search_pipeline")
 @patch("boss_agent_cli.commands.search.CacheStore")
 @patch("boss_agent_cli.commands.search.AuthManager")
-@patch("boss_agent_cli.commands.search.BossClient")
+@patch("boss_agent_cli.commands.search.get_platform_instance")
 def test_search_account_risk_returns_error(mock_client_cls, mock_auth_cls, mock_cache_cls, mock_pipeline):
 	"""搜索触发风控 code 36 时应返回 ACCOUNT_RISK 错误码"""
 	from boss_agent_cli.api.client import AccountRiskError

--- a/tests/test_export_extended.py
+++ b/tests/test_export_extended.py
@@ -48,7 +48,7 @@ def _api_response(jobs: list[dict], has_more: bool = False) -> dict:
 # ── 文件输出 · CSV ────────────────────────────────────────────────────
 
 
-@patch("boss_agent_cli.commands.export.BossClient")
+@patch("boss_agent_cli.commands.export.get_platform_instance")
 @patch("boss_agent_cli.commands.export.AuthManager")
 def test_export_csv_to_file(mock_auth_cls, mock_client_cls, tmp_path: Path):
 	mock_client = _ctx_mock(mock_client_cls)
@@ -73,7 +73,7 @@ def test_export_csv_to_file(mock_auth_cls, mock_client_cls, tmp_path: Path):
 	assert parsed["data"]["path"] == str(out_path)
 
 
-@patch("boss_agent_cli.commands.export.BossClient")
+@patch("boss_agent_cli.commands.export.get_platform_instance")
 @patch("boss_agent_cli.commands.export.AuthManager")
 def test_export_csv_formula_injection_sanitized(mock_auth_cls, mock_client_cls, tmp_path: Path):
 	"""CSV 公式注入防护：以 =+@- 开头的值应前置单引号。"""
@@ -94,7 +94,7 @@ def test_export_csv_formula_injection_sanitized(mock_auth_cls, mock_client_cls, 
 	assert rows[0]["company"].startswith("'+")
 
 
-@patch("boss_agent_cli.commands.export.BossClient")
+@patch("boss_agent_cli.commands.export.get_platform_instance")
 @patch("boss_agent_cli.commands.export.AuthManager")
 def test_export_csv_empty_result_writes_empty_file(mock_auth_cls, mock_client_cls, tmp_path: Path):
 	mock_client = _ctx_mock(mock_client_cls)
@@ -111,7 +111,7 @@ def test_export_csv_empty_result_writes_empty_file(mock_auth_cls, mock_client_cl
 # ── 文件输出 · JSON ──────────────────────────────────────────────────
 
 
-@patch("boss_agent_cli.commands.export.BossClient")
+@patch("boss_agent_cli.commands.export.get_platform_instance")
 @patch("boss_agent_cli.commands.export.AuthManager")
 def test_export_json_to_file(mock_auth_cls, mock_client_cls, tmp_path: Path):
 	mock_client = _ctx_mock(mock_client_cls)
@@ -135,7 +135,7 @@ def test_export_json_to_file(mock_auth_cls, mock_client_cls, tmp_path: Path):
 # ── 文件输出 · HTML ──────────────────────────────────────────────────
 
 
-@patch("boss_agent_cli.commands.export.BossClient")
+@patch("boss_agent_cli.commands.export.get_platform_instance")
 @patch("boss_agent_cli.commands.export.AuthManager")
 def test_export_html_to_file(mock_auth_cls, mock_client_cls, tmp_path: Path):
 	mock_client = _ctx_mock(mock_client_cls)
@@ -162,7 +162,7 @@ def test_export_html_to_file(mock_auth_cls, mock_client_cls, tmp_path: Path):
 	assert "共 1 条" in content
 
 
-@patch("boss_agent_cli.commands.export.BossClient")
+@patch("boss_agent_cli.commands.export.get_platform_instance")
 @patch("boss_agent_cli.commands.export.AuthManager")
 def test_export_html_empty_result(mock_auth_cls, mock_client_cls, tmp_path: Path):
 	mock_client = _ctx_mock(mock_client_cls)
@@ -176,7 +176,7 @@ def test_export_html_empty_result(mock_auth_cls, mock_client_cls, tmp_path: Path
 	assert "无数据" in content
 
 
-@patch("boss_agent_cli.commands.export.BossClient")
+@patch("boss_agent_cli.commands.export.get_platform_instance")
 @patch("boss_agent_cli.commands.export.AuthManager")
 def test_export_html_escapes_user_content(mock_auth_cls, mock_client_cls, tmp_path: Path):
 	"""HTML 输出必须转义用户数据避免 XSS。"""
@@ -198,7 +198,7 @@ def test_export_html_escapes_user_content(mock_auth_cls, mock_client_cls, tmp_pa
 # ── 分页循环 ──────────────────────────────────────────────────────────
 
 
-@patch("boss_agent_cli.commands.export.BossClient")
+@patch("boss_agent_cli.commands.export.get_platform_instance")
 @patch("boss_agent_cli.commands.export.AuthManager")
 def test_export_paginates_until_count_reached(mock_auth_cls, mock_client_cls, tmp_path: Path):
 	"""当 count > 15 时应翻页直到达量或无 hasMore。"""
@@ -226,7 +226,7 @@ def test_export_paginates_until_count_reached(mock_auth_cls, mock_client_cls, tm
 	assert mock_client.search_jobs.call_count == 2
 
 
-@patch("boss_agent_cli.commands.export.BossClient")
+@patch("boss_agent_cli.commands.export.get_platform_instance")
 @patch("boss_agent_cli.commands.export.AuthManager")
 def test_export_stops_when_no_more_and_last_page_short(mock_auth_cls, mock_client_cls, tmp_path: Path):
 	"""页数据少于 count 且 hasMore=False 时应提前终止，不造成空循环。"""
@@ -242,7 +242,7 @@ def test_export_stops_when_no_more_and_last_page_short(mock_auth_cls, mock_clien
 	assert mock_client.search_jobs.call_count == 1
 
 
-@patch("boss_agent_cli.commands.export.BossClient")
+@patch("boss_agent_cli.commands.export.get_platform_instance")
 @patch("boss_agent_cli.commands.export.AuthManager")
 def test_export_stops_when_job_list_empty(mock_auth_cls, mock_client_cls, tmp_path: Path):
 	"""空 jobList 也应触发终止。"""

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -205,7 +205,7 @@ def test_me_basic(mock_auth_cls, mock_client_cls):
 # ── history ──────────────────────────────────────────────────────────
 
 
-@patch("boss_agent_cli.commands.history.BossClient")
+@patch("boss_agent_cli.commands.history.get_platform_instance")
 @patch("boss_agent_cli.commands.history.AuthManager")
 def test_history_success(mock_auth_cls, mock_client_cls):
 	mock_client = _ctx_mock(mock_client_cls)
@@ -232,7 +232,7 @@ def test_history_success(mock_auth_cls, mock_client_cls):
 	assert parsed["ok"] is True
 
 
-@patch("boss_agent_cli.commands.history.BossClient")
+@patch("boss_agent_cli.commands.history.get_platform_instance")
 @patch("boss_agent_cli.commands.history.AuthManager")
 def test_history_uses_client_context_manager(mock_auth_cls, mock_client_cls):
 	instance = mock_client_cls.return_value

--- a/tests/test_preset.py
+++ b/tests/test_preset.py
@@ -62,7 +62,7 @@ def test_preset_add_list_remove(tmp_path):
 	assert remove_parsed["data"]["removed"] is True
 
 
-@patch("boss_agent_cli.commands.search.BossClient")
+@patch("boss_agent_cli.commands.search.get_platform_instance")
 @patch("boss_agent_cli.commands.search.AuthManager")
 @patch("boss_agent_cli.commands.search.CacheStore")
 @patch("boss_agent_cli.commands.search.try_save_index")

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -63,7 +63,7 @@ def test_watch_add_list_remove(tmp_path):
 	assert remove_parsed["data"]["removed"] is True
 
 
-@patch("boss_agent_cli.commands.watch.BossClient")
+@patch("boss_agent_cli.commands.watch.get_platform_instance")
 @patch("boss_agent_cli.commands.watch.AuthManager")
 def test_watch_run_marks_only_new_items(mock_auth_cls, mock_client_cls, tmp_path):
 	mock_client = _ctx_mock(mock_client_cls)

--- a/tests/test_welfare_filter.py
+++ b/tests/test_welfare_filter.py
@@ -36,7 +36,7 @@ def _ctx_mock(mock_cls):
 
 @patch("boss_agent_cli.commands.search.try_save_index")
 @patch("boss_agent_cli.commands.search.CacheStore")
-@patch("boss_agent_cli.commands.search.BossClient")
+@patch("boss_agent_cli.commands.search.get_platform_instance")
 @patch("boss_agent_cli.commands.search.AuthManager")
 def test_welfare_filter_tag_match(mock_auth, mock_client_cls, mock_cache_cls, mock_save):
 	"""福利筛选：标签直接匹配不需要查详情"""
@@ -65,7 +65,7 @@ def test_welfare_filter_tag_match(mock_auth, mock_client_cls, mock_cache_cls, mo
 
 @patch("boss_agent_cli.commands.search.try_save_index")
 @patch("boss_agent_cli.commands.search.CacheStore")
-@patch("boss_agent_cli.commands.search.BossClient")
+@patch("boss_agent_cli.commands.search.get_platform_instance")
 @patch("boss_agent_cli.commands.search.AuthManager")
 def test_welfare_filter_detail_fallback(mock_auth, mock_client_cls, mock_cache_cls, mock_save):
 	"""福利筛选：标签不够时并行查详情"""


### PR DESCRIPTION
## 背景

Issue #129 Week 1c 最终收口：把剩余 6 个还在直接用 `BossClient` 的命令全部迁移到 Platform 抽象。此 PR 后，`commands/` 目录下除 `_platform.py`（桥接层）外**再无任何 BossClient 直接引用**。

## 变更

### 命令迁移（6 个）

| 命令 | 关键 Platform 方法 |
|------|------------------|
| `search` | `search_jobs`（通过 `run_search_pipeline` 传 Platform 实例） |
| `export` | `search_jobs` |
| `chat_summary` | `friend_list` + `chat_history` |
| `history` | `job_history` |
| `status` | `user_info` |
| `watch run` | `search_jobs`（通过 `run_search_pipeline`） |

### Platform ABC 扩展

- `job_history(page=1)` 新增（history 命令所需），BossPlatform 透传

### search_filters.py 零改动

`run_search_pipeline(client: Any, ...)` 参数签名保持 `Any` 泛型，Platform 实例可直接传入——因为 Platform 和 BossClient 对外暴露的 `search_jobs` / `job_card` 签名一致。

### 累计 Week 1c 战果

| 批次 | 命令 | 数量 |
|------|------|------|
| PR #133 | greet / apply | 2 |
| PR #135 | batch-greet | 1 |
| PR #136 | interviews / detail / show / me / recommend | 5 |
| PR #137 | chat / chatmsg / mark / exchange / pipeline / digest | 6 |
| 本 PR | search / export / chat_summary / history / status / watch | 6 |
| **合计** | **20 个命令** | |

## 验证

\`\`\`
$ uv run pytest tests/ -q
998 passed in 45.01s

$ uv run mypy src/boss_agent_cli
Success: no issues found in 80 source files

$ grep -rn "from boss_agent_cli.api.client import BossClient\|with BossClient(" src/boss_agent_cli/commands/
src/boss_agent_cli/commands/_platform.py:22:from boss_agent_cli.api.client import BossClient
(只剩桥接层)
\`\`\`

- 全量 998 测试通过（零回归）
- mypy strict 0 错误
- Week 1c 目标 100% 达成