### PR TITLE
fix: 放宽 headless 预热等待策略

### DIFF
--- a/skills/boss-agent-cli/SKILL.md
+++ b/skills/boss-agent-cli/SKILL.md
@@ -114,6 +114,14 @@ patchright install chromium    # QR httpx 模式可省略此步
 
 > Codex 环境中所有命令加 `--data-dir /tmp/boss-agent-codex`
 
+### 搜索前的环境兜底
+
+- `boss search` / `boss recommend` / `boss greet` 依赖浏览器通道，不是纯 `httpx`
+- 如果上一条相关命令报 `NETWORK_ERROR`，不要直接判断成“skill 参数错了”或“未登录”
+- 先执行 `boss --data-dir /tmp/boss-agent-codex --json doctor`
+- 若 `network=ok` 但 `browser_channel=warn` 或 `cdp=warn`，说明命令会降级到 `headless patchright`，此时更容易出现页面预热超时或风控
+- 优先修复浏览器通道后再重试：启动带 `--remote-debugging-port=9222` 的 Chrome，或接入 Bridge；仅在 `status` / `doctor` 也失败时，再回头排查 data dir、登录态或网络
+
 ## 命令速查（32 个）
 
 运行 `boss schema` 获取完整命令定义。运行 `boss <cmd> --help` 查看单个命令帮助。

--- a/src/boss_agent_cli/api/browser_client.py
+++ b/src/boss_agent_cli/api/browser_client.py
@@ -23,6 +23,7 @@ HOME_URL = "https://www.zhipin.com/"
 # 超时常量
 _CDP_PROBE_TIMEOUT = 3           # CDP 探测 HTTP 超时（秒）
 _NAV_TIMEOUT_MS = 15000          # 页面导航超时（毫秒）
+_HEADLESS_NETWORKIDLE_GRACE_MS = 3000  # headless 预热的额外宽限，避免卡满 30s
 
 # macOS / Linux / Windows Chrome user data 默认路径
 _CHROME_USER_DATA_CANDIDATES = [
@@ -212,8 +213,13 @@ class BrowserSession:
 			for name, value in self._cookies.items()
 		])
 		self._page = self._context.new_page()
-		self._page.goto(HOME_URL, wait_until="domcontentloaded")
-		self._page.wait_for_load_state("networkidle")
+		self._page.goto(HOME_URL, wait_until="domcontentloaded", timeout=_NAV_TIMEOUT_MS)
+		try:
+			self._page.wait_for_load_state("networkidle", timeout=_HEADLESS_NETWORKIDLE_GRACE_MS)
+		except Exception as e:
+			# zhipin 首页常驻请求较多，headless 模式下不一定能进入 networkidle；
+			# 页面 JS 环境已可用时，继续直接发起 fetch 请求更稳。
+			self._log(f"[boss] headless 首页未进入 networkidle（{e}），继续直接发起请求")
 		self._started = True
 		self._is_cdp = False
 		self._log("[boss] CDP 不可用（提示：需以 --remote-debugging-port=9222 启动 Chrome），降级到 headless patchright")

--- a/tests/test_browser_client.py
+++ b/tests/test_browser_client.py
@@ -2,7 +2,12 @@ from unittest.mock import patch, MagicMock
 
 import httpx
 
-from boss_agent_cli.api.browser_client import BrowserSession
+from boss_agent_cli.api.browser_client import (
+	HOME_URL,
+	_HEADLESS_NETWORKIDLE_GRACE_MS,
+	_NAV_TIMEOUT_MS,
+	BrowserSession,
+)
 
 
 def test_browser_session_defaults():
@@ -140,3 +145,37 @@ def test_try_connect_creates_new_context_when_none_exists():
 	mock_new_context.add_cookies.assert_called_once()
 	cookies_arg = mock_new_context.add_cookies.call_args[0][0]
 	assert any(c["name"] == "wt2" for c in cookies_arg)
+
+
+def test_start_headless_tolerates_networkidle_timeout():
+	"""Headless 预热不应因 networkidle 等待超时而直接失败。"""
+	logger = MagicMock()
+	session = BrowserSession(cookies={"wt2": "abc"}, user_agent="UA", logger=logger)
+	session._pw = MagicMock()
+
+	mock_browser = MagicMock()
+	mock_context = MagicMock()
+	mock_page = MagicMock()
+	mock_page.wait_for_load_state.side_effect = Exception("Timeout 30000ms exceeded")
+	mock_context.new_page.return_value = mock_page
+	mock_browser.new_context.return_value = mock_context
+	session._pw.chromium.launch.return_value = mock_browser
+
+	session._start_headless()
+
+	assert session._started is True
+	assert session._is_cdp is False
+	mock_page.goto.assert_called_once_with(
+		HOME_URL,
+		wait_until="domcontentloaded",
+		timeout=_NAV_TIMEOUT_MS,
+	)
+	mock_page.wait_for_load_state.assert_called_once_with(
+		"networkidle",
+		timeout=_HEADLESS_NETWORKIDLE_GRACE_MS,
+	)
+	logger.info.assert_any_call("[boss] CDP 不可用（提示：需以 --remote-debugging-port=9222 启动 Chrome），降级到 headless patchright")
+	assert any(
+		"headless 首页未进入 networkidle" in call.args[0]
+		for call in logger.info.call_args_list
+	)


### PR DESCRIPTION
## Summary
- tolerate `networkidle` timeout during headless homepage warm-up and continue once the JS context is usable
- add a focused regression test for the degraded headless path
- document the browser-channel fallback advice in the skill guide

## Verification
- `UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest tests/test_browser_client.py -q`
- `UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q tests/test_browser_client.py tests/test_api.py`
- `UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run ruff check src/boss_agent_cli/api/browser_client.py tests/test_browser_client.py`
- `UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run mypy src/boss_agent_cli/api/browser_client.py`
