### PR TITLE
chore: 忽略本地技能备份目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,9 @@ AGENTS.md
 GEMINI.md
 .ace-tool/
 .agents/skills/
+.agents/skills.disabled-*/
 .trellis/
+skills/*.disabled-*/
 *.html
 !src/**/*.html
 !demo/**/*.html


### PR DESCRIPTION
## 背景

当前仓库存在本地技能目录备份带来的 Git 噪音：

- `.agents/skills.disabled-*`
- `skills/*.disabled-*`

这些目录是本地备份产物，不属于正式仓库内容，但会持续污染 `git status`，影响后续开发和推送判断。

## 本 PR 包含

- 在 `.gitignore` 中新增精确规则：
  - `.agents/skills.disabled-*/`
  - `skills/*.disabled-*/`
- 保持正式仓库内容不受影响：
  - `skills/boss-agent-cli/SKILL.md` 仍由仓库管理
  - `.agents/skills/boss-agent-cli` 仍由仓库管理

## 说明

这不是删除 skill 正式内容，而是只屏蔽本地 disabled 备份目录，避免把本地临时产物误带入后续开发流。
