### PR TITLE
chore: 忽略 .codex 本地过程文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 build/
 .pytest_cache/
 .playwright-mcp/
+.codex/
 .worktrees/
 .claude/
 docs/superpowers/


### PR DESCRIPTION
## Summary
- add `.codex/` to `.gitignore`
- keep local Codex process notes out of normal Git history and future pushes
