### PR TITLE
docs: 对齐当前主线文档口径

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@
 
 ## [Unreleased]
 
+### Added
+- MCP server 新增 `stdio` / `sse` / `http` 三种传输模式，`boss-mcp --transport http --port 8765` 与 `boss-mcp --transport sse` 可直接启动，默认仍保持 `stdio`
+- `mcp-server/README.md` 补齐 SSE / HTTP Streaming 启动示例、默认路径和自定义路径说明
+
 ### Changed
 - 测试依赖 `pytest` 最低版本提升到 `9.0.3`，并同步更新锁文件，修复 Dependabot 报告的临时目录处理漏洞告警
+- ROADMAP / README / README.en 对齐当前主线事实：`#48` 已完成，智联候选者侧登录与读写链路已接通，招聘者侧仍保持显式拒绝
 
 ## [1.11.0] - 2026-04-23
 

--- a/README.en.md
+++ b/README.en.md
@@ -70,7 +70,7 @@ Every command outputs **structured JSON** that AI Agents parse directly. No frag
 - **Schema-first integration**: `boss schema` is the capability source of truth for shell agents, SDKs, and tool-export formats
 - **Structured transport**: stdout is JSON-only, stderr is logs-only, which keeps automation stable
 - **Platform-aware login**: `zhipin` uses Cookie → CDP → QR httpx → patchright; `zhilian` uses Cookie → CDP → browser login
-- **Cross-platform adapter layer**: `Platform` / `RecruiterPlatform` registries are live; BOSS is available on both candidate and recruiter sides, and Zhaopin already has candidate-side envelope and command compatibility wired in
+- **Cross-platform adapter layer**: `Platform` / `RecruiterPlatform` registries are live; BOSS is available on both candidate and recruiter sides, and Zhaopin already has candidate-side login plus read/write flow wired in
 - **MCP server with 49 tools**: ready for Claude Desktop / Cursor / Windsurf, including recruiter-side tools without wrapping your own bridge
 
 ## 📦 Install
@@ -135,7 +135,7 @@ boss-agent-cli covers both the job-seeker and the recruiter side, with a pluggab
 | Platform | Candidate | Recruiter | Status |
 |----------|:---------:|:---------:|--------|
 | BOSS Zhipin (`zhipin`) | ✅ | ✅ | default |
-| Zhaopin (`zhilian`)    | 🟡 envelope + command compatibility wired | — | recruiter side not implemented yet, tracked in [Issue #140](https://github.com/can4hou6joeng4/boss-agent-cli/issues/140) |
+| Zhaopin (`zhilian`)    | 🟡 candidate-side login + read/write flow wired | — | recruiter side is still intentionally unavailable at runtime |
 
 ```bash
 # pick a platform
@@ -145,7 +145,8 @@ boss config set platform zhilian
 
 Notes:
 - `boss login` follows the current platform selection
-- `boss --platform zhilian login` is now available for candidate-side auth
+- `boss --platform zhilian login` is available for candidate-side auth
+- candidate-side `search / detail / recommend / user_info / greet / apply` are wired for `zhilian`
 - `boss --platform zhilian hr ...` is still intentionally rejected at runtime because recruiter support is not implemented yet
 
 Architecture notes: [docs/platform-abstraction.md](docs/platform-abstraction.md).

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ boss digest                                                  # 每日汇报
 
 ### 平台与集成基础
 
-- `🔌 多平台抽象`：`Platform` / `RecruiterPlatform` 双注册表已落地；BOSS 直聘求职者/招聘者均可用，智联招聘已接通求职者侧包络与命令兼容。命令：`--platform zhipin|zhilian`
+- `🔌 多平台抽象`：`Platform` / `RecruiterPlatform` 双注册表已落地；BOSS 直聘求职者/招聘者均可用，智联招聘已接通求职者侧登录、只读与写操作链路。命令：`--platform zhipin|zhilian`
 - `📤 结构化输出`：stdout 只输出 JSON 信封，适合 CLI 编排、Shell Agent、MCP 和 Python SDK。命令：`schema` `export`
 - `🧩 Agent 接入`：同一套能力可通过 Skill、subprocess、MCP、Python SDK 四种路径暴露给 Agent。文档：`docs/agent-quickstart.md` `docs/agent-hosts.md`
 
@@ -176,8 +176,9 @@ boss hr jobs list                     # 我发布的职位
 
 补充说明：
 - `boss login` 默认按当前 `--platform` / 配置文件里的 `platform` 工作
-- `boss --platform zhilian login` 已可用，但目前只覆盖**求职者侧**认证链路
-- `boss --platform zhilian hr ...` 仍不支持，招聘者侧继续追踪 [Issue #140](https://github.com/can4hou6joeng4/boss-agent-cli/issues/140)
+- `boss --platform zhilian login` 已可用，当前覆盖**求职者侧**认证链路
+- `boss --platform zhilian` 目前已支持候选者侧 `search / detail / recommend / user_info / greet / apply`
+- `boss --platform zhilian hr ...` 仍不支持，CLI 会直接拒绝执行招聘者侧子命令
 
 <details>
 <summary>📖 CDP 启动示例</summary>
@@ -231,7 +232,7 @@ boss hr candidates "Golang"
 | 平台 | 求职者 | 招聘者 | 状态 |
 |------|:------:|:------:|------|
 | BOSS 直聘 (`zhipin`) | ✅ | ✅ | 默认 |
-| 智联招聘 (`zhilian`) | 🟡 包络与命令兼容已接通 | — | 招聘者侧未接入，继续追踪 [Issue #140](https://github.com/can4hou6joeng4/boss-agent-cli/issues/140) |
+| 智联招聘 (`zhilian`) | 🟡 候选者侧登录 + 读写链路已接通 | — | 招聘者侧未接入，运行时会直接拒绝 `hr` 子命令 |
 
 ```bash
 # 指定平台
@@ -544,7 +545,7 @@ CLI (Click)
     │
     ├── Platform 抽象层（多平台注册表）
     │       ├── BossPlatform (求职者) / BossRecruiterPlatform (招聘者)
-    │       └── ZhilianPlatform (求职者侧包络与命令兼容已接通，招聘者侧未接入)
+    │       └── ZhilianPlatform (求职者侧登录 + 读写链路已接通，招聘者侧未接入)
     │
     ├── BossClient / BossRecruiterClient ── httpx (低风险) + 浏览器 (高风险) 双通道
     │       ├── RequestThrottle (高斯延迟 + 突发惩罚)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@
 
 完整历史见 [CHANGELOG.md](CHANGELOG.md)。
 
-## 🎯 近期（v1.8.x）
+## 🎯 近期（当前主线）
 
 ### 数据可视化
 - [x] `boss stats --format html` 输出交互式漏斗报表（v1.7.1）
@@ -18,7 +18,7 @@
 - [x] codecov badge 集成到 README（v1.7.1）
 
 ### Agent 集成
-- [ ] MCP 服务支持 HTTP streaming（stdio 已支持）— Issue #48 外部贡献者认领中
+- [x] MCP 服务支持 HTTP streaming / SSE / stdio 三种传输（2026-04-27，PR #160）
 - [x] Codex / Cursor / Windsurf 专用接入示例（v1.8.1，docs/integrations/ 全覆盖）
 - [x] OpenAI Functions 格式导出 `boss schema --format openai-tools`（v1.7.1）
 
@@ -42,8 +42,9 @@
   - [x] Week 1b：`--platform` 全局 CLI 选项 + `get_platform_instance` helper + schema 暴露 current_platform
   - [x] Week 1c：命令层全量迁移到 Platform 接口（**20 个命令**：greet / apply / batch-greet / interviews / detail / show / me / recommend / chat / chatmsg / mark / exchange / pipeline / digest / search / export / chat_summary / history / status / watch）
   - [x] Week 1d：ZhilianPlatform stub 接入注册表（抽象自证，包络适配完整实现，P0/P1/P2 暂 NotImplementedError）
-  - [ ] Week 2：ZhilianPlatform 只读实现（search / detail / recommend / user_info）
-  - [ ] Week 3：ZhilianPlatform 写操作（greet / apply）+ 文档 + MCP 适配
+  - [x] Week 2：ZhilianPlatform 只读实现（search / detail / recommend / user_info）
+  - [x] Week 3：ZhilianPlatform 写操作（greet / apply）+ 文档 + MCP 适配
+  - [ ] Week 4：招聘者侧能力评估与是否接入的产品决策（当前仅候选者侧可用）
 
 ### 社区建设
 - [ ] 中文 + 英文视频 demo

--- a/docs/awesome-submissions.md
+++ b/docs/awesome-submissions.md
@@ -1,12 +1,12 @@
 # Awesome List Submissions
 
-本文件记录 boss-agent-cli 向各大 awesome 列表投稿的模板，供维护者提交用。最后更新：v1.11.0 (2026-04-23)。
+本文件记录 boss-agent-cli 向各大 awesome 列表投稿的模板，供维护者提交用。最后更新：master 当前状态 (2026-04-27)。
 
 ## 项目一句话介绍
 
 **中文**：专为 AI Agent 设计的 BOSS 直聘求职 CLI，33 个顶层命令 + 7 个招聘者子命令 + 49 个 MCP 工具，全部输出 JSON，支持 Claude Desktop/Cursor/Windsurf 无缝接入，覆盖求职者与招聘者双端工作流。
 
-**English**: AI-agent-first CLI for BOSS Zhipin. 33 top-level commands + 7 recruiter subcommands + 43 MCP tools, JSON envelope output, typed Python SDK (PEP 561), and out-of-the-box integration for Claude Desktop / Cursor / Windsurf.
+**English**: AI-agent-first CLI for BOSS Zhipin. 33 top-level commands + 7 recruiter subcommands + 49 MCP tools, JSON envelope output, typed Python SDK (PEP 561), and out-of-the-box integration for Claude Desktop / Cursor / Windsurf.
 
 ## 推荐投稿目标
 
@@ -15,7 +15,7 @@
 分类：Productivity / Job Search
 
 ```markdown
-- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - BOSS Zhipin (China's largest recruitment platform) integration for AI agents, exposing 43 MCP tools covering search, greet, chat, pipeline, resume management, and AI-powered interview prep / chat coaching.
+- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - BOSS Zhipin (China's largest recruitment platform) integration for AI agents, exposing 49 MCP tools covering search, greet, chat, pipeline, recruiter ops, resume management, and AI-powered interview prep / chat coaching.
 ```
 
 ### 2. [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code)
@@ -31,7 +31,7 @@
 分类：Specialized Agents
 
 ```markdown
-- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) ![](https://img.shields.io/github/stars/can4hou6joeng4/boss-agent-cli) - Job-hunt CLI purpose-built for AI agents. BOSS Zhipin integration with 33 top-level commands, recruiter workflow subcommands, 43 MCP tools, JSON envelope output, and local-first encrypted storage.
+- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) ![](https://img.shields.io/github/stars/can4hou6joeng4/boss-agent-cli) - Job-hunt CLI purpose-built for AI agents. BOSS Zhipin integration with 33 top-level commands, recruiter workflow subcommands, 49 MCP tools, JSON envelope output, and local-first encrypted storage.
 ```
 
 ### 4. [awesome-python-cli](https://github.com/shinokada/awesome-python-cli)
@@ -45,16 +45,16 @@
 分类：Agents & Automation
 
 ```markdown
-- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - Let your AI agent handle the job hunt. 33 top-level CLI commands + 7 recruiter subcommands + 43 MCP tools covering search, chat, pipeline, recruiter operations, interview prep, and AI resume coaching on BOSS Zhipin.
+- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - Let your AI agent handle the job hunt. 33 top-level CLI commands + 7 recruiter subcommands + 49 MCP tools covering search, chat, pipeline, recruiter operations, interview prep, and AI resume coaching on BOSS Zhipin.
 ```
 
-## 投稿前 Checklist（v1.11.0 最新状态）
+## 投稿前 Checklist（master 当前状态）
 
 - [x] README 双语（中文 + 英文）
 - [x] MIT License
-- [x] CI 全绿 + **1042 测试**
-- [x] 发布到 PyPI（`pip install boss-agent-cli`，当前 1.11.0）
-- [x] GitHub Release 规范（v1.11.0 已发）
+- [x] CI 全绿 + **1119 测试**
+- [x] 发布到 PyPI（`pip install boss-agent-cli`，当前 latest release 1.11.0）
+- [x] GitHub Release 规范（latest release 1.11.0 已发）
 - [x] CHANGELOG 完整
 - [x] Code of Conduct + Security Policy
 - [x] Issue / PR 模板
@@ -64,7 +64,7 @@
 - [x] **mypy / typecheck 阻塞 CI，核心业务模块严格化持续推进**
 - [x] **Cursor / Windsurf / Codex / Claude Code 四个 Agent 宿主集成文档**
 - [x] 英文贡献者指南（CONTRIBUTING.en.md）
-- [x] ≥30 stars（当前 89）
+- [x] ≥30 stars（当前 108）
 - [ ] 视频或 asciinema demo
 
 ## 推广平台
@@ -86,7 +86,7 @@
 3. "`boss ai interview-prep` — 把 JD 扔进 AI，秒出 10 道模拟面试题"
 4. "你只负责描述期望，AI Agent 负责搜、聊、投、跟进"
 5. "MIT License，本地加密存储，数据不出机"
-6. "1042 测试、49 个 MCP 工具、下游 Python 嵌入零学习成本"
+6. "1119 测试、49 个 MCP 工具、下游 Python 嵌入零学习成本"
 
 ## 实际投稿记录 & 渠道约束（2026-04-20 复盘）
 
@@ -94,7 +94,7 @@
 |------|------|---------|------|---------|
 | [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) | 2026-04-17 | PR #4992 | ⏳ 机器人要求先注册 [Glama.ai](https://glama.ai/mcp/servers) | **阻塞**：需在 Glama.ai 提交 MCP server → 通过 server introspection check → 加 `[![...](...badges/score.svg)](...)` 徽章到 PR → 重新 push |
 | [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code) | — | — | ⚠️ 渠道限制 | **必须通过 Web UI issue 表单**（`/issues/new?template=recommend-resource.yml`），**禁止 gh CLI**（违规会被封禁，见 docs/CONTRIBUTING.md 明文警告） |
-| [awesome-agents (kyrolabs)](https://github.com/kyrolabs/awesome-agents) | — | — | 🟢 已具备 traction | 规则明确：brand new repo without demonstrated traction 自动拒绝。当前 89 star 已跨过基础门槛，可进入候选投稿队列 |
+| [awesome-agents (kyrolabs)](https://github.com/kyrolabs/awesome-agents) | — | — | 🟢 已具备 traction | 规则明确：brand new repo without demonstrated traction 自动拒绝。当前 108 star 已跨过基础门槛，可进入候选投稿队列 |
 | [awesome-ai-tools (mahseema)](https://github.com/mahseema/awesome-ai-tools) | — | — | 🟢 可投 | 无明确门槛，可考虑投稿 Agents & Automation 分区 |
 | ~~awesome-python-cli (shinokada)~~ | — | — | ❌ 仓库不存在 | 404，从投稿列表移除 |
 

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -102,6 +102,6 @@
 说明：
 - **通道**：httpx 为直接 API 请求（低风险），浏览器为 CDP/patchright 通道（高风险操作需要真实浏览器指纹），AI 服务为第三方大模型 API。
 - 若以 CLI 直连为主，优先通过 `boss schema` 进行能力发现与参数校验；当前 schema 会同时暴露 `supported_platforms` 与 `supported_recruiter_platforms`。
-- 当前多平台状态：`zhipin` 已覆盖求职者与招聘者；`zhilian` 已接通求职者侧包络与命令兼容，招聘者侧暂未接入。
+- 当前多平台状态：`zhipin` 已覆盖求职者与招聘者；`zhilian` 已接通候选者侧登录、只读与写操作链路，招聘者侧暂未接入。
 - 当前登录状态：`zhipin` 保留四级降级登录；`zhilian` 已接通候选者侧浏览器登录基础链路（Cookie / CDP / 浏览器兜底），但 recruiter 侧仍未接入。
 - 以 `boss schema` 为准：当前暴露 33 个顶层命令；其中 `hr` 下还有 7 个一级招聘者子命令，`ai` / `resume` 为命令组入口。

--- a/docs/platform-abstraction.md
+++ b/docs/platform-abstraction.md
@@ -192,6 +192,6 @@ _REGISTRY: dict[str, type[Platform]] = {
 ## 参考
 
 - [Issue #129 — Week 1 设计 + 实施](https://github.com/can4hou6joeng4/boss-agent-cli/issues/129)
-- [Issue #140 — Week 2 Zhilian 真实现追踪](https://github.com/can4hou6joeng4/boss-agent-cli/issues/140)
+- Zhilian 候选者侧真实现已并入主线（PR #157 / #158 及后续修复），招聘者侧能力仍未接入
 - [Issue #90 — 多平台 API 调研](https://github.com/can4hou6joeng4/boss-agent-cli/issues/90)
 - PR #131 / #132 / #133 / #134 / #135 / #136 / #137 / #138 / #139 / #141 — Week 1 全部 PR


### PR DESCRIPTION
## Summary
- align ROADMAP with the current master state, including completed MCP HTTP/SSE streaming and Zhilian candidate-side milestones
- refresh README / README.en / capability docs so current Zhilian support is described as candidate-side login plus read/write flow
- update awesome submission material and changelog unreleased notes to match the latest MCP tool count, test count, and repo traction

## Verification
- `UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest tests/test_agent_docs.py -q`
