### PR TITLE
refactor: 智联自证 stub 错误消息指向追踪 issue

### DIFF
--- a/src/boss_agent_cli/platforms/zhilian.py
+++ b/src/boss_agent_cli/platforms/zhilian.py
@@ -34,7 +34,7 @@ _ERROR_CODE_MAP: dict[int, str] = {
 }
 
 # Week 2 时会替换为真实实现
-_NOT_YET_MSG = "Zhilian Week 2 待实现，当前为注册自证 stub，详见 Issue #129"
+_NOT_YET_MSG = "Zhilian Week 2 待实现，当前为注册自证 stub，追踪进度见 Issue #140（https://github.com/can4hou6joeng4/boss-agent-cli/issues/140）"
 
 
 class ZhilianPlatform(Platform):


### PR DESCRIPTION
ZhilianPlatform 的 NotImplementedError 消息从 "详见 Issue #129" 更新为 "追踪进度见 Issue #140"，对齐 #129 闭环后 Week 2 新追踪 issue 的位置。

## 验证

- `uv run pytest tests/test_zhilian_stub.py -q`：27 pass
- `uv run mypy src/boss_agent_cli`：0 errors in 80 files