### PR TITLE
fix: 放宽认证链路首页预热等待策略

### DIFF
--- a/src/boss_agent_cli/auth/browser.py
+++ b/src/boss_agent_cli/auth/browser.py
@@ -11,6 +11,7 @@ _DEFAULT_CDP_URL = "http://localhost:9222"
 # 超时常量（秒/毫秒）
 _CDP_PROBE_TIMEOUT = 3           # CDP 探测 HTTP 超时（秒）
 _NAV_TIMEOUT_MS = 15000          # 页面导航超时（毫秒）
+_NETWORKIDLE_GRACE_MS = 3000     # 首页进入 networkidle 的额外宽限（毫秒）
 _POST_LOGIN_WAIT = 3             # 登录成功后等待 cookie 传播（秒）
 _STOKEN_GENERATION_WAIT = 2      # stoken 生成等待（秒）
 
@@ -51,6 +52,18 @@ def _extract_zhilian_client_id(page: Any) -> str:
 		"""))
 	except Exception:
 		return ""
+
+
+def _warm_home_for_runtime(page: Any, home_url: str, *, stage: str) -> None:
+	"""预热首页运行时；networkidle 只尽力等待，不作为必须条件。"""
+	try:
+		page.goto(home_url, wait_until="domcontentloaded", timeout=_NAV_TIMEOUT_MS)
+	except Exception as e:
+		print(f"[boss] {stage}：首页导航未在预期时间完成（{e}），继续尝试提取凭证", file=sys.stderr)
+	try:
+		page.wait_for_load_state("networkidle", timeout=_NETWORKIDLE_GRACE_MS)
+	except Exception as e:
+		print(f"[boss] {stage}：首页未进入 networkidle（{e}），继续提取凭证", file=sys.stderr)
 
 
 def probe_cdp(cdp_url: str | None = None) -> str | None:
@@ -181,8 +194,7 @@ def login_via_browser(*, timeout: int = 120, platform: str = "zhipin") -> dict[s
 		time.sleep(_POST_LOGIN_WAIT)
 
 		# 跳转主站提取完整 cookies 和 stoken
-		page.goto(home_url, wait_until="domcontentloaded")
-		page.wait_for_load_state("networkidle")
+		_warm_home_for_runtime(page, home_url, stage="登录后回到首页")
 
 		cookies_list = context.cookies()
 		cookies = {c["name"]: c["value"] for c in cookies_list if cookie_domain in c.get("domain", "")}
@@ -238,8 +250,7 @@ def refresh_stoken(cookies: dict[str, Any], user_agent: str) -> str:
 			for name, value in cookies.items()
 		])
 		page = context.new_page()
-		page.goto(HOME_URL)
-		page.wait_for_load_state("networkidle")
+		_warm_home_for_runtime(page, HOME_URL, stage="刷新 stoken")
 		stoken = _extract_stoken(page)
 		browser.close()
 

--- a/tests/test_auth_browser.py
+++ b/tests/test_auth_browser.py
@@ -1,0 +1,74 @@
+from unittest.mock import MagicMock, patch
+
+from boss_agent_cli.auth.browser import (
+	HOME_URL,
+	LOGIN_PAGE_URL,
+	_NAV_TIMEOUT_MS,
+	_NETWORKIDLE_GRACE_MS,
+	login_via_browser,
+	refresh_stoken,
+)
+
+
+def _mock_playwright_context(mock_browser: MagicMock) -> MagicMock:
+	mock_chromium = MagicMock()
+	mock_chromium.launch.return_value = mock_browser
+	mock_playwright = MagicMock()
+	mock_playwright.chromium = mock_chromium
+	mock_context_manager = MagicMock()
+	mock_context_manager.__enter__ = MagicMock(return_value=mock_playwright)
+	mock_context_manager.__exit__ = MagicMock(return_value=False)
+	return mock_context_manager
+
+
+@patch("boss_agent_cli.auth.browser._extract_stoken", return_value="fresh-stoken")
+@patch("boss_agent_cli.auth.browser.time.sleep", return_value=None)
+def test_login_via_browser_tolerates_networkidle_timeout(mock_sleep, mock_extract_stoken):
+	mock_page = MagicMock()
+	mock_page.wait_for_load_state.side_effect = Exception("Timeout 30000ms exceeded")
+	mock_page.evaluate.return_value = "UA"
+
+	mock_context = MagicMock()
+	mock_context.new_page.return_value = mock_page
+	mock_context.cookies.side_effect = [
+		[{"name": "wt2", "value": "token", "domain": ".zhipin.com"}],
+		[{"name": "wt2", "value": "token", "domain": ".zhipin.com"}],
+	]
+
+	mock_browser = MagicMock()
+	mock_browser.new_context.return_value = mock_context
+
+	with patch("boss_agent_cli.auth.browser.sync_playwright", return_value=_mock_playwright_context(mock_browser)):
+		result = login_via_browser(timeout=2, platform="zhipin")
+
+	assert result["stoken"] == "fresh-stoken"
+	assert result["user_agent"] == "UA"
+	mock_browser.new_context.assert_called_once()
+	mock_page.goto.assert_any_call(LOGIN_PAGE_URL, wait_until="domcontentloaded")
+	mock_page.goto.assert_any_call(HOME_URL, wait_until="domcontentloaded", timeout=_NAV_TIMEOUT_MS)
+	mock_page.wait_for_load_state.assert_called_once_with("networkidle", timeout=_NETWORKIDLE_GRACE_MS)
+	mock_extract_stoken.assert_called_once_with(mock_page)
+	mock_browser.close.assert_called_once()
+
+
+@patch("boss_agent_cli.auth.browser._extract_stoken", return_value="fresh-stoken")
+def test_refresh_stoken_tolerates_networkidle_timeout(mock_extract_stoken):
+	mock_page = MagicMock()
+	mock_page.wait_for_load_state.side_effect = Exception("Timeout 30000ms exceeded")
+
+	mock_context = MagicMock()
+	mock_context.new_page.return_value = mock_page
+
+	mock_browser = MagicMock()
+	mock_browser.new_context.return_value = mock_context
+
+	with patch("boss_agent_cli.auth.browser.sync_playwright", return_value=_mock_playwright_context(mock_browser)):
+		result = refresh_stoken({"wt2": "cookie"}, "UA")
+
+	assert result == "fresh-stoken"
+	mock_browser.new_context.assert_called_once_with(user_agent="UA")
+	mock_context.add_cookies.assert_called_once()
+	mock_page.goto.assert_called_once_with(HOME_URL, wait_until="domcontentloaded", timeout=_NAV_TIMEOUT_MS)
+	mock_page.wait_for_load_state.assert_called_once_with("networkidle", timeout=_NETWORKIDLE_GRACE_MS)
+	mock_extract_stoken.assert_called_once_with(mock_page)
+	mock_browser.close.assert_called_once()


### PR DESCRIPTION
Closes #171

## Summary
- tolerate homepage `networkidle` timeout in `login_via_browser()` and `refresh_stoken()` instead of treating it as a hard failure
- extract shared homepage warm-up logic in `auth/browser.py` so auth fallback paths follow the same degraded strategy
- add regression tests covering login credential extraction and headless stoken refresh under `networkidle` timeout

## Verification
- `UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest tests/test_auth_browser.py tests/test_auth_manager_extended.py tests/test_auth_manager_flow.py -q`
- `UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest tests/ -q`
- `UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run ruff check src/boss_agent_cli/auth/browser.py tests/test_auth_browser.py`
- `UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run mypy src/boss_agent_cli/auth/browser.py`
