### PR TITLE
feat: 支持MCP的HTTP与SSE传输

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -134,13 +134,39 @@ Claude Desktop / Cursor / Codex 等通过 stdin/stdout 直接对接。上述 `cl
 boss-mcp
 ```
 
-### HTTP / SSE（规划中，见 [Issue #48](https://github.com/can4hou6joeng4/boss-agent-cli/issues/48)）
+### SSE
 
-面向远程宿主、自定义编排器的 Server-Sent Events 传输，允许跨机部署 MCP 服务。
+面向支持传统 MCP SSE 传输的宿主或自定义编排器。
 
 ```bash
-# 规划形态（未实现，等 PR 合入）
-python3 mcp-server/server.py --transport sse --host 127.0.0.1 --port 8765
+boss-mcp --transport sse --host 127.0.0.1 --port 8765
+```
+
+默认路径：
+- SSE 建链：`/sse`
+- 消息回传：`/messages/`
+
+如需自定义：
+
+```bash
+boss-mcp --transport sse --port 8765 --sse-path /events --message-path /inbox
+```
+
+### HTTP Streaming
+
+面向支持新版 MCP Streamable HTTP 传输的宿主。
+
+```bash
+boss-mcp --transport http --host 127.0.0.1 --port 8765
+```
+
+默认路径：
+- HTTP Streaming：`/mcp`
+
+如需自定义路径：
+
+```bash
+boss-mcp --transport http --port 8765 --path /rpc
 ```
 
 **设计约束**：

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -13,7 +13,13 @@ _impl = importlib.import_module("boss_agent_cli.mcp_server")
 
 TOOLS = _impl.TOOLS
 _build_args = _impl._build_args
+_create_sse_app = _impl._create_sse_app
+_create_streamable_http_app = _impl._create_streamable_http_app
+_parse_cli_args = _impl._parse_cli_args
+_run_http_server = _impl._run_http_server
 _run_boss = _impl._run_boss
+_run_sse_server = _impl._run_sse_server
+_serve_asgi_app = _impl._serve_asgi_app
 call_tool = _impl.call_tool
 list_tools = _impl.list_tools
 main = _impl.main

--- a/src/boss_agent_cli/mcp_server.py
+++ b/src/boss_agent_cli/mcp_server.py
@@ -1,5 +1,7 @@
 """MCP Server for boss-agent-cli — 让 Claude Desktop / Cursor 直接调用 BOSS 直聘求职工具。"""
 
+import argparse
+import asyncio
 import copy
 import json
 import subprocess
@@ -13,6 +15,12 @@ from boss_agent_cli.commands.schema import SCHEMA_DATA, _availability_note, _inj
 from boss_agent_cli.platforms import list_platforms, list_recruiter_platforms
 
 server = Server("boss-agent-cli")
+DEFAULT_TRANSPORT = "stdio"
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8765
+DEFAULT_HTTP_PATH = "/mcp"
+DEFAULT_SSE_PATH = "/sse"
+DEFAULT_MESSAGE_PATH = "/messages/"
 
 
 def _build_schema_with_availability() -> dict[str, Any]:
@@ -910,9 +918,111 @@ async def main():
 		await server.run(read_stream, write_stream, server.create_initialization_options())
 
 
-def run() -> None:
-	import asyncio
-	asyncio.run(main())
+def _normalize_path(path: str) -> str:
+	if not path.startswith("/"):
+		return f"/{path}"
+	return path
+
+
+def _create_sse_app(*, sse_path: str = DEFAULT_SSE_PATH, message_path: str = DEFAULT_MESSAGE_PATH):
+	from mcp.server.sse import SseServerTransport
+	from starlette.applications import Starlette
+	from starlette.requests import Request
+	from starlette.responses import Response
+	from starlette.routing import Mount, Route
+
+	sse_path = _normalize_path(sse_path)
+	message_path = _normalize_path(message_path)
+	sse = SseServerTransport(message_path)
+
+	async def handle_sse(scope, receive, send):
+		async with sse.connect_sse(scope, receive, send) as streams:
+			await server.run(
+				streams[0],
+				streams[1],
+				server.create_initialization_options(),
+			)
+		return Response()
+
+	async def sse_endpoint(request: Request) -> Response:
+		return await handle_sse(request.scope, request.receive, request._send)
+
+	return Starlette(
+		routes=[
+			Route(sse_path, endpoint=sse_endpoint, methods=["GET"]),
+			Mount(message_path, app=sse.handle_post_message),
+		]
+	)
+
+
+class _StreamableHTTPASGIApp:
+	def __init__(self, session_manager):
+		self.session_manager = session_manager
+
+	async def __call__(self, scope, receive, send) -> None:
+		await self.session_manager.handle_request(scope, receive, send)
+
+
+def _create_streamable_http_app(*, path: str = DEFAULT_HTTP_PATH):
+	from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+	from starlette.applications import Starlette
+	from starlette.routing import Route
+
+	path = _normalize_path(path)
+	session_manager = StreamableHTTPSessionManager(app=server)
+	http_app = _StreamableHTTPASGIApp(session_manager)
+
+	async def lifespan(app):
+		async with session_manager.run():
+			yield
+
+	return Starlette(
+		routes=[Route(path, endpoint=http_app)],
+		lifespan=lifespan,
+	)
+
+
+def _serve_asgi_app(app, *, host: str, port: int) -> None:
+	import uvicorn
+
+	uvicorn.run(app, host=host, port=port, log_level="info")
+
+
+def _run_sse_server(*, host: str, port: int, sse_path: str, message_path: str) -> None:
+	app = _create_sse_app(sse_path=sse_path, message_path=message_path)
+	_serve_asgi_app(app, host=host, port=port)
+
+
+def _run_http_server(*, host: str, port: int, path: str) -> None:
+	app = _create_streamable_http_app(path=path)
+	_serve_asgi_app(app, host=host, port=port)
+
+
+def _parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
+	parser = argparse.ArgumentParser(description="Run boss-agent-cli MCP server")
+	parser.add_argument(
+		"--transport",
+		choices=("stdio", "sse", "http"),
+		default=DEFAULT_TRANSPORT,
+		help="MCP 传输模式（默认 stdio）",
+	)
+	parser.add_argument("--host", default=DEFAULT_HOST, help="HTTP/SSE 监听地址")
+	parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="HTTP/SSE 监听端口")
+	parser.add_argument("--path", default=DEFAULT_HTTP_PATH, help="HTTP streaming 路径")
+	parser.add_argument("--sse-path", default=DEFAULT_SSE_PATH, help="SSE 建链路径")
+	parser.add_argument("--message-path", default=DEFAULT_MESSAGE_PATH, help="SSE 消息回传路径")
+	return parser.parse_args(argv)
+
+
+def run(argv: list[str] | None = None) -> None:
+	args = _parse_cli_args(argv)
+	if args.transport == "stdio":
+		asyncio.run(main())
+		return
+	if args.transport == "sse":
+		_run_sse_server(host=args.host, port=args.port, sse_path=args.sse_path, message_path=args.message_path)
+		return
+	_run_http_server(host=args.host, port=args.port, path=args.path)
 
 
 if __name__ == "__main__":

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,5 +1,5 @@
 """模型上下文协议服务测试 — 覆盖工具定义、参数构建和调用逻辑。"""
-
+import inspect
 import sys
 import types
 from pathlib import Path
@@ -24,7 +24,15 @@ sys.modules.setdefault("mcp.server.stdio", _mcp_stdio)
 sys.modules.setdefault("mcp.types", _mcp_types)
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "mcp-server"))
-from server import TOOLS, _build_args, _run_boss  # noqa: E402
+from server import (  # noqa: E402
+	TOOLS,
+	_build_args,
+	_parse_cli_args,
+	_run_boss,
+	_run_http_server,
+	_run_sse_server,
+	run,
+)
 
 
 # ── 工具定义完整性 ──────────────────────────────────────────────────
@@ -351,6 +359,78 @@ def test_run_boss_timeout(mock_run):
 	mock_run.return_value = MagicMock(stdout='{"ok": true}', stderr="")
 	_run_boss("doctor")
 	assert mock_run.call_args[1]["timeout"] == 120
+
+
+def test_parse_cli_args_defaults():
+	args = _parse_cli_args([])
+	assert args.transport == "stdio"
+	assert args.host == "127.0.0.1"
+	assert args.port == 8765
+	assert args.path == "/mcp"
+	assert args.sse_path == "/sse"
+	assert args.message_path == "/messages/"
+
+
+def test_parse_cli_args_http_overrides():
+	args = _parse_cli_args([
+		"--transport", "http",
+		"--host", "0.0.0.0",
+		"--port", "9000",
+		"--path", "/rpc",
+	])
+	assert args.transport == "http"
+	assert args.host == "0.0.0.0"
+	assert args.port == 9000
+	assert args.path == "/rpc"
+
+
+@patch("boss_agent_cli.mcp_server.asyncio.run")
+@patch("boss_agent_cli.mcp_server.main")
+def test_run_defaults_to_stdio(mock_main, mock_asyncio_run):
+	mock_main.return_value = "stdio-coro"
+	run([])
+	mock_main.assert_called_once_with()
+	mock_asyncio_run.assert_called_once()
+	coro = mock_asyncio_run.call_args.args[0]
+	assert inspect.iscoroutine(coro)
+	coro.close()
+
+
+@patch("boss_agent_cli.mcp_server._run_sse_server")
+def test_run_dispatches_sse_transport(mock_run_sse):
+	run(["--transport", "sse", "--host", "0.0.0.0", "--port", "9001", "--sse-path", "/events", "--message-path", "/inbox"])
+	mock_run_sse.assert_called_once_with(
+		host="0.0.0.0",
+		port=9001,
+		sse_path="/events",
+		message_path="/inbox",
+	)
+
+
+@patch("boss_agent_cli.mcp_server._run_http_server")
+def test_run_dispatches_http_transport(mock_run_http):
+	run(["--transport", "http", "--host", "127.0.0.1", "--port", "9002", "--path", "/rpc"])
+	mock_run_http.assert_called_once_with(host="127.0.0.1", port=9002, path="/rpc")
+
+
+@patch("boss_agent_cli.mcp_server._serve_asgi_app")
+@patch("boss_agent_cli.mcp_server._create_sse_app")
+def test_run_sse_server_builds_app_and_serves(mock_create_app, mock_serve):
+	fake_app = object()
+	mock_create_app.return_value = fake_app
+	_run_sse_server(host="127.0.0.1", port=8765, sse_path="/sse", message_path="/messages/")
+	mock_create_app.assert_called_once_with(sse_path="/sse", message_path="/messages/")
+	mock_serve.assert_called_once_with(fake_app, host="127.0.0.1", port=8765)
+
+
+@patch("boss_agent_cli.mcp_server._serve_asgi_app")
+@patch("boss_agent_cli.mcp_server._create_streamable_http_app")
+def test_run_http_server_builds_app_and_serves(mock_create_app, mock_serve):
+	fake_app = object()
+	mock_create_app.return_value = fake_app
+	_run_http_server(host="127.0.0.1", port=8765, path="/mcp")
+	mock_create_app.assert_called_once_with(path="/mcp")
+	mock_serve.assert_called_once_with(fake_app, host="127.0.0.1", port=8765)
 
 
 # ── 新增工具 _build_args 覆盖（PR #41 扩展）─────────────────


### PR DESCRIPTION
## Summary
- add MCP transport selection with `stdio`, `sse`, and streamable `http` modes while keeping stdio as default
- expose transport helpers through the compatibility wrapper and cover transport dispatch in `tests/test_mcp_server.py`
- update `mcp-server/README.md` with runnable SSE / HTTP transport examples and default paths

## Verification
- `UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q`
- `UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run ruff check .`
- `UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run mypy src/boss_agent_cli`
- smoke tested `uv run boss-mcp --transport http --host 127.0.0.1 --port 8765` with official MCP Python client (`initialize -> list_tools -> call_tool`)

Closes #48
