### PR TITLE
chore: 完善仓库协作治理配置

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# Default owner for the whole repository.
+* @can4hou6joeng4
+
+# Release and packaging surface.
+/pyproject.toml @can4hou6joeng4
+/uv.lock @can4hou6joeng4
+/src/boss_agent_cli/__init__.py @can4hou6joeng4
+
+# Public agent-facing contracts and docs.
+/README.md @can4hou6joeng4
+/README.en.md @can4hou6joeng4
+/SKILL.md @can4hou6joeng4
+/docs/ @can4hou6joeng4
+/mcp-server/ @can4hou6joeng4
+
+# GitHub automation and governance.
+/.github/ @can4hou6joeng4

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -50,6 +50,7 @@ Closes #
 - [ ] 如新增 MCP 工具：已更新 `mcp-server/server.py` 和 `mcp-server/README.md`
 - [ ] 如新增错误码：已添加到 `schema.py` 的 `error_codes`
 - [ ] 已更新 `CHANGELOG.md` 的 `[Unreleased]` 段落
+- [ ] 如变更 Agent 主卖点或安装路径：已同步检查 `SKILL.md` / PyPI 版本 / GitHub Release 说明
 
 ## 安全与规范 / Safety & Convention
 


### PR DESCRIPTION
## Summary

继续补齐 boss-agent-cli 在 GitHub 层的协作治理配置，使其更接近高星开源仓库的维护体验，同时保持当前以 skill / Agent 为核心卖点的分发路径一致。

### 本次改动
- 新增 `.github/CODEOWNERS`，为仓库关键路径建立默认 owner
- 更新 PR 模板，加入 `SKILL.md / PyPI / GitHub Release` 三条分发路径的一致性检查

## Why

本轮没有继续调整 `Projects`，因为当前 GitHub token 缺少 `read:project` scope，无法无损确认 ProjectV2 是否在使用；在证据不足时选择保守保留。

## Verification

- `git diff --check`
- 读取 `.github/CODEOWNERS`
- 校验 `.github/PULL_REQUEST_TEMPLATE.md` 中新增的 release/skill 对齐检查项