### PR TITLE
feat: 实现智联客户端基础认证头与生命周期

### DIFF
--- a/src/boss_agent_cli/api/zhilian_client.py
+++ b/src/boss_agent_cli/api/zhilian_client.py
@@ -9,6 +9,11 @@
 - 实现 search_jobs / job_detail / recommend_jobs / user_info 四个 P0 只读方法
 - 认证链路（Cookie + X-Lagou-Token 或智联对应 token）
 
+**P0-1 已实施**（本文件 `_get_httpx_client`）：
+- httpx.Client lazy 初始化 + 资源生命周期闭环
+- 注入 Cookie / User-Agent / sec-ch-ua-platform / x-zp-client-id / Referer / Origin
+- 多域名（fe-api / i / www zhaopin.com）不绑死 base_url，调用时传完整 URL
+
 **设计依据**：
 - [docs/research/platforms/zhaopin.md](../../docs/research/platforms/zhaopin.md) §2 端点清单
 - [src/boss_agent_cli/platforms/zhilian.py](../platforms/zhilian.py) Platform 适配层
@@ -17,9 +22,12 @@
 from __future__ import annotations
 
 import atexit
+import sys
 import weakref
 from types import TracebackType
 from typing import TYPE_CHECKING, Any
+
+import httpx
 
 if TYPE_CHECKING:
 	from boss_agent_cli.auth.manager import AuthManager
@@ -29,6 +37,37 @@ _NOT_YET_MSG = (
 	"Zhilian client Week 2 待实现，当前为 stub 占位，"
 	"追踪进度见 Issue #140（https://github.com/can4hou6joeng4/boss-agent-cli/issues/140）"
 )
+
+# 智联站点常量 — 多域名不绑死 base_url，只用于 Referer / Origin
+ZHAOPIN_HOME = "https://www.zhaopin.com"
+ZHAOPIN_DOMAIN = "https://www.zhaopin.com/"
+
+# 兜底 UA（真实浏览器指纹，token 未提供时用）
+_DEFAULT_USER_AGENT = (
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+	"AppleWebKit/537.36 (KHTML, like Gecko) "
+	"Chrome/123.0.0.0 Safari/537.36"
+)
+
+# sec-ch-ua-platform 按运行平台动态映射
+_SEC_CH_UA_PLATFORM_MAP: dict[str, str] = {
+	"win32": '"Windows"',
+	"linux": '"Linux"',
+	"darwin": '"macOS"',
+}
+
+# 默认 header 模板（不含 token / 平台动态字段）
+_DEFAULT_HEADERS: dict[str, str] = {
+	"Accept": "application/json, text/plain, */*",
+	"Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+	"sec-ch-ua": '"Chromium";v="123", "Not:A-Brand";v="8", "Google Chrome";v="123"',
+	"sec-ch-ua-mobile": "?0",
+	"Sec-Fetch-Site": "same-site",
+	"Sec-Fetch-Mode": "cors",
+	"Sec-Fetch-Dest": "empty",
+	"Referer": ZHAOPIN_DOMAIN,
+	"Origin": ZHAOPIN_HOME,
+}
 
 
 # atexit safeguard：类比 BossClient 的管理方式
@@ -62,13 +101,50 @@ class ZhilianClient:
 		self._auth = auth_manager
 		self._delay = delay
 		self._cdp_url = cdp_url
+		self._httpx_client: httpx.Client | None = None
 		self._closed = False
 		_OPEN_CLIENTS.add(self)
 
 	# ── 资源生命周期 ───────────────────────────────
 
+	def _get_httpx_client(self) -> httpx.Client:
+		"""惰性初始化 httpx.Client，注入认证 Cookie 与浏览器指纹头。
+
+		设计要点：
+		- 不绑 ``base_url``：智联多域名（fe-api / i / www zhaopin.com），
+		  调用方传完整 URL 即可。
+		- token 字段优先：``user_agent`` / ``x_zp_client_id`` 由
+		  ``auth_manager.get_token()`` 提供，缺失则用兜底 UA 与跳过 client_id。
+		- ``sec-ch-ua-platform`` 按 ``sys.platform`` 动态映射，避免 headless 检测。
+		"""
+		if self._httpx_client is None:
+			token = self._auth.get_token()
+			headers = dict(_DEFAULT_HEADERS)
+
+			ua = token.get("user_agent")
+			headers["User-Agent"] = ua if ua else _DEFAULT_USER_AGENT
+
+			headers["sec-ch-ua-platform"] = _SEC_CH_UA_PLATFORM_MAP.get(sys.platform, '"macOS"')
+
+			client_id = token.get("x_zp_client_id")
+			if client_id:
+				headers["x-zp-client-id"] = client_id
+
+			self._httpx_client = httpx.Client(
+				cookies=token.get("cookies", {}),
+				headers=headers,
+				follow_redirects=True,
+				timeout=30,
+			)
+		return self._httpx_client
+
 	def close(self) -> None:
 		"""释放底层资源。Week 2 真实现后会关闭 httpx client 和 browser session。"""
+		if self._httpx_client is not None:
+			try:
+				self._httpx_client.close()
+			except Exception:
+				pass
 		self._closed = True
 
 	def __enter__(self) -> "ZhilianClient":

--- a/tests/test_zhilian_client.py
+++ b/tests/test_zhilian_client.py
@@ -6,8 +6,10 @@ Zhilian 内部 HTTP 客户端骨架，Week 2 真实现之前只提供类结构 /
 
 from __future__ import annotations
 
+import sys
 from unittest.mock import MagicMock
 
+import httpx
 import pytest
 
 from boss_agent_cli.api.zhilian_client import ZhilianClient
@@ -75,6 +77,105 @@ class TestZhilianClientStubMethods:
 		with pytest.raises(NotImplementedError) as exc_info:
 			self.client.user_info()
 		assert "#140" in str(exc_info.value)
+
+
+class TestZhilianClientHttpxClient:
+	"""P0-1：`_get_httpx_client()` 基础认证头与生命周期（Issue #140）。"""
+
+	def _make_auth(
+		self,
+		*,
+		cookies: dict[str, str] | None = None,
+		user_agent: str | None = None,
+		client_id: str | None = None,
+	) -> MagicMock:
+		auth = MagicMock()
+		token: dict[str, object] = {"cookies": cookies or {}}
+		if user_agent is not None:
+			token["user_agent"] = user_agent
+		if client_id is not None:
+			token["x_zp_client_id"] = client_id
+		auth.get_token.return_value = token
+		return auth
+
+	def test_returns_httpx_client_instance(self) -> None:
+		client = ZhilianClient(self._make_auth())
+		http = client._get_httpx_client()
+		assert isinstance(http, httpx.Client)
+
+	def test_lazy_init_returns_same_instance(self) -> None:
+		client = ZhilianClient(self._make_auth())
+		first = client._get_httpx_client()
+		second = client._get_httpx_client()
+		assert first is second
+
+	def test_cookies_come_from_token(self) -> None:
+		auth = self._make_auth(cookies={"zp_token": "T", "x-zp-client-id": "ID"})
+		client = ZhilianClient(auth)
+		http = client._get_httpx_client()
+		assert http.cookies.get("zp_token") == "T"
+		assert http.cookies.get("x-zp-client-id") == "ID"
+
+	def test_user_agent_from_token(self) -> None:
+		auth = self._make_auth(user_agent="Mozilla/5.0 (TestUA) Chrome/123")
+		client = ZhilianClient(auth)
+		http = client._get_httpx_client()
+		assert http.headers.get("User-Agent") == "Mozilla/5.0 (TestUA) Chrome/123"
+
+	def test_default_user_agent_when_token_missing(self) -> None:
+		client = ZhilianClient(self._make_auth())
+		http = client._get_httpx_client()
+		ua = http.headers.get("User-Agent") or ""
+		assert "Mozilla" in ua  # 兜底有合理 UA
+
+	def test_sec_ch_ua_platform_present(self) -> None:
+		client = ZhilianClient(self._make_auth())
+		http = client._get_httpx_client()
+		platform_header = http.headers.get("sec-ch-ua-platform")
+		assert platform_header is not None
+		assert platform_header.startswith('"') and platform_header.endswith('"')
+		expected_map = {"win32": '"Windows"', "linux": '"Linux"', "darwin": '"macOS"'}
+		assert platform_header == expected_map.get(sys.platform, '"macOS"')
+
+	def test_x_zp_client_id_header_when_token_provides(self) -> None:
+		auth = self._make_auth(client_id="abc-123")
+		client = ZhilianClient(auth)
+		http = client._get_httpx_client()
+		assert http.headers.get("x-zp-client-id") == "abc-123"
+
+	def test_referer_and_origin_headers_zhaopin(self) -> None:
+		client = ZhilianClient(self._make_auth())
+		http = client._get_httpx_client()
+		assert "zhaopin.com" in (http.headers.get("Referer") or "")
+		assert "zhaopin.com" in (http.headers.get("Origin") or "")
+
+	def test_follow_redirects_and_timeout(self) -> None:
+		client = ZhilianClient(self._make_auth())
+		http = client._get_httpx_client()
+		assert http.follow_redirects is True
+		# httpx Timeout 对象支持 read 属性
+		assert http.timeout.read == 30
+
+	def test_close_releases_httpx_client(self) -> None:
+		client = ZhilianClient(self._make_auth())
+		http = client._get_httpx_client()
+		assert http.is_closed is False
+		client.close()
+		assert http.is_closed is True
+		assert client._closed is True
+
+	def test_close_is_idempotent_after_httpx_init(self) -> None:
+		client = ZhilianClient(self._make_auth())
+		client._get_httpx_client()
+		client.close()
+		client.close()  # 第二次不抛错
+
+	def test_context_manager_closes_httpx_client(self) -> None:
+		auth = self._make_auth()
+		with ZhilianClient(auth) as client:
+			http = client._get_httpx_client()
+			assert http.is_closed is False
+		assert http.is_closed is True
 
 
 class TestPlatformInstanceRoutesToClient:


### PR DESCRIPTION
## Summary

Issue #140 Week 2 P0-1 落地：`ZhilianClient._get_httpx_client()` 与资源生命周期闭环。

- httpx.Client 惰性初始化，调用方传完整 URL（多域名 fe-api / i / www zhaopin.com 不绑死 base_url）
- 注入 token 维度的 Cookie / User-Agent / x-zp-client-id
- 注入浏览器指纹头：sec-ch-ua-platform 按 sys.platform 动态映射、sec-ch-ua / Sec-Fetch-* / Referer / Origin 静态默认
- close() 关闭 httpx client 并幂等；with 上下文管理器同步释放
- search_jobs / job_detail / recommend_jobs / user_info 仍抛 NotImplementedError，留给 P0-3 至 P0-6 落地

## Test plan

- [x] 新增 12 条契约测试（TestZhilianClientHttpxClient）覆盖：lazy 初始化、token 字段映射、平台动态头、生命周期、上下文管理器
- [x] 全量测试 1066 passed（含原 13 条 ZhilianClient 骨架契约 + 12 新增）
- [x] `uv run ruff check src/boss_agent_cli/api/zhilian_client.py tests/test_zhilian_client.py` 全过
- [x] `uv run mypy src/boss_agent_cli/api/zhilian_client.py` 全过
- [x] tab 缩进与项目其他文件对齐（unexpand 后再次回归测试）

## 设计依据

- [docs/research/platforms/zhaopin.md](docs/research/platforms/zhaopin.md) §2-§3 端点与签名机制
- 对齐 `BossClient._get_client()` 的 lazy / token 注入模式