### PR TITLE
feat: 推进智联 Week 2 候选者链路落地

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -70,7 +70,7 @@ Every command outputs **structured JSON** that AI Agents parse directly. No frag
 - **Schema-first integration**: `boss schema` is the capability source of truth for shell agents, SDKs, and tool-export formats
 - **Structured transport**: stdout is JSON-only, stderr is logs-only, which keeps automation stable
 - **4-tier login fallback**: Cookie extract → CDP → QR httpx → patchright
-- **Cross-platform adapter layer**: `Platform` / `RecruiterPlatform` registries are live; Zhaopin is tracked as the next real adapter in [Issue #140](https://github.com/can4hou6joeng4/boss-agent-cli/issues/140)
+- **Cross-platform adapter layer**: `Platform` / `RecruiterPlatform` registries are live; BOSS is available on both candidate and recruiter sides, and Zhaopin already has candidate-side envelope and command compatibility wired in
 - **MCP server with 49 tools**: ready for Claude Desktop / Cursor / Windsurf, including recruiter-side tools without wrapping your own bridge
 
 ## 📦 Install
@@ -135,7 +135,7 @@ boss-agent-cli covers both the job-seeker and the recruiter side, with a pluggab
 | Platform | Candidate | Recruiter | Status |
 |----------|:---------:|:---------:|--------|
 | BOSS Zhipin (`zhipin`) | ✅ | ✅ | default |
-| Zhaopin (`zhilian`)    | 🟡 skeleton | — | real implementation tracked in [Issue #140](https://github.com/can4hou6joeng4/boss-agent-cli/issues/140) |
+| Zhaopin (`zhilian`)    | 🟡 envelope + command compatibility wired | — | recruiter side not implemented yet, tracked in [Issue #140](https://github.com/can4hou6joeng4/boss-agent-cli/issues/140) |
 
 ```bash
 # pick a platform

--- a/README.en.md
+++ b/README.en.md
@@ -69,7 +69,7 @@ Every command outputs **structured JSON** that AI Agents parse directly. No frag
 
 - **Schema-first integration**: `boss schema` is the capability source of truth for shell agents, SDKs, and tool-export formats
 - **Structured transport**: stdout is JSON-only, stderr is logs-only, which keeps automation stable
-- **4-tier login fallback**: Cookie extract → CDP → QR httpx → patchright
+- **Platform-aware login**: `zhipin` uses Cookie → CDP → QR httpx → patchright; `zhilian` uses Cookie → CDP → browser login
 - **Cross-platform adapter layer**: `Platform` / `RecruiterPlatform` registries are live; BOSS is available on both candidate and recruiter sides, and Zhaopin already has candidate-side envelope and command compatibility wired in
 - **MCP server with 49 tools**: ready for Claude Desktop / Cursor / Windsurf, including recruiter-side tools without wrapping your own bridge
 
@@ -142,6 +142,11 @@ boss-agent-cli covers both the job-seeker and the recruiter side, with a pluggab
 boss --platform zhilian search "Python"
 boss config set platform zhilian
 ```
+
+Notes:
+- `boss login` follows the current platform selection
+- `boss --platform zhilian login` is now available for candidate-side auth
+- `boss --platform zhilian hr ...` is still intentionally rejected at runtime because recruiter support is not implemented yet
 
 Architecture notes: [docs/platform-abstraction.md](docs/platform-abstraction.md).
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ uv run patchright install chromium
 # 1. 环境自检
 boss doctor
 
-# 2. 登录（自动四级降级）
+# 2. 登录（按平台选择链路）
 boss login
 
 # 3. 验证登录态
@@ -167,14 +167,17 @@ boss hr jobs list                     # 我发布的职位
 
 ## 🔐 登录链路
 
-`boss login` 采用**四级降级策略**，适配不同环境：
+`boss login` 会按当前平台选择登录链路：
 
-| 级别 | 方式 | 说明 | 需要浏览器？ |
-|:---:|------|------|:---:|
-| 1 | **Cookie 提取** | 从本地 Chrome/Firefox/Edge 等 10+ 浏览器免扫码提取 | 否 |
-| 2 | **CDP 登录** | 复用带 `--remote-debugging-port` 的 Chrome | 需 Chrome |
-| 3 | **QR httpx** | 纯 HTTP 二维码扫码，无需安装任何浏览器 | 否 |
-| 4 | **patchright** | 反检测 Chromium 兜底 | 需 Chromium |
+| 平台 | 登录链路 | 说明 |
+|------|----------|------|
+| `zhipin` | **Cookie 提取 → CDP → QR httpx → patchright** | 保留现有四级降级链路 |
+| `zhilian` | **Cookie 提取 → CDP → 浏览器登录** | 当前优先复用本地浏览器登录态；无 QR httpx 分支 |
+
+补充说明：
+- `boss login` 默认按当前 `--platform` / 配置文件里的 `platform` 工作
+- `boss --platform zhilian login` 已可用，但目前只覆盖**求职者侧**认证链路
+- `boss --platform zhilian hr ...` 仍不支持，招聘者侧继续追踪 [Issue #140](https://github.com/can4hou6joeng4/boss-agent-cli/issues/140)
 
 <details>
 <summary>📖 CDP 启动示例</summary>
@@ -216,6 +219,10 @@ boss --role recruiter ...
 boss hr applications
 boss hr candidates "Golang"
 ```
+
+注意：
+- `boss hr ...` 当前仅支持默认招聘者平台 `zhipin-recruiter`
+- 若当前平台是 `zhilian`，CLI 会在入口直接提示切回 `boss --platform zhipin hr ...`
 
 ### 多平台抽象
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ boss digest                                                  # 每日汇报
 
 ### 平台与集成基础
 
-- `🔌 多平台抽象`：`Platform` / `RecruiterPlatform` 双注册表已落地，BOSS 直聘可用、智联招聘骨架已接入。命令：`--platform zhipin|zhilian`
+- `🔌 多平台抽象`：`Platform` / `RecruiterPlatform` 双注册表已落地；BOSS 直聘求职者/招聘者均可用，智联招聘已接通求职者侧包络与命令兼容。命令：`--platform zhipin|zhilian`
 - `📤 结构化输出`：stdout 只输出 JSON 信封，适合 CLI 编排、Shell Agent、MCP 和 Python SDK。命令：`schema` `export`
 - `🧩 Agent 接入`：同一套能力可通过 Skill、subprocess、MCP、Python SDK 四种路径暴露给 Agent。文档：`docs/agent-quickstart.md` `docs/agent-hosts.md`
 
@@ -224,7 +224,7 @@ boss hr candidates "Golang"
 | 平台 | 求职者 | 招聘者 | 状态 |
 |------|:------:|:------:|------|
 | BOSS 直聘 (`zhipin`) | ✅ | ✅ | 默认 |
-| 智联招聘 (`zhilian`) | 🟡 骨架 | — | 真实现追踪 [Issue #140](https://github.com/can4hou6joeng4/boss-agent-cli/issues/140) |
+| 智联招聘 (`zhilian`) | 🟡 包络与命令兼容已接通 | — | 招聘者侧未接入，继续追踪 [Issue #140](https://github.com/can4hou6joeng4/boss-agent-cli/issues/140) |
 
 ```bash
 # 指定平台
@@ -537,7 +537,7 @@ CLI (Click)
     │
     ├── Platform 抽象层（多平台注册表）
     │       ├── BossPlatform (求职者) / BossRecruiterPlatform (招聘者)
-    │       └── ZhilianPlatform (骨架已接入，真实现 tracking Issue #140)
+    │       └── ZhilianPlatform (求职者侧包络与命令兼容已接通，招聘者侧未接入)
     │
     ├── BossClient / BossRecruiterClient ── httpx (低风险) + 浏览器 (高风险) 双通道
     │       ├── RequestThrottle (高斯延迟 + 突发惩罚)

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -42,6 +42,7 @@ boss greet <security_id> <job_id>
 解析约定：
 - `stdout` 只读 JSON 信封
 - `ok=true` 代表成功，`ok=false` 时读取 `error.code` 与 `error.recovery_action`
+- `boss schema` 除了返回 `supported_platforms` / `supported_recruiter_platforms`，还会给每个命令附带 `availability`，可直接按 `role/platform` 做工具路由
 
 ### 招聘者最小闭环
 

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -22,6 +22,7 @@ boss status
 完成标准：
 - `boss doctor` 返回 `ok=true`
 - `boss status` 返回当前登录态
+- 若使用 `zhilian`，请显式带上平台：`boss --platform zhilian doctor && boss --platform zhilian login`
 
 如果你不是直接在终端里手动跑命令，而是准备把它接进 Agent 宿主，先看 [Agent Host Examples](agent-hosts.md) 选择对应接入模板。
 
@@ -65,6 +66,7 @@ boss hr request-resume <friend_id> --job-id <job_id>
 - 先把 `boss schema` 里的 `hr` 命令组当作招聘者能力真源
 - `boss hr <subcommand>` 会自动切到 recruiter 角色，不需要额外推断 `--role`
 - 求职者与招聘者两端都遵守同一套 `stdout JSON / stderr 日志` 契约
+- 当前 `hr` 只支持 `zhipin-recruiter`；若当前平台切到 `zhilian`，CLI 会直接拒绝执行 recruiter 子命令
 
 ## 3) 失败恢复与排障
 

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -101,5 +101,6 @@
 
 说明：
 - **通道**：httpx 为直接 API 请求（低风险），浏览器为 CDP/patchright 通道（高风险操作需要真实浏览器指纹），AI 服务为第三方大模型 API。
-- 若以 CLI 直连为主，优先通过 `boss schema` 进行能力发现与参数校验。
+- 若以 CLI 直连为主，优先通过 `boss schema` 进行能力发现与参数校验；当前 schema 会同时暴露 `supported_platforms` 与 `supported_recruiter_platforms`。
+- 当前多平台状态：`zhipin` 已覆盖求职者与招聘者；`zhilian` 已接通求职者侧包络与命令兼容，招聘者侧暂未接入。
 - 以 `boss schema` 为准：当前暴露 33 个顶层命令；其中 `hr` 下还有 7 个一级招聘者子命令，`ai` / `resume` 为命令组入口。

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -103,4 +103,5 @@
 - **通道**：httpx 为直接 API 请求（低风险），浏览器为 CDP/patchright 通道（高风险操作需要真实浏览器指纹），AI 服务为第三方大模型 API。
 - 若以 CLI 直连为主，优先通过 `boss schema` 进行能力发现与参数校验；当前 schema 会同时暴露 `supported_platforms` 与 `supported_recruiter_platforms`。
 - 当前多平台状态：`zhipin` 已覆盖求职者与招聘者；`zhilian` 已接通求职者侧包络与命令兼容，招聘者侧暂未接入。
+- 当前登录状态：`zhipin` 保留四级降级登录；`zhilian` 已接通候选者侧浏览器登录基础链路（Cookie / CDP / 浏览器兜底），但 recruiter 侧仍未接入。
 - 以 `boss schema` 为准：当前暴露 33 个顶层命令；其中 `hr` 下还有 7 个一级招聘者子命令，`ai` / `resume` 为命令组入口。

--- a/docs/integrations/python-sdk.md
+++ b/docs/integrations/python-sdk.md
@@ -21,6 +21,10 @@
 
 后两种格式可直接喂给对应 SDK 的 `tools=` 参数，无需手写转换。
 
+补充说明：
+- `native` schema 里每个命令都带有 `availability`，可用于在业务侧先做 `role/platform` 过滤
+- `openai-tools` / `anthropic-tools` 导出的 `description` 也会内嵌同一份可用性提示，方便模型直接感知边界
+
 ## 最小 OpenAI 示例
 
 `examples/openai_agent.py`：

--- a/docs/smoke-testing.md
+++ b/docs/smoke-testing.md
@@ -2,6 +2,8 @@
 
 `scripts/smoke_p0.py` provides a minimal structured smoke harness for the current P0 golden path.
 
+By default it targets `zhipin`. Set `BOSS_SMOKE_PLATFORM=zhilian` to run the same P0 shape against the Zhilian candidate path and have each step automatically prepend `--platform zhilian`.
+
 ## Covered Steps
 
 - `doctor`
@@ -15,6 +17,7 @@ The script prints JSON describing each step:
 
 - `name`
 - `purpose`
+- `platform`
 - `preconditions`
 - `failure_classification`
 - `command`

--- a/scripts/smoke_p0.py
+++ b/scripts/smoke_p0.py
@@ -11,42 +11,52 @@ ROOT = Path(__file__).resolve().parents[1]
 @dataclass(frozen=True)
 class SmokeStep:
 	name: str
+	platform: str
 	purpose: str
 	preconditions: list[str]
 	failure_classification: str
 	command: list[str]
 
 
-DEFAULT_STEPS = [
-	SmokeStep(
-		name="doctor",
-		purpose="验证本地环境、自检和网络前提",
-		preconditions=["command:boss"],
-		failure_classification="env_error",
-		command=["boss", "doctor"],
-	),
-	SmokeStep(
-		name="status",
-		purpose="验证本地登录态是否存在且可读取",
-		preconditions=["command:boss"],
-		failure_classification="env_error",
-		command=["boss", "status"],
-	),
-	SmokeStep(
-		name="search",
-		purpose="验证最小职位发现路径可执行",
-		preconditions=["command:boss", "env:BOSS_SMOKE_QUERY"],
-		failure_classification="command_error",
-		command=["boss", "search", "golang"],
-	),
-	SmokeStep(
-		name="detail",
-		purpose="验证职位详情路径具备可测试入口",
-		preconditions=["command:boss", "env:BOSS_SMOKE_SECURITY_ID"],
-		failure_classification="command_error",
-		command=["boss", "detail", "demo-security-id"],
-	),
-]
+def build_default_steps(platform: str = "zhipin") -> list[SmokeStep]:
+	platform_args = ["--platform", platform] if platform != "zhipin" else []
+	return [
+		SmokeStep(
+			name="doctor",
+			platform=platform,
+			purpose="验证本地环境、自检和网络前提",
+			preconditions=["command:boss"],
+			failure_classification="env_error",
+			command=["boss", *platform_args, "doctor"],
+		),
+		SmokeStep(
+			name="status",
+			platform=platform,
+			purpose="验证本地登录态是否存在且可读取",
+			preconditions=["command:boss"],
+			failure_classification="env_error",
+			command=["boss", *platform_args, "status"],
+		),
+		SmokeStep(
+			name="search",
+			platform=platform,
+			purpose="验证最小职位发现路径可执行",
+			preconditions=["command:boss", "env:BOSS_SMOKE_QUERY"],
+			failure_classification="command_error",
+			command=["boss", *platform_args, "search", "golang"],
+		),
+		SmokeStep(
+			name="detail",
+			platform=platform,
+			purpose="验证职位详情路径具备可测试入口",
+			preconditions=["command:boss", "env:BOSS_SMOKE_SECURITY_ID"],
+			failure_classification="command_error",
+			command=["boss", *platform_args, "detail", "demo-security-id"],
+		),
+	]
+
+
+DEFAULT_STEPS = build_default_steps()
 
 
 class SmokeRunner:
@@ -91,7 +101,8 @@ class SmokeRunner:
 
 
 def main():
-	runner = SmokeRunner(DEFAULT_STEPS)
+	platform = os.environ.get("BOSS_SMOKE_PLATFORM", "zhipin").strip() or "zhipin"
+	runner = SmokeRunner(build_default_steps(platform))
 	print(json.dumps(runner.run(), ensure_ascii=False))
 
 

--- a/src/boss_agent_cli/api/zhilian_client.py
+++ b/src/boss_agent_cli/api/zhilian_client.py
@@ -17,6 +17,7 @@ Week 2 P0 先落地只读链路：基础 httpx client + 4 个读接口，
 from __future__ import annotations
 
 import atexit
+from html.parser import HTMLParser
 import random
 import sys
 import time
@@ -38,6 +39,9 @@ SEARCH_URL = "https://fe-api.zhaopin.com/api/c/salesman-search/v2"
 DETAIL_URL_TEMPLATE = "https://fe-api.zhaopin.com/api/c/jobs/{job_id}/info"
 RECOMMEND_URL = "https://fe-api.zhaopin.com/api/c/recom-position"
 USER_INFO_URL = "https://i.zhaopin.com/api/c/account/profile"
+CSRF_BOOTSTRAP_URL = "https://www.zhaopin.com/"
+GREET_URL = "https://fe-api.zhaopin.com/c/i/liaoliao/startConversation"
+APPLY_URL = "https://fe-api.zhaopin.com/c/i/sou/deliverPosition"
 
 _DEFAULT_HEADERS: dict[str, str] = {
 	"Accept": "application/json, text/plain, */*",
@@ -54,6 +58,27 @@ _REFERER_MAP: dict[str, str] = {
 
 # atexit safeguard：类比 BossClient 的管理方式
 _OPEN_CLIENTS: weakref.WeakSet["ZhilianClient"] = weakref.WeakSet()
+
+
+class _CsrfMetaParser(HTMLParser):
+	"""从 HTML meta 标签中提取 csrf-token。"""
+
+	def __init__(self) -> None:
+		super().__init__()
+		self.csrf_token: str | None = None
+
+	def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+		if tag.lower() != "meta" or self.csrf_token:
+			return
+		attr_map = {key.lower(): value for key, value in attrs}
+		if attr_map.get("name") == "csrf-token" and attr_map.get("content"):
+			self.csrf_token = attr_map["content"]
+
+
+def _extract_csrf_token(html: str) -> str | None:
+	parser = _CsrfMetaParser()
+	parser.feed(html)
+	return parser.csrf_token
 
 
 def _close_open_clients() -> None:
@@ -84,6 +109,7 @@ class ZhilianClient:
 		self._delay = delay
 		self._cdp_url = cdp_url
 		self._client: httpx.Client | None = None
+		self._csrf_token: str | None = None
 		self._throttle = RequestThrottle(delay)
 		self._closed = False
 		_OPEN_CLIENTS.add(self)
@@ -113,6 +139,33 @@ class ZhilianClient:
 	def _headers_for(self, url: str) -> dict[str, str]:
 		return {"Referer": _REFERER_MAP.get(url, "https://www.zhaopin.com/")}
 
+	def _fetch_csrf_token(self) -> str:
+		for attempt in range(_MAX_RETRIES + 1):
+			client = self._get_client()
+			self._throttle.wait()
+			resp = client.get(
+				CSRF_BOOTSTRAP_URL,
+				headers={"Referer": CSRF_BOOTSTRAP_URL, "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"},
+			)
+			self._throttle.mark()
+			self._merge_cookies(resp)
+
+			if resp.status_code in (401, 403) and attempt < _MAX_RETRIES:
+				backoff = (2 ** attempt) + random.uniform(0.3, 0.9)
+				time.sleep(backoff)
+				self._auth.force_refresh(cdp_url=self._cdp_url)
+				self._client = None
+				self._csrf_token = None
+				continue
+
+			resp.raise_for_status()
+			token = _extract_csrf_token(resp.text)
+			if token:
+				return token
+			raise RuntimeError("智联页面未找到 csrf-token")
+
+		raise RuntimeError("智联 csrf-token 获取失败，已达最大重试次数")
+
 	def _merge_cookies(self, resp: httpx.Response) -> None:
 		for name, value in resp.cookies.items():
 			if value:
@@ -122,7 +175,9 @@ class ZhilianClient:
 		for attempt in range(_MAX_RETRIES + 1):
 			client = self._get_client()
 			self._throttle.wait()
-			resp = client.request(method, url, headers=self._headers_for(url), **kwargs)
+			extra_headers = kwargs.pop("headers", {})
+			headers = {**self._headers_for(url), **extra_headers}
+			resp = client.request(method, url, headers=headers, **kwargs)
 			self._throttle.mark()
 			self._merge_cookies(resp)
 
@@ -177,6 +232,40 @@ class ZhilianClient:
 		self.close()
 
 	# ── P0 只读 ────────────────────────────────────
+
+	def get_csrf_token(self, *, force_refresh: bool = False) -> str:
+		"""获取并缓存智联写操作所需的 csrf-token。"""
+		if force_refresh or not self._csrf_token:
+			self._csrf_token = self._fetch_csrf_token()
+		return self._csrf_token
+
+	def greet(self, security_id: str, job_id: str, message: str = "") -> dict[str, Any]:
+		payload: dict[str, Any] = {
+			"securityId": security_id,
+			"jobId": job_id,
+		}
+		if message:
+			payload["message"] = message
+		return self._request(
+			"POST",
+			GREET_URL,
+			data=payload,
+			headers={"csrf-token": self.get_csrf_token()},
+		)
+
+	def apply(self, security_id: str, job_id: str, lid: str = "") -> dict[str, Any]:
+		payload: dict[str, Any] = {
+			"securityId": security_id,
+			"jobId": job_id,
+		}
+		if lid:
+			payload["lid"] = lid
+		return self._request(
+			"POST",
+			APPLY_URL,
+			data=payload,
+			headers={"csrf-token": self.get_csrf_token()},
+		)
 
 	def search_jobs(self, query: str, **filters: Any) -> dict[str, Any]:
 		params: dict[str, Any] = {

--- a/src/boss_agent_cli/api/zhilian_client.py
+++ b/src/boss_agent_cli/api/zhilian_client.py
@@ -1,34 +1,55 @@
-"""智联招聘内部 HTTP 客户端骨架（Week 2 实施前占位）。
+"""智联招聘内部 HTTP 客户端。
 
-**当前状态**：类结构 + __init__/close 签名对齐 BossClient，所有 P0/P1/P2 方法抛
-``NotImplementedError("Zhilian client Week 2 待实现，详见 Issue #140")``。
+Week 2 P0 先落地只读链路：基础 httpx client + 4 个读接口，
+保持 ``BossClient`` 风格的资源生命周期和重试语义。
 
-**Week 2 TODO**（Issue #140）：
-- 基于 httpx 实现真实 HTTP 调用
-- 基于 BrowserSession / Bridge 获取 CSRF token
-- 实现 search_jobs / job_detail / recommend_jobs / user_info 四个 P0 只读方法
-- 认证链路（Cookie + X-Lagou-Token 或智联对应 token）
+**当前范围**：
+- ``search_jobs`` / ``job_detail`` / ``recommend_jobs`` / ``user_info``
+- Cookie + User-Agent + ``x-zp-client-id`` 透传
+- 401/403 刷新、429 退避
 
-**设计依据**：
-- [docs/research/platforms/zhaopin.md](../../docs/research/platforms/zhaopin.md) §2 端点清单
-- [src/boss_agent_cli/platforms/zhilian.py](../platforms/zhilian.py) Platform 适配层
+**暂不包含**：
+- CSRF token 获取
+- greet / apply 写操作
+- BrowserSession / Bridge 写通道
 """
 
 from __future__ import annotations
 
 import atexit
+import random
+import sys
+import time
 import weakref
 from types import TracebackType
 from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from boss_agent_cli.api.throttle import RequestThrottle
 
 if TYPE_CHECKING:
 	from boss_agent_cli.auth.manager import AuthManager
 
 
-_NOT_YET_MSG = (
-	"Zhilian client Week 2 待实现，当前为 stub 占位，"
-	"追踪进度见 Issue #140（https://github.com/can4hou6joeng4/boss-agent-cli/issues/140）"
-)
+_MAX_RETRIES = 3
+
+SEARCH_URL = "https://fe-api.zhaopin.com/api/c/salesman-search/v2"
+DETAIL_URL_TEMPLATE = "https://fe-api.zhaopin.com/api/c/jobs/{job_id}/info"
+RECOMMEND_URL = "https://fe-api.zhaopin.com/api/c/recom-position"
+USER_INFO_URL = "https://i.zhaopin.com/api/c/account/profile"
+
+_DEFAULT_HEADERS: dict[str, str] = {
+	"Accept": "application/json, text/plain, */*",
+	"X-Requested-With": "XMLHttpRequest",
+	"Referer": "https://www.zhaopin.com/",
+}
+
+_REFERER_MAP: dict[str, str] = {
+	SEARCH_URL: "https://sou.zhaopin.com/",
+	RECOMMEND_URL: "https://www.zhaopin.com/",
+	USER_INFO_URL: "https://i.zhaopin.com/",
+}
 
 
 # atexit safeguard：类比 BossClient 的管理方式
@@ -62,14 +83,87 @@ class ZhilianClient:
 		self._auth = auth_manager
 		self._delay = delay
 		self._cdp_url = cdp_url
+		self._client: httpx.Client | None = None
+		self._throttle = RequestThrottle(delay)
 		self._closed = False
 		_OPEN_CLIENTS.add(self)
+
+	def _get_client(self) -> httpx.Client:
+		if self._client is None:
+			token = self._auth.get_token()
+			headers = dict(_DEFAULT_HEADERS)
+			if ua := token.get("user_agent"):
+				headers["User-Agent"] = str(ua)
+			if client_id := token.get("x_zp_client_id") or token.get("client_id"):
+				headers["x-zp-client-id"] = str(client_id)
+			if sys.platform == "win32":
+				headers["sec-ch-ua-platform"] = '"Windows"'
+			elif sys.platform == "linux":
+				headers["sec-ch-ua-platform"] = '"Linux"'
+			else:
+				headers["sec-ch-ua-platform"] = '"macOS"'
+			self._client = httpx.Client(
+				cookies=token.get("cookies", {}),
+				headers=headers,
+				follow_redirects=True,
+				timeout=30,
+			)
+		return self._client
+
+	def _headers_for(self, url: str) -> dict[str, str]:
+		return {"Referer": _REFERER_MAP.get(url, "https://www.zhaopin.com/")}
+
+	def _merge_cookies(self, resp: httpx.Response) -> None:
+		for name, value in resp.cookies.items():
+			if value:
+				self._get_client().cookies.set(name, value)
+
+	def _request(self, method: str, url: str, **kwargs: Any) -> dict[str, Any]:
+		for attempt in range(_MAX_RETRIES + 1):
+			client = self._get_client()
+			self._throttle.wait()
+			resp = client.request(method, url, headers=self._headers_for(url), **kwargs)
+			self._throttle.mark()
+			self._merge_cookies(resp)
+
+			status_code = resp.status_code
+			if status_code in (401, 403) and attempt < _MAX_RETRIES:
+				backoff = (2 ** attempt) + random.uniform(0.3, 0.9)
+				time.sleep(backoff)
+				self._auth.force_refresh(cdp_url=self._cdp_url)
+				self._client = None
+				continue
+			if status_code == 429 and attempt < _MAX_RETRIES:
+				time.sleep(min(30, 5 * (2 ** attempt)))
+				continue
+
+			resp.raise_for_status()
+			data = resp.json()
+			code = data.get("code")
+			if code in (401, 403) and attempt < _MAX_RETRIES:
+				backoff = (2 ** attempt) + random.uniform(0.3, 0.9)
+				time.sleep(backoff)
+				self._auth.force_refresh(cdp_url=self._cdp_url)
+				self._client = None
+				continue
+			if code == 429 and attempt < _MAX_RETRIES:
+				time.sleep(min(30, 5 * (2 ** attempt)))
+				continue
+			return data
+
+		raise RuntimeError("智联请求失败，已达最大重试次数")
 
 	# ── 资源生命周期 ───────────────────────────────
 
 	def close(self) -> None:
-		"""释放底层资源。Week 2 真实现后会关闭 httpx client 和 browser session。"""
+		"""释放底层资源。"""
+		if self._closed:
+			return
 		self._closed = True
+		if self._client is not None:
+			self._client.close()
+			self._client = None
+		_OPEN_CLIENTS.discard(self)
 
 	def __enter__(self) -> "ZhilianClient":
 		return self
@@ -82,16 +176,35 @@ class ZhilianClient:
 	) -> None:
 		self.close()
 
-	# ── P0 只读（Week 2 待实现）─────────────────────
+	# ── P0 只读 ────────────────────────────────────
 
 	def search_jobs(self, query: str, **filters: Any) -> dict[str, Any]:
-		raise NotImplementedError(f"{_NOT_YET_MSG}: search_jobs(query={query!r}, filters={filters!r})")
+		params: dict[str, Any] = {
+			"keyword": query,
+			"pageNum": filters.get("page", 1),
+		}
+		if page_size := filters.get("page_size"):
+			params["pageSize"] = page_size
+		filter_map = {
+			"city": "cityId",
+			"salary": "salary",
+			"experience": "workExp",
+			"education": "education",
+			"scale": "companySize",
+			"industry": "industry",
+			"stage": "financingStage",
+			"job_type": "jobType",
+		}
+		for source_key, target_key in filter_map.items():
+			if value := filters.get(source_key):
+				params[target_key] = value
+		return self._request("GET", SEARCH_URL, params=params)
 
 	def job_detail(self, job_id: str) -> dict[str, Any]:
-		raise NotImplementedError(f"{_NOT_YET_MSG}: job_detail(job_id={job_id!r})")
+		return self._request("GET", DETAIL_URL_TEMPLATE.format(job_id=job_id))
 
 	def recommend_jobs(self, page: int = 1) -> dict[str, Any]:
-		raise NotImplementedError(f"{_NOT_YET_MSG}: recommend_jobs(page={page})")
+		return self._request("GET", RECOMMEND_URL, params={"pageNum": page})
 
 	def user_info(self) -> dict[str, Any]:
-		raise NotImplementedError(f"{_NOT_YET_MSG}: user_info()")
+		return self._request("GET", USER_INFO_URL)

--- a/src/boss_agent_cli/api/zhilian_client.py
+++ b/src/boss_agent_cli/api/zhilian_client.py
@@ -194,6 +194,8 @@ class ZhilianClient:
 
 			resp.raise_for_status()
 			data = resp.json()
+			if not isinstance(data, dict):
+				raise RuntimeError("智联响应格式异常：期望 JSON object")
 			code = data.get("code")
 			if code in (401, 403) and attempt < _MAX_RETRIES:
 				backoff = (2 ** attempt) + random.uniform(0.3, 0.9)

--- a/src/boss_agent_cli/auth/browser.py
+++ b/src/boss_agent_cli/auth/browser.py
@@ -14,6 +14,44 @@ _NAV_TIMEOUT_MS = 15000          # 页面导航超时（毫秒）
 _POST_LOGIN_WAIT = 3             # 登录成功后等待 cookie 传播（秒）
 _STOKEN_GENERATION_WAIT = 2      # stoken 生成等待（秒）
 
+_PLATFORM_BROWSER_CONFIG: dict[str, dict[str, str]] = {
+	"zhipin": {
+		"login_page_url": LOGIN_PAGE_URL,
+		"home_url": HOME_URL,
+		"cookie_domain": "zhipin",
+		"success_cookie": "wt2",
+	},
+	"zhilian": {
+		"login_page_url": "https://passport.zhaopin.com/v5/login",
+		"home_url": "https://www.zhaopin.com/",
+		"cookie_domain": "zhaopin",
+		"success_cookie": "zp_token",
+	},
+}
+
+
+def _get_platform_config(platform: str) -> dict[str, str]:
+	config = _PLATFORM_BROWSER_CONFIG.get(platform)
+	if config is None:
+		raise ValueError(f"unsupported platform: {platform}")
+	return config
+
+
+def _extract_zhilian_client_id(page: Any) -> str:
+	try:
+		return cast("str", page.evaluate("""
+			() => {
+				const keys = ["x-zp-client-id", "x_zp_client_id", "clientId"];
+				for (const key of keys) {
+					const value = window.localStorage.getItem(key) || window.sessionStorage.getItem(key);
+					if (value) return value;
+				}
+				return '';
+			}
+		"""))
+	except Exception:
+		return ""
+
 
 def probe_cdp(cdp_url: str | None = None) -> str | None:
 	"""探测 CDP 是否可用，返回 WebSocket URL 或 None。"""
@@ -26,11 +64,16 @@ def probe_cdp(cdp_url: str | None = None) -> str | None:
 		return None
 
 
-def login_via_cdp(*, cdp_url: str | None = None, timeout: int = 120) -> dict[str, Any]:
+def login_via_cdp(*, cdp_url: str | None = None, timeout: int = 120, platform: str = "zhipin") -> dict[str, Any]:
 	"""
 	通过 CDP 连接用户 Chrome 扫码登录。
 	返回 token dict，失败抛异常。
 	"""
+	config = _get_platform_config(platform)
+	login_page_url = config["login_page_url"]
+	home_url = config["home_url"]
+	cookie_domain = config["cookie_domain"]
+	success_cookie = config["success_cookie"]
 	ws_url = probe_cdp(cdp_url)
 	if not ws_url:
 		raise ConnectionError("CDP 不可用，请先运行 boss-chrome 启动带调试端口的 Chrome")
@@ -43,7 +86,7 @@ def login_via_cdp(*, cdp_url: str | None = None, timeout: int = 120) -> dict[str
 
 	try:
 		page.goto(
-			f"{LOGIN_PAGE_URL}?ka=header-login",
+			login_page_url,
 			wait_until="commit", timeout=_NAV_TIMEOUT_MS,
 		)
 	except Exception:
@@ -54,8 +97,8 @@ def login_via_cdp(*, cdp_url: str | None = None, timeout: int = 120) -> dict[str
 	for i in range(timeout):
 		time.sleep(1)
 		cookies = ctx.cookies()
-		wt2 = [c for c in cookies if c["name"] == "wt2" and "zhipin" in c.get("domain", "")]
-		if wt2:
+		success = [c for c in cookies if c["name"] == success_cookie and cookie_domain in c.get("domain", "")]
+		if success:
 			print("[boss] 检测到登录成功！", file=sys.stderr)
 			break
 		if i > 0 and i % 15 == 0:
@@ -65,20 +108,33 @@ def login_via_cdp(*, cdp_url: str | None = None, timeout: int = 120) -> dict[str
 		pw.stop()
 		raise TimeoutError(f"CDP 扫码登录超时（{timeout}s）")
 
-	all_cookies = {c["name"]: c["value"] for c in ctx.cookies() if "zhipin" in c.get("domain", "")}
+	try:
+		page.goto(home_url, wait_until="domcontentloaded", timeout=_NAV_TIMEOUT_MS)
+	except Exception:
+		pass
+	all_cookies = {c["name"]: c["value"] for c in ctx.cookies() if cookie_domain in c.get("domain", "")}
 	ua = page.evaluate("navigator.userAgent")
+	x_zp_client_id = _extract_zhilian_client_id(page) if platform == "zhilian" else ""
 
 	page.close()
 	pw.stop()
 
-	return {"cookies": all_cookies, "stoken": "", "user_agent": ua}
+	result: dict[str, Any] = {"cookies": all_cookies, "stoken": "", "user_agent": ua}
+	if x_zp_client_id:
+		result["x_zp_client_id"] = x_zp_client_id
+	return result
 
 
-def login_via_browser(*, timeout: int = 120) -> dict[str, Any]:
+def login_via_browser(*, timeout: int = 120, platform: str = "zhipin") -> dict[str, Any]:
 	"""
 	使用 patchright（Playwright 反检测 fork）打开登录页。
 	双重检测登录成功：监听 API 响应 + 轮询 wt2 cookie。
 	"""
+	config = _get_platform_config(platform)
+	login_page_url = config["login_page_url"]
+	home_url = config["home_url"]
+	cookie_domain = config["cookie_domain"]
+	success_cookie = config["success_cookie"]
 	with sync_playwright() as p:
 		browser = p.chromium.launch(headless=False)
 		context = browser.new_context(
@@ -88,7 +144,7 @@ def login_via_browser(*, timeout: int = 120) -> dict[str, Any]:
 		)
 		page = context.new_page()
 
-		page.goto(LOGIN_PAGE_URL, wait_until="domcontentloaded")
+		page.goto(login_page_url, wait_until="domcontentloaded")
 		print("已打开 BOSS 直聘登录页。", file=sys.stderr)
 		print(f"请扫码或手机号登录（超时 {timeout} 秒）...", file=sys.stderr)
 
@@ -110,7 +166,7 @@ def login_via_browser(*, timeout: int = 120) -> dict[str, Any]:
 			# 也通过 cookie 检测（覆盖 API 匹配不上的情况）
 			try:
 				cookies_list = context.cookies()
-				if any(c["name"] == "wt2" for c in cookies_list):
+				if any(c["name"] == success_cookie and cookie_domain in c.get("domain", "") for c in cookies_list):
 					login_detected = True
 					break
 			except Exception:
@@ -125,21 +181,25 @@ def login_via_browser(*, timeout: int = 120) -> dict[str, Any]:
 		time.sleep(_POST_LOGIN_WAIT)
 
 		# 跳转主站提取完整 cookies 和 stoken
-		page.goto(HOME_URL, wait_until="domcontentloaded")
+		page.goto(home_url, wait_until="domcontentloaded")
 		page.wait_for_load_state("networkidle")
 
 		cookies_list = context.cookies()
-		cookies = {c["name"]: c["value"] for c in cookies_list}
+		cookies = {c["name"]: c["value"] for c in cookies_list if cookie_domain in c.get("domain", "")}
 		user_agent = page.evaluate("navigator.userAgent")
-		stoken = _extract_stoken(page)
+		stoken = _extract_stoken(page) if platform == "zhipin" else ""
+		x_zp_client_id = _extract_zhilian_client_id(page) if platform == "zhilian" else ""
 
 		browser.close()
 
-	return {
+	result: dict[str, Any] = {
 		"cookies": cookies,
 		"stoken": stoken,
 		"user_agent": user_agent,
 	}
+	if x_zp_client_id:
+		result["x_zp_client_id"] = x_zp_client_id
+	return result
 
 
 def refresh_stoken_via_cdp(cdp_url: str | None = None) -> str:

--- a/src/boss_agent_cli/auth/cookie_extract.py
+++ b/src/boss_agent_cli/auth/cookie_extract.py
@@ -2,9 +2,23 @@ import sys
 from typing import Any, Callable
 
 
-def extract_cookies(source: str | None = None) -> dict[str, Any] | None:
+_PLATFORM_COOKIE_CONFIG: dict[str, dict[str, str]] = {
+	"zhipin": {
+		"domain": ".zhipin.com",
+		"required_cookie": "wt2",
+		"stoken_cookie": "__zp_stoken__",
+	},
+	"zhilian": {
+		"domain": ".zhaopin.com",
+		"required_cookie": "zp_token",
+		"stoken_cookie": "",
+	},
+}
+
+
+def extract_cookies(source: str | None = None, *, platform: str = "zhipin") -> dict[str, Any] | None:
 	"""
-	从本地浏览器提取 zhipin.com 的 Cookie。
+	从本地浏览器提取指定平台的 Cookie。
 	source: 指定浏览器名（如 "chrome"），None 则自动检测。
 	返回 {"cookies": {...}, "user_agent": "", "stoken": ""} 或 None。
 	"""
@@ -12,6 +26,13 @@ def extract_cookies(source: str | None = None) -> dict[str, Any] | None:
 		import browser_cookie3
 	except ImportError:
 		return None
+	config = _PLATFORM_COOKIE_CONFIG.get(platform)
+	if config is None:
+		print(f"不支持的平台: {platform}", file=sys.stderr)
+		return None
+	domain_name = config["domain"]
+	required_cookie = config["required_cookie"]
+	stoken_cookie = config["stoken_cookie"]
 
 	# 浏览器加载函数映射
 	loaders = {
@@ -29,29 +50,46 @@ def extract_cookies(source: str | None = None) -> dict[str, Any] | None:
 		if loader is None:
 			print(f"不支持的浏览器: {source}，支持: {', '.join(loaders.keys())}", file=sys.stderr)
 			return None
-		return _try_extract(loader)
+		return _try_extract(
+			loader,
+			domain_name=domain_name,
+			required_cookie=required_cookie,
+			stoken_cookie=stoken_cookie,
+		)
 
 	# 自动检测：按优先级尝试
 	for name, loader in loaders.items():
-		result = _try_extract(loader)
+		result = _try_extract(
+			loader,
+			domain_name=domain_name,
+			required_cookie=required_cookie,
+			stoken_cookie=stoken_cookie,
+		)
 		if result:
-			print(f"从 {name} 提取到 BOSS 直聘 Cookie", file=sys.stderr)
+			print(f"从 {name} 提取到 {platform} Cookie", file=sys.stderr)
 			return result
 
 	return None
 
 
-def _try_extract(loader: Callable[..., Any]) -> dict[str, Any] | None:
-	"""尝试从单个浏览器提取 zhipin.com cookies"""
+def _try_extract(
+	loader: Callable[..., Any],
+	*,
+	domain_name: str = ".zhipin.com",
+	required_cookie: str = "wt2",
+	stoken_cookie: str = "__zp_stoken__",
+) -> dict[str, Any] | None:
+	"""尝试从单个浏览器提取指定域名 cookies。"""
 	try:
-		cj = loader(domain_name=".zhipin.com")
-		cookies = {c.name: c.value for c in cj if "zhipin.com" in (c.domain or "")}
-		if not cookies or "wt2" not in cookies:
+		cj = loader(domain_name=domain_name)
+		domain_fragment = domain_name.lstrip(".")
+		cookies = {c.name: c.value for c in cj if domain_fragment in (c.domain or "")}
+		if not cookies or required_cookie not in cookies:
 			return None
 		return {
 			"cookies": cookies,
 			"user_agent": "",  # browser-cookie3 无法获取 UA，后续由 httpx 默认 UA 补充
-			"stoken": cookies.get("__zp_stoken__", ""),
+			"stoken": cookies.get(stoken_cookie, "") if stoken_cookie else "",
 		}
 	except Exception:
 		# 故意捕获所有异常：browser_cookie3 在浏览器未安装、profile 路径不可访问、

--- a/src/boss_agent_cli/auth/manager.py
+++ b/src/boss_agent_cli/auth/manager.py
@@ -17,8 +17,10 @@ class TokenRefreshFailed(Exception):
 
 
 class AuthManager:
-	def __init__(self, data_dir: Path, *, logger: Logger | None = None) -> None:
-		self._store = TokenStore(data_dir / "auth")
+	def __init__(self, data_dir: Path, *, logger: Logger | None = None, platform: str = "zhipin") -> None:
+		self._platform = platform or "zhipin"
+		auth_dir = data_dir / "auth" if self._platform == "zhipin" else data_dir / "auth" / self._platform
+		self._store = TokenStore(auth_dir)
 		self._token: dict[str, Any] | None = None
 		self._logger = logger or Logger()
 

--- a/src/boss_agent_cli/auth/manager.py
+++ b/src/boss_agent_cli/auth/manager.py
@@ -24,12 +24,15 @@ class AuthManager:
 		self._token: dict[str, Any] | None = None
 		self._logger = logger or Logger()
 
+	def _login_action(self) -> str:
+		return "boss --platform zhilian login" if self._platform == "zhilian" else "boss login"
+
 	def get_token(self) -> dict[str, Any]:
 		if self._token is not None:
 			return self._token
 		self._token = self._store.load()
 		if self._token is None:
-			raise AuthRequired("未登录，请先执行 boss login")
+			raise AuthRequired(f"未登录，请先执行 {self._login_action()}")
 		return self._token
 
 	def login(

--- a/src/boss_agent_cli/auth/manager.py
+++ b/src/boss_agent_cli/auth/manager.py
@@ -51,7 +51,7 @@ class AuthManager:
 		if force_cdp:
 			# --cdp 强制模式：跳过 Cookie，CDP 不可用直接抛异常
 			self._logger.info("强制 CDP 模式，跳过 Cookie 提取")
-			token = login_via_cdp(cdp_url=cdp_url, timeout=timeout)
+			token = login_via_cdp(cdp_url=cdp_url, timeout=timeout, platform=self._platform)
 			method = "CDP 扫码"
 			self._store.save(token)
 			self._token = token
@@ -59,8 +59,8 @@ class AuthManager:
 
 		# 第一步：尝试从本地浏览器提取 Cookie
 		self._logger.info("尝试从本地浏览器提取 Cookie...")
-		token = extract_cookies(cookie_source)
-		if token and token.get("cookies", {}).get("wt2"):
+		token = extract_cookies(cookie_source, platform=self._platform)
+		if token and self._has_primary_cookie(token):
 			if self._verify_cookie(token):
 				self._store.save(token)
 				self._token = token
@@ -74,7 +74,7 @@ class AuthManager:
 		if probe_cdp(cdp_url):
 			self._logger.info("检测到 CDP 可用，尝试 CDP 登录...")
 			try:
-				token = login_via_cdp(cdp_url=cdp_url, timeout=timeout)
+				token = login_via_cdp(cdp_url=cdp_url, timeout=timeout, platform=self._platform)
 				method = "CDP 扫码"
 				self._store.save(token)
 				self._token = token
@@ -84,31 +84,52 @@ class AuthManager:
 		else:
 			self._logger.info("CDP 不可用，尝试 QR 纯 httpx 登录")
 
-		# 第三步：QR 纯 httpx 登录（无需浏览器）
-		try:
-			self._logger.info("尝试 QR 纯 httpx 登录...")
-			token = qr_login_httpx(timeout=timeout)
-			method = "QR httpx 登录"
-			self._store.save(token)
-			self._token = token
-			return {**token, "_method": method}
-		except Exception as e:
-			self._logger.info(f"QR httpx 登录失败（{e}），降级到 patchright")
+		# 第三步：QR 纯 httpx 登录（仅 zhipin）
+		if self._platform == "zhipin":
+			try:
+				self._logger.info("尝试 QR 纯 httpx 登录...")
+				token = qr_login_httpx(timeout=timeout)
+				method = "QR httpx 登录"
+				self._store.save(token)
+				self._token = token
+				return {**token, "_method": method}
+			except Exception as e:
+				self._logger.info(f"QR httpx 登录失败（{e}），降级到 patchright")
 
 		# 第四步：patchright 扫码（兜底）
-		token = login_via_browser(timeout=timeout)
+		token = login_via_browser(timeout=timeout, platform=self._platform)
 		method = "扫码登录"
 		self._store.save(token)
 		self._token = token
 		return {**token, "_method": method}
 
+	def _has_primary_cookie(self, token: dict[str, Any]) -> bool:
+		cookies = token.get("cookies", {})
+		primary_cookie = "wt2" if self._platform == "zhipin" else "zp_token"
+		return bool(cookies.get(primary_cookie))
+
 	def _verify_cookie(self, token: dict[str, Any]) -> bool:
-		"""验证 Cookie 是否有效（不依赖 stoken，直接用 Cookie 请求用户信息）"""
+		"""验证 Cookie 是否有效。"""
 		try:
 			import httpx
+			if self._platform == "zhilian":
+				from boss_agent_cli.api.zhilian_client import USER_INFO_URL
+				headers = {
+					"User-Agent": token.get("user_agent") or "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+					"Referer": "https://i.zhaopin.com/",
+				}
+				if client_id := token.get("x_zp_client_id") or token.get("client_id"):
+					headers["x-zp-client-id"] = str(client_id)
+				resp = httpx.get(
+					USER_INFO_URL,
+					cookies=token.get("cookies", {}),
+					headers=headers,
+					timeout=10,
+				)
+				data = resp.json()
+				return bool(data.get("code") == 200)
+
 			from boss_agent_cli.api import endpoints
-			# 不传 stoken——user_info 接口即使 stoken 为空/错误也能返回用户信息
-			# 只要 Cookie（wt2）有效就会返回 code=0
 			resp = httpx.get(
 				endpoints.USER_INFO_URL,
 				cookies=token.get("cookies", {}),
@@ -130,6 +151,16 @@ class AuthManager:
 				raise TokenRefreshFailed("无法刷新 Token，请重新登录")
 			self._logger.info("Token 过期，正在静默刷新...")
 			try:
+				if self._platform == "zhilian":
+					refreshed = extract_cookies(None, platform=self._platform)
+					if not refreshed or not self._verify_cookie(refreshed):
+						refreshed = login_via_cdp(cdp_url=cdp_url, timeout=30, platform=self._platform)
+					if not refreshed or not self._verify_cookie(refreshed):
+						raise TokenRefreshFailed("智联登录态刷新失败，请重新登录")
+					self._store.save(refreshed)
+					self._token = refreshed
+					return
+
 				# CDP 优先：指纹一致，不会被 BOSS 直聘拒绝
 				if probe_cdp(cdp_url):
 					self._logger.info("检测到 CDP，使用 CDP 刷新 stoken")

--- a/src/boss_agent_cli/commands/apply.py
+++ b/src/boss_agent_cli/commands/apply.py
@@ -28,7 +28,7 @@ def apply_cmd(ctx: click.Context, security_id: str, job_id: str, lid: str) -> No
 			)
 			return
 
-		auth = AuthManager(data_dir, logger=logger)
+		auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 		with get_platform_instance(ctx, auth) as platform:
 			resp = platform.apply(security_id, job_id, lid=lid)
 			if not platform.is_success(resp):

--- a/src/boss_agent_cli/commands/apply.py
+++ b/src/boss_agent_cli/commands/apply.py
@@ -31,11 +31,12 @@ def apply_cmd(ctx: click.Context, security_id: str, job_id: str, lid: str) -> No
 		auth = AuthManager(data_dir, logger=logger)
 		with get_platform_instance(ctx, auth) as platform:
 			resp = platform.apply(security_id, job_id, lid=lid)
-			if resp.get("code") not in (None, 0):
+			if not platform.is_success(resp):
+				error_code, _ = platform.parse_error(resp)
 				handle_error_output(
 					ctx,
 					"apply",
-					code="NETWORK_ERROR",
+					code=error_code if error_code != "UNKNOWN" else "NETWORK_ERROR",
 					message=resp.get("message") or "投递/立即沟通提交失败",
 					recoverable=True,
 					recovery_action="重试",

--- a/src/boss_agent_cli/commands/apply.py
+++ b/src/boss_agent_cli/commands/apply.py
@@ -3,7 +3,7 @@ import click
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.cache.store import CacheStore
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_message_panel
+from boss_agent_cli.display import boss_command_for_ctx, handle_auth_errors, handle_error_output, handle_output, render_message_panel
 
 
 @click.command("apply")
@@ -24,7 +24,12 @@ def apply_cmd(ctx: click.Context, security_id: str, job_id: str, lid: str) -> No
 				"apply",
 				code="ALREADY_APPLIED",
 				message="已对该职位发起过投递/立即沟通",
-				hints={"next_actions": ["boss me --section deliver", "boss chat"]},
+				hints={
+					"next_actions": [
+						boss_command_for_ctx(ctx, "me --section deliver"),
+						boss_command_for_ctx(ctx, "chat"),
+					]
+				},
 			)
 			return
 
@@ -55,5 +60,10 @@ def apply_cmd(ctx: click.Context, security_id: str, job_id: str, lid: str) -> No
 			"message": "投递/立即沟通已提交",
 		},
 		render=lambda d: render_message_panel(d, title="apply"),
-		hints={"next_actions": ["boss me --section deliver", "boss chat"]},
+		hints={
+			"next_actions": [
+				boss_command_for_ctx(ctx, "me --section deliver"),
+				boss_command_for_ctx(ctx, "chat"),
+			]
+		},
 	)

--- a/src/boss_agent_cli/commands/chat.py
+++ b/src/boss_agent_cli/commands/chat.py
@@ -12,7 +12,7 @@ from boss_agent_cli.commands.chat_utils import (
 	RELATION_LABELS, FROM_FILTER, MSG_STATUS_LABELS,
 	sanitize_csv_cell, escape_md_cell,
 )
-from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_simple_list
+from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, login_action_for_ctx, render_simple_list
 
 # 向后兼容别名（旧测试引用 chat._sanitize_csv_cell 等）
 _RELATION_LABELS = RELATION_LABELS
@@ -43,11 +43,12 @@ def chat_cmd(ctx: click.Context, page: int, from_who: str | None, days: int | No
 
 	token = auth.check_status()
 	if token is None:
+		login_action = login_action_for_ctx(ctx)
 		handle_error_output(
 			ctx, "chat",
 			code="AUTH_REQUIRED",
-			message="未登录，请先执行 boss login",
-			recoverable=True, recovery_action="boss login",
+			message=f"未登录，请先执行 {login_action}",
+			recoverable=True, recovery_action=login_action,
 		)
 		return
 

--- a/src/boss_agent_cli/commands/chat.py
+++ b/src/boss_agent_cli/commands/chat.py
@@ -53,8 +53,8 @@ def chat_cmd(ctx: click.Context, page: int, from_who: str | None, days: int | No
 
 	with get_platform_instance(ctx, auth) as platform:
 		resp = platform.friend_list(page=page)
-		zp_data = resp.get("zpData", {})
-		items = zp_data.get("result") or zp_data.get("friendList") or []
+		platform_data = platform.unwrap_data(resp) or {}
+		items = platform_data.get("result") or platform_data.get("friendList") or []
 
 		# 时间筛选阈值
 		cutoff_ts = None

--- a/src/boss_agent_cli/commands/chat.py
+++ b/src/boss_agent_cli/commands/chat.py
@@ -39,7 +39,7 @@ def chat_cmd(ctx: click.Context, page: int, from_who: str | None, days: int | No
 	"""查看沟通列表（支持按发起方、时间筛选，支持导出）"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	auth = AuthManager(data_dir, logger=logger)
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 
 	token = auth.check_status()
 	if token is None:

--- a/src/boss_agent_cli/commands/chat_summary.py
+++ b/src/boss_agent_cli/commands/chat_summary.py
@@ -15,7 +15,7 @@ from boss_agent_cli.display import handle_auth_errors, handle_error_output, hand
 def chat_summary_cmd(ctx: click.Context, security_id: str, page: int, count: int) -> None:
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	auth = AuthManager(data_dir, logger=logger)
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 
 	with get_platform_instance(ctx, auth) as platform:
 		friends_resp = platform.friend_list(page=1)

--- a/src/boss_agent_cli/commands/chat_summary.py
+++ b/src/boss_agent_cli/commands/chat_summary.py
@@ -19,7 +19,8 @@ def chat_summary_cmd(ctx: click.Context, security_id: str, page: int, count: int
 
 	with get_platform_instance(ctx, auth) as platform:
 		friends_resp = platform.friend_list(page=1)
-		items = friends_resp.get("zpData", {}).get("result") or friends_resp.get("zpData", {}).get("friendList") or []
+		friends_data = platform.unwrap_data(friends_resp) or {}
+		items = friends_data.get("result") or friends_data.get("friendList") or []
 
 		gid = None
 		friend_name = "-"
@@ -39,7 +40,8 @@ def chat_summary_cmd(ctx: click.Context, security_id: str, page: int, count: int
 			return
 
 		resp = platform.chat_history(gid, security_id, page=page, count=count)
-		messages = resp.get("zpData", {}).get("messages") or resp.get("zpData", {}).get("historyMsgList") or []
+		msg_data = platform.unwrap_data(resp) or {}
+		messages = msg_data.get("messages") or msg_data.get("historyMsgList") or []
 		summary = summarize_messages(messages, friend_uid=gid)
 
 	handle_output(

--- a/src/boss_agent_cli/commands/chat_summary.py
+++ b/src/boss_agent_cli/commands/chat_summary.py
@@ -3,7 +3,7 @@ import click
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.chat_summary import summarize_messages
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_message_panel
+from boss_agent_cli.display import boss_command_for_ctx, handle_auth_errors, handle_error_output, handle_output, render_message_panel
 
 
 @click.command("chat-summary")
@@ -53,5 +53,10 @@ def chat_summary_cmd(ctx: click.Context, security_id: str, page: int, count: int
 			**summary,
 		},
 		render=lambda d: render_message_panel(d, title="chat-summary"),
-		hints={"next_actions": ["boss chat", f"boss chatmsg {security_id}"]},
+		hints={
+			"next_actions": [
+				boss_command_for_ctx(ctx, "chat"),
+				boss_command_for_ctx(ctx, f"chatmsg {security_id}"),
+			]
+		},
 	)

--- a/src/boss_agent_cli/commands/chatmsg.py
+++ b/src/boss_agent_cli/commands/chatmsg.py
@@ -27,8 +27,8 @@ def chatmsg_cmd(ctx: click.Context, security_id: str, page: int, count: int) -> 
 
 	with get_platform_instance(ctx, auth) as platform:
 		friends_resp = platform.friend_list(page=1)
-		zp_data = friends_resp.get("zpData", {})
-		items = zp_data.get("result") or zp_data.get("friendList") or []
+		platform_data = platform.unwrap_data(friends_resp) or {}
+		items = platform_data.get("result") or platform_data.get("friendList") or []
 
 		gid = None
 		friend_name = None
@@ -47,7 +47,7 @@ def chatmsg_cmd(ctx: click.Context, security_id: str, page: int, count: int) -> 
 			return
 
 		resp = platform.chat_history(gid, security_id, page=page, count=count)
-		msg_data = resp.get("zpData", {})
+		msg_data = platform.unwrap_data(resp) or {}
 		messages = msg_data.get("messages") or msg_data.get("historyMsgList") or []
 
 		result = []

--- a/src/boss_agent_cli/commands/chatmsg.py
+++ b/src/boss_agent_cli/commands/chatmsg.py
@@ -23,7 +23,7 @@ def chatmsg_cmd(ctx: click.Context, security_id: str, page: int, count: int) -> 
 	"""查看与指定好友的聊天消息历史"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	auth = AuthManager(data_dir, logger=logger)
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 
 	with get_platform_instance(ctx, auth) as platform:
 		friends_resp = platform.friend_list(page=1)

--- a/src/boss_agent_cli/commands/chatmsg.py
+++ b/src/boss_agent_cli/commands/chatmsg.py
@@ -5,7 +5,7 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_simple_list
+from boss_agent_cli.display import boss_command_for_ctx, handle_auth_errors, handle_error_output, handle_output, render_simple_list
 
 _MSG_TYPE_MAP = {
 	1: "文本", 2: "图片", 3: "招呼", 4: "简历", 5: "系统",
@@ -89,7 +89,7 @@ def chatmsg_cmd(ctx: click.Context, security_id: str, page: int, count: int) -> 
 			ctx, "chatmsg", result,
 			render=_render,
 			hints={"next_actions": [
-				"boss chat — 返回沟通列表",
-				f"boss detail {security_id} — 查看职位详情",
+				f"{boss_command_for_ctx(ctx, 'chat')} — 返回沟通列表",
+				f"{boss_command_for_ctx(ctx, f'detail {security_id}')} — 查看职位详情",
 			]},
 		)

--- a/src/boss_agent_cli/commands/detail.py
+++ b/src/boss_agent_cli/commands/detail.py
@@ -56,10 +56,10 @@ def detail_cmd(ctx: click.Context, security_id: str, lid: str, job_id: str) -> N
 def _detail_via_httpx(platform: Platform, security_id: str, job_id: str, data_dir: Path) -> dict[str, Any] | None:
 	"""快速通道：通过 httpx 获取职位详情（不需要浏览器）"""
 	raw = platform.job_detail(job_id)
-	zp = raw.get("zpData", {})
-	job_info = zp.get("jobInfo", {})
-	boss_info = zp.get("bossInfo", {})
-	brand_info = zp.get("brandComInfo", {})
+	platform_data = platform.unwrap_data(raw) or {}
+	job_info = platform_data.get("jobInfo", {})
+	boss_info = platform_data.get("bossInfo", {})
+	brand_info = platform_data.get("brandComInfo", {})
 
 	if not job_info:
 		return None
@@ -75,7 +75,7 @@ def _detail_via_httpx(platform: Platform, security_id: str, job_id: str, data_di
 		"city": job_info.get("cityName", ""),
 		"experience": job_info.get("experienceName", ""),
 		"education": job_info.get("degreeName", ""),
-		"description": zp.get("jobDetail", "") or job_info.get("postDescription", ""),
+		"description": platform_data.get("jobDetail", "") or job_info.get("postDescription", ""),
 		"address": job_info.get("address", ""),
 		"skills": job_info.get("jobLabels", []) or job_info.get("skills", []),
 		"boss_name": boss_info.get("name", ""),
@@ -89,7 +89,8 @@ def _detail_via_httpx(platform: Platform, security_id: str, job_id: str, data_di
 def _detail_via_browser(platform: Platform, security_id: str, lid: str, data_dir: Path) -> dict[str, Any] | None:
 	"""兜底通道：通过浏览器 job_card 获取职位详情"""
 	raw = platform.job_card(security_id, lid)
-	card = raw.get("zpData", {}).get("jobCard", {})
+	platform_data = platform.unwrap_data(raw) or {}
+	card = platform_data.get("jobCard", {})
 	if not card:
 		return None
 

--- a/src/boss_agent_cli/commands/detail.py
+++ b/src/boss_agent_cli/commands/detail.py
@@ -21,7 +21,7 @@ def detail_cmd(ctx: click.Context, security_id: str, lid: str, job_id: str) -> N
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
 
-	auth = AuthManager(data_dir, logger=logger)
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	with get_platform_instance(ctx, auth) as platform:
 		# 优先走 httpx 快速通道：显式传入 > 缓存查找 > 降级浏览器通道
 		if not job_id:

--- a/src/boss_agent_cli/commands/detail.py
+++ b/src/boss_agent_cli/commands/detail.py
@@ -6,7 +6,7 @@ import click
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.cache.store import CacheStore
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_job_detail
+from boss_agent_cli.display import boss_command_for_ctx, handle_auth_errors, handle_error_output, handle_output, render_job_detail
 from boss_agent_cli.platforms import Platform
 
 
@@ -48,9 +48,16 @@ def detail_cmd(ctx: click.Context, security_id: str, lid: str, job_id: str) -> N
 		)
 		return
 
-	greet_target = f"boss greet {security_id} {result['job_id']}"
-	hints = {"next_actions": [greet_target, "boss search <query>"]}
-	handle_output(ctx, "detail", result, render=render_job_detail, hints=hints)
+	greet_target = boss_command_for_ctx(ctx, f"greet {security_id} {result['job_id']}")
+	search_target = boss_command_for_ctx(ctx, "search <query>")
+	hints = {"next_actions": [greet_target, search_target]}
+	handle_output(
+		ctx,
+		"detail",
+		result,
+		render=lambda data: render_job_detail(data, greet_command=greet_target),
+		hints=hints,
+	)
 
 
 def _detail_via_httpx(platform: Platform, security_id: str, job_id: str, data_dir: Path) -> dict[str, Any] | None:

--- a/src/boss_agent_cli/commands/digest.py
+++ b/src/boss_agent_cli/commands/digest.py
@@ -35,9 +35,11 @@ def digest_cmd(ctx: click.Context, days_stale: int, now_ts_ms: int | None, outpu
 
 	with get_platform_instance(ctx, auth) as platform:
 		friend_resp = platform.friend_list(page=1)
-		chat_items = friend_resp.get("zpData", {}).get("result") or friend_resp.get("zpData", {}).get("friendList") or []
+		friend_data = platform.unwrap_data(friend_resp) or {}
+		chat_items = friend_data.get("result") or friend_data.get("friendList") or []
 		interview_resp = platform.interview_data()
-		interview_items = interview_resp.get("zpData", {}).get("interviewList") or []
+		interview_data = platform.unwrap_data(interview_resp) or {}
+		interview_items = interview_data.get("interviewList") or []
 
 	items = build_pipeline_items(
 		chat_items=chat_items,

--- a/src/boss_agent_cli/commands/digest.py
+++ b/src/boss_agent_cli/commands/digest.py
@@ -31,7 +31,7 @@ from boss_agent_cli.pipeline_state import build_pipeline_items, select_follow_up
 def digest_cmd(ctx: click.Context, days_stale: int, now_ts_ms: int | None, output_format: str, output_path: Path | None) -> None:
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	auth = AuthManager(data_dir, logger=logger)
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 
 	with get_platform_instance(ctx, auth) as platform:
 		friend_resp = platform.friend_list(page=1)

--- a/src/boss_agent_cli/commands/doctor.py
+++ b/src/boss_agent_cli/commands/doctor.py
@@ -18,7 +18,7 @@ from boss_agent_cli.display import handle_output, render_simple_list
 def doctor_cmd(ctx: click.Context) -> None:
 	"""诊断本地运行环境、依赖和登录条件。"""
 	data_dir = ctx.obj["data_dir"]
-	auth = AuthManager(data_dir)
+	auth = AuthManager(data_dir, platform=ctx.obj.get("platform", "zhipin"))
 	cdp_url = ctx.obj.get("cdp_url")
 
 	checks: list[dict[str, Any]] = []

--- a/src/boss_agent_cli/commands/doctor.py
+++ b/src/boss_agent_cli/commands/doctor.py
@@ -12,13 +12,40 @@ from boss_agent_cli.auth.cookie_extract import extract_cookies
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.display import handle_output, render_simple_list
 
+_PLATFORM_DIAG_CONFIG: dict[str, dict[str, Any]] = {
+	"zhipin": {
+		"auth_dir_suffix": (),
+		"primary_cookie": "wt2",
+		"secondary_token_label": "stoken",
+		"secondary_token_key": "stoken",
+		"aux_cookies": ["wbg", "zp_at"],
+		"cookie_domain_label": "zhipin",
+		"site_url": "https://www.zhipin.com/",
+		"site_host": "zhipin.com",
+		"login_action": "boss login",
+	},
+	"zhilian": {
+		"auth_dir_suffix": ("zhilian",),
+		"primary_cookie": "zp_token",
+		"secondary_token_label": "x-zp-client-id",
+		"secondary_token_key": "x_zp_client_id",
+		"aux_cookies": ["at", "rt"],
+		"cookie_domain_label": "zhaopin",
+		"site_url": "https://www.zhaopin.com/",
+		"site_host": "zhaopin.com",
+		"login_action": "boss --platform zhilian login",
+	},
+}
+
 
 @click.command("doctor")
 @click.pass_context
 def doctor_cmd(ctx: click.Context) -> None:
 	"""诊断本地运行环境、依赖和登录条件。"""
 	data_dir = ctx.obj["data_dir"]
-	auth = AuthManager(data_dir, platform=ctx.obj.get("platform", "zhipin"))
+	platform_name = ctx.obj.get("platform", "zhipin")
+	config = _PLATFORM_DIAG_CONFIG.get(platform_name, _PLATFORM_DIAG_CONFIG["zhipin"])
+	auth = AuthManager(data_dir, platform=platform_name)
 	cdp_url = ctx.obj.get("cdp_url")
 
 	checks: list[dict[str, Any]] = []
@@ -84,21 +111,25 @@ def doctor_cmd(ctx: click.Context) -> None:
 
 	# 2) Auth storage
 	auth_dir = data_dir / "auth"
+	for suffix in config["auth_dir_suffix"]:
+		auth_dir = auth_dir / suffix
 	session_path = auth_dir / "session.enc"
 	salt_path = auth_dir / "salt"
 	token = auth.check_status()
 	has_token = token is not None
 	if token:
 		cookie_count = len(token.get("cookies", {}))
-		stoken_state = "存在" if token.get("stoken") else "缺失"
-		add_check("auth_session", "ok", f"检测到登录态文件: {session_path}（cookies={cookie_count}, stoken={stoken_state}）")
+		secondary_label = config["secondary_token_label"]
+		secondary_key = config["secondary_token_key"]
+		secondary_state = "存在" if token.get(secondary_key) or token.get("stoken") else "缺失"
+		add_check("auth_session", "ok", f"检测到登录态文件: {session_path}（cookies={cookie_count}, {secondary_label}={secondary_state}）")
 	else:
 		status = "warn"
 		detail = "未检测到本地登录态"
 		if session_path.exists():
 			status = "error"
 			detail = f"检测到 session 文件但无法解密/已损坏: {session_path}"
-		add_check("auth_session", status, detail, "运行 boss login 完成登录；如为旧密钥残留，可先 boss logout")
+		add_check("auth_session", status, detail, f"运行 {config['login_action']} 完成登录；如为旧密钥残留，可先 boss logout")
 
 	add_check(
 		"auth_salt",
@@ -109,42 +140,45 @@ def doctor_cmd(ctx: click.Context) -> None:
 
 	if token:
 		cookies = token.get("cookies", {}) or {}
-		has_wt2 = bool(cookies.get("wt2"))
-		has_stoken = bool(token.get("stoken"))
-		if has_wt2 and has_stoken:
+		primary_cookie = config["primary_cookie"]
+		secondary_label = config["secondary_token_label"]
+		secondary_key = config["secondary_token_key"]
+		has_primary_cookie = bool(cookies.get(primary_cookie))
+		has_secondary_token = bool(token.get(secondary_key) or token.get("stoken"))
+		if has_primary_cookie and has_secondary_token:
 			quality_status = "ok"
-			quality_detail = "登录态完整：wt2/stoken 均存在"
+			quality_detail = f"登录态完整：{primary_cookie}/{secondary_label} 均存在"
 			quality_hint = "可直接运行 boss status / boss search 验证实际可用性"
-		elif has_wt2 and not has_stoken:
+		elif has_primary_cookie and not has_secondary_token:
 			quality_status = "warn"
-			quality_detail = "登录态部分可用：wt2 存在，但 stoken 缺失"
-			quality_hint = "通常仍可读信息；若请求失败可先运行 boss status，必要时 boss login 触发重建/刷新"
-		elif not has_wt2 and has_stoken:
+			quality_detail = f"登录态部分可用：{primary_cookie} 存在，但 {secondary_label} 缺失"
+			quality_hint = f"通常仍可读信息；若请求失败可先运行 boss status，必要时 {config['login_action']} 触发重建/刷新"
+		elif not has_primary_cookie and has_secondary_token:
 			quality_status = "error"
-			quality_detail = "登录态异常：stoken 存在，但关键 Cookie wt2 缺失"
-			quality_hint = "执行 boss logout && boss login 重建登录态"
+			quality_detail = f"登录态异常：{secondary_label} 存在，但关键 Cookie {primary_cookie} 缺失"
+			quality_hint = f"执行 boss logout && {config['login_action']} 重建登录态"
 		else:
 			quality_status = "error"
-			quality_detail = "登录态无效：wt2/stoken 均缺失"
-			quality_hint = "执行 boss login 建立有效登录态"
+			quality_detail = f"登录态无效：{primary_cookie}/{secondary_label} 均缺失"
+			quality_hint = f"执行 {config['login_action']} 建立有效登录态"
 		add_check("auth_token_quality", quality_status, quality_detail, quality_hint)
 		# Cookie 完整性检查（辅助 Cookie）
-		_AUX_COOKIES = ["wbg", "zp_at"]
-		missing_aux = [c for c in _AUX_COOKIES if not cookies.get(c)]
+		missing_aux = [c for c in config["aux_cookies"] if not cookies.get(c)]
 		if not missing_aux:
-			add_check("cookie_completeness", "ok", "辅助 Cookie 完整：wbg/zp_at 均存在")
+			aux_str = "/".join(config["aux_cookies"])
+			add_check("cookie_completeness", "ok", f"辅助 Cookie 完整：{aux_str} 均存在")
 		else:
 			missing_str = "/".join(missing_aux)
 			add_check(
 				"cookie_completeness", "warn",
 				f"辅助 Cookie 缺失：{missing_str}",
-				"部分接口可能受影响；重新登录通常可补全：boss logout && boss login",
+				f"部分接口可能受影响；重新登录通常可补全：boss logout && {config['login_action']}",
 			)
 	else:
-		add_check("auth_token_quality", "warn", "未检测到可评估的登录态", "先运行 boss login，再用 boss doctor / boss status 复查")
+		add_check("auth_token_quality", "warn", "未检测到可评估的登录态", f"先运行 {config['login_action']}，再用 boss doctor / boss status 复查")
 
 	# 3) Cookie extraction support
-	cookie_probe = extract_cookies(None)
+	cookie_probe = extract_cookies(None, platform=platform_name)
 	if cookie_probe:
 		cookie_sources = ",".join(sorted(cookie_probe.get("cookies", {}).keys())[:5])
 		add_check(
@@ -156,8 +190,8 @@ def doctor_cmd(ctx: click.Context) -> None:
 		add_check(
 			"cookie_extract",
 			"warn",
-			"未从本地浏览器提取到 zhipin Cookie",
-			"请先在本机浏览器登录 zhipin.com，或使用 boss login 走 CDP/扫码",
+			f"未从本地浏览器提取到 {config['cookie_domain_label']} Cookie",
+			f"请先在本机浏览器登录 {config['site_host']}，或使用 {config['login_action']}",
 		)
 
 	# 4) CDP availability
@@ -184,11 +218,11 @@ def doctor_cmd(ctx: click.Context) -> None:
 
 	# 5) Network probe
 	try:
-		resp = httpx.get("https://www.zhipin.com/", timeout=5, follow_redirects=True)
+		resp = httpx.get(config["site_url"], timeout=5, follow_redirects=True)
 		status = "ok" if resp.status_code < 400 else "warn"
-		add_check("network", status, f"访问 zhipin.com 返回 HTTP {resp.status_code}")
+		add_check("network", status, f"访问 {config['site_host']} 返回 HTTP {resp.status_code}")
 	except Exception as e:
-		add_check("network", "warn", f"访问 zhipin.com 失败: {e}", "检查网络、代理或风控拦截")
+		add_check("network", "warn", f"访问 {config['site_host']} 失败: {e}", "检查网络、代理或风控拦截")
 
 	# 5.5) Browser channel risk assessment
 	cdp_ok = any(item["name"] == "cdp" and item["status"] == "ok" for item in checks)
@@ -211,7 +245,7 @@ def doctor_cmd(ctx: click.Context) -> None:
 		add_check(
 			"browser_channel",
 			"warn",
-			"CDP 和 Bridge 均不可用，搜索/推荐/打招呼将降级到 headless patchright（可能触发 BOSS 直聘风控 code 36）",
+			"CDP 和 Bridge 均不可用，相关浏览器操作将降级到 patchright/手动登录链路",
 			"以 --remote-debugging-port=9222 启动 Chrome（推荐），或安装 Bridge 扩展",
 		)
 
@@ -231,20 +265,20 @@ def doctor_cmd(ctx: click.Context) -> None:
 
 	next_actions = []
 	if not has_token:
-		next_actions.append("boss login — 建立登录态")
+		next_actions.append(f"{config['login_action']} — 建立登录态")
 	else:
 		auth_quality = next((item for item in checks if item["name"] == "auth_token_quality"), None)
 		if auth_quality and auth_quality["status"] == "warn":
-			next_actions.append("boss status — 验证缺失 stoken 的登录态是否仍可用")
-			next_actions.append("如状态异常，执行 boss login — 重建或刷新登录态")
+			next_actions.append(f"boss status — 验证缺失 {config['secondary_token_label']} 的登录态是否仍可用")
+			next_actions.append(f"如状态异常，执行 {config['login_action']} — 重建或刷新登录态")
 		elif auth_quality and auth_quality["status"] == "error":
-			next_actions.append("boss logout && boss login — 重建损坏的登录态")
+			next_actions.append(f"boss logout && {config['login_action']} — 重建损坏的登录态")
 		else:
 			next_actions.append("boss status — 验证当前账号是否可用")
 	if not any(item["name"] == "cdp" and item["status"] == "ok" for item in checks):
 		next_actions.append("boss --cdp-url http://localhost:9222 doctor — 检查指定 CDP 地址")
 	if not any(item["name"] == "cookie_extract" and item["status"] == "ok" for item in checks):
-		next_actions.append("先在本机浏览器登录 zhipin.com，再重试 boss login")
+		next_actions.append(f"先在本机浏览器登录 {config['site_host']}，再重试 {config['login_action']}")
 
 	data = {
 		"summary": summary,

--- a/src/boss_agent_cli/commands/exchange.py
+++ b/src/boss_agent_cli/commands/exchange.py
@@ -21,8 +21,8 @@ def exchange_cmd(ctx: click.Context, security_id: str, exchange_type: str) -> No
 
 	with get_platform_instance(ctx, auth) as platform:
 		friends_resp = platform.friend_list(page=1)
-		zp_data = friends_resp.get("zpData", {})
-		items = zp_data.get("result") or zp_data.get("friendList") or []
+		friend_data = platform.unwrap_data(friends_resp) or {}
+		items = friend_data.get("result") or friend_data.get("friendList") or []
 
 		uid = None
 		friend_name: str = "-"

--- a/src/boss_agent_cli/commands/exchange.py
+++ b/src/boss_agent_cli/commands/exchange.py
@@ -14,7 +14,7 @@ def exchange_cmd(ctx: click.Context, security_id: str, exchange_type: str) -> No
 	"""请求交换联系方式（手机号或微信）"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	auth = AuthManager(data_dir, logger=logger)
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 
 	type_id = 2 if exchange_type == "wechat" else 1
 	type_label = "微信" if exchange_type == "wechat" else "手机号"

--- a/src/boss_agent_cli/commands/export.py
+++ b/src/boss_agent_cli/commands/export.py
@@ -34,8 +34,8 @@ def export_cmd(ctx: click.Context, query: str, city: str | None, salary: str | N
 		while len(all_items) < count and page <= max_pages:
 			logger.info(f"正在获取第 {page} 页...")
 			raw = platform.search_jobs(query, city=city, salary=salary, page=page)
-			zp_data = raw.get("zpData", {})
-			job_list = zp_data.get("jobList", [])
+			platform_data = platform.unwrap_data(raw) or {}
+			job_list = platform_data.get("jobList", [])
 			if not job_list:
 				break
 
@@ -45,7 +45,7 @@ def export_cmd(ctx: click.Context, query: str, city: str | None, salary: str | N
 				item = JobItem.from_api(raw_item)
 				all_items.append(item.to_dict())
 
-			if not zp_data.get("hasMore", False):
+			if not platform_data.get("hasMore", False):
 				break
 			page += 1
 

--- a/src/boss_agent_cli/commands/export.py
+++ b/src/boss_agent_cli/commands/export.py
@@ -25,7 +25,7 @@ def export_cmd(ctx: click.Context, query: str, city: str | None, salary: str | N
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
 
-	auth = AuthManager(data_dir, logger=logger)
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	with get_platform_instance(ctx, auth) as platform:
 		all_items: list[dict[str, Any]] = []
 		page = 1

--- a/src/boss_agent_cli/commands/greet.py
+++ b/src/boss_agent_cli/commands/greet.py
@@ -43,7 +43,7 @@ def greet_cmd(ctx: click.Context, security_id: str, job_id: str, message: str) -
 			)
 			return
 
-		auth = AuthManager(data_dir, logger=logger)
+		auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 		with get_platform_instance(ctx, auth) as platform:
 			# greet_before hook — allows veto
 			hooks = ctx.obj.get("hooks")
@@ -125,7 +125,7 @@ def batch_greet_cmd(ctx: click.Context, query: str, city: str | None, salary: st
 	count = min(count, 10)
 
 	with CacheStore(data_dir / "cache" / "boss_agent.db") as cache:
-		auth = AuthManager(data_dir, logger=logger)
+		auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 		with get_platform_instance(ctx, auth) as platform:
 			raw = platform.search_jobs(
 				query, city=city, salary=salary, experience=experience,

--- a/src/boss_agent_cli/commands/greet.py
+++ b/src/boss_agent_cli/commands/greet.py
@@ -62,7 +62,17 @@ def greet_cmd(ctx: click.Context, security_id: str, job_id: str, message: str) -
 					)
 					return
 
-			platform.greet(security_id, job_id, message)
+			resp = platform.greet(security_id, job_id, message)
+			if not platform.is_success(resp):
+				error_code, _ = platform.parse_error(resp)
+				handle_error_output(
+					ctx, "greet",
+					code=error_code if error_code != "UNKNOWN" else "NETWORK_ERROR",
+					message=resp.get("message") or "打招呼失败",
+					recoverable=True,
+					recovery_action="重试",
+				)
+				return
 
 			cache.record_greet(security_id, job_id)
 
@@ -122,8 +132,8 @@ def batch_greet_cmd(ctx: click.Context, query: str, city: str | None, salary: st
 				education=education, industry=industry, scale=scale,
 				stage=stage, job_type=job_type,
 			)
-			zp_data = raw.get("zpData", {})
-			job_list = zp_data.get("jobList", [])
+			platform_data = platform.unwrap_data(raw) or {}
+			job_list = platform_data.get("jobList", [])
 
 			candidates = []
 			for raw_item in job_list:
@@ -154,7 +164,10 @@ def batch_greet_cmd(ctx: click.Context, query: str, city: str | None, salary: st
 
 				while retry_count <= 1:
 					try:
-						platform.greet(item.security_id, item.job_id)
+						resp = platform.greet(item.security_id, item.job_id)
+						if not platform.is_success(resp):
+							error_code, _ = platform.parse_error(resp)
+							raise RuntimeError(error_code if error_code != "UNKNOWN" else (resp.get("message") or "greet failed"))
 						cache.record_greet(item.security_id, item.job_id)
 						results.append({
 							"security_id": item.security_id,

--- a/src/boss_agent_cli/commands/history.py
+++ b/src/boss_agent_cli/commands/history.py
@@ -15,7 +15,7 @@ def history_cmd(ctx: click.Context, page: int) -> None:
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
 
-	auth = AuthManager(data_dir, logger=logger)
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	with get_platform_instance(ctx, auth) as platform:
 		raw = platform.job_history(page)
 		platform_data = platform.unwrap_data(raw) or {}

--- a/src/boss_agent_cli/commands/history.py
+++ b/src/boss_agent_cli/commands/history.py
@@ -18,14 +18,14 @@ def history_cmd(ctx: click.Context, page: int) -> None:
 	auth = AuthManager(data_dir, logger=logger)
 	with get_platform_instance(ctx, auth) as platform:
 		raw = platform.job_history(page)
-		zp_data = raw.get("zpData", {})
-		job_list = zp_data.get("jobList", [])
+		platform_data = platform.unwrap_data(raw) or {}
+		job_list = platform_data.get("jobList", [])
 
 		items = [JobItem.from_api(raw_item).to_dict() for raw_item in job_list]
 
 	pagination = {
 		"page": page,
-		"has_more": zp_data.get("hasMore", False),
+		"has_more": platform_data.get("hasMore", False),
 		"total": len(items),
 	}
 	hints = {
@@ -41,7 +41,7 @@ def history_cmd(ctx: click.Context, page: int) -> None:
 		render=lambda data: render_job_table(
 			data, "history",
 			page=page,
-			hint_next=f"more: boss history --page {page + 1}" if zp_data.get("hasMore") else "",
+			hint_next=f"more: boss history --page {page + 1}" if platform_data.get("hasMore") else "",
 		),
 		pagination=pagination, hints=hints,
 	)

--- a/src/boss_agent_cli/commands/history.py
+++ b/src/boss_agent_cli/commands/history.py
@@ -3,7 +3,7 @@ import click
 from boss_agent_cli.api.models import JobItem
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_output, render_job_table
+from boss_agent_cli.display import boss_command_for_ctx, handle_auth_errors, handle_output, render_job_table
 
 
 @click.command("history")
@@ -30,9 +30,9 @@ def history_cmd(ctx: click.Context, page: int) -> None:
 	}
 	hints = {
 		"next_actions": [
-			"使用 boss detail <security_id> 查看职位详情",
-			"使用 boss greet <security_id> <job_id> 打招呼",
-			"使用 boss history --page {} 查看下一页".format(page + 1),
+			f"使用 {boss_command_for_ctx(ctx, 'detail <security_id>')} 查看职位详情",
+			f"使用 {boss_command_for_ctx(ctx, 'greet <security_id> <job_id>')} 打招呼",
+			f"使用 {boss_command_for_ctx(ctx, f'history --page {page + 1}')} 查看下一页",
 		],
 	}
 
@@ -41,7 +41,10 @@ def history_cmd(ctx: click.Context, page: int) -> None:
 		render=lambda data: render_job_table(
 			data, "history",
 			page=page,
-			hint_next=f"more: boss history --page {page + 1}" if platform_data.get("hasMore") else "",
+			hint_next=(
+				f"more: {boss_command_for_ctx(ctx, f'history --page {page + 1}')}"
+				if platform_data.get("hasMore") else ""
+			),
 		),
 		pagination=pagination, hints=hints,
 	)

--- a/src/boss_agent_cli/commands/interviews.py
+++ b/src/boss_agent_cli/commands/interviews.py
@@ -2,7 +2,7 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_simple_list
+from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, login_action_for_ctx, render_simple_list
 from typing import Any
 
 
@@ -17,11 +17,12 @@ def interviews_cmd(ctx: click.Context) -> None:
 
 	token = auth.check_status()
 	if token is None:
+		login_action = login_action_for_ctx(ctx)
 		handle_error_output(
 			ctx, "interviews",
 			code="AUTH_REQUIRED",
-			message="未登录，请先执行 boss login",
-			recoverable=True, recovery_action="boss login",
+			message=f"未登录，请先执行 {login_action}",
+			recoverable=True, recovery_action=login_action,
 		)
 		return
 

--- a/src/boss_agent_cli/commands/interviews.py
+++ b/src/boss_agent_cli/commands/interviews.py
@@ -27,7 +27,8 @@ def interviews_cmd(ctx: click.Context) -> None:
 
 	with get_platform_instance(ctx, auth) as platform:
 		raw = platform.interview_data()
-		interview_list = raw.get("zpData", {}).get("interviewList", [])
+		platform_data = platform.unwrap_data(raw) or {}
+		interview_list = platform_data.get("interviewList", [])
 
 	items = [
 		{

--- a/src/boss_agent_cli/commands/interviews.py
+++ b/src/boss_agent_cli/commands/interviews.py
@@ -13,7 +13,7 @@ def interviews_cmd(ctx: click.Context) -> None:
 	"""查看面试邀请列表"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	auth = AuthManager(data_dir, logger=logger)
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 
 	token = auth.check_status()
 	if token is None:

--- a/src/boss_agent_cli/commands/login.py
+++ b/src/boss_agent_cli/commands/login.py
@@ -14,8 +14,19 @@ def login_cmd(ctx: click.Context, timeout: int, cookie_source: str | None, cdp: 
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
 	cdp_url = ctx.obj.get("cdp_url")
+	platform_name = ctx.obj.get("platform") or "zhipin"
 
-	auth = AuthManager(data_dir, logger=logger)
+	if platform_name != "zhipin":
+		emit_error(
+			"login",
+			code="INVALID_PARAM",
+			message=f"当前仅支持 zhipin 平台登录，{platform_name} 登录链路仍在开发中",
+			recoverable=True,
+			recovery_action="boss --platform zhipin login",
+		)
+		return
+
+	auth = AuthManager(data_dir, logger=logger, platform=platform_name)
 	try:
 		token = auth.login(
 			timeout=timeout,

--- a/src/boss_agent_cli/commands/login.py
+++ b/src/boss_agent_cli/commands/login.py
@@ -1,6 +1,7 @@
 import click
 
 from boss_agent_cli.auth.manager import AuthManager
+from boss_agent_cli.display import login_action_for_ctx
 from boss_agent_cli.output import emit_error, emit_success
 
 
@@ -46,7 +47,7 @@ def login_cmd(ctx: click.Context, timeout: int, cookie_source: str | None, cdp: 
 			code="NETWORK_ERROR",
 			message=str(e),
 			recoverable=True,
-			recovery_action="boss login",
+			recovery_action=login_action_for_ctx(ctx),
 		)
 	except Exception as e:
 		emit_error(
@@ -54,5 +55,5 @@ def login_cmd(ctx: click.Context, timeout: int, cookie_source: str | None, cdp: 
 			code="NETWORK_ERROR",
 			message=f"登录失败: {e}",
 			recoverable=True,
-			recovery_action="boss login",
+			recovery_action=login_action_for_ctx(ctx),
 		)

--- a/src/boss_agent_cli/commands/login.py
+++ b/src/boss_agent_cli/commands/login.py
@@ -16,16 +16,6 @@ def login_cmd(ctx: click.Context, timeout: int, cookie_source: str | None, cdp: 
 	cdp_url = ctx.obj.get("cdp_url")
 	platform_name = ctx.obj.get("platform") or "zhipin"
 
-	if platform_name != "zhipin":
-		emit_error(
-			"login",
-			code="INVALID_PARAM",
-			message=f"当前仅支持 zhipin 平台登录，{platform_name} 登录链路仍在开发中",
-			recoverable=True,
-			recovery_action="boss --platform zhipin login",
-		)
-		return
-
 	auth = AuthManager(data_dir, logger=logger, platform=platform_name)
 	try:
 		token = auth.login(

--- a/src/boss_agent_cli/commands/login.py
+++ b/src/boss_agent_cli/commands/login.py
@@ -1,7 +1,7 @@
 import click
 
 from boss_agent_cli.auth.manager import AuthManager
-from boss_agent_cli.display import login_action_for_ctx
+from boss_agent_cli.display import boss_command_for_ctx, login_action_for_ctx
 from boss_agent_cli.output import emit_error, emit_success
 
 
@@ -11,7 +11,7 @@ from boss_agent_cli.output import emit_error, emit_success
 @click.option("--cdp", is_flag=True, default=False, help="强制 CDP 模式（跳过 Cookie 提取，CDP 不可用直接报错）")
 @click.pass_context
 def login_cmd(ctx: click.Context, timeout: int, cookie_source: str | None, cdp: bool) -> None:
-	"""登录 BOSS 直聘（三级降级：Cookie 提取 → CDP 自动探测 → patchright 扫码）"""
+	"""登录当前招聘平台（按平台走对应的 Cookie / CDP / 浏览器降级链路）"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
 	cdp_url = ctx.obj.get("cdp_url")
@@ -26,11 +26,14 @@ def login_cmd(ctx: click.Context, timeout: int, cookie_source: str | None, cdp: 
 			force_cdp=cdp,
 		)
 		method = token.pop("_method", "未知")
+		status_cmd = boss_command_for_ctx(ctx, "status")
+		search_cmd = boss_command_for_ctx(ctx, "search <query>")
+		recommend_cmd = boss_command_for_ctx(ctx, "recommend")
 		emit_success("login", {"message": f"登录成功（{method}）"}, hints={
 			"next_actions": [
-				"boss status — 验证登录态",
-				"boss search <query> — 搜索职位",
-				"boss recommend — 获取个性化推荐",
+				f"{status_cmd} — 验证登录态",
+				f"{search_cmd} — 搜索职位",
+				f"{recommend_cmd} — 获取个性化推荐",
 			],
 		})
 	except ConnectionError as e:

--- a/src/boss_agent_cli/commands/logout.py
+++ b/src/boss_agent_cli/commands/logout.py
@@ -10,7 +10,7 @@ def logout_cmd(ctx: click.Context) -> None:
 	"""退出登录，清除本地保存的登录态"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	auth = AuthManager(data_dir, logger=logger)
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	try:
 		auth.logout()
 		emit_success("logout", {"message": "已退出登录"}, hints={

--- a/src/boss_agent_cli/commands/logout.py
+++ b/src/boss_agent_cli/commands/logout.py
@@ -1,5 +1,6 @@
 import click
 
+from boss_agent_cli.display import login_action_for_ctx
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.output import emit_error, emit_success
 
@@ -15,7 +16,7 @@ def logout_cmd(ctx: click.Context) -> None:
 		auth.logout()
 		emit_success("logout", {"message": "已退出登录"}, hints={
 			"next_actions": [
-				"boss login — 重新登录",
+				f"{login_action_for_ctx(ctx)} — 重新登录",
 			],
 		})
 	except Exception as e:

--- a/src/boss_agent_cli/commands/mark.py
+++ b/src/boss_agent_cli/commands/mark.py
@@ -44,8 +44,8 @@ def mark_cmd(ctx: click.Context, security_id: str, label: str, remove: bool) -> 
 
 	with get_platform_instance(ctx, auth) as platform:
 		friends_resp = platform.friend_list(page=1)
-		zp_data = friends_resp.get("zpData", {})
-		items = zp_data.get("result") or zp_data.get("friendList") or []
+		friend_data = platform.unwrap_data(friends_resp) or {}
+		items = friend_data.get("result") or friend_data.get("friendList") or []
 
 		friend_id = None
 		friend_source = 0

--- a/src/boss_agent_cli/commands/mark.py
+++ b/src/boss_agent_cli/commands/mark.py
@@ -36,7 +36,7 @@ def mark_cmd(ctx: click.Context, security_id: str, label: str, remove: bool) -> 
 	"""给联系人添加/移除标签"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	auth = AuthManager(data_dir, logger=logger)
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 
 	label_id = _resolve_label(label)
 	label_name = _LABEL_NAMES.get(label_id, str(label_id))

--- a/src/boss_agent_cli/commands/me.py
+++ b/src/boss_agent_cli/commands/me.py
@@ -3,7 +3,7 @@ import click
 from boss_agent_cli.api.client import AuthError
 from boss_agent_cli.auth.manager import AuthManager, AuthRequired, TokenRefreshFailed
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import handle_error_output, handle_output, render_sectioned_record
+from boss_agent_cli.display import handle_error_output, handle_output, login_action_for_ctx, render_sectioned_record
 
 
 @click.command("me")
@@ -69,8 +69,8 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 			)
 
 	except (AuthRequired, TokenRefreshFailed):
-		handle_error_output(ctx, "me", code="AUTH_REQUIRED", message="未登录", recoverable=True, recovery_action="boss login")
+		handle_error_output(ctx, "me", code="AUTH_REQUIRED", message="未登录", recoverable=True, recovery_action=login_action_for_ctx(ctx))
 	except AuthError:
-		handle_error_output(ctx, "me", code="AUTH_EXPIRED", message="登录态过期", recoverable=True, recovery_action="boss login")
+		handle_error_output(ctx, "me", code="AUTH_EXPIRED", message="登录态过期", recoverable=True, recovery_action=login_action_for_ctx(ctx))
 	except Exception as e:
 		handle_error_output(ctx, "me", code="NETWORK_ERROR", message=str(e), recoverable=True, recovery_action="重试")

--- a/src/boss_agent_cli/commands/me.py
+++ b/src/boss_agent_cli/commands/me.py
@@ -17,7 +17,7 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 	logger = ctx.obj.get("logger")
 
 	try:
-		auth = AuthManager(data_dir, logger=logger)
+		auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 		with get_platform_instance(ctx, auth) as platform:
 			result = {}
 

--- a/src/boss_agent_cli/commands/me.py
+++ b/src/boss_agent_cli/commands/me.py
@@ -27,7 +27,7 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 				if logger:
 					logger.info("获取用户基本信息...")
 				resp = platform.user_info()
-				zp_data = resp.get("zpData", {})
+				zp_data = platform.unwrap_data(resp) or {}
 				result["user"] = {
 					"name": zp_data.get("name", ""),
 					"email": zp_data.get("email", ""),
@@ -40,21 +40,21 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 				if logger:
 					logger.info("获取简历基本信息...")
 				resp = platform.resume_baseinfo()
-				zp_data = resp.get("zpData", {})
+				zp_data = platform.unwrap_data(resp) or {}
 				result["resume"] = zp_data
 
 			if "expect" in sections:
 				if logger:
 					logger.info("获取求职期望...")
 				resp = platform.resume_expect()
-				zp_data = resp.get("zpData", {})
+				zp_data = platform.unwrap_data(resp) or {}
 				result["expect"] = zp_data
 
 			if "deliver" in sections:
 				if logger:
 					logger.info("获取投递记录...")
 				resp = platform.deliver_list(page=deliver_page)
-				zp_data = resp.get("zpData", {})
+				zp_data = platform.unwrap_data(resp) or {}
 				result["deliver"] = zp_data
 
 			handle_output(

--- a/src/boss_agent_cli/commands/me.py
+++ b/src/boss_agent_cli/commands/me.py
@@ -3,7 +3,7 @@ import click
 from boss_agent_cli.api.client import AuthError
 from boss_agent_cli.auth.manager import AuthManager, AuthRequired, TokenRefreshFailed
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import handle_error_output, handle_output, login_action_for_ctx, render_sectioned_record
+from boss_agent_cli.display import boss_command_for_ctx, handle_error_output, handle_output, login_action_for_ctx, render_sectioned_record
 
 
 @click.command("me")
@@ -62,8 +62,8 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 				render=lambda d: render_sectioned_record(d, title="me"),
 				hints={
 					"next_actions": [
-						"boss search <关键词> --city <城市>",
-						"boss recommend",
+						boss_command_for_ctx(ctx, "search <关键词> --city <城市>"),
+						boss_command_for_ctx(ctx, "recommend"),
 					],
 				},
 			)

--- a/src/boss_agent_cli/commands/pipeline.py
+++ b/src/boss_agent_cli/commands/pipeline.py
@@ -16,9 +16,11 @@ def _collect_pipeline_items(ctx: click.Context, *, now_ts_ms: int | None, stale_
 
 	with get_platform_instance(ctx, auth) as platform:
 		friend_resp = platform.friend_list(page=1)
-		chat_items = friend_resp.get("zpData", {}).get("result") or friend_resp.get("zpData", {}).get("friendList") or []
+		friend_data = platform.unwrap_data(friend_resp) or {}
+		chat_items = friend_data.get("result") or friend_data.get("friendList") or []
 		interview_resp = platform.interview_data()
-		interview_items = interview_resp.get("zpData", {}).get("interviewList") or []
+		interview_data = platform.unwrap_data(interview_resp) or {}
+		interview_items = interview_data.get("interviewList") or []
 
 	return build_pipeline_items(
 		chat_items=chat_items,

--- a/src/boss_agent_cli/commands/pipeline.py
+++ b/src/boss_agent_cli/commands/pipeline.py
@@ -12,7 +12,7 @@ from boss_agent_cli.pipeline_state import build_pipeline_items, select_follow_up
 def _collect_pipeline_items(ctx: click.Context, *, now_ts_ms: int | None, stale_days: int) -> list[dict[str, Any]]:
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	auth = AuthManager(data_dir, logger=logger)
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 
 	with get_platform_instance(ctx, auth) as platform:
 		friend_resp = platform.friend_list(page=1)

--- a/src/boss_agent_cli/commands/recommend.py
+++ b/src/boss_agent_cli/commands/recommend.py
@@ -19,7 +19,7 @@ def recommend_cmd(ctx: click.Context, page: int, with_score: bool) -> None:
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
 
-	auth = AuthManager(data_dir, logger=logger)
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	with get_platform_instance(ctx, auth) as platform:
 		with CacheStore(data_dir / "cache" / "boss_agent.db") as cache:
 			expect_data = None

--- a/src/boss_agent_cli/commands/recommend.py
+++ b/src/boss_agent_cli/commands/recommend.py
@@ -22,11 +22,18 @@ def recommend_cmd(ctx: click.Context, page: int, with_score: bool) -> None:
 	auth = AuthManager(data_dir, logger=logger)
 	with get_platform_instance(ctx, auth) as platform:
 		with CacheStore(data_dir / "cache" / "boss_agent.db") as cache:
-			expect_data = platform.resume_expect().get("zpData", {}) if with_score else None
+			expect_data = None
+			if with_score:
+				try:
+					expect_resp = platform.resume_expect()
+				except NotImplementedError:
+					expect_data = None
+				else:
+					expect_data = platform.unwrap_data(expect_resp) or {}
 
 			raw = platform.recommend_jobs(page=page)
-			zp_data = raw.get("zpData", {})
-			job_list = zp_data.get("jobList", [])
+			platform_data = platform.unwrap_data(raw) or {}
+			job_list = platform_data.get("jobList", [])
 
 			items = []
 			for raw_item in job_list:
@@ -41,7 +48,7 @@ def recommend_cmd(ctx: click.Context, page: int, with_score: bool) -> None:
 
 		pagination = {
 			"page": page,
-			"has_more": zp_data.get("hasMore", False),
+			"has_more": platform_data.get("hasMore", False),
 			"total": len(items),
 		}
 		hints = {

--- a/src/boss_agent_cli/commands/recruiter/applications.py
+++ b/src/boss_agent_cli/commands/recruiter/applications.py
@@ -17,7 +17,7 @@ def applications_cmd(ctx: click.Context, job_id: str | None, label_id: int, page
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
 
-	auth = AuthManager(data_dir, logger=logger)
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	with get_recruiter_platform_instance(ctx, auth) as platform:
 		result = platform.friend_list(page=page, label_id=label_id, job_id=job_id)
 		data = platform.unwrap_data(result) or {}

--- a/src/boss_agent_cli/commands/recruiter/applications.py
+++ b/src/boss_agent_cli/commands/recruiter/applications.py
@@ -20,7 +20,7 @@ def applications_cmd(ctx: click.Context, job_id: str | None, label_id: int, page
 	auth = AuthManager(data_dir, logger=logger)
 	with get_recruiter_platform_instance(ctx, auth) as platform:
 		result = platform.friend_list(page=page, label_id=label_id, job_id=job_id)
-		data = result.get("zpData", {})
+		data = platform.unwrap_data(result) or {}
 		handle_output(
 			ctx, "recruiter-applications", data,
 			hints={"next_actions": [

--- a/src/boss_agent_cli/commands/recruiter/candidates.py
+++ b/src/boss_agent_cli/commands/recruiter/candidates.py
@@ -26,7 +26,7 @@ def candidates_cmd(ctx: click.Context, query: str, city: str | None, job_id: str
 			query, city=city, page=page, job_id=job_id,
 			experience=experience, degree=degree,
 		)
-		data = result.get("zpData", {})
+		data = platform.unwrap_data(result) or {}
 		handle_output(
 			ctx, "recruiter-candidates", data,
 			hints={"next_actions": [

--- a/src/boss_agent_cli/commands/recruiter/candidates.py
+++ b/src/boss_agent_cli/commands/recruiter/candidates.py
@@ -20,7 +20,7 @@ def candidates_cmd(ctx: click.Context, query: str, city: str | None, job_id: str
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
 
-	auth = AuthManager(data_dir, logger=logger)
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	with get_recruiter_platform_instance(ctx, auth) as platform:
 		result = platform.search_geeks(
 			query, city=city, page=page, job_id=job_id,

--- a/src/boss_agent_cli/commands/recruiter/chat.py
+++ b/src/boss_agent_cli/commands/recruiter/chat.py
@@ -17,7 +17,7 @@ def recruiter_chat_cmd(ctx: click.Context, page: int, job_id: str | None, label_
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
 
-	auth = AuthManager(data_dir, logger=logger)
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	with get_recruiter_platform_instance(ctx, auth) as platform:
 		result = platform.friend_list(page=page, label_id=label_id, job_id=job_id)
 		data = platform.unwrap_data(result) or {}

--- a/src/boss_agent_cli/commands/recruiter/chat.py
+++ b/src/boss_agent_cli/commands/recruiter/chat.py
@@ -20,7 +20,7 @@ def recruiter_chat_cmd(ctx: click.Context, page: int, job_id: str | None, label_
 	auth = AuthManager(data_dir, logger=logger)
 	with get_recruiter_platform_instance(ctx, auth) as platform:
 		result = platform.friend_list(page=page, label_id=label_id, job_id=job_id)
-		data = result.get("zpData", {})
+		data = platform.unwrap_data(result) or {}
 		handle_output(
 			ctx, "recruiter-chat", data,
 			hints={"next_actions": [

--- a/src/boss_agent_cli/commands/recruiter/jobs.py
+++ b/src/boss_agent_cli/commands/recruiter/jobs.py
@@ -21,7 +21,7 @@ def jobs_list_cmd(ctx: click.Context) -> None:
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
 
-	auth = AuthManager(data_dir, logger=logger)
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	with get_recruiter_platform_instance(ctx, auth) as platform:
 		result = platform.list_jobs()
 		data = platform.unwrap_data(result) or {}
@@ -37,7 +37,7 @@ def jobs_offline_cmd(ctx: click.Context, job_id: str) -> None:
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
 
-	auth = AuthManager(data_dir, logger=logger)
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	with get_recruiter_platform_instance(ctx, auth) as platform:
 		platform.job_offline(job_id)
 		data = {"job_id": job_id, "message": "职位已下线"}
@@ -53,7 +53,7 @@ def jobs_online_cmd(ctx: click.Context, job_id: str) -> None:
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
 
-	auth = AuthManager(data_dir, logger=logger)
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	with get_recruiter_platform_instance(ctx, auth) as platform:
 		platform.job_online(job_id)
 		data = {"job_id": job_id, "message": "职位已上线"}

--- a/src/boss_agent_cli/commands/recruiter/jobs.py
+++ b/src/boss_agent_cli/commands/recruiter/jobs.py
@@ -24,7 +24,7 @@ def jobs_list_cmd(ctx: click.Context) -> None:
 	auth = AuthManager(data_dir, logger=logger)
 	with get_recruiter_platform_instance(ctx, auth) as platform:
 		result = platform.list_jobs()
-		data = result.get("zpData", {})
+		data = platform.unwrap_data(result) or {}
 		handle_output(ctx, "recruiter-jobs-list", data)
 
 

--- a/src/boss_agent_cli/commands/recruiter/reply.py
+++ b/src/boss_agent_cli/commands/recruiter/reply.py
@@ -16,7 +16,7 @@ def reply_cmd(ctx: click.Context, friend_id: int, message: str) -> None:
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
 
-	auth = AuthManager(data_dir, logger=logger)
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	with get_recruiter_platform_instance(ctx, auth) as platform:
 		result = platform.send_message(friend_id, message)
 		data = {

--- a/src/boss_agent_cli/commands/recruiter/request_resume.py
+++ b/src/boss_agent_cli/commands/recruiter/request_resume.py
@@ -16,7 +16,7 @@ def request_resume_cmd(ctx: click.Context, friend_id: int, job_id: int) -> None:
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
 
-	auth = AuthManager(data_dir, logger=logger)
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	with get_recruiter_platform_instance(ctx, auth) as platform:
 		# friend_id 就是 uid，gid 也设为 uid
 		result = platform.exchange_request(3, friend_id, job_id, friend_id)

--- a/src/boss_agent_cli/commands/recruiter/resume.py
+++ b/src/boss_agent_cli/commands/recruiter/resume.py
@@ -22,7 +22,7 @@ def resume_cmd(ctx: click.Context, geek_id: str, job_id: str, security_id: str |
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
 
-	auth = AuthManager(data_dir, logger=logger)
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	with get_recruiter_platform_instance(ctx, auth) as platform:
 		if exchange_contact:
 			if not uid or not gid or not job_id:

--- a/src/boss_agent_cli/commands/recruiter/resume.py
+++ b/src/boss_agent_cli/commands/recruiter/resume.py
@@ -34,7 +34,7 @@ def resume_cmd(ctx: click.Context, geek_id: str, job_id: str, security_id: str |
 				)
 				return
 			result = platform.exchange_request(1, uid, int(job_id), gid)
-			data = result.get("zpData", {})
+			data = platform.unwrap_data(result) or {}
 			data["message"] = "联系方式交换请求已发送"
 		elif security_id and job_id:
 			result = platform.view_geek(geek_id, job_id, security_id=security_id)

--- a/src/boss_agent_cli/commands/recruiter/resume_parser.py
+++ b/src/boss_agent_cli/commands/recruiter/resume_parser.py
@@ -93,7 +93,8 @@ def parse_resume(raw: dict[str, Any]) -> dict[str, Any]:
 	Parameters
 	----------
 	raw : dict
-		view_geek 返回的完整响应（含 code/zpData）。
+		view_geek 返回的完整响应（含 code/zpData 或 code/data），
+		也可直接传入已解包的数据体。
 
 	Returns
 	-------
@@ -101,8 +102,8 @@ def parse_resume(raw: dict[str, Any]) -> dict[str, Any]:
 		结构化简历：basic / expectation / work_experience /
 		project_experience / education / competitive_analysis / certifications
 	"""
-	zp = raw.get("zpData", {})
-	info = zp.get("geekDetailInfo", {})
+	payload = raw.get("zpData") if "zpData" in raw else raw.get("data", raw)
+	info = payload.get("geekDetailInfo", {})
 
 	certs = [_safe_str(c.get("certName")) for c in info.get("geekCertificationList", []) if c.get("certName")]
 

--- a/src/boss_agent_cli/commands/recruiter/resume_parser.py
+++ b/src/boss_agent_cli/commands/recruiter/resume_parser.py
@@ -103,6 +103,8 @@ def parse_resume(raw: dict[str, Any]) -> dict[str, Any]:
 		project_experience / education / competitive_analysis / certifications
 	"""
 	payload = raw.get("zpData") if "zpData" in raw else raw.get("data", raw)
+	if not isinstance(payload, dict):
+		payload = {}
 	info = payload.get("geekDetailInfo", {})
 
 	certs = [_safe_str(c.get("certName")) for c in info.get("geekCertificationList", []) if c.get("certName")]

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -3,7 +3,7 @@ from typing import Any
 import click
 
 from boss_agent_cli.output import emit_success
-from boss_agent_cli.platforms import list_platforms
+from boss_agent_cli.platforms import list_platforms, list_recruiter_platforms
 
 # 类型转换：native schema → JSON Schema 基础类型
 _JSON_SCHEMA_TYPE_MAP = {
@@ -58,15 +58,97 @@ def _command_to_json_schema(cmd_name: str, cmd_spec: dict[str, Any]) -> dict[str
 	return schema
 
 
+_ROLE_BOTH_COMMANDS = {
+	"login", "status", "doctor", "logout", "schema", "config", "clean", "cities",
+}
+
+_CANDIDATE_COMMANDS = {
+	"search", "detail", "greet", "batch-greet", "recommend", "export", "me", "show",
+	"history", "chat", "chatmsg", "chat-summary", "mark", "exchange", "interviews",
+	"watch", "preset", "pipeline", "follow-up", "apply", "shortlist", "digest",
+	"stats", "resume", "ai",
+}
+
+
+def _availability_note(availability: dict[str, Any]) -> str:
+	roles = ", ".join(availability.get("roles", [])) or "none"
+	candidate_platforms = ", ".join(availability.get("candidate_platforms", [])) or "-"
+	recruiter_platforms = ", ".join(availability.get("recruiter_platforms", [])) or "-"
+	return (
+		f"可用性: roles={roles}; "
+		f"candidate_platforms={candidate_platforms}; "
+		f"recruiter_platforms={recruiter_platforms}"
+	)
+
+
+def _command_availability(
+	cmd_name: str,
+	*,
+	candidate_platforms: list[str],
+	recruiter_platforms: list[str],
+) -> dict[str, Any]:
+	if cmd_name == "hr":
+		subcommand_availability = {
+			sub_name: {
+				"roles": ["recruiter"],
+				"candidate_platforms": [],
+				"recruiter_platforms": recruiter_platforms,
+			}
+			for sub_name in SCHEMA_DATA["commands"]["hr"].get("subcommands", {})
+		}
+		return {
+			"roles": ["recruiter"],
+			"candidate_platforms": [],
+			"recruiter_platforms": recruiter_platforms,
+			"subcommands": subcommand_availability,
+		}
+	if cmd_name in _ROLE_BOTH_COMMANDS:
+		return {
+			"roles": ["candidate", "recruiter"],
+			"candidate_platforms": candidate_platforms,
+			"recruiter_platforms": recruiter_platforms,
+		}
+	if cmd_name in _CANDIDATE_COMMANDS:
+		return {
+			"roles": ["candidate"],
+			"candidate_platforms": candidate_platforms,
+			"recruiter_platforms": [],
+		}
+	return {
+		"roles": ["candidate"],
+		"candidate_platforms": candidate_platforms,
+		"recruiter_platforms": [],
+	}
+
+
+def _inject_availability(data: dict[str, Any]) -> dict[str, Any]:
+	candidate_platforms = data.get("supported_platforms", [])
+	recruiter_platforms = data.get("supported_recruiter_platforms", [])
+	commands: dict[str, Any] = {}
+	for cmd_name, cmd_spec in data["commands"].items():
+		cmd_copy = dict(cmd_spec)
+		cmd_copy["availability"] = _command_availability(
+			cmd_name,
+			candidate_platforms=candidate_platforms,
+			recruiter_platforms=recruiter_platforms,
+		)
+		commands[cmd_name] = cmd_copy
+	data["commands"] = commands
+	return data
+
+
 def _format_openai_tools(data: dict[str, Any]) -> list[dict[str, Any]]:
 	"""OpenAI Functions / Tools API 格式。"""
 	tools = []
 	for cmd_name, cmd_spec in data["commands"].items():
+		description = cmd_spec.get("description", "")
+		if availability := cmd_spec.get("availability"):
+			description = f"{description} [{_availability_note(availability)}]"
 		tools.append({
 			"type": "function",
 			"function": {
 				"name": f"boss_{cmd_name.replace('-', '_')}",
-				"description": cmd_spec.get("description", ""),
+				"description": description,
 				"parameters": _command_to_json_schema(cmd_name, cmd_spec),
 			},
 		})
@@ -77,9 +159,12 @@ def _format_anthropic_tools(data: dict[str, Any]) -> list[dict[str, Any]]:
 	"""Anthropic Tool Use 格式。"""
 	tools = []
 	for cmd_name, cmd_spec in data["commands"].items():
+		description = cmd_spec.get("description", "")
+		if availability := cmd_spec.get("availability"):
+			description = f"{description} [{_availability_note(availability)}]"
 		tools.append({
 			"name": f"boss_{cmd_name.replace('-', '_')}",
-			"description": cmd_spec.get("description", ""),
+			"description": description,
 			"input_schema": _command_to_json_schema(cmd_name, cmd_spec),
 		})
 	return tools
@@ -571,7 +656,7 @@ SCHEMA_DATA = {
 		"--platform": {
 			"type": "string",
 			"default": "zhipin",
-			"description": "招聘平台适配器（zhipin=BOSS 直聘生产可用；zhilian=智联招聘 stub，Week 2 真实现）",
+			"description": "招聘平台适配器（zhipin=BOSS 直聘求职者/招聘者均可用；zhilian=智联招聘已接通求职者侧包络与命令兼容，招聘者侧暂未接入）",
 			"choices": ["zhipin", "zhilian"],
 		},
 		"--json": {
@@ -720,6 +805,8 @@ def schema_cmd(ctx: click.Context, output_format: str) -> None:
 	data["current_platform"] = current
 	data["current_role"] = (ctx.obj or {}).get("role") or "candidate"
 	data["supported_platforms"] = list_platforms()
+	data["supported_recruiter_platforms"] = list_recruiter_platforms()
+	data = _inject_availability(data)
 
 	if output_format == "openai-tools":
 		emit_success("schema", {"format": "openai-tools", "tools": _format_openai_tools(data)})

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -175,7 +175,7 @@ SCHEMA_DATA = {
 	"description": "BOSS直聘求职工具。33 个顶层命令覆盖搜索、筛选、打招呼、沟通、流水线、招聘者工作流与简历优化全流程。",
 	"commands": {
 		"login": {
-			"description": "登录 BOSS 直聘（四级降级：Cookie 提取 → CDP → QR httpx 扫码 → patchright 扫码）",
+			"description": "按当前平台登录（zhipin: Cookie 提取 → CDP → QR httpx → patchright；zhilian: Cookie 提取 → CDP → 浏览器登录）",
 			"args": [],
 			"options": {
 				"--timeout": {

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, cast
 
 import click
 
@@ -88,13 +88,20 @@ def _command_availability(
 	recruiter_platforms: list[str],
 ) -> dict[str, Any]:
 	if cmd_name == "hr":
+		commands = cast(dict[str, Any], SCHEMA_DATA.get("commands", {}))
+		hr_spec = commands.get("hr", {})
+		if not isinstance(hr_spec, dict):
+			hr_spec = {}
+		subcommands = hr_spec.get("subcommands", {})
+		if not isinstance(subcommands, dict):
+			subcommands = {}
 		subcommand_availability = {
 			sub_name: {
 				"roles": ["recruiter"],
 				"candidate_platforms": [],
 				"recruiter_platforms": recruiter_platforms,
 			}
-			for sub_name in SCHEMA_DATA["commands"]["hr"].get("subcommands", {})
+			for sub_name in subcommands
 		}
 		return {
 			"roles": ["recruiter"],

--- a/src/boss_agent_cli/commands/search.py
+++ b/src/boss_agent_cli/commands/search.py
@@ -107,7 +107,7 @@ def search_cmd(ctx: click.Context, query: str, preset: str | None, city: str | N
 				)
 				return
 
-		auth = AuthManager(data_dir, logger=logger)
+		auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 		with get_platform_instance(ctx, auth) as platform:
 			max_pages = 5 if welfare_conditions else 1
 			pipeline_result = run_search_pipeline(

--- a/src/boss_agent_cli/commands/shortlist.py
+++ b/src/boss_agent_cli/commands/shortlist.py
@@ -1,7 +1,7 @@
 import click
 
 from boss_agent_cli.cache.store import CacheStore
-from boss_agent_cli.display import handle_output, render_simple_list
+from boss_agent_cli.display import boss_command_for_ctx, handle_output, render_simple_list
 
 
 @click.group("shortlist")
@@ -44,7 +44,12 @@ def shortlist_add_cmd(ctx: click.Context, security_id: str, job_id: str, title: 
 			"salary": salary,
 			"source": source,
 		},
-		hints={"next_actions": ["boss shortlist list", f"boss shortlist remove {security_id} {job_id}"]},
+		hints={
+			"next_actions": [
+				boss_command_for_ctx(ctx, "shortlist list"),
+				boss_command_for_ctx(ctx, f"shortlist remove {security_id} {job_id}"),
+			]
+		},
 	)
 
 
@@ -68,7 +73,7 @@ def shortlist_list_cmd(ctx: click.Context) -> None:
 				("source", "source", "magenta"),
 			],
 		),
-		hints={"next_actions": ["boss detail <security_id> --job-id <job_id>"]},
+		hints={"next_actions": [boss_command_for_ctx(ctx, "detail <security_id> --job-id <job_id>")]},
 	)
 
 
@@ -83,5 +88,5 @@ def shortlist_remove_cmd(ctx: click.Context, security_id: str, job_id: str) -> N
 		ctx,
 		"shortlist",
 		{"action": "remove", "security_id": security_id, "job_id": job_id, "removed": removed},
-		hints={"next_actions": ["boss shortlist list"]},
+		hints={"next_actions": [boss_command_for_ctx(ctx, "shortlist list")]},
 	)

--- a/src/boss_agent_cli/commands/show.py
+++ b/src/boss_agent_cli/commands/show.py
@@ -47,7 +47,8 @@ def show_cmd(ctx: click.Context, index: int) -> None:
 	with get_platform_instance(ctx, auth) as platform:
 		raw = platform.job_card(security_id)
 
-	card = raw.get("zpData", {}).get("jobCard", {})
+	platform_data = platform.unwrap_data(raw) or {}
+	card = platform_data.get("jobCard", {})
 	if not card:
 		handle_error_output(
 			ctx, "show",

--- a/src/boss_agent_cli/commands/show.py
+++ b/src/boss_agent_cli/commands/show.py
@@ -43,7 +43,7 @@ def show_cmd(ctx: click.Context, index: int) -> None:
 		)
 		return
 
-	auth = AuthManager(data_dir, logger=logger)
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	with get_platform_instance(ctx, auth) as platform:
 		raw = platform.job_card(security_id)
 

--- a/src/boss_agent_cli/commands/show.py
+++ b/src/boss_agent_cli/commands/show.py
@@ -3,7 +3,7 @@ import click
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.cache.store import CacheStore
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_job_detail
+from boss_agent_cli.display import boss_command_for_ctx, handle_auth_errors, handle_error_output, handle_output, render_job_detail
 from boss_agent_cli.index_cache import get_index_info, get_job_by_index
 
 
@@ -81,10 +81,13 @@ def show_cmd(ctx: click.Context, index: int) -> None:
 		"index": index,
 	}
 
-	hints = {
-		"next_actions": [
-			f"boss greet {security_id} {job_id}",
-			"boss search <query>",
-		],
-	}
-	handle_output(ctx, "show", result, render=render_job_detail, hints=hints)
+	greet_target = boss_command_for_ctx(ctx, f"greet {security_id} {job_id}")
+	search_target = boss_command_for_ctx(ctx, "search <query>")
+	hints = {"next_actions": [greet_target, search_target]}
+	handle_output(
+		ctx,
+		"show",
+		result,
+		render=lambda data: render_job_detail(data, greet_command=greet_target),
+		hints=hints,
+	)

--- a/src/boss_agent_cli/commands/status.py
+++ b/src/boss_agent_cli/commands/status.py
@@ -26,7 +26,8 @@ def status_cmd(ctx: click.Context) -> None:
 
 	with get_platform_instance(ctx, auth) as platform:
 		info = platform.user_info()
-		user_name = info.get("zpData", {}).get("name", "未知用户")
+		user_info = platform.unwrap_data(info) or {}
+		user_name = user_info.get("name", "未知用户")
 		data = {
 			"logged_in": True,
 			"user_name": user_name,

--- a/src/boss_agent_cli/commands/status.py
+++ b/src/boss_agent_cli/commands/status.py
@@ -12,7 +12,7 @@ def status_cmd(ctx: click.Context) -> None:
 	"""检查当前登录态"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
-	auth = AuthManager(data_dir, logger=logger)
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 
 	token = auth.check_status()
 	if token is None:

--- a/src/boss_agent_cli/commands/status.py
+++ b/src/boss_agent_cli/commands/status.py
@@ -2,7 +2,7 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_status
+from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, login_action_for_ctx, render_status
 
 
 @click.command("status")
@@ -16,11 +16,12 @@ def status_cmd(ctx: click.Context) -> None:
 
 	token = auth.check_status()
 	if token is None:
+		login_action = login_action_for_ctx(ctx)
 		handle_error_output(
 			ctx, "status",
 			code="AUTH_REQUIRED",
-			message="未登录，请先执行 boss login",
-			recoverable=True, recovery_action="boss login",
+			message=f"未登录，请先执行 {login_action}",
+			recoverable=True, recovery_action=login_action,
 		)
 		return
 

--- a/src/boss_agent_cli/commands/status.py
+++ b/src/boss_agent_cli/commands/status.py
@@ -34,4 +34,9 @@ def status_cmd(ctx: click.Context) -> None:
 			"user_name": user_name,
 			"token_expires_in": None,
 		}
-		handle_output(ctx, "status", data, render=render_status)
+		handle_output(
+			ctx,
+			"status",
+			data,
+			render=lambda payload: render_status(payload, login_action=login_action_for_ctx(ctx)),
+		)

--- a/src/boss_agent_cli/commands/watch.py
+++ b/src/boss_agent_cli/commands/watch.py
@@ -147,7 +147,7 @@ def watch_run_cmd(ctx: click.Context, name: str) -> None:
 			stage=params.get("stage"),
 			job_type=params.get("job_type"),
 		)
-		auth = AuthManager(data_dir, logger=logger)
+		auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 		with get_platform_instance(ctx, auth) as platform:
 			pipeline_result = run_search_pipeline(
 				platform,

--- a/src/boss_agent_cli/display.py
+++ b/src/boss_agent_cli/display.py
@@ -18,6 +18,14 @@ from boss_agent_cli.output import emit_success
 console = Console(stderr=True)
 
 
+def login_action_for_ctx(ctx: Any) -> str:
+	"""Return the platform-aware login recovery command."""
+	platform_name = "zhipin"
+	if ctx and getattr(ctx, "obj", None):
+		platform_name = ctx.obj.get("platform") or "zhipin"
+	return "boss --platform zhilian login" if platform_name == "zhilian" else "boss login"
+
+
 def is_json_mode(ctx) -> bool:
 	"""Check if --json flag is set or stdout is piped (non-TTY)."""
 	force_json = ctx.obj.get("json_output", False) if ctx and ctx.obj else False
@@ -288,16 +296,18 @@ def handle_auth_errors(command_name: str) -> Callable[[Callable[..., Any]], Call
 			try:
 				return func(ctx, *args, **kwargs)
 			except AuthRequired:
+				login_action = login_action_for_ctx(ctx)
 				handle_error_output(
 					ctx, command_name, code="AUTH_REQUIRED",
-					message="未登录，请先执行 boss login",
-					recoverable=True, recovery_action="boss login",
+					message=f"未登录，请先执行 {login_action}",
+					recoverable=True, recovery_action=login_action,
 				)
 			except TokenRefreshFailed:
+				login_action = login_action_for_ctx(ctx)
 				handle_error_output(
 					ctx, command_name, code="TOKEN_REFRESH_FAILED",
 					message="Token 刷新失败，请重新登录",
-					recoverable=True, recovery_action="boss login",
+					recoverable=True, recovery_action=login_action,
 				)
 			except AccountRiskError as e:
 				recovery = (

--- a/src/boss_agent_cli/display.py
+++ b/src/boss_agent_cli/display.py
@@ -18,12 +18,18 @@ from boss_agent_cli.output import emit_success
 console = Console(stderr=True)
 
 
-def login_action_for_ctx(ctx: Any) -> str:
-	"""Return the platform-aware login recovery command."""
+def boss_command_for_ctx(ctx: Any, command: str) -> str:
+	"""Return a platform-aware boss subcommand."""
 	platform_name = "zhipin"
 	if ctx and getattr(ctx, "obj", None):
 		platform_name = ctx.obj.get("platform") or "zhipin"
-	return "boss --platform zhilian login" if platform_name == "zhilian" else "boss login"
+	prefix = "boss --platform zhilian" if platform_name == "zhilian" else "boss"
+	return f"{prefix} {command}".strip()
+
+
+def login_action_for_ctx(ctx: Any) -> str:
+	"""Return the platform-aware login recovery command."""
+	return boss_command_for_ctx(ctx, "login")
 
 
 def is_json_mode(ctx) -> bool:
@@ -157,13 +163,13 @@ def render_job_detail(data: dict) -> None:
 		console.print(f"  [dim]greet: boss greet {sid} {jid}[/dim]")
 
 
-def render_status(data: dict) -> None:
+def render_status(data: dict, *, login_action: str = "boss login") -> None:
 	"""Render login status."""
 	if data.get("logged_in"):
 		name = data.get("user_name", "unknown")
 		console.print(f"[green]logged in[/green] as [bold]{name}[/bold]")
 	else:
-		console.print("[yellow]not logged in[/yellow] - run: boss login")
+		console.print(f"[yellow]not logged in[/yellow] - run: {login_action}")
 
 
 def render_simple_list(

--- a/src/boss_agent_cli/display.py
+++ b/src/boss_agent_cli/display.py
@@ -124,7 +124,7 @@ def render_job_table(
 		console.print(f"  [dim]{hint_next}[/dim]")
 
 
-def render_job_detail(data: dict) -> None:
+def render_job_detail(data: dict, *, greet_command: str | None = None) -> None:
 	"""Render job detail as a rich panel."""
 	title = data.get("title", "-")
 	salary = data.get("salary", "-")
@@ -160,7 +160,8 @@ def render_job_detail(data: dict) -> None:
 	sid = data.get("security_id", "")
 	jid = data.get("job_id", "")
 	if sid and jid:
-		console.print(f"  [dim]greet: boss greet {sid} {jid}[/dim]")
+		greet_command = greet_command or f"boss greet {sid} {jid}"
+		console.print(f"  [dim]greet: {greet_command}[/dim]")
 
 
 def render_status(data: dict, *, login_action: str = "boss login") -> None:

--- a/src/boss_agent_cli/main.py
+++ b/src/boss_agent_cli/main.py
@@ -12,9 +12,10 @@ from boss_agent_cli.commands.recruiter import candidates as recruiter_candidates
 from boss_agent_cli.commands.recruiter import reply as recruiter_reply
 from boss_agent_cli.commands.recruiter import request_resume as recruiter_request_resume
 from boss_agent_cli.config import load_config
+from boss_agent_cli.display import handle_error_output
 from boss_agent_cli.hooks import create_hook_bus
 from boss_agent_cli.output import Logger
-from boss_agent_cli.platforms import list_platforms
+from boss_agent_cli.platforms import list_platforms, list_recruiter_platforms
 
 
 @click.group(context_settings={"allow_interspersed_args": False})
@@ -102,6 +103,22 @@ cli.add_command(stats.stats_cmd, "stats")
 @click.pass_context
 def hr_group(ctx: click.Context) -> None:
 	ctx.obj["role"] = "recruiter"
+	platform_name = ctx.obj.get("platform") or "zhipin"
+	recruiter_name = f"{platform_name}-recruiter"
+	supported = list_recruiter_platforms()
+	if recruiter_name not in supported:
+		handle_error_output(
+			ctx,
+			"hr",
+			code="INVALID_PARAM",
+			message=(
+				f"招聘者模式暂不支持平台 {platform_name!r}；"
+				f"当前仅支持: {', '.join(supported)}"
+			),
+			recoverable=True,
+			recovery_action="boss --platform zhipin hr ...",
+		)
+		raise SystemExit(1)
 
 cli.add_command(hr_group, "hr")
 hr_group.add_command(recruiter_applications.applications_cmd, "applications")

--- a/src/boss_agent_cli/mcp_server.py
+++ b/src/boss_agent_cli/mcp_server.py
@@ -1,5 +1,6 @@
 """MCP Server for boss-agent-cli — 让 Claude Desktop / Cursor 直接调用 BOSS 直聘求职工具。"""
 
+import copy
 import json
 import subprocess
 from typing import Any
@@ -8,7 +9,59 @@ from mcp.server import Server
 from mcp.server.stdio import stdio_server
 from mcp.types import TextContent, Tool
 
+from boss_agent_cli.commands.schema import SCHEMA_DATA, _availability_note, _inject_availability
+from boss_agent_cli.platforms import list_platforms, list_recruiter_platforms
+
 server = Server("boss-agent-cli")
+
+
+def _build_schema_with_availability() -> dict[str, Any]:
+	data = copy.deepcopy(SCHEMA_DATA)
+	data["supported_platforms"] = list_platforms()
+	data["supported_recruiter_platforms"] = list_recruiter_platforms()
+	return _inject_availability(data)
+
+
+_SCHEMA_WITH_AVAILABILITY = _build_schema_with_availability()
+
+
+def _tool_availability(tool_name: str) -> dict[str, Any] | None:
+	name = tool_name.removeprefix("boss_")
+	commands = _SCHEMA_WITH_AVAILABILITY["commands"]
+
+	direct_map = {
+		"chat_summary": "chat-summary",
+		"batch_greet": "batch-greet",
+		"follow_up": "follow-up",
+	}
+	if name in direct_map:
+		return commands[direct_map[name]].get("availability")
+	if name in commands:
+		return commands[name].get("availability")
+
+	if name.startswith("ai_"):
+		sub_name = name.removeprefix("ai_").replace("_", "-")
+		return commands["ai"].get("availability")
+	if name.startswith("resume_"):
+		return commands["resume"].get("availability")
+	if name.startswith("watch_"):
+		return commands["watch"].get("availability")
+	if name.startswith("preset_"):
+		return commands["preset"].get("availability")
+	if name.startswith("shortlist_"):
+		return commands["shortlist"].get("availability")
+	if name.startswith("hr_"):
+		sub_name = name.removeprefix("hr_").replace("_", "-")
+		hr_availability = commands["hr"].get("availability") or {}
+		return hr_availability.get("subcommands", {}).get(sub_name, hr_availability)
+	return None
+
+
+def _decorate_tool_descriptions() -> None:
+	for tool in TOOLS:
+		availability = _tool_availability(tool.name)
+		if availability:
+			tool.description = f"{tool.description} [可用性: {_availability_note(availability)}]"
 
 # ── Tool 定义 ──────────────────────────────────────────────────────
 
@@ -564,6 +617,8 @@ TOOLS = [
 		},
 	),
 ]
+
+_decorate_tool_descriptions()
 
 
 # ── Tool 调用逻辑 ──────────────────────────────────────────────────

--- a/src/boss_agent_cli/platforms/zhilian.py
+++ b/src/boss_agent_cli/platforms/zhilian.py
@@ -1,18 +1,7 @@
-"""智联招聘平台 stub 实现。
+"""智联招聘平台实现。
 
-**当前状态：Week 1d 自证 stub** — 包络适配方法按 zhaopin.md 调研给出真实逻辑，
-P0/P1/P2 抽象方法暂抛 `NotImplementedError("Week 2 待实现")`，
-让 Platform 抽象在两个平台上都可编译 / 注册 / schema 可见。
-
-**Week 2 TODO**（Issue #129 Week 2）：
-- 实现 ZhilianClient（基于 BrowserSession / Bridge 通道）
-- 实现 search_jobs / job_detail / recommend_jobs / user_info 只读方法
-- 基于调研 [docs/research/platforms/zhaopin.md](../../docs/research/platforms/zhaopin.md)
-
-协议核心差异（对比 BOSS 直聘）：
-- 成功码：`code == 200`（BOSS 是 `code == 0`）
-- 数据包络：`response["data"]`（BOSS 是 `response["zpData"]`）
-- 错误码：401 未授权 / 403 风控 / 429 限流（BOSS 用 code 9/36/37）
+Week 2 P0 先接通只读能力，命令层通过 ``Platform`` 抽象即可无差别调用
+``search_jobs`` / ``job_detail`` / ``recommend_jobs`` / ``user_info``。
 """
 
 from __future__ import annotations
@@ -22,8 +11,7 @@ from typing import TYPE_CHECKING, Any
 from boss_agent_cli.platforms.base import Platform
 
 if TYPE_CHECKING:
-	# Week 2 引入 ZhilianClient；当前 stub 无依赖
-	pass
+	from boss_agent_cli.api.zhilian_client import ZhilianClient
 
 
 # 智联错误码 → 统一错误码映射（对齐 CLAUDE.md 错误码枚举）
@@ -33,19 +21,16 @@ _ERROR_CODE_MAP: dict[int, str] = {
 	429: "RATE_LIMITED",
 }
 
-# Week 2 时会替换为真实实现
-_NOT_YET_MSG = "Zhilian Week 2 待实现，当前为注册自证 stub，追踪进度见 Issue #140（https://github.com/can4hou6joeng4/boss-agent-cli/issues/140）"
-
-
 class ZhilianPlatform(Platform):
-	"""智联招聘平台实现（当前为 Week 1d 自证 stub）。"""
+	"""智联招聘平台实现。"""
 
 	name = "zhilian"
 	display_name = "智联招聘"
 	base_url = "https://m.zhaopin.com"
 
-	def __init__(self, client: Any) -> None:
+	def __init__(self, client: "ZhilianClient") -> None:
 		super().__init__(client)
+		self._client: "ZhilianClient" = client
 
 	# ── 包络适配（Week 1d 已按 zhaopin.md 调研完成）──
 
@@ -61,18 +46,18 @@ class ZhilianPlatform(Platform):
 		unified = _ERROR_CODE_MAP.get(code, "UNKNOWN") if isinstance(code, int) else "UNKNOWN"
 		return unified, message
 
-	# ── P0 只读（Week 2 待实现）─────────────────────
+	# ── P0 只读委托 ────────────────────────────────
 
 	def search_jobs(self, query: str, **filters: Any) -> dict[str, Any]:
-		raise NotImplementedError(f"{_NOT_YET_MSG}: search_jobs(query={query!r}, filters={filters!r})")
+		return self._client.search_jobs(query, **filters)
 
 	def job_detail(self, job_id: str) -> dict[str, Any]:
-		raise NotImplementedError(f"{_NOT_YET_MSG}: job_detail(job_id={job_id!r})")
+		return self._client.job_detail(job_id)
 
 	def recommend_jobs(self, page: int = 1) -> dict[str, Any]:
-		raise NotImplementedError(f"{_NOT_YET_MSG}: recommend_jobs(page={page})")
+		return self._client.recommend_jobs(page)
 
 	def user_info(self) -> dict[str, Any]:
-		raise NotImplementedError(f"{_NOT_YET_MSG}: user_info()")
+		return self._client.user_info()
 
 	# greet / apply / friend_list 沿用 Platform 基类的 NotImplementedError 默认

--- a/src/boss_agent_cli/platforms/zhilian.py
+++ b/src/boss_agent_cli/platforms/zhilian.py
@@ -60,4 +60,8 @@ class ZhilianPlatform(Platform):
 	def user_info(self) -> dict[str, Any]:
 		return self._client.user_info()
 
-	# greet / apply / friend_list 沿用 Platform 基类的 NotImplementedError 默认
+	def greet(self, security_id: str, job_id: str, message: str = "") -> dict[str, Any]:
+		return self._client.greet(security_id, job_id, message)
+
+	def apply(self, security_id: str, job_id: str, lid: str = "") -> dict[str, Any]:
+		return self._client.apply(security_id, job_id, lid)

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -36,6 +36,24 @@ def test_apply_success(mock_cache_cls, mock_auth_cls, mock_get_platform):
 @patch("boss_agent_cli.commands.apply.get_platform_instance")
 @patch("boss_agent_cli.commands.apply.AuthManager")
 @patch("boss_agent_cli.commands.apply.CacheStore")
+def test_apply_success_for_zhilian_http_style_code(mock_cache_cls, mock_auth_cls, mock_get_platform):
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.is_applied.return_value = False
+	mock_platform = _ctx_mock(mock_get_platform)
+	mock_platform.apply.return_value = {"code": 200, "data": {}}
+	mock_platform.is_success.return_value = True
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "apply", "sec_001", "job_001"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	mock_cache.record_apply.assert_called_once_with("sec_001", "job_001")
+
+
+@patch("boss_agent_cli.commands.apply.get_platform_instance")
+@patch("boss_agent_cli.commands.apply.AuthManager")
+@patch("boss_agent_cli.commands.apply.CacheStore")
 def test_apply_duplicate_is_blocked(mock_cache_cls, mock_auth_cls, mock_get_platform):
 	mock_cache = _ctx_mock(mock_cache_cls)
 	mock_cache.is_applied.return_value = True
@@ -55,6 +73,8 @@ def test_apply_failure_does_not_record_local_state(mock_cache_cls, mock_auth_cls
 	mock_cache.is_applied.return_value = False
 	mock_platform = _ctx_mock(mock_get_platform)
 	mock_platform.apply.return_value = {"code": 1, "message": "失败"}
+	mock_platform.is_success.return_value = False
+	mock_platform.parse_error.return_value = ("NETWORK_ERROR", "失败")
 
 	runner = CliRunner()
 	result = runner.invoke(cli, ["apply", "sec_001", "job_001"])

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -54,6 +54,24 @@ def test_apply_success_for_zhilian_http_style_code(mock_cache_cls, mock_auth_cls
 @patch("boss_agent_cli.commands.apply.get_platform_instance")
 @patch("boss_agent_cli.commands.apply.AuthManager")
 @patch("boss_agent_cli.commands.apply.CacheStore")
+def test_apply_zhilian_hints_use_platform_specific_commands(mock_cache_cls, mock_auth_cls, mock_get_platform):
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.is_applied.return_value = False
+	mock_platform = _ctx_mock(mock_get_platform)
+	mock_platform.apply.return_value = {"code": 200, "data": {}}
+	mock_platform.is_success.return_value = True
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "--platform", "zhilian", "apply", "sec_001", "job_001"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["hints"]["next_actions"][0] == "boss --platform zhilian me --section deliver"
+	assert parsed["hints"]["next_actions"][1] == "boss --platform zhilian chat"
+
+
+@patch("boss_agent_cli.commands.apply.get_platform_instance")
+@patch("boss_agent_cli.commands.apply.AuthManager")
+@patch("boss_agent_cli.commands.apply.CacheStore")
 def test_apply_duplicate_is_blocked(mock_cache_cls, mock_auth_cls, mock_get_platform):
 	mock_cache = _ctx_mock(mock_cache_cls)
 	mock_cache.is_applied.return_value = True
@@ -63,6 +81,21 @@ def test_apply_duplicate_is_blocked(mock_cache_cls, mock_auth_cls, mock_get_plat
 	assert result.exit_code == 1
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "ALREADY_APPLIED"
+
+
+@patch("boss_agent_cli.commands.apply.get_platform_instance")
+@patch("boss_agent_cli.commands.apply.AuthManager")
+@patch("boss_agent_cli.commands.apply.CacheStore")
+def test_apply_duplicate_zhilian_hints_use_platform_specific_commands(mock_cache_cls, mock_auth_cls, mock_get_platform):
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.is_applied.return_value = True
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "--platform", "zhilian", "apply", "sec_001", "job_001"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["hints"]["next_actions"][0] == "boss --platform zhilian me --section deliver"
+	assert parsed["hints"]["next_actions"][1] == "boss --platform zhilian chat"
 
 
 @patch("boss_agent_cli.commands.apply.get_platform_instance")

--- a/tests/test_auth_and_login_extended.py
+++ b/tests/test_auth_and_login_extended.py
@@ -220,6 +220,16 @@ def test_login_success(mock_auth_cls):
 	mock_auth.login.assert_called_once()
 
 
+def test_login_rejects_non_zhipin_platform():
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--platform", "zhilian", "login"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "INVALID_PARAM"
+	assert "仅支持 zhipin" in parsed["error"]["message"]
+	assert parsed["error"]["recovery_action"] == "boss --platform zhipin login"
+
+
 @patch("boss_agent_cli.commands.login.AuthManager")
 def test_login_connection_error_recovery_is_boss_chrome(mock_auth_cls):
 	"""ConnectionError 应返回 NETWORK_ERROR + boss-chrome 恢复建议。"""

--- a/tests/test_auth_and_login_extended.py
+++ b/tests/test_auth_and_login_extended.py
@@ -220,14 +220,20 @@ def test_login_success(mock_auth_cls):
 	mock_auth.login.assert_called_once()
 
 
-def test_login_rejects_non_zhipin_platform():
+@patch("boss_agent_cli.commands.login.AuthManager")
+def test_login_supports_zhilian_platform(mock_auth_cls):
+	mock_auth = MagicMock()
+	mock_auth.login.return_value = {
+		"cookies": {"zp_token": "x"}, "user_agent": "ua", "_method": "Cookie 提取",
+	}
+	mock_auth_cls.return_value = mock_auth
+
 	runner = CliRunner()
 	result = runner.invoke(cli, ["--platform", "zhilian", "login"])
-	assert result.exit_code == 1
+	assert result.exit_code == 0
 	parsed = json.loads(result.output)
-	assert parsed["error"]["code"] == "INVALID_PARAM"
-	assert "仅支持 zhipin" in parsed["error"]["message"]
-	assert parsed["error"]["recovery_action"] == "boss --platform zhipin login"
+	assert parsed["ok"] is True
+	mock_auth.login.assert_called_once()
 
 
 @patch("boss_agent_cli.commands.login.AuthManager")

--- a/tests/test_auth_and_login_extended.py
+++ b/tests/test_auth_and_login_extended.py
@@ -267,6 +267,19 @@ def test_login_timeout_error_recovery_is_retry(mock_auth_cls):
 
 
 @patch("boss_agent_cli.commands.login.AuthManager")
+def test_zhilian_login_timeout_uses_platform_specific_recovery(mock_auth_cls):
+	mock_auth = MagicMock()
+	mock_auth.login.side_effect = TimeoutError("扫码超时")
+	mock_auth_cls.return_value = mock_auth
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--platform", "zhilian", "login"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["recovery_action"] == "boss --platform zhilian login"
+
+
+@patch("boss_agent_cli.commands.login.AuthManager")
 def test_login_generic_exception_wrapped_as_network_error(mock_auth_cls):
 	"""泛型异常也应被 wrap 成 NETWORK_ERROR，不裸泄给用户。"""
 	mock_auth = MagicMock()
@@ -279,6 +292,19 @@ def test_login_generic_exception_wrapped_as_network_error(mock_auth_cls):
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "NETWORK_ERROR"
 	assert "登录失败" in parsed["error"]["message"]
+
+
+@patch("boss_agent_cli.commands.login.AuthManager")
+def test_zhilian_login_generic_exception_uses_platform_specific_recovery(mock_auth_cls):
+	mock_auth = MagicMock()
+	mock_auth.login.side_effect = RuntimeError("some unexpected error")
+	mock_auth_cls.return_value = mock_auth
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--platform", "zhilian", "login"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["recovery_action"] == "boss --platform zhilian login"
 
 
 @patch("boss_agent_cli.commands.login.AuthManager")

--- a/tests/test_auth_and_login_extended.py
+++ b/tests/test_auth_and_login_extended.py
@@ -233,6 +233,8 @@ def test_login_supports_zhilian_platform(mock_auth_cls):
 	assert result.exit_code == 0
 	parsed = json.loads(result.output)
 	assert parsed["ok"] is True
+	assert parsed["hints"]["next_actions"][0] == "boss --platform zhilian status — 验证登录态"
+	assert parsed["hints"]["next_actions"][1] == "boss --platform zhilian search <query> — 搜索职位"
 	mock_auth.login.assert_called_once()
 
 

--- a/tests/test_auth_manager_extended.py
+++ b/tests/test_auth_manager_extended.py
@@ -34,6 +34,18 @@ def test_get_token_raises_auth_required_when_no_session(mock_store_cls, tmp_path
 
 
 @patch("boss_agent_cli.auth.manager.TokenStore")
+def test_auth_manager_uses_default_zhipin_store_path(mock_store_cls, tmp_path):
+	AuthManager(tmp_path)
+	mock_store_cls.assert_called_once_with(tmp_path / "auth")
+
+
+@patch("boss_agent_cli.auth.manager.TokenStore")
+def test_auth_manager_uses_platform_scoped_store_path_for_zhilian(mock_store_cls, tmp_path):
+	AuthManager(tmp_path, platform="zhilian")
+	mock_store_cls.assert_called_once_with(tmp_path / "auth" / "zhilian")
+
+
+@patch("boss_agent_cli.auth.manager.TokenStore")
 def test_get_token_loads_from_store_and_caches(mock_store_cls, tmp_path):
 	token = {"cookies": {"wt2": "c1"}, "stoken": "s1"}
 	store = _make_store(token=token)

--- a/tests/test_auth_manager_extended.py
+++ b/tests/test_auth_manager_extended.py
@@ -120,7 +120,7 @@ def test_login_falls_back_to_patchright_when_qr_fails(
 	result = manager.login(timeout=20)
 
 	mock_qr_login.assert_called_once()
-	mock_login_via_browser.assert_called_once_with(timeout=20)
+	mock_login_via_browser.assert_called_once_with(timeout=20, platform="zhipin")
 	assert result["_method"] == "扫码登录"
 	assert manager._token["stoken"] == "bt"
 
@@ -211,6 +211,22 @@ def test_verify_cookie_returns_false_on_value_error(mock_get, mock_store_cls, tm
 
 	manager = AuthManager(tmp_path)
 	assert manager._verify_cookie({"cookies": {"wt2": "x"}}) is False
+
+
+@patch("boss_agent_cli.auth.manager.TokenStore")
+@patch("httpx.get")
+def test_verify_cookie_supports_zhilian_http_style_code(mock_get, mock_store_cls, tmp_path):
+	mock_store_cls.return_value = _make_store()
+	mock_resp = MagicMock()
+	mock_resp.json.return_value = {"code": 200, "data": {"name": "tester"}}
+	mock_get.return_value = mock_resp
+
+	manager = AuthManager(tmp_path, platform="zhilian")
+	result = manager._verify_cookie({"cookies": {"zp_token": "abc"}, "user_agent": "UA", "x_zp_client_id": "cid"})
+	assert result is True
+	call = mock_get.call_args
+	assert call.kwargs["cookies"] == {"zp_token": "abc"}
+	assert call.kwargs["headers"]["x-zp-client-id"] == "cid"
 
 
 # ── force_refresh 剩余分支 ────────────────────────────────

--- a/tests/test_auth_manager_extended.py
+++ b/tests/test_auth_manager_extended.py
@@ -34,6 +34,16 @@ def test_get_token_raises_auth_required_when_no_session(mock_store_cls, tmp_path
 
 
 @patch("boss_agent_cli.auth.manager.TokenStore")
+def test_get_token_raises_platform_specific_auth_required_for_zhilian(mock_store_cls, tmp_path):
+	store = _make_store(token=None)
+	mock_store_cls.return_value = store
+	manager = AuthManager(tmp_path, platform="zhilian")
+
+	with pytest.raises(AuthRequired, match="boss --platform zhilian login"):
+		manager.get_token()
+
+
+@patch("boss_agent_cli.auth.manager.TokenStore")
 def test_auth_manager_uses_default_zhipin_store_path(mock_store_cls, tmp_path):
 	AuthManager(tmp_path)
 	mock_store_cls.assert_called_once_with(tmp_path / "auth")

--- a/tests/test_auth_manager_flow.py
+++ b/tests/test_auth_manager_flow.py
@@ -28,7 +28,7 @@ def test_login_force_cdp_skips_cookie_extraction(mock_extract, mock_login_via_cd
 	result = manager.login(timeout=45, cdp_url="http://127.0.0.1:9222", force_cdp=True)
 
 	mock_extract.assert_not_called()
-	mock_login_via_cdp.assert_called_once_with(cdp_url="http://127.0.0.1:9222", timeout=45)
+	mock_login_via_cdp.assert_called_once_with(cdp_url="http://127.0.0.1:9222", timeout=45, platform="zhipin")
 	store.save.assert_called_once_with({"cookies": {"wt2": "cdp-cookie"}, "stoken": "cdp-token"})
 	assert result["_method"] == "CDP 扫码"
 	assert manager._token["stoken"] == "cdp-token"
@@ -90,8 +90,8 @@ def test_login_falls_back_to_browser_when_cdp_login_fails(
 		patch("boss_agent_cli.auth.manager.qr_login_httpx", side_effect=RuntimeError("qr failed")):
 		result = manager.login(timeout=30)
 
-	mock_login_via_cdp.assert_called_once_with(cdp_url=None, timeout=30)
-	mock_login_via_browser.assert_called_once_with(timeout=30)
+	mock_login_via_cdp.assert_called_once_with(cdp_url=None, timeout=30, platform="zhipin")
+	mock_login_via_browser.assert_called_once_with(timeout=30, platform="zhipin")
 	store.save.assert_called_once_with({"cookies": {"wt2": "browser-cookie"}, "stoken": "browser-token"})
 	assert result["_method"] == "扫码登录"
 
@@ -124,6 +124,63 @@ def test_login_uses_qr_httpx_when_cdp_unavailable(
 	mock_login_via_browser.assert_not_called()
 	store.save.assert_called_once_with(qr_token)
 	assert result["_method"] == "QR httpx 登录"
+
+
+@patch("boss_agent_cli.auth.manager.TokenStore")
+@patch("boss_agent_cli.auth.manager.login_via_browser")
+@patch("boss_agent_cli.auth.manager.login_via_cdp")
+@patch("boss_agent_cli.auth.manager.probe_cdp")
+@patch("boss_agent_cli.auth.manager.extract_cookies")
+def test_zhilian_login_uses_valid_cookie_without_qr_or_browser(
+	mock_extract,
+	mock_probe_cdp,
+	mock_login_via_cdp,
+	mock_login_via_browser,
+	mock_store_cls,
+	tmp_path,
+):
+	store = _make_store()
+	mock_store_cls.return_value = store
+	cookie_token = {"cookies": {"zp_token": "cookie-token"}, "user_agent": "ua", "x_zp_client_id": "cid"}
+	mock_extract.return_value = cookie_token
+
+	manager = AuthManager(tmp_path, platform="zhilian")
+
+	with patch.object(manager, "_verify_cookie", return_value=True):
+		result = manager.login()
+
+	mock_probe_cdp.assert_not_called()
+	mock_login_via_cdp.assert_not_called()
+	mock_login_via_browser.assert_not_called()
+	store.save.assert_called_once_with(cookie_token)
+	assert result["_method"] == "Cookie 提取"
+
+
+@patch("boss_agent_cli.auth.manager.TokenStore")
+@patch("boss_agent_cli.auth.manager.login_via_browser")
+@patch("boss_agent_cli.auth.manager.login_via_cdp")
+@patch("boss_agent_cli.auth.manager.probe_cdp")
+@patch("boss_agent_cli.auth.manager.extract_cookies")
+def test_zhilian_login_falls_back_to_browser_when_cookie_and_cdp_unavailable(
+	mock_extract,
+	mock_probe_cdp,
+	mock_login_via_cdp,
+	mock_login_via_browser,
+	mock_store_cls,
+	tmp_path,
+):
+	store = _make_store()
+	mock_store_cls.return_value = store
+	mock_extract.return_value = None
+	mock_probe_cdp.return_value = False
+	mock_login_via_browser.return_value = {"cookies": {"zp_token": "browser-cookie"}, "user_agent": "ua"}
+
+	manager = AuthManager(tmp_path, platform="zhilian")
+	result = manager.login(timeout=25)
+
+	mock_login_via_cdp.assert_not_called()
+	mock_login_via_browser.assert_called_once_with(timeout=25, platform="zhilian")
+	assert result["_method"] == "扫码登录"
 
 
 @patch("boss_agent_cli.auth.manager.TokenStore")
@@ -163,3 +220,36 @@ def test_force_refresh_prefers_cdp_and_persists_new_stoken(
 	saved_token = store.save.call_args.args[0]
 	assert saved_token["stoken"] == "new-token"
 	assert manager._token["stoken"] == "new-token"
+
+
+@patch("boss_agent_cli.auth.manager.TokenStore")
+@patch("boss_agent_cli.auth.manager.extract_cookies")
+def test_zhilian_force_refresh_prefers_browser_cookie_extract(mock_extract, mock_store_cls, tmp_path):
+	current = {"cookies": {"zp_token": "old"}, "user_agent": "ua"}
+	store = _make_store(token=current.copy())
+	mock_store_cls.return_value = store
+	mock_extract.return_value = {"cookies": {"zp_token": "new"}, "user_agent": "ua", "x_zp_client_id": "cid"}
+
+	manager = AuthManager(tmp_path, platform="zhilian")
+	with patch.object(manager, "_verify_cookie", return_value=True):
+		manager.force_refresh()
+
+	mock_extract.assert_called_once_with(None, platform="zhilian")
+	store.save.assert_called_once_with({"cookies": {"zp_token": "new"}, "user_agent": "ua", "x_zp_client_id": "cid"})
+
+
+@patch("boss_agent_cli.auth.manager.TokenStore")
+@patch("boss_agent_cli.auth.manager.login_via_cdp")
+@patch("boss_agent_cli.auth.manager.extract_cookies")
+def test_zhilian_force_refresh_falls_back_to_cdp(mock_extract, mock_login_via_cdp, mock_store_cls, tmp_path):
+	current = {"cookies": {"zp_token": "old"}, "user_agent": "ua"}
+	store = _make_store(token=current.copy())
+	mock_store_cls.return_value = store
+	mock_extract.return_value = None
+	mock_login_via_cdp.return_value = {"cookies": {"zp_token": "fresh"}, "user_agent": "ua", "x_zp_client_id": "cid"}
+
+	manager = AuthManager(tmp_path, platform="zhilian")
+	with patch.object(manager, "_verify_cookie", return_value=True):
+		manager.force_refresh(cdp_url="http://127.0.0.1:9222")
+
+	mock_login_via_cdp.assert_called_once_with(cdp_url="http://127.0.0.1:9222", timeout=30, platform="zhilian")

--- a/tests/test_chat_summary_command.py
+++ b/tests/test_chat_summary_command.py
@@ -10,6 +10,7 @@ def _ctx_mock(mock_cls):
 	instance = mock_cls.return_value
 	instance.__enter__ = lambda self: self
 	instance.__exit__ = lambda self, *a: None
+	instance.unwrap_data.side_effect = lambda response: response.get("zpData") if "zpData" in response else response.get("data")
 	return instance
 
 

--- a/tests/test_chatmsg_extended.py
+++ b/tests/test_chatmsg_extended.py
@@ -12,6 +12,7 @@ def _ctx_mock(mock_cls):
 	instance = mock_cls.return_value
 	instance.__enter__ = lambda self: self
 	instance.__exit__ = lambda self, *a: None
+	instance.unwrap_data.side_effect = lambda response: response.get("zpData") if "zpData" in response else response.get("data")
 	return instance
 
 
@@ -398,6 +399,7 @@ def test_chatmsg_uses_client_context_manager(mock_auth_cls, mock_client_cls):
 	instance = mock_client_cls.return_value
 	instance.__enter__ = MagicMock(return_value=instance)
 	instance.__exit__ = MagicMock(return_value=None)
+	instance.unwrap_data.side_effect = lambda response: response.get("zpData") if "zpData" in response else response.get("data")
 	instance.friend_list.return_value = _friend_list_response([_make_friend()])
 	instance.chat_history.return_value = {"zpData": {"messages": []}}
 	runner = CliRunner()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -40,6 +40,16 @@ def test_status_not_logged_in(mock_auth_cls):
 	assert parsed["error"]["code"] == "AUTH_REQUIRED"
 
 
+@patch("boss_agent_cli.commands.status.AuthManager")
+def test_status_not_logged_in_for_zhilian_has_platform_specific_recovery(mock_auth_cls):
+	mock_auth_cls.return_value.check_status.return_value = None
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--platform", "zhilian", "status"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["recovery_action"] == "boss --platform zhilian login"
+
+
 @patch("boss_agent_cli.commands.status.get_platform_instance")
 @patch("boss_agent_cli.commands.status.AuthManager")
 def test_status_logged_in_happy_path(mock_auth_cls, mock_client_cls):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -11,6 +11,7 @@ def _ctx_mock(mock_cls):
 	instance = mock_cls.return_value
 	instance.__enter__ = lambda self: self
 	instance.__exit__ = lambda self, *a: None
+	instance.unwrap_data.side_effect = lambda response: response.get("zpData") if "zpData" in response else response.get("data")
 	return instance
 
 
@@ -48,6 +49,7 @@ def test_status_logged_in_happy_path(mock_auth_cls, mock_client_cls):
 	mock_client.__enter__ = lambda self: self
 	mock_client.__exit__ = lambda self, *a: None
 	mock_client.user_info.return_value = {"zpData": {"name": "张三"}}
+	mock_client.unwrap_data.return_value = {"name": "张三"}
 
 	runner = CliRunner()
 	result = runner.invoke(cli, ["--json", "status"])
@@ -67,6 +69,7 @@ def test_status_logged_in_unknown_user(mock_auth_cls, mock_client_cls):
 	mock_client.__enter__ = lambda self: self
 	mock_client.__exit__ = lambda self, *a: None
 	mock_client.user_info.return_value = {"zpData": {}}
+	mock_client.unwrap_data.return_value = {}
 
 	runner = CliRunner()
 	result = runner.invoke(cli, ["--json", "status"])
@@ -251,6 +254,7 @@ def test_recommend_success(mock_auth_cls, mock_client_cls, mock_cache_cls):
 			],
 		},
 	}
+	mock_client.unwrap_data.return_value = mock_client.recommend_jobs.return_value["zpData"]
 	runner = CliRunner()
 	result = runner.invoke(cli, ["recommend"])
 	assert result.exit_code == 0
@@ -296,12 +300,58 @@ def test_recommend_with_score(mock_auth_cls, mock_client_cls, mock_cache_cls):
 			],
 		},
 	}
+	def unwrap_data_side_effect(payload):
+		return payload.get("zpData")
+	mock_client.unwrap_data.side_effect = unwrap_data_side_effect
 	runner = CliRunner()
 	result = runner.invoke(cli, ["recommend", "--with-score"])
 	assert result.exit_code == 0
 	parsed = json.loads(result.output)
 	assert parsed["data"][0]["match_score"] >= 0
 	assert "match_reasons" in parsed["data"][0]
+
+
+@patch("boss_agent_cli.commands.recommend.CacheStore")
+@patch("boss_agent_cli.commands.recommend.get_platform_instance")
+@patch("boss_agent_cli.commands.recommend.AuthManager")
+def test_recommend_supports_zhilian_style_data(mock_auth_cls, mock_client_cls, mock_cache_cls):
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.is_greeted.return_value = False
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.recommend_jobs.return_value = {
+		"code": 200,
+		"data": {
+			"hasMore": False,
+			"jobList": [
+				{
+					"encryptJobId": "j1",
+					"jobName": "Go 开发",
+					"brandName": "TestCo",
+					"salaryDesc": "20K",
+					"cityName": "广州",
+					"areaDistrict": "天河区",
+					"jobExperience": "3-5年",
+					"jobDegree": "本科",
+					"skills": ["Golang"],
+					"welfareList": ["五险一金"],
+					"brandIndustry": "互联网",
+					"brandScaleName": "100-499人",
+					"brandStageName": "A轮",
+					"bossName": "李",
+					"bossTitle": "HR",
+					"bossOnline": True,
+					"securityId": "sec_r1",
+				},
+			],
+		},
+	}
+	mock_client.unwrap_data.return_value = mock_client.recommend_jobs.return_value["data"]
+	runner = CliRunner()
+	result = runner.invoke(cli, ["recommend"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["pagination"]["has_more"] is False
 
 
 @patch("boss_agent_cli.commands.search.run_search_pipeline")
@@ -384,6 +434,7 @@ def test_recommend_ignores_index_cache_write_failure(mock_auth_cls, mock_client_
 			],
 		},
 	}
+	mock_client.unwrap_data.return_value = mock_client.recommend_jobs.return_value["zpData"]
 	runner = CliRunner()
 	result = runner.invoke(cli, ["recommend"])
 	assert result.exit_code == 0
@@ -468,6 +519,45 @@ def test_export_to_stdout(mock_auth_cls, mock_client_cls):
 	assert parsed["data"]["count"] == 1
 	assert parsed["data"]["format"] == "csv"
 	assert len(parsed["data"]["jobs"]) == 1
+
+
+@patch("boss_agent_cli.commands.export.get_platform_instance")
+@patch("boss_agent_cli.commands.export.AuthManager")
+def test_export_supports_data_envelope(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.search_jobs.return_value = {
+		"code": 200,
+		"data": {
+			"hasMore": False,
+			"jobList": [
+				{
+					"encryptJobId": "j1",
+					"jobName": "Go 开发",
+					"brandName": "智联科技",
+					"salaryDesc": "20K-30K",
+					"cityName": "上海",
+					"areaDistrict": "浦东",
+					"jobExperience": "3-5年",
+					"jobDegree": "本科",
+					"skills": ["Go"],
+					"welfareList": ["双休"],
+					"brandIndustry": "互联网",
+					"brandScaleName": "100-499人",
+					"brandStageName": "A轮",
+					"bossName": "王经理",
+					"bossTitle": "HRBP",
+					"bossOnline": True,
+					"securityId": "sec_z1",
+				},
+			],
+		},
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "--platform", "zhilian", "export", "golang", "--count", "1"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["jobs"][0]["company"] == "智联科技"
 
 
 def _make_friend_item(name, brand, relation_type, last_ts):
@@ -923,6 +1013,107 @@ def test_chat_export_html_xss_prevention(mock_auth_cls, mock_client_cls, tmp_pat
 	# 转义后的实体应该存在
 	assert "&lt;script&gt;" in content
 	assert "&amp;名" in content
+
+
+@patch("boss_agent_cli.commands.chat_summary.get_platform_instance")
+@patch("boss_agent_cli.commands.chat_summary.AuthManager")
+def test_chat_summary_supports_data_envelope(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = {
+		"code": 200,
+		"data": {"result": [_make_friend_item("张HR", "智联科技", 1, 1700000000000) | {"uid": 12345}]},
+	}
+	mock_client.chat_history.return_value = {
+		"code": 200,
+		"data": {
+			"messages": [
+				{"from": {"uid": 12345, "name": "张HR"}, "text": "您好", "type": 1, "time": 1700000000000},
+				{"from": {"uid": 88888, "name": "我"}, "text": "收到", "type": 1, "time": 1700000001000},
+			],
+		},
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "--platform", "zhilian", "chat-summary", "sec_张HR"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["security_id"] == "sec_张HR"
+
+
+@patch("boss_agent_cli.commands.pipeline.get_platform_instance")
+@patch("boss_agent_cli.commands.pipeline.AuthManager")
+def test_pipeline_supports_data_envelope(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = {
+		"code": 200,
+		"data": {
+			"result": [
+				{
+					"name": "张HR",
+					"title": "后端工程师",
+					"brandName": "智联科技",
+					"lastMsg": "你好",
+					"lastTime": "今天 10:00",
+					"lastTS": 1700000000000,
+					"securityId": "sec_001",
+					"encryptJobId": "job_001",
+					"unreadMsgCount": 1,
+					"relationType": 1,
+					"friendSource": 0,
+				},
+			],
+		},
+	}
+	mock_client.interview_data.return_value = {
+		"code": 200,
+		"data": {
+			"interviewList": [
+				{"jobName": "后端工程师", "brandName": "智联科技", "interviewTimeDesc": "明天 10:00"},
+			],
+		},
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "--platform", "zhilian", "pipeline", "--now-ts-ms", "1700000000000"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert len(parsed["data"]) >= 1
+
+
+@patch("boss_agent_cli.commands.digest.get_platform_instance")
+@patch("boss_agent_cli.commands.digest.AuthManager")
+def test_digest_supports_data_envelope(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = {
+		"code": 200,
+		"data": {
+			"result": [
+				{
+					"name": "张HR",
+					"title": "后端工程师",
+					"brandName": "智联科技",
+					"lastMsg": "你好",
+					"lastTime": "今天 10:00",
+					"lastTS": 1700000000000,
+					"securityId": "sec_001",
+					"encryptJobId": "job_001",
+					"unreadMsgCount": 1,
+					"relationType": 1,
+					"friendSource": 0,
+				},
+			],
+		},
+	}
+	mock_client.interview_data.return_value = {
+		"code": 200,
+		"data": {"interviewList": []},
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "--platform", "zhilian", "digest", "--now-ts-ms", "1700000000000"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert "follow_ups" in parsed["data"]
 
 
 @patch("boss_agent_cli.commands.search.run_search_pipeline")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -410,6 +410,45 @@ def test_search_with_score(mock_client_cls, mock_auth_cls, mock_cache_cls, mock_
 	assert "match_reasons" in parsed["data"][0]
 
 
+@patch("boss_agent_cli.commands.search.run_search_pipeline")
+@patch("boss_agent_cli.commands.search.CacheStore")
+@patch("boss_agent_cli.commands.search.AuthManager")
+@patch("boss_agent_cli.commands.search.get_platform_instance")
+def test_search_supports_zhilian_platform_minimal_loop(mock_client_cls, mock_auth_cls, mock_cache_cls, mock_pipeline):
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.get_search.return_value = None
+	_ctx_mock(mock_client_cls)
+	mock_pipeline.return_value = SimpleNamespace(
+		items=[{
+			"job_id": "zl_001",
+			"title": "Go 开发",
+			"company": "智联测试公司",
+			"salary": "20-30K",
+			"city": "广州",
+			"experience": "3-5年",
+			"education": "本科",
+			"security_id": "zl_sec_001",
+			"greeted": False,
+		}],
+		has_more=False,
+		total=1,
+		stats=SimpleNamespace(
+			pages_scanned=1,
+			jobs_seen=1,
+			jobs_prefiltered=0,
+			detail_checks=0,
+		),
+	)
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--platform", "zhilian", "search", "golang"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"][0]["job_id"] == "zl_001"
+	mock_auth_cls.assert_called_once()
+	assert mock_auth_cls.call_args.kwargs["platform"] == "zhilian"
+
+
 @patch("boss_agent_cli.index_cache.save_index", side_effect=PermissionError("readonly"))
 @patch("boss_agent_cli.commands.recommend.CacheStore")
 @patch("boss_agent_cli.commands.recommend.get_platform_instance")

--- a/tests/test_cookie_extract_regression.py
+++ b/tests/test_cookie_extract_regression.py
@@ -91,6 +91,21 @@ def test_try_extract_success_without_stoken_returns_empty_string():
 	assert result["stoken"] == ""
 
 
+def test_try_extract_supports_zhilian_primary_cookie():
+	def loader(domain_name=None):
+		return [_fake_cookie("zp_token", "zp-token-value", domain=".zhaopin.com")]
+
+	result = _try_extract(
+		loader,
+		domain_name=".zhaopin.com",
+		required_cookie="zp_token",
+		stoken_cookie="",
+	)
+	assert result is not None
+	assert result["cookies"]["zp_token"] == "zp-token-value"
+	assert result["stoken"] == ""
+
+
 # ── extract_cookies 自动检测降级链 ───────────────────────────────
 
 
@@ -173,6 +188,20 @@ def test_extract_cookies_explicit_browser_with_success():
 		result = extract_cookies(source="chrome")
 
 	assert result["cookies"]["wt2"] == "specific-chrome"
+
+
+def test_extract_cookies_supports_zhilian_platform():
+	def chrome_loader(domain_name=None):
+		return [_fake_cookie("zp_token", "zp-chrome", domain=".zhaopin.com")]
+
+	fake_module = MagicMock()
+	fake_module.chrome = chrome_loader
+
+	with patch.dict("sys.modules", {"browser_cookie3": fake_module}):
+		result = extract_cookies(source="chrome", platform="zhilian")
+
+	assert result is not None
+	assert result["cookies"]["zp_token"] == "zp-chrome"
 
 
 def test_extract_cookies_returns_none_when_browser_cookie3_not_installed():

--- a/tests/test_coverage_second_sprint.py
+++ b/tests/test_coverage_second_sprint.py
@@ -12,6 +12,7 @@ def _ctx_mock(mock_cls):
 	instance = mock_cls.return_value
 	instance.__enter__ = lambda self: self
 	instance.__exit__ = lambda self, *a: None
+	instance.unwrap_data.side_effect = lambda response: response.get("zpData") if "zpData" in response else response.get("data")
 	return instance
 
 
@@ -73,6 +74,7 @@ def test_show_job_card_empty_returns_not_found(mock_get_job, mock_auth_cls, mock
 	mock_get_job.return_value = {"security_id": "sec1"}
 	client = _ctx_mock(mock_client_cls)
 	client.job_card.return_value = {"zpData": {"jobCard": {}}}  # 空 card
+	client.unwrap_data.return_value = client.job_card.return_value["zpData"]
 	runner = CliRunner()
 	result = runner.invoke(cli, ["--json", "show", "1"])
 	parsed = json.loads(result.output)

--- a/tests/test_digest_command.py
+++ b/tests/test_digest_command.py
@@ -10,6 +10,7 @@ def _ctx_mock(mock_cls):
 	instance = mock_cls.return_value
 	instance.__enter__ = lambda self: self
 	instance.__exit__ = lambda self, *a: None
+	instance.unwrap_data.side_effect = lambda response: response.get("zpData") if "zpData" in response else response.get("data")
 	return instance
 
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -8,6 +8,7 @@ from boss_agent_cli.display import (
 	handle_output,
 	handle_error_output,
 	handle_auth_errors,
+	login_action_for_ctx,
 )
 
 
@@ -80,6 +81,7 @@ class TestHandleAuthErrors:
 			mock_err.assert_called_once()
 			call_kwargs = mock_err.call_args
 			assert call_kwargs[1]["code"] == "AUTH_REQUIRED"
+			assert call_kwargs[1]["recovery_action"] == "boss login"
 
 	def test_token_refresh_failed(self):
 		from boss_agent_cli.auth.manager import TokenRefreshFailed
@@ -95,6 +97,22 @@ class TestHandleAuthErrors:
 			mock_err.assert_called_once()
 			call_kwargs = mock_err.call_args
 			assert call_kwargs[1]["code"] == "TOKEN_REFRESH_FAILED"
+			assert call_kwargs[1]["recovery_action"] == "boss login"
+
+	def test_auth_required_uses_zhilian_login_action(self):
+		from boss_agent_cli.auth.manager import AuthRequired
+		ctx = MagicMock()
+		ctx.obj = {"json_output": True, "platform": "zhilian"}
+
+		@handle_auth_errors("search")
+		def impl(ctx):
+			raise AuthRequired()
+
+		with patch("boss_agent_cli.display.handle_error_output") as mock_err:
+			impl(ctx)
+			mock_err.assert_called_once()
+			call_kwargs = mock_err.call_args
+			assert call_kwargs[1]["recovery_action"] == "boss --platform zhilian login"
 
 	def test_generic_exception(self):
 		ctx = MagicMock()
@@ -134,6 +152,18 @@ class TestHandleOutputFallback:
 			mock_out.isatty.return_value = True
 			handle_output(ctx, "test", {"key": "val"})
 			mock_emit.assert_called_once()
+
+
+class TestLoginActionForCtx:
+	def test_default_platform_uses_plain_login(self):
+		ctx = MagicMock()
+		ctx.obj = {}
+		assert login_action_for_ctx(ctx) == "boss login"
+
+	def test_zhilian_platform_uses_platform_specific_login(self):
+		ctx = MagicMock()
+		ctx.obj = {"platform": "zhilian"}
+		assert login_action_for_ctx(ctx) == "boss --platform zhilian login"
 
 
 # ── handle_error_output TTY 分支 ─────────────────────────────

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -4,6 +4,7 @@ import sys
 from unittest.mock import patch, MagicMock
 
 from boss_agent_cli.display import (
+	boss_command_for_ctx,
 	is_json_mode,
 	handle_output,
 	handle_error_output,
@@ -155,6 +156,16 @@ class TestHandleOutputFallback:
 
 
 class TestLoginActionForCtx:
+	def test_default_platform_uses_plain_boss_command(self):
+		ctx = MagicMock()
+		ctx.obj = {}
+		assert boss_command_for_ctx(ctx, "status") == "boss status"
+
+	def test_zhilian_platform_uses_platform_specific_boss_command(self):
+		ctx = MagicMock()
+		ctx.obj = {"platform": "zhilian"}
+		assert boss_command_for_ctx(ctx, "status") == "boss --platform zhilian status"
+
 	def test_default_platform_uses_plain_login(self):
 		ctx = MagicMock()
 		ctx.obj = {}
@@ -271,6 +282,10 @@ class TestRenderers:
 	def test_render_status_not_logged_in(self):
 		from boss_agent_cli.display import render_status
 		render_status({"logged_in": False})
+
+	def test_render_status_not_logged_in_with_custom_login_action(self):
+		from boss_agent_cli.display import render_status
+		render_status({"logged_in": False}, login_action="boss --platform zhilian login")
 
 	def test_render_simple_list_empty(self):
 		from boss_agent_cli.display import render_simple_list

--- a/tests/test_doctor_extended.py
+++ b/tests/test_doctor_extended.py
@@ -20,7 +20,7 @@ def _base_patches():
 	}
 
 
-def _invoke_doctor(tmp_path=None, **overrides):
+def _invoke_doctor(tmp_path=None, platform="zhipin", **overrides):
 	"""执行 doctor 命令并返回 (exit_code, parsed_json)。
 
 	overrides 可以覆盖 token / cdp_ws / cookie / http_status / http_exc。
@@ -50,6 +50,8 @@ def _invoke_doctor(tmp_path=None, **overrides):
 		cli_args = []
 		if tmp_path is not None:
 			cli_args.extend(["--data-dir", str(tmp_path)])
+		if platform != "zhipin":
+			cli_args.extend(["--platform", platform])
 		cli_args.append("doctor")
 		result = runner.invoke(cli, cli_args)
 	parsed = json.loads(result.output)
@@ -397,3 +399,23 @@ def test_cookie_completeness_both_missing(tmp_path):
 	assert completeness["status"] == "warn"
 	assert "wbg" in completeness["detail"]
 	assert "zp_at" in completeness["detail"]
+
+
+def test_zhilian_doctor_uses_platform_specific_auth_quality(tmp_path):
+	token = {"cookies": {"zp_token": "tok"}, "x_zp_client_id": "cid"}
+	code, parsed = _invoke_doctor(tmp_path, platform="zhilian", token=token, cookie={"cookies": {"zp_token": "tok"}})
+	quality = _find_check(parsed["data"]["checks"], "auth_token_quality")
+	assert quality is not None
+	assert quality["status"] == "ok"
+	assert "zp_token/x-zp-client-id" in quality["detail"]
+
+
+def test_zhilian_doctor_uses_platform_specific_cookie_and_network_messages(tmp_path):
+	code, parsed = _invoke_doctor(tmp_path, platform="zhilian", token=None, cookie=None, http_status=200)
+	ce = _find_check(parsed["data"]["checks"], "cookie_extract")
+	assert ce is not None
+	assert "zhaopin" in ce["detail"]
+	assert "boss --platform zhilian login" in ce["hint"]
+	network = _find_check(parsed["data"]["checks"], "network")
+	assert network is not None
+	assert "zhaopin.com" in network["detail"]

--- a/tests/test_export_extended.py
+++ b/tests/test_export_extended.py
@@ -16,6 +16,7 @@ def _ctx_mock(mock_cls):
 	instance = mock_cls.return_value
 	instance.__enter__ = lambda self: self
 	instance.__exit__ = lambda self, *a: None
+	instance.unwrap_data.side_effect = lambda response: response.get("zpData") if "zpData" in response else response.get("data")
 	return instance
 
 

--- a/tests/test_greet_detail_extended.py
+++ b/tests/test_greet_detail_extended.py
@@ -18,7 +18,7 @@ _PATCHES = {
 }
 
 
-def _invoke_greet(*args, tmp_path, cache_greeted=False, greet_side_effect=None):
+def _invoke_greet(*args, tmp_path, cache_greeted=False, greet_side_effect=None, greet_result=None, is_success=True, parse_error=("UNKNOWN", "")):
 	runner = CliRunner()
 	with (
 		patch(_PATCHES["auth"]),
@@ -33,6 +33,10 @@ def _invoke_greet(*args, tmp_path, cache_greeted=False, greet_side_effect=None):
 		mock_platform = MagicMock()
 		if greet_side_effect:
 			mock_platform.greet.side_effect = greet_side_effect
+		else:
+			mock_platform.greet.return_value = greet_result if greet_result is not None else {"code": 0, "zpData": {}}
+		mock_platform.is_success.return_value = is_success
+		mock_platform.parse_error.return_value = parse_error
 		mock_get_platform.return_value.__enter__ = lambda s: mock_platform
 		mock_get_platform.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -55,6 +59,19 @@ def test_greet_success(tmp_path):
 	assert parsed["data"]["security_id"] == "sid1"
 	mock_client.greet.assert_called_once_with("sid1", "jid1", "")
 	mock_cache.record_greet.assert_called_once_with("sid1", "jid1")
+
+
+def test_greet_failure_does_not_record_cache(tmp_path):
+	"""业务失败码不应误记成功。"""
+	code, parsed, mock_cache, mock_client = _invoke_greet(
+		"greet", "sid1", "jid1", tmp_path=tmp_path,
+		greet_result={"code": 401, "message": "unauthorized"},
+		is_success=False,
+		parse_error=("AUTH_EXPIRED", "unauthorized"),
+	)
+	assert code == 1
+	assert parsed["error"]["code"] == "AUTH_EXPIRED"
+	mock_cache.record_greet.assert_not_called()
 
 
 def test_greet_already_greeted(tmp_path):
@@ -122,6 +139,7 @@ def _invoke_batch_greet(*args, tmp_path, search_result=None, greeted_ids=None):
 				 "activeTimeDesc": "今日活跃"},
 			]},
 		}
+		mock_client.unwrap_data.side_effect = lambda payload: payload.get("zpData") if "zpData" in payload else payload.get("data")
 		mock_client_cls.return_value.__enter__ = lambda s: mock_client
 		mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -212,6 +230,9 @@ def _invoke_detail(*args, tmp_path, detail_result=None, cache_job_id=None):
 			"brandName": "字节跳动", "bossName": "张经理",
 			"bossTitle": "技术总监", "activeTimeDesc": "刚刚活跃",
 		}}}
+		def unwrap_data_side_effect(payload):
+			return payload.get("zpData")
+		mock_client.unwrap_data.side_effect = unwrap_data_side_effect
 		mock_client_cls.return_value.__enter__ = lambda s: mock_client
 		mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
 

--- a/tests/test_greet_extended.py
+++ b/tests/test_greet_extended.py
@@ -15,6 +15,7 @@ def _ctx_mock(mock_cls):
 	instance = mock_cls.return_value
 	instance.__enter__ = lambda self: self
 	instance.__exit__ = lambda self, *a: None
+	instance.unwrap_data.side_effect = lambda response: response.get("zpData") if "zpData" in response else response.get("data")
 	return instance
 
 
@@ -50,7 +51,8 @@ def test_greet_success_renders_message_and_records_cache(mock_cache_cls, mock_au
 	mock_cache = _ctx_mock(mock_cache_cls)
 	mock_cache.is_greeted.return_value = False
 	mock_platform = _ctx_mock(mock_get_platform)
-	mock_platform.greet.return_value = None
+	mock_platform.greet.return_value = {"code": 0, "zpData": {}}
+	mock_platform.is_success.return_value = True
 
 	runner = CliRunner()
 	result = runner.invoke(cli, ["greet", "sec_001", "job_001"])
@@ -84,7 +86,8 @@ def test_batch_greet_success_all(mock_cache_cls, mock_auth_cls, mock_client_cls,
 	mock_client.search_jobs.return_value = {
 		"zpData": {"jobList": [_make_raw_job("Go 1", "sec_1"), _make_raw_job("Go 2", "sec_2")]}
 	}
-	mock_client.greet.return_value = None  # 成功
+	mock_client.greet.return_value = {"code": 0, "zpData": {}}
+	mock_client.is_success.return_value = True
 	mock_time.sleep = MagicMock()
 
 	runner = CliRunner()
@@ -119,10 +122,11 @@ def test_batch_greet_rate_limited_stops_remaining(mock_cache_cls, mock_auth_cls,
 
 	def greet_side_effect(sid, jid, msg=""):
 		if sid == "s1":
-			return None
+			return {"code": 0, "zpData": {}}
 		raise RuntimeError("RATE_LIMITED 请求频率过高")
 
 	mock_client.greet.side_effect = greet_side_effect
+	mock_client.is_success.return_value = True
 	mock_time.sleep = MagicMock()
 
 	runner = CliRunner()
@@ -146,6 +150,7 @@ def test_batch_greet_greet_limit_stops_remaining(mock_cache_cls, mock_auth_cls, 
 		"zpData": {"jobList": [_make_raw_job("A", "s1"), _make_raw_job("B", "s2")]}
 	}
 	mock_client.greet.side_effect = RuntimeError("GREET_LIMIT 今日上限已达")
+	mock_client.is_success.return_value = True
 	mock_time.sleep = MagicMock()
 
 	runner = CliRunner()
@@ -176,9 +181,10 @@ def test_batch_greet_network_error_retries_once_then_skips(mock_cache_cls, mock_
 		if sid == "s1":
 			call_counts["s1"] += 1
 			raise ConnectionError("network timeout")
-		return None
+		return {"code": 0, "zpData": {}}
 
 	mock_client.greet.side_effect = greet_side_effect
+	mock_client.is_success.return_value = True
 	mock_time.sleep = MagicMock()
 
 	runner = CliRunner()
@@ -212,9 +218,10 @@ def test_batch_greet_network_error_first_retry_succeeds(mock_cache_cls, mock_aut
 		call_count["n"] += 1
 		if call_count["n"] == 1:
 			raise ConnectionError("transient")
-		return None  # 第二次成功
+		return {"code": 0, "zpData": {}}  # 第二次成功
 
 	mock_client.greet.side_effect = greet_side_effect
+	mock_client.is_success.return_value = True
 	mock_time.sleep = MagicMock()
 
 	runner = CliRunner()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -42,6 +42,21 @@ def test_all_tools_have_name_and_description():
 		assert tool.description, f"{tool.name} 缺少描述"
 
 
+def test_candidate_tool_description_includes_availability():
+	search = next(t for t in TOOLS if t.name == "boss_search")
+	assert "可用性:" in search.description
+	assert "roles=candidate" in search.description
+	assert "zhilian" in search.description
+	assert "zhipin" in search.description
+
+
+def test_recruiter_tool_description_includes_availability():
+	tool = next(t for t in TOOLS if t.name == "boss_hr_candidates")
+	assert "可用性:" in tool.description
+	assert "roles=recruiter" in tool.description
+	assert "zhipin-recruiter" in tool.description
+
+
 def test_all_tools_have_input_schema():
 	"""每个工具都应有输入模式定义。"""
 	for tool in TOOLS:

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -10,6 +10,7 @@ def _ctx_mock(mock_cls):
 	instance = mock_cls.return_value
 	instance.__enter__ = lambda self: self
 	instance.__exit__ = lambda self, *a: None
+	instance.unwrap_data.side_effect = lambda response: response.get("zpData") if "zpData" in response else response.get("data")
 	return instance
 
 
@@ -63,6 +64,27 @@ def test_chatmsg_not_found(mock_auth_cls, mock_client_cls):
 	assert result.exit_code == 1
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "JOB_NOT_FOUND"
+
+
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
+@patch("boss_agent_cli.commands.chatmsg.AuthManager")
+def test_chatmsg_supports_data_envelope(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = {"code": 200, "data": {"result": [_make_friend()]}}
+	mock_client.chat_history.return_value = {
+		"code": 200,
+		"data": {
+			"messages": [
+				{"from": {"uid": 99, "name": "张HR"}, "type": 1, "text": "智联你好", "time": 1700000000000},
+			],
+		},
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chatmsg", "sec_001"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"][0]["text"] == "智联你好"
 
 
 # ── mark ─────────────────────────────────────────────────────────────
@@ -174,6 +196,7 @@ def test_detail_with_job_id(mock_auth_cls, mock_client_cls, mock_cache_cls):
 			},
 		},
 	}
+	mock_client.unwrap_data.return_value = mock_client.job_detail.return_value["zpData"]
 	runner = CliRunner()
 	result = runner.invoke(cli, ["detail", "sec_001", "--job-id", "enc_001"])
 	assert result.exit_code == 0
@@ -202,6 +225,19 @@ def test_me_basic(mock_auth_cls, mock_client_cls):
 	assert "测试用户" in str(parsed["data"])
 
 
+@patch("boss_agent_cli.commands.me.get_platform_instance")
+@patch("boss_agent_cli.commands.me.AuthManager")
+def test_me_user_section_supports_data_envelope(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.user_info.return_value = {"code": 200, "data": {"name": "智联用户", "email": "z@demo.dev"}}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["me", "--section", "user"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["user"]["name"] == "智联用户"
+
+
 # ── history ──────────────────────────────────────────────────────────
 
 
@@ -225,6 +261,7 @@ def test_history_success(mock_auth_cls, mock_client_cls):
 			],
 		},
 	}
+	mock_client.unwrap_data.return_value = mock_client.job_history.return_value["zpData"]
 	runner = CliRunner()
 	result = runner.invoke(cli, ["history"])
 	assert result.exit_code == 0
@@ -239,6 +276,7 @@ def test_history_uses_client_context_manager(mock_auth_cls, mock_client_cls):
 	instance.__enter__ = MagicMock(return_value=instance)
 	instance.__exit__ = MagicMock(return_value=None)
 	instance.job_history.return_value = {"code": 0, "zpData": {"hasMore": False, "jobList": []}}
+	instance.unwrap_data.return_value = instance.job_history.return_value["zpData"]
 	runner = CliRunner()
 	result = runner.invoke(cli, ["history"])
 	assert result.exit_code == 0
@@ -257,11 +295,29 @@ def test_interviews_success(mock_auth_cls, mock_client_cls):
 		"code": 0,
 		"zpData": {"interviewList": []},
 	}
+	mock_client.unwrap_data.return_value = mock_client.interview_data.return_value["zpData"]
 	runner = CliRunner()
 	result = runner.invoke(cli, ["interviews"])
 	assert result.exit_code == 0
 	parsed = json.loads(result.output)
 	assert parsed["ok"] is True
+
+
+@patch("boss_agent_cli.commands.interviews.get_platform_instance")
+@patch("boss_agent_cli.commands.interviews.AuthManager")
+def test_interviews_supports_zhilian_style_data(mock_auth_cls, mock_client_cls):
+	mock_auth_cls.return_value.check_status.return_value = {"cookies": {"zp_token": "x"}}
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.interview_data.return_value = {
+		"code": 200,
+		"data": {"interviewList": [{"jobName": "测试岗位"}]},
+	}
+	mock_client.unwrap_data.return_value = mock_client.interview_data.return_value["data"]
+	runner = CliRunner()
+	result = runner.invoke(cli, ["interviews"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["data"][0]["jobName"] == "测试岗位"
 
 
 @patch("boss_agent_cli.commands.detail.CacheStore")
@@ -281,6 +337,7 @@ def test_detail_uses_client_context_manager(mock_auth_cls, mock_client_cls, mock
 			"brandComInfo": {"brandName": "TestCo"},
 		},
 	}
+	instance.unwrap_data.return_value = instance.job_detail.return_value["zpData"]
 	runner = CliRunner()
 	result = runner.invoke(cli, ["detail", "sec_001", "--job-id", "enc_001"])
 	assert result.exit_code == 0
@@ -318,6 +375,9 @@ def test_detail_httpx_fallback_to_browser_on_auth_error(mock_auth_cls, mock_clie
 			}
 		}
 	}
+	def unwrap_data_side_effect(payload):
+		return payload.get("zpData")
+	mock_client.unwrap_data.side_effect = unwrap_data_side_effect
 	runner = CliRunner()
 	result = runner.invoke(cli, ["detail", "sec_001", "--job-id", "enc_001"])
 	assert result.exit_code == 0, f"exit_code={result.exit_code}, output={result.output}"
@@ -358,6 +418,9 @@ def test_detail_httpx_fallback_to_browser_on_none(mock_auth_cls, mock_client_cls
 			}
 		}
 	}
+	def unwrap_data_side_effect(payload):
+		return payload.get("zpData")
+	mock_client.unwrap_data.side_effect = unwrap_data_side_effect
 	runner = CliRunner()
 	result = runner.invoke(cli, ["detail", "sec_001", "--job-id", "enc_001"])
 	assert result.exit_code == 0
@@ -390,6 +453,7 @@ def test_show_uses_client_context_manager(mock_auth_cls, mock_client_cls, mock_g
 			},
 		},
 	}
+	instance.unwrap_data.return_value = instance.job_card.return_value["zpData"]
 	runner = CliRunner()
 	result = runner.invoke(cli, ["show", "1"])
 	assert result.exit_code == 0
@@ -405,6 +469,7 @@ def test_interviews_uses_client_context_manager(mock_auth_cls, mock_client_cls):
 	instance.__enter__ = MagicMock(return_value=instance)
 	instance.__exit__ = MagicMock(return_value=None)
 	instance.interview_data.return_value = {"code": 0, "zpData": {"interviewList": []}}
+	instance.unwrap_data.return_value = instance.interview_data.return_value["zpData"]
 	runner = CliRunner()
 	result = runner.invoke(cli, ["interviews"])
 	assert result.exit_code == 0

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -513,6 +513,16 @@ def test_logout_success(mock_auth_cls):
 	assert parsed["ok"] is True
 
 
+@patch("boss_agent_cli.commands.logout.AuthManager")
+def test_logout_success_for_zhilian_has_platform_specific_next_action(mock_auth_cls):
+	mock_auth_cls.return_value.logout.return_value = None
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--platform", "zhilian", "logout"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["hints"]["next_actions"][0] == "boss --platform zhilian login — 重新登录"
+
+
 # ── schema 包含新命令 ────────────────────────────────────────────────
 
 

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -87,6 +87,27 @@ def test_chatmsg_supports_data_envelope(mock_auth_cls, mock_client_cls):
 	assert parsed["data"][0]["text"] == "智联你好"
 
 
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
+@patch("boss_agent_cli.commands.chatmsg.AuthManager")
+def test_chatmsg_zhilian_hints_use_platform_specific_commands(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = {"code": 200, "data": {"result": [_make_friend()]}}
+	mock_client.chat_history.return_value = {
+		"code": 200,
+		"data": {
+			"messages": [
+				{"from": {"uid": 99, "name": "张HR"}, "type": 1, "text": "智联你好", "time": 1700000000000},
+			],
+		},
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--platform", "zhilian", "chatmsg", "sec_001"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["hints"]["next_actions"][0] == "boss --platform zhilian chat — 返回沟通列表"
+	assert parsed["hints"]["next_actions"][1] == "boss --platform zhilian detail sec_001 — 查看职位详情"
+
+
 # ── mark ─────────────────────────────────────────────────────────────
 
 
@@ -206,6 +227,36 @@ def test_detail_with_job_id(mock_auth_cls, mock_client_cls, mock_cache_cls):
 	assert "Golang" in parsed["data"]["skills"]
 
 
+@patch("boss_agent_cli.commands.detail.CacheStore")
+@patch("boss_agent_cli.commands.detail.get_platform_instance")
+@patch("boss_agent_cli.commands.detail.AuthManager")
+def test_detail_zhilian_hints_use_platform_specific_commands(mock_auth_cls, mock_client_cls, mock_cache_cls):
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.is_greeted.return_value = False
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.job_detail.return_value = {
+		"code": 200,
+		"data": {
+			"jobInfo": {
+				"jobName": "Go 开发",
+				"salaryDesc": "30K",
+				"experienceName": "3-5年",
+				"degreeName": "本科",
+				"jobLabels": ["Golang"],
+			},
+			"bossInfo": {"name": "张总", "title": "CTO"},
+			"brandComInfo": {"brandName": "智联测试公司"},
+		},
+	}
+	mock_client.unwrap_data.return_value = mock_client.job_detail.return_value["data"]
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--platform", "zhilian", "detail", "sec_001", "--job-id", "enc_001"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["hints"]["next_actions"][0] == "boss --platform zhilian greet sec_001 enc_001"
+	assert parsed["hints"]["next_actions"][1] == "boss --platform zhilian search <query>"
+
+
 # ── me ───────────────────────────────────────────────────────────────
 
 
@@ -236,6 +287,19 @@ def test_me_user_section_supports_data_envelope(mock_auth_cls, mock_client_cls):
 	parsed = json.loads(result.output)
 	assert parsed["ok"] is True
 	assert parsed["data"]["user"]["name"] == "智联用户"
+
+
+@patch("boss_agent_cli.commands.me.get_platform_instance")
+@patch("boss_agent_cli.commands.me.AuthManager")
+def test_me_zhilian_hints_use_platform_specific_commands(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.user_info.return_value = {"code": 200, "data": {"name": "智联用户"}}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--platform", "zhilian", "me", "--section", "user"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["hints"]["next_actions"][0] == "boss --platform zhilian search <关键词> --city <城市>"
+	assert parsed["hints"]["next_actions"][1] == "boss --platform zhilian recommend"
 
 
 # ── history ──────────────────────────────────────────────────────────
@@ -282,6 +346,36 @@ def test_history_uses_client_context_manager(mock_auth_cls, mock_client_cls):
 	assert result.exit_code == 0
 	instance.__enter__.assert_called_once()
 	instance.__exit__.assert_called_once()
+
+
+@patch("boss_agent_cli.commands.history.get_platform_instance")
+@patch("boss_agent_cli.commands.history.AuthManager")
+def test_history_zhilian_hints_use_platform_specific_commands(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.job_history.return_value = {
+		"code": 200,
+		"data": {
+			"hasMore": True,
+			"jobList": [
+				{
+					"encryptJobId": "j1", "jobName": "测试岗位",
+					"brandName": "公司A", "salaryDesc": "20K",
+					"cityName": "北京", "jobExperience": "3-5年",
+					"jobDegree": "本科", "bossName": "HR",
+					"bossTitle": "招聘", "bossOnline": True,
+					"securityId": "sec_h1",
+				},
+			],
+		},
+	}
+	mock_client.unwrap_data.return_value = mock_client.job_history.return_value["data"]
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--platform", "zhilian", "history"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["hints"]["next_actions"][0] == "使用 boss --platform zhilian detail <security_id> 查看职位详情"
+	assert parsed["hints"]["next_actions"][1] == "使用 boss --platform zhilian greet <security_id> <job_id> 打招呼"
+	assert parsed["hints"]["next_actions"][2] == "使用 boss --platform zhilian history --page 2 查看下一页"
 
 
 # ── interviews ───────────────────────────────────────────────────────

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -257,6 +257,38 @@ def test_detail_zhilian_hints_use_platform_specific_commands(mock_auth_cls, mock
 	assert parsed["hints"]["next_actions"][1] == "boss --platform zhilian search <query>"
 
 
+@patch("boss_agent_cli.commands.show.CacheStore")
+@patch("boss_agent_cli.commands.show.get_job_by_index")
+@patch("boss_agent_cli.commands.show.get_platform_instance")
+@patch("boss_agent_cli.commands.show.AuthManager")
+def test_show_zhilian_hints_use_platform_specific_commands(mock_auth_cls, mock_client_cls, mock_get_job_by_index, mock_cache_cls):
+	mock_get_job_by_index.return_value = {"security_id": "sec_001"}
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.is_greeted.return_value = False
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.job_card.return_value = {
+		"code": 200,
+		"data": {
+			"jobCard": {
+				"encryptJobId": "enc_001",
+				"jobName": "Go 开发",
+				"brandName": "智联测试公司",
+				"salaryDesc": "30K",
+				"cityName": "北京",
+				"experienceName": "3-5年",
+				"degreeName": "本科",
+			},
+		},
+	}
+	mock_client.unwrap_data.return_value = mock_client.job_card.return_value["data"]
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--platform", "zhilian", "show", "1"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["hints"]["next_actions"][0] == "boss --platform zhilian greet sec_001 enc_001"
+	assert parsed["hints"]["next_actions"][1] == "boss --platform zhilian search <query>"
+
+
 # ── me ───────────────────────────────────────────────────────────────
 
 
@@ -412,6 +444,31 @@ def test_interviews_supports_zhilian_style_data(mock_auth_cls, mock_client_cls):
 	assert result.exit_code == 0
 	parsed = json.loads(result.output)
 	assert parsed["data"][0]["jobName"] == "测试岗位"
+
+
+@patch("boss_agent_cli.commands.chat_summary.get_platform_instance")
+@patch("boss_agent_cli.commands.chat_summary.AuthManager")
+def test_chat_summary_zhilian_hints_use_platform_specific_commands(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = {
+		"code": 200,
+		"data": {"result": [_make_friend("张HR", "sec_001", 12345)]},
+	}
+	mock_client.chat_history.return_value = {
+		"code": 200,
+		"data": {
+			"messages": [
+				{"from": {"uid": 12345, "name": "张HR"}, "text": "您好", "type": 1, "time": 1700000000000},
+				{"from": {"uid": 99999, "name": "我"}, "text": "收到", "type": 1, "time": 1700000001000},
+			],
+		},
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "--platform", "zhilian", "chat-summary", "sec_001"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["hints"]["next_actions"][0] == "boss --platform zhilian chat"
+	assert parsed["hints"]["next_actions"][1] == "boss --platform zhilian chatmsg sec_001"
 
 
 @patch("boss_agent_cli.commands.detail.CacheStore")

--- a/tests/test_pipeline_commands.py
+++ b/tests/test_pipeline_commands.py
@@ -10,6 +10,7 @@ def _ctx_mock(mock_cls):
 	instance = mock_cls.return_value
 	instance.__enter__ = lambda self: self
 	instance.__exit__ = lambda self, *a: None
+	instance.unwrap_data.side_effect = lambda response: response.get("zpData") if "zpData" in response else response.get("data")
 	return instance
 
 

--- a/tests/test_platform_base.py
+++ b/tests/test_platform_base.py
@@ -9,7 +9,6 @@
 
 from __future__ import annotations
 
-from typing import Any
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/test_platform_cli.py
+++ b/tests/test_platform_cli.py
@@ -27,7 +27,27 @@ class TestPlatformGlobalOption:
 		meta = payload["data"]
 		assert "supported_platforms" in meta
 		assert "zhipin" in meta["supported_platforms"]
+		assert "supported_recruiter_platforms" in meta
+		assert "zhipin-recruiter" in meta["supported_recruiter_platforms"]
 		assert meta.get("current_platform") == "zhipin"
+
+	def test_schema_exposes_command_availability(self, runner: CliRunner) -> None:
+		from boss_agent_cli.main import cli
+
+		result = runner.invoke(cli, ["schema"])
+		assert result.exit_code == 0
+		payload = json.loads(result.output)
+		commands = payload["data"]["commands"]
+		search_availability = commands["search"]["availability"]
+		assert search_availability["roles"] == ["candidate"]
+		assert "zhipin" in search_availability["candidate_platforms"]
+		assert "zhilian" in search_availability["candidate_platforms"]
+		assert search_availability["recruiter_platforms"] == []
+
+		hr_availability = commands["hr"]["availability"]
+		assert hr_availability["roles"] == ["recruiter"]
+		assert "zhipin-recruiter" in hr_availability["recruiter_platforms"]
+		assert "applications" in hr_availability["subcommands"]
 
 	def test_schema_current_platform_reflects_option(self, runner: CliRunner) -> None:
 		from boss_agent_cli.main import cli
@@ -51,6 +71,17 @@ class TestPlatformGlobalOption:
 		payload = json.loads(result.output)
 		global_opts = payload["data"]["global_options"]
 		assert "--platform" in global_opts
+
+	def test_openai_tools_description_includes_availability(self, runner: CliRunner) -> None:
+		from boss_agent_cli.main import cli
+
+		result = runner.invoke(cli, ["schema", "--format", "openai-tools"])
+		assert result.exit_code == 0
+		payload = json.loads(result.output)
+		tool = next(t for t in payload["data"]["tools"] if t["function"]["name"] == "boss_search")
+		assert "candidate_platforms=" in tool["function"]["description"]
+		assert "zhilian" in tool["function"]["description"]
+		assert "zhipin" in tool["function"]["description"]
 
 
 class TestGetPlatformInstanceHelper:

--- a/tests/test_platform_cli.py
+++ b/tests/test_platform_cli.py
@@ -83,6 +83,16 @@ class TestPlatformGlobalOption:
 		assert "zhilian" in tool["function"]["description"]
 		assert "zhipin" in tool["function"]["description"]
 
+	def test_schema_login_description_mentions_platform_aware_flow(self, runner: CliRunner) -> None:
+		from boss_agent_cli.main import cli
+
+		result = runner.invoke(cli, ["schema"])
+		assert result.exit_code == 0
+		payload = json.loads(result.output)
+		login_desc = payload["data"]["commands"]["login"]["description"]
+		assert "zhipin" in login_desc
+		assert "zhilian" in login_desc
+
 
 class TestGetPlatformInstanceHelper:
 	"""get_platform_instance(ctx, auth) helper。"""

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -104,12 +104,10 @@ def test_ai_service_error_is_exception():
 
 
 def test_platform_is_abstract():
-	import abc
 	assert inspect_abstract(boss_agent_cli.Platform)
 
 
 def inspect_abstract(cls: type) -> bool:
-	import abc
 	return bool(getattr(cls, "__abstractmethods__", set()))
 
 

--- a/tests/test_recruiter_commands.py
+++ b/tests/test_recruiter_commands.py
@@ -1,95 +1,152 @@
-"""Recruiter command group tests."""
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from click.testing import CliRunner
 
 from boss_agent_cli.main import cli
+from boss_agent_cli.commands.recruiter.resume_parser import parse_resume
 
 
 def _ctx_mock(mock_cls):
 	instance = mock_cls.return_value
 	instance.__enter__ = lambda self: self
 	instance.__exit__ = lambda self, *a: None
+	instance.unwrap_data.side_effect = lambda response: response.get("zpData") if "zpData" in response else response.get("data")
 	return instance
 
 
-def test_recruiter_group_is_registered():
+def _invoke(*args):
 	runner = CliRunner()
-	result = runner.invoke(cli, ["--help"])
-	assert result.exit_code == 0
-	assert "hr" in result.output
-	assert "\n  recruiter" not in result.output
-
-
-def test_recruiter_role_flag_is_accepted():
-	runner = CliRunner()
-	result = runner.invoke(cli, ["--role", "recruiter", "--help"])
-	assert result.exit_code == 0
-
-
-@patch("boss_agent_cli.commands.recruiter.applications.get_recruiter_platform_instance")
-@patch("boss_agent_cli.commands.recruiter.applications.AuthManager")
-def test_applications_command_lists_friends(mock_auth_cls, mock_get_platform):
-	mock_platform = _ctx_mock(mock_get_platform)
-	mock_platform.friend_list.return_value = {"code": 0, "zpData": {"list": []}}
-
-	runner = CliRunner()
-	result = runner.invoke(cli, ["--role", "recruiter", "hr", "applications"])
-	assert result.exit_code == 0
-	parsed = json.loads(result.output)
-	assert parsed["ok"] is True
-	assert parsed["command"] == "recruiter-applications"
+	return runner.invoke(cli, ["--role", "recruiter", *args])
 
 
 @patch("boss_agent_cli.commands.recruiter.candidates.get_recruiter_platform_instance")
 @patch("boss_agent_cli.commands.recruiter.candidates.AuthManager")
-def test_candidates_command_searches(mock_auth_cls, mock_get_platform):
-	mock_platform = _ctx_mock(mock_get_platform)
-	mock_platform.search_geeks.return_value = {"code": 0, "zpData": {"list": []}}
-
-	runner = CliRunner()
-	result = runner.invoke(cli, ["--role", "recruiter", "hr", "candidates", "Python"])
+def test_recruiter_candidates_supports_data_envelope(mock_auth_cls, mock_platform_cls):
+	mock_platform = _ctx_mock(mock_platform_cls)
+	mock_platform.search_geeks.return_value = {
+		"code": 200,
+		"data": {"geekList": [{"name": "候选人A"}], "hasMore": False},
+	}
+	result = _invoke("hr", "candidates", "python")
 	assert result.exit_code == 0
 	parsed = json.loads(result.output)
 	assert parsed["ok"] is True
-	assert parsed["command"] == "recruiter-candidates"
+	assert parsed["data"]["geekList"][0]["name"] == "候选人A"
 
 
 @patch("boss_agent_cli.commands.recruiter.chat.get_recruiter_platform_instance")
 @patch("boss_agent_cli.commands.recruiter.chat.AuthManager")
-def test_chat_command_lists_friends(mock_auth_cls, mock_get_platform):
-	mock_platform = _ctx_mock(mock_get_platform)
-	mock_platform.friend_list.return_value = {"code": 0, "zpData": {"list": []}}
-
-	runner = CliRunner()
-	result = runner.invoke(cli, ["--role", "recruiter", "hr", "chat"])
+def test_recruiter_chat_supports_data_envelope(mock_auth_cls, mock_platform_cls):
+	mock_platform = _ctx_mock(mock_platform_cls)
+	mock_platform.friend_list.return_value = {
+		"code": 200,
+		"data": {"friendList": [{"name": "候选人B"}]},
+	}
+	result = _invoke("hr", "chat")
 	assert result.exit_code == 0
 	parsed = json.loads(result.output)
-	assert parsed["ok"] is True
-	assert parsed["command"] == "recruiter-chat"
+	assert parsed["data"]["friendList"][0]["name"] == "候选人B"
 
 
-def test_role_default_is_candidate():
-	runner = CliRunner()
-	result = runner.invoke(cli, ["schema"])
+@patch("boss_agent_cli.commands.recruiter.applications.get_recruiter_platform_instance")
+@patch("boss_agent_cli.commands.recruiter.applications.AuthManager")
+def test_recruiter_applications_supports_data_envelope(mock_auth_cls, mock_platform_cls):
+	mock_platform = _ctx_mock(mock_platform_cls)
+	mock_platform.friend_list.return_value = {
+		"code": 200,
+		"data": {"friendList": [{"name": "候选人C"}]},
+	}
+	result = _invoke("hr", "applications")
 	assert result.exit_code == 0
 	parsed = json.loads(result.output)
-	assert parsed["data"].get("current_role", "candidate") == "candidate"
+	assert parsed["data"]["friendList"][0]["name"] == "候选人C"
 
 
-def test_recruiter_in_schema():
-	runner = CliRunner()
-	result = runner.invoke(cli, ["schema"])
+@patch("boss_agent_cli.commands.recruiter.jobs.get_recruiter_platform_instance")
+@patch("boss_agent_cli.commands.recruiter.jobs.AuthManager")
+def test_recruiter_jobs_list_supports_data_envelope(mock_auth_cls, mock_platform_cls):
+	mock_platform = _ctx_mock(mock_platform_cls)
+	mock_platform.list_jobs.return_value = {
+		"code": 200,
+		"data": {"jobList": [{"jobName": "后端工程师"}]},
+	}
+	result = _invoke("hr", "jobs", "list")
 	assert result.exit_code == 0
 	parsed = json.loads(result.output)
-	assert "hr" in parsed["data"]["commands"]
-	assert "recruiter" not in parsed["data"]["commands"]
+	assert parsed["data"]["jobList"][0]["jobName"] == "后端工程师"
 
 
-def test_recruiter_role_in_schema_output():
-	runner = CliRunner()
-	result = runner.invoke(cli, ["--role", "recruiter", "schema"])
+@patch("boss_agent_cli.commands.recruiter.resume.get_recruiter_platform_instance")
+@patch("boss_agent_cli.commands.recruiter.resume.AuthManager")
+def test_recruiter_resume_exchange_supports_data_envelope(mock_auth_cls, mock_platform_cls):
+	mock_platform = _ctx_mock(mock_platform_cls)
+	mock_platform.exchange_request.return_value = {
+		"code": 200,
+		"data": {"exchangeStatus": "sent"},
+	}
+	result = _invoke("hr", "resume", "geek-1", "--exchange", "--uid", "1", "--gid", "2", "--job-id", "3")
 	assert result.exit_code == 0
 	parsed = json.loads(result.output)
-	assert parsed["data"]["current_role"] == "recruiter"
+	assert parsed["data"]["exchangeStatus"] == "sent"
+	assert "联系方式交换请求已发送" == parsed["data"]["message"]
+
+
+@patch("boss_agent_cli.commands.recruiter.resume.get_recruiter_platform_instance")
+@patch("boss_agent_cli.commands.recruiter.resume.AuthManager")
+def test_recruiter_resume_parse_supports_data_envelope(mock_auth_cls, mock_platform_cls):
+	mock_platform = _ctx_mock(mock_platform_cls)
+	mock_platform.view_geek.return_value = {
+		"code": 200,
+		"data": {
+			"geekDetailInfo": {
+				"geekBaseInfo": {
+					"name": "张三",
+					"gender": 1,
+					"ageDesc": "28岁",
+					"degreeCategory": "本科",
+					"workYearDesc": "5年",
+					"activeTimeDesc": "今日活跃",
+				},
+				"showExpectPosition": {
+					"positionName": "后端工程师",
+					"salaryDesc": "30-40K",
+					"locationName": "上海",
+				},
+			},
+		},
+	}
+	result = _invoke("hr", "resume", "geek-1", "--job-id", "job-1", "--security-id", "sec-1")
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["data"]["basic"]["name"] == "张三"
+	assert parsed["data"]["expectation"]["position"] == "后端工程师"
+
+
+def test_parse_resume_accepts_data_envelope():
+	result = parse_resume(
+		{
+			"code": 200,
+			"data": {
+				"geekDetailInfo": {
+					"geekBaseInfo": {"name": "李四", "gender": 1},
+					"showExpectPosition": {"positionName": "Python 工程师"},
+				},
+			},
+		}
+	)
+	assert result["basic"]["name"] == "李四"
+	assert result["expectation"]["position"] == "Python 工程师"
+
+
+def test_parse_resume_accepts_unwrapped_payload():
+	result = parse_resume(
+		{
+			"geekDetailInfo": {
+				"geekBaseInfo": {"name": "王五", "gender": 0},
+				"showExpectPosition": {"positionName": "测试工程师"},
+			},
+		}
+	)
+	assert result["basic"]["name"] == "王五"
+	assert result["expectation"]["position"] == "测试工程师"

--- a/tests/test_recruiter_commands.py
+++ b/tests/test_recruiter_commands.py
@@ -150,3 +150,14 @@ def test_parse_resume_accepts_unwrapped_payload():
 	)
 	assert result["basic"]["name"] == "王五"
 	assert result["expectation"]["position"] == "测试工程师"
+
+
+def test_hr_group_rejects_unsupported_zhilian_platform():
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--platform", "zhilian", "--json", "hr", "candidates", "python"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["error"]["code"] == "INVALID_PARAM"
+	assert "暂不支持平台" in parsed["error"]["message"]
+	assert "boss --platform zhipin hr ..." == parsed["error"]["recovery_action"]

--- a/tests/test_shortlist.py
+++ b/tests/test_shortlist.py
@@ -37,6 +37,36 @@ def test_shortlist_add_list_remove(tmp_path):
 	assert remove_parsed["data"]["removed"] is True
 
 
+def test_shortlist_zhilian_hints_use_platform_specific_commands(tmp_path):
+	runner = CliRunner()
+	add_result = runner.invoke(
+		cli,
+		[
+			"--data-dir", str(tmp_path),
+			"--json",
+			"--platform", "zhilian",
+			"shortlist", "add", "sec_001", "job_001",
+		],
+	)
+	assert add_result.exit_code == 0
+	add_parsed = json.loads(add_result.output)
+	assert add_parsed["hints"]["next_actions"][0] == "boss --platform zhilian shortlist list"
+	assert add_parsed["hints"]["next_actions"][1] == "boss --platform zhilian shortlist remove sec_001 job_001"
+
+	list_result = runner.invoke(cli, ["--data-dir", str(tmp_path), "--json", "--platform", "zhilian", "shortlist", "list"])
+	assert list_result.exit_code == 0
+	list_parsed = json.loads(list_result.output)
+	assert list_parsed["hints"]["next_actions"][0] == "boss --platform zhilian detail <security_id> --job-id <job_id>"
+
+	remove_result = runner.invoke(
+		cli,
+		["--data-dir", str(tmp_path), "--json", "--platform", "zhilian", "shortlist", "remove", "sec_001", "job_001"],
+	)
+	assert remove_result.exit_code == 0
+	remove_parsed = json.loads(remove_result.output)
+	assert remove_parsed["hints"]["next_actions"][0] == "boss --platform zhilian shortlist list"
+
+
 def test_shortlist_schema_is_exposed():
 	runner = CliRunner()
 	result = runner.invoke(cli, ["schema"])

--- a/tests/test_smoke_p0.py
+++ b/tests/test_smoke_p0.py
@@ -25,9 +25,23 @@ def test_smoke_script_step_metadata_is_complete():
 	module = importlib.util.module_from_spec(spec)
 	spec.loader.exec_module(module)
 	for step in module.DEFAULT_STEPS:
+		assert step.platform
 		assert step.purpose
 		assert step.preconditions
 		assert step.failure_classification
+
+
+def test_smoke_script_can_build_zhilian_steps():
+	spec = importlib.util.spec_from_file_location("smoke_p0", SMOKE_SCRIPT)
+	assert spec is not None and spec.loader is not None
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+
+	steps = module.build_default_steps("zhilian")
+	assert [step.name for step in steps] == ["doctor", "status", "search", "detail"]
+	assert all(step.platform == "zhilian" for step in steps)
+	assert steps[0].command == ["boss", "--platform", "zhilian", "doctor"]
+	assert steps[1].command == ["boss", "--platform", "zhilian", "status"]
 
 
 def test_smoke_runner_distinguishes_step_failure_types():
@@ -40,6 +54,7 @@ def test_smoke_runner_distinguishes_step_failure_types():
 		steps=[
 			module.SmokeStep(
 				name="ok",
+				platform="zhipin",
 				purpose="pass",
 				preconditions=["none"],
 				failure_classification="command_error",
@@ -47,6 +62,7 @@ def test_smoke_runner_distinguishes_step_failure_types():
 			),
 			module.SmokeStep(
 				name="missing",
+				platform="zhipin",
 				purpose="skip",
 				preconditions=["env:BOSS_AGENT_FAKE_TOKEN"],
 				failure_classification="env_error",

--- a/tests/test_zhilian_client.py
+++ b/tests/test_zhilian_client.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 from boss_agent_cli.api.zhilian_client import (
+	APPLY_URL,
+	CSRF_BOOTSTRAP_URL,
 	DETAIL_URL_TEMPLATE,
+	GREET_URL,
 	RECOMMEND_URL,
 	SEARCH_URL,
 	USER_INFO_URL,
 	ZhilianClient,
+	_extract_csrf_token,
 )
 
 
@@ -126,6 +130,91 @@ class TestZhilianClientReadonlyMethods:
 		self.client.user_info()
 		call = self.client._request.call_args
 		assert call.args == ("GET", USER_INFO_URL)
+
+	def test_greet_posts_with_csrf_header(self) -> None:
+		self.client.get_csrf_token = MagicMock(return_value="csrf-123")
+		self.client.greet("sec-1", "job-1", "hello")
+		call = self.client._request.call_args
+		assert call.args == ("POST", GREET_URL)
+		assert call.kwargs["data"] == {
+			"securityId": "sec-1",
+			"jobId": "job-1",
+			"message": "hello",
+		}
+		assert call.kwargs["headers"] == {"csrf-token": "csrf-123"}
+
+	def test_apply_posts_with_csrf_header(self) -> None:
+		self.client.get_csrf_token = MagicMock(return_value="csrf-123")
+		self.client.apply("sec-1", "job-1", lid="list-1")
+		call = self.client._request.call_args
+		assert call.args == ("POST", APPLY_URL)
+		assert call.kwargs["data"] == {
+			"securityId": "sec-1",
+			"jobId": "job-1",
+			"lid": "list-1",
+		}
+		assert call.kwargs["headers"] == {"csrf-token": "csrf-123"}
+
+
+class TestZhilianClientCsrf:
+	"""CSRF token 获取与缓存。"""
+
+	def test_extract_csrf_token_from_meta(self) -> None:
+		html = '<html><head><meta content="csrf-123" name="csrf-token"></head></html>'
+		assert _extract_csrf_token(html) == "csrf-123"
+
+	def test_get_csrf_token_fetches_and_caches_value(self) -> None:
+		client = ZhilianClient(_StubAuth())
+		mock_httpx = MagicMock()
+		mock_resp = MagicMock()
+		mock_resp.status_code = 200
+		mock_resp.text = '<meta name="csrf-token" content="csrf-123">'
+		mock_resp.cookies.items.return_value = []
+		mock_resp.raise_for_status.return_value = None
+		mock_httpx.get.return_value = mock_resp
+		client._get_client = MagicMock(return_value=mock_httpx)
+		client._merge_cookies = MagicMock()
+		client._throttle.wait = MagicMock()
+		client._throttle.mark = MagicMock()
+
+		assert client.get_csrf_token() == "csrf-123"
+		assert client.get_csrf_token() == "csrf-123"
+		mock_httpx.get.assert_called_once_with(
+			CSRF_BOOTSTRAP_URL,
+			headers={
+				"Referer": CSRF_BOOTSTRAP_URL,
+				"Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+			},
+		)
+
+	def test_get_csrf_token_force_refresh_refetches_page(self) -> None:
+		client = ZhilianClient(_StubAuth())
+		client._fetch_csrf_token = MagicMock(side_effect=["csrf-1", "csrf-2"])
+
+		assert client.get_csrf_token() == "csrf-1"
+		assert client.get_csrf_token(force_refresh=True) == "csrf-2"
+		assert client._fetch_csrf_token.call_count == 2
+
+	def test_get_csrf_token_raises_when_meta_missing(self) -> None:
+		client = ZhilianClient(_StubAuth())
+		mock_httpx = MagicMock()
+		mock_resp = MagicMock()
+		mock_resp.status_code = 200
+		mock_resp.text = "<html></html>"
+		mock_resp.cookies.items.return_value = []
+		mock_resp.raise_for_status.return_value = None
+		mock_httpx.get.return_value = mock_resp
+		client._get_client = MagicMock(return_value=mock_httpx)
+		client._merge_cookies = MagicMock()
+		client._throttle.wait = MagicMock()
+		client._throttle.mark = MagicMock()
+
+		try:
+			client.get_csrf_token()
+		except RuntimeError as exc:
+			assert "csrf-token" in str(exc)
+		else:
+			raise AssertionError("expected RuntimeError when csrf meta is missing")
 
 
 class TestPlatformInstanceRoutesToClient:

--- a/tests/test_zhilian_client.py
+++ b/tests/test_zhilian_client.py
@@ -1,80 +1,131 @@
-"""ZhilianClient 契约测试。
-
-Zhilian 内部 HTTP 客户端骨架，Week 2 真实现之前只提供类结构 / __init__ 签名 / 资源生命周期。
-所有 API 调用方法抛 NotImplementedError 并附 Issue #140 链接。
-"""
+"""ZhilianClient P0 契约测试。"""
 
 from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-import pytest
+from boss_agent_cli.api.zhilian_client import (
+	DETAIL_URL_TEMPLATE,
+	RECOMMEND_URL,
+	SEARCH_URL,
+	USER_INFO_URL,
+	ZhilianClient,
+)
 
-from boss_agent_cli.api.zhilian_client import ZhilianClient
+
+class _StubAuth:
+	def __init__(self) -> None:
+		self.token = {
+			"cookies": {"zp_token": "token"},
+			"user_agent": "UA",
+			"x_zp_client_id": "client-id-1",
+		}
+
+	def get_token(self):
+		return self.token
+
+	def force_refresh(self, cdp_url=None):
+		self.token = {**self.token, "zp_token": "refreshed"}
 
 
 class TestZhilianClientStructure:
 	"""ZhilianClient 类结构对齐 BossClient 的公开面。"""
 
 	def test_can_instantiate_with_auth_manager(self) -> None:
-		client = ZhilianClient(MagicMock())
+		client = ZhilianClient(_StubAuth())
 		assert client is not None
 
 	def test_init_accepts_delay_keyword(self) -> None:
-		client = ZhilianClient(MagicMock(), delay=(2.0, 4.0))
+		client = ZhilianClient(_StubAuth(), delay=(2.0, 4.0))
 		assert client._delay == (2.0, 4.0)
 
 	def test_init_accepts_cdp_url_keyword(self) -> None:
-		client = ZhilianClient(MagicMock(), cdp_url="http://localhost:9222")
+		client = ZhilianClient(_StubAuth(), cdp_url="http://localhost:9222")
 		assert client._cdp_url == "http://localhost:9222"
 
 	def test_close_is_callable_and_idempotent(self) -> None:
-		client = ZhilianClient(MagicMock())
+		client = ZhilianClient(_StubAuth())
 		client.close()
 		client.close()  # 重复调用不抛错
+
+	def test_get_client_applies_auth_headers(self) -> None:
+		client = ZhilianClient(_StubAuth())
+		httpx_client = client._get_client()
+		assert httpx_client.headers["User-Agent"] == "UA"
+		assert httpx_client.headers["x-zp-client-id"] == "client-id-1"
+		assert httpx_client.cookies.get("zp_token") == "token"
 
 
 class TestZhilianClientContextManager:
 	"""with 上下文管理器支持。"""
 
 	def test_enter_returns_self(self) -> None:
-		client = ZhilianClient(MagicMock())
+		client = ZhilianClient(_StubAuth())
 		with client as c:
 			assert c is client
 
 	def test_exit_calls_close(self) -> None:
-		client = ZhilianClient(MagicMock())
+		client = ZhilianClient(_StubAuth())
 		with client:
 			assert not client._closed
 		assert client._closed
 
 
-class TestZhilianClientStubMethods:
-	"""Week 2 待实现方法抛清晰 NotImplementedError。"""
+class TestZhilianClientReadonlyMethods:
+	"""P0 只读能力参数构造正确。"""
 
 	def setup_method(self) -> None:
-		self.client = ZhilianClient(MagicMock())
+		self.client = ZhilianClient(_StubAuth())
+		self.client._request = MagicMock(return_value={"code": 200, "data": {}})
 
-	def test_search_jobs_raises(self) -> None:
-		with pytest.raises(NotImplementedError, match="Week 2"):
-			self.client.search_jobs("Python")
+	def test_search_jobs_minimal_params(self) -> None:
+		self.client.search_jobs("Python")
+		call = self.client._request.call_args
+		assert call.args == ("GET", SEARCH_URL)
+		assert call.kwargs["params"] == {"keyword": "Python", "pageNum": 1}
 
-	def test_job_detail_raises(self) -> None:
-		with pytest.raises(NotImplementedError, match="Week 2"):
-			self.client.job_detail("abc")
+	def test_search_jobs_maps_supported_filters(self) -> None:
+		self.client.search_jobs(
+			"Python",
+			page=2,
+			page_size=20,
+			city="530",
+			salary="20K-30K",
+			experience="3-5年",
+			education="本科",
+			scale="100-499人",
+			industry="互联网",
+			stage="A轮",
+			job_type="全职",
+		)
+		params = self.client._request.call_args.kwargs["params"]
+		assert params["keyword"] == "Python"
+		assert params["pageNum"] == 2
+		assert params["pageSize"] == 20
+		assert params["cityId"] == "530"
+		assert params["salary"] == "20K-30K"
+		assert params["workExp"] == "3-5年"
+		assert params["education"] == "本科"
+		assert params["companySize"] == "100-499人"
+		assert params["industry"] == "互联网"
+		assert params["financingStage"] == "A轮"
+		assert params["jobType"] == "全职"
 
-	def test_recommend_jobs_raises(self) -> None:
-		with pytest.raises(NotImplementedError, match="Week 2"):
-			self.client.recommend_jobs()
+	def test_job_detail_uses_path_param_url(self) -> None:
+		self.client.job_detail("job-1")
+		call = self.client._request.call_args
+		assert call.args == ("GET", DETAIL_URL_TEMPLATE.format(job_id="job-1"))
 
-	def test_user_info_raises(self) -> None:
-		with pytest.raises(NotImplementedError, match="Week 2"):
-			self.client.user_info()
+	def test_recommend_jobs_uses_page_num(self) -> None:
+		self.client.recommend_jobs(page=3)
+		call = self.client._request.call_args
+		assert call.args == ("GET", RECOMMEND_URL)
+		assert call.kwargs["params"] == {"pageNum": 3}
 
-	def test_error_messages_point_to_issue_140(self) -> None:
-		with pytest.raises(NotImplementedError) as exc_info:
-			self.client.user_info()
-		assert "#140" in str(exc_info.value)
+	def test_user_info_no_params(self) -> None:
+		self.client.user_info()
+		call = self.client._request.call_args
+		assert call.args == ("GET", USER_INFO_URL)
 
 
 class TestPlatformInstanceRoutesToClient:

--- a/tests/test_zhilian_stub.py
+++ b/tests/test_zhilian_stub.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import json
 from unittest.mock import MagicMock
-
-import pytest
 from click.testing import CliRunner
 
 from boss_agent_cli.platforms import BossPlatform, Platform, get_platform, list_platforms
@@ -119,14 +117,15 @@ class TestZhilianDelegation:
 		self.plat.user_info()
 		self.mock_client.user_info.assert_called_once_with()
 
-	def test_greet_not_implemented_defaults_from_base(self) -> None:
-		"""Platform 基类 greet 抛 NotImplementedError，Zhilian P0 暂沿用。"""
-		with pytest.raises(NotImplementedError):
-			self.plat.greet("sid", "jid")
+	def test_greet_delegates(self) -> None:
+		self.mock_client.greet.return_value = {"code": 200, "data": {}}
+		self.plat.greet("sid", "jid", "hi")
+		self.mock_client.greet.assert_called_once_with("sid", "jid", "hi")
 
-	def test_apply_not_implemented_defaults_from_base(self) -> None:
-		with pytest.raises(NotImplementedError):
-			self.plat.apply("sid", "jid")
+	def test_apply_delegates(self) -> None:
+		self.mock_client.apply.return_value = {"code": 200, "data": {}}
+		self.plat.apply("sid", "jid", "lid-1")
+		self.mock_client.apply.assert_called_once_with("sid", "jid", "lid-1")
 
 	def test_platform_can_enter_with_context(self) -> None:
 		mock_client = MagicMock()
@@ -156,6 +155,7 @@ class TestZhilianCliIntegration:
 		assert result.exit_code == 0
 		payload = json.loads(result.output)
 		assert "zhilian" in payload["data"]["supported_platforms"]
+		assert "zhipin-recruiter" in payload["data"]["supported_recruiter_platforms"]
 
 	def test_schema_platform_choice_updated(self) -> None:
 		"""schema 的 --platform 选项 choices 应包含 zhilian。"""
@@ -167,3 +167,14 @@ class TestZhilianCliIntegration:
 		payload = json.loads(result.output)
 		platform_opt = payload["data"]["global_options"]["--platform"]
 		assert "zhilian" in platform_opt.get("choices", [])
+
+	def test_schema_marks_hr_as_recruiter_only(self) -> None:
+		from boss_agent_cli.main import cli
+
+		runner = CliRunner()
+		result = runner.invoke(cli, ["schema"])
+		assert result.exit_code == 0
+		payload = json.loads(result.output)
+		availability = payload["data"]["commands"]["hr"]["availability"]
+		assert availability["roles"] == ["recruiter"]
+		assert availability["candidate_platforms"] == []

--- a/tests/test_zhilian_stub.py
+++ b/tests/test_zhilian_stub.py
@@ -1,11 +1,4 @@
-"""ZhilianPlatform stub 契约测试。
-
-Zhilian 在 Week 1d 以 stub 形态接入 Platform 注册表，P0/P1/P2 方法暂抛 NotImplementedError，
-但 is_success / unwrap_data / parse_error 按智联真实协议返回正确值，
-验证 Platform 抽象设计对第二平台也自洽（Issue #129 Week 1d 自证）。
-
-Week 2 会把 stub 替换为真实实现。
-"""
+"""ZhilianPlatform 契约测试。"""
 
 from __future__ import annotations
 
@@ -98,30 +91,36 @@ class TestZhilianEnvelopeAdapter:
 		assert code == "UNKNOWN"
 
 
-class TestZhilianStubBehavior:
-	"""Stub 方法在 Week 2 之前应抛 NotImplementedError 附友好提示。"""
+class TestZhilianDelegation:
+	"""ZhilianPlatform 只读方法委托给底层 ZhilianClient。"""
 
 	def setup_method(self) -> None:
-		self.plat = ZhilianPlatform(MagicMock())
+		self.mock_client = MagicMock()
+		self.plat = ZhilianPlatform(self.mock_client)
 
-	def test_search_jobs_not_implemented(self) -> None:
-		with pytest.raises(NotImplementedError, match="Week 2"):
-			self.plat.search_jobs("Python")
+	def test_search_jobs_delegates(self) -> None:
+		self.mock_client.search_jobs.return_value = {"code": 200, "data": {}}
+		result = self.plat.search_jobs("Python", city="530")
+		self.mock_client.search_jobs.assert_called_once_with("Python", city="530")
+		assert result == {"code": 200, "data": {}}
 
-	def test_job_detail_not_implemented(self) -> None:
-		with pytest.raises(NotImplementedError, match="Week 2"):
-			self.plat.job_detail("abc")
+	def test_job_detail_delegates(self) -> None:
+		self.mock_client.job_detail.return_value = {"code": 200, "data": {}}
+		self.plat.job_detail("job-1")
+		self.mock_client.job_detail.assert_called_once_with("job-1")
 
-	def test_recommend_jobs_not_implemented(self) -> None:
-		with pytest.raises(NotImplementedError, match="Week 2"):
-			self.plat.recommend_jobs()
+	def test_recommend_jobs_delegates(self) -> None:
+		self.mock_client.recommend_jobs.return_value = {"code": 200, "data": {}}
+		self.plat.recommend_jobs(page=2)
+		self.mock_client.recommend_jobs.assert_called_once_with(2)
 
-	def test_user_info_not_implemented(self) -> None:
-		with pytest.raises(NotImplementedError, match="Week 2"):
-			self.plat.user_info()
+	def test_user_info_delegates(self) -> None:
+		self.mock_client.user_info.return_value = {"code": 200, "data": {}}
+		self.plat.user_info()
+		self.mock_client.user_info.assert_called_once_with()
 
 	def test_greet_not_implemented_defaults_from_base(self) -> None:
-		"""Platform 基类 greet 抛 NotImplementedError，Zhilian stub 沿用。"""
+		"""Platform 基类 greet 抛 NotImplementedError，Zhilian P0 暂沿用。"""
 		with pytest.raises(NotImplementedError):
 			self.plat.greet("sid", "jid")
 
@@ -129,8 +128,7 @@ class TestZhilianStubBehavior:
 		with pytest.raises(NotImplementedError):
 			self.plat.apply("sid", "jid")
 
-	def test_stub_can_enter_with_context(self) -> None:
-		"""with 上下文即使 P0 方法抛错也能正常关闭（客户端是 MagicMock）。"""
+	def test_platform_can_enter_with_context(self) -> None:
 		mock_client = MagicMock()
 		plat = ZhilianPlatform(mock_client)
 		with plat:


### PR DESCRIPTION
## 背景

继续推进 #140，目标是把 `ZhilianPlatform` 从 Week 2 的“只读/路由可用”推进到候选者侧更真实的可用状态，并把多平台登录、诊断、恢复动作、命令提示和 smoke 证据补齐到可以进入主干评审的程度。

## 本 PR 包含

- 接通智联候选者侧浏览器登录基础链路
- 隔离多平台登录态存储，避免 `zhipin` / `zhilian` 串用 session
- 平台化 `doctor` / `status` / 登录恢复动作 / 主流程 next actions
- 收紧 `zhilian recruiter` 运行时边界，避免误入不支持路径
- 补齐 `zhilian` 候选者最小闭环 smoke 与命令级测试
- 统一 `detail / me / history / chatmsg / show / apply / chat-summary / shortlist` 在 `zhilian` 下的提示输出
- 同步多平台登录与 smoke 文档
- 合并 `master` 最新基线（含已合入的 #157 / #155）

## 验证

- `UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q`
- `UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run ruff check .`

当前分支全量回归结果：`1112 passed`

## 关联 Issue

- Closes #140
