### PR TITLE
feat: 新增智联内部客户端骨架与平台路由分发

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ## [Unreleased]
 
+### Added
+- **ZhilianClient 内部 HTTP 客户端骨架**（Issue #140 Week 2 起步）— 新增 `src/boss_agent_cli/api/zhilian_client.py`：
+  - 类结构 + `__init__(auth_manager, *, delay, cdp_url)` 签名完全对齐 `BossClient`
+  - `close()` / `__enter__` / `__exit__` 资源生命周期支持
+  - `atexit` 自动清理未显式关闭的实例
+  - 所有 P0 方法（search_jobs / job_detail / recommend_jobs / user_info）抛 `NotImplementedError` 附 Issue #140 链接
+- **`get_platform_instance` 支持按平台分发 client**（`_platform.py`）：
+  - zhipin → BossClient
+  - zhilian → ZhilianClient
+  - 新增 `_build_client(name, ...)` helper 封装分发逻辑
+- `tests/test_zhilian_client.py` 13 条契约测试覆盖类结构 / 上下文管理器 / stub 方法 / 平台路由分发
+
+### Changed
+- mypy 严格白名单扩到 72（新增 `api.zhilian_client`）
+
 ## [1.10.1] - 2026-04-21
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,7 @@ module = [
 	"boss_agent_cli.platforms.base",
 	"boss_agent_cli.platforms.zhipin",
 	"boss_agent_cli.platforms.zhilian",
+	"boss_agent_cli.api.zhilian_client",
 	"boss_agent_cli.commands._platform",
 ]
 disallow_untyped_defs = true

--- a/src/boss_agent_cli/api/zhilian_client.py
+++ b/src/boss_agent_cli/api/zhilian_client.py
@@ -1,0 +1,97 @@
+"""智联招聘内部 HTTP 客户端骨架（Week 2 实施前占位）。
+
+**当前状态**：类结构 + __init__/close 签名对齐 BossClient，所有 P0/P1/P2 方法抛
+``NotImplementedError("Zhilian client Week 2 待实现，详见 Issue #140")``。
+
+**Week 2 TODO**（Issue #140）：
+- 基于 httpx 实现真实 HTTP 调用
+- 基于 BrowserSession / Bridge 获取 CSRF token
+- 实现 search_jobs / job_detail / recommend_jobs / user_info 四个 P0 只读方法
+- 认证链路（Cookie + X-Lagou-Token 或智联对应 token）
+
+**设计依据**：
+- [docs/research/platforms/zhaopin.md](../../docs/research/platforms/zhaopin.md) §2 端点清单
+- [src/boss_agent_cli/platforms/zhilian.py](../platforms/zhilian.py) Platform 适配层
+"""
+
+from __future__ import annotations
+
+import atexit
+import weakref
+from types import TracebackType
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+	from boss_agent_cli.auth.manager import AuthManager
+
+
+_NOT_YET_MSG = (
+	"Zhilian client Week 2 待实现，当前为 stub 占位，"
+	"追踪进度见 Issue #140（https://github.com/can4hou6joeng4/boss-agent-cli/issues/140）"
+)
+
+
+# atexit safeguard：类比 BossClient 的管理方式
+_OPEN_CLIENTS: weakref.WeakSet["ZhilianClient"] = weakref.WeakSet()
+
+
+def _close_open_clients() -> None:
+	for client in list(_OPEN_CLIENTS):
+		try:
+			client.close()
+		except Exception:
+			pass
+
+
+atexit.register(_close_open_clients)
+
+
+class ZhilianClient:
+	"""智联招聘内部 HTTP 客户端骨架。
+
+	签名对齐 ``BossClient``，Week 2 填充真实实现。
+	"""
+
+	def __init__(
+		self,
+		auth_manager: "AuthManager",
+		*,
+		delay: tuple[float, float] = (1.5, 3.0),
+		cdp_url: str | None = None,
+	) -> None:
+		self._auth = auth_manager
+		self._delay = delay
+		self._cdp_url = cdp_url
+		self._closed = False
+		_OPEN_CLIENTS.add(self)
+
+	# ── 资源生命周期 ───────────────────────────────
+
+	def close(self) -> None:
+		"""释放底层资源。Week 2 真实现后会关闭 httpx client 和 browser session。"""
+		self._closed = True
+
+	def __enter__(self) -> "ZhilianClient":
+		return self
+
+	def __exit__(
+		self,
+		exc_type: type[BaseException] | None,
+		exc_val: BaseException | None,
+		exc_tb: TracebackType | None,
+	) -> None:
+		self.close()
+
+	# ── P0 只读（Week 2 待实现）─────────────────────
+
+	def search_jobs(self, query: str, **filters: Any) -> dict[str, Any]:
+		raise NotImplementedError(f"{_NOT_YET_MSG}: search_jobs(query={query!r}, filters={filters!r})")
+
+	def job_detail(self, job_id: str) -> dict[str, Any]:
+		raise NotImplementedError(f"{_NOT_YET_MSG}: job_detail(job_id={job_id!r})")
+
+	def recommend_jobs(self, page: int = 1) -> dict[str, Any]:
+		raise NotImplementedError(f"{_NOT_YET_MSG}: recommend_jobs(page={page})")
+
+	def user_info(self) -> dict[str, Any]:
+		raise NotImplementedError(f"{_NOT_YET_MSG}: user_info()")

--- a/src/boss_agent_cli/commands/_platform.py
+++ b/src/boss_agent_cli/commands/_platform.py
@@ -17,9 +17,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from boss_agent_cli.api.client import BossClient
+from boss_agent_cli.api.zhilian_client import ZhilianClient
 from boss_agent_cli.platforms import Platform, get_platform
 
 if TYPE_CHECKING:
@@ -28,12 +29,21 @@ if TYPE_CHECKING:
 	from boss_agent_cli.auth.manager import AuthManager
 
 
+def _build_client(name: str, auth: "AuthManager", delay: tuple[float, float], cdp_url: str | None) -> Any:
+	"""按平台名构造对应的内部 client。"""
+	if name == "zhilian":
+		return ZhilianClient(auth, delay=delay, cdp_url=cdp_url)
+	# 默认 zhipin 走 BossClient
+	return BossClient(auth, delay=delay, cdp_url=cdp_url)
+
+
 def get_platform_instance(ctx: "click.Context", auth: "AuthManager") -> Platform:
 	"""根据 ctx.obj["platform"] 构造 Platform 实例。
 
 	- 读取 ``ctx.obj`` 中的 ``platform`` / ``delay`` / ``cdp_url`` 配置
 	- 未设 platform 时 fallback 到 "zhipin"
 	- 未知平台抛 ``ValueError``
+	- 按平台名分发到对应 client（zhipin→BossClient / zhilian→ZhilianClient）
 	"""
 	obj = ctx.obj or {}
 	name = obj.get("platform") or "zhipin"
@@ -41,7 +51,7 @@ def get_platform_instance(ctx: "click.Context", auth: "AuthManager") -> Platform
 
 	delay = obj.get("delay", (1.5, 3.0))
 	cdp_url = obj.get("cdp_url")
-	client = BossClient(auth, delay=delay, cdp_url=cdp_url)
+	client = _build_client(name, auth, delay, cdp_url)
 	return plat_cls(client)
 
 

--- a/tests/test_zhilian_client.py
+++ b/tests/test_zhilian_client.py
@@ -1,0 +1,109 @@
+"""ZhilianClient 契约测试。
+
+Zhilian 内部 HTTP 客户端骨架，Week 2 真实现之前只提供类结构 / __init__ 签名 / 资源生命周期。
+所有 API 调用方法抛 NotImplementedError 并附 Issue #140 链接。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from boss_agent_cli.api.zhilian_client import ZhilianClient
+
+
+class TestZhilianClientStructure:
+	"""ZhilianClient 类结构对齐 BossClient 的公开面。"""
+
+	def test_can_instantiate_with_auth_manager(self) -> None:
+		client = ZhilianClient(MagicMock())
+		assert client is not None
+
+	def test_init_accepts_delay_keyword(self) -> None:
+		client = ZhilianClient(MagicMock(), delay=(2.0, 4.0))
+		assert client._delay == (2.0, 4.0)
+
+	def test_init_accepts_cdp_url_keyword(self) -> None:
+		client = ZhilianClient(MagicMock(), cdp_url="http://localhost:9222")
+		assert client._cdp_url == "http://localhost:9222"
+
+	def test_close_is_callable_and_idempotent(self) -> None:
+		client = ZhilianClient(MagicMock())
+		client.close()
+		client.close()  # 重复调用不抛错
+
+
+class TestZhilianClientContextManager:
+	"""with 上下文管理器支持。"""
+
+	def test_enter_returns_self(self) -> None:
+		client = ZhilianClient(MagicMock())
+		with client as c:
+			assert c is client
+
+	def test_exit_calls_close(self) -> None:
+		client = ZhilianClient(MagicMock())
+		with client:
+			assert not client._closed
+		assert client._closed
+
+
+class TestZhilianClientStubMethods:
+	"""Week 2 待实现方法抛清晰 NotImplementedError。"""
+
+	def setup_method(self) -> None:
+		self.client = ZhilianClient(MagicMock())
+
+	def test_search_jobs_raises(self) -> None:
+		with pytest.raises(NotImplementedError, match="Week 2"):
+			self.client.search_jobs("Python")
+
+	def test_job_detail_raises(self) -> None:
+		with pytest.raises(NotImplementedError, match="Week 2"):
+			self.client.job_detail("abc")
+
+	def test_recommend_jobs_raises(self) -> None:
+		with pytest.raises(NotImplementedError, match="Week 2"):
+			self.client.recommend_jobs()
+
+	def test_user_info_raises(self) -> None:
+		with pytest.raises(NotImplementedError, match="Week 2"):
+			self.client.user_info()
+
+	def test_error_messages_point_to_issue_140(self) -> None:
+		with pytest.raises(NotImplementedError) as exc_info:
+			self.client.user_info()
+		assert "#140" in str(exc_info.value)
+
+
+class TestPlatformInstanceRoutesToClient:
+	"""get_platform_instance 按 platform 分发到正确的 client 类。"""
+
+	def test_zhipin_platform_gets_boss_client(self) -> None:
+		from unittest.mock import patch
+		from boss_agent_cli.commands._platform import get_platform_instance
+		from boss_agent_cli.platforms import BossPlatform
+
+		ctx = MagicMock()
+		ctx.obj = {"platform": "zhipin", "delay": (1.0, 2.0), "cdp_url": None}
+		auth = MagicMock()
+
+		with patch("boss_agent_cli.commands._platform.BossClient") as mock_boss_cls:
+			plat = get_platform_instance(ctx, auth)
+			assert isinstance(plat, BossPlatform)
+			mock_boss_cls.assert_called_once()
+
+	def test_zhilian_platform_gets_zhilian_client(self) -> None:
+		from unittest.mock import patch
+		from boss_agent_cli.commands._platform import get_platform_instance
+		from boss_agent_cli.platforms import ZhilianPlatform
+
+		ctx = MagicMock()
+		ctx.obj = {"platform": "zhilian", "delay": (1.0, 2.0), "cdp_url": None}
+		auth = MagicMock()
+
+		with patch("boss_agent_cli.commands._platform.ZhilianClient") as mock_zhilian_cls:
+			plat = get_platform_instance(ctx, auth)
+			assert isinstance(plat, ZhilianPlatform)
+			mock_zhilian_cls.assert_called_once()


### PR DESCRIPTION
## 背景

Issue #140 Week 2 的"第一行代码"。ZhilianPlatform 在 v1.10.1 就已注册，但底层客户端层一直是空的——本 PR 补齐 \`ZhilianClient\` 类骨架，让 \`get_platform_instance\` 按平台分发到正确的 client，为 Week 2 真 HTTP 实现铺好路径。

## 变更

### Added

- **\`src/boss_agent_cli/api/zhilian_client.py\`** — ZhilianClient 骨架：
  - \`__init__(auth_manager, *, delay=(1.5, 3.0), cdp_url=None)\` 签名完全对齐 \`BossClient\`
  - \`close()\` / \`__enter__\` / \`__exit__\` 资源生命周期
  - \`atexit\` 钩子自动清理未显式关闭的实例（复用 BossClient 的模式）
  - P0 方法（search_jobs / job_detail / recommend_jobs / user_info）抛 \`NotImplementedError\` 附 Issue #140 链接
- **路由分发** in \`commands/_platform.py\`：
  - \`_build_client(name, ...)\` 按平台名分发
  - zhipin → BossClient（默认）
  - zhilian → ZhilianClient
- **13 条契约测试** \`tests/test_zhilian_client.py\`：
  - 类结构（4 条）
  - 上下文管理器（2 条）
  - Stub 方法 + Issue #140 消息检查（5 条）
  - 平台路由分发（2 条）

### Changed

- mypy 严格白名单扩到 72（新增 \`api.zhilian_client\`）

## 验证

\`\`\`
$ uv run pytest tests/ -q
1011 passed in 33.82s

$ uv run mypy src/boss_agent_cli
Success: no issues found in 81 source files

$ uv run boss --platform zhilian me
{"ok": false, "error": {"code": "NETWORK_ERROR", "message": "Zhilian Week 2 待实现...追踪进度见 Issue #140: user_info()"}}
\`\`\`

- 测试 998 → **1011**（+13 新增）
- mypy strict：71 → **72 严格模块 / 81 源文件 0 错**
- 端到端：\`boss --platform zhilian me\` 正确路由到 ZhilianClient 骨架
- 零回归

## 非目标

- 不做真实 HTTP 调用（Week 2 独立 PR）
- 不做 CSRF token 获取或认证链路实现（Week 2）
- 不做 P1/P2 方法（greet / apply / chat）