### PR TITLE
docs: 对齐仓库内双语接入文档

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -18,9 +18,11 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/can4hou6joeng4/boss-agent-cli/pulls)
 [![Open in Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/can4hou6joeng4/boss-agent-cli)
 
-[Install](#-install) · [Quickstart](#-quickstart) · [Roles & Platforms](#-roles--platforms) · [Agent Integration](#-agent-integration) · [Commands](#-commands) · [Troubleshooting](#-troubleshooting) · [Architecture](#-architecture) · [Changelog](CHANGELOG.md)
+[Install](#-install) · [Quickstart](#-quickstart) · [Roles & Platforms](#-roles--platforms) · [Agent Integration](#-agent-integration) · [Commands](#-commands) · [Troubleshooting](#-troubleshooting) · [Architecture](#-architecture) · [Changelog](CHANGELOG.md) · [Roadmap](ROADMAP.md)
 
 [中文](README.md) | **English**
+
+<img src="demo.gif" alt="boss-agent-cli terminal demo" width="100%">
 
 </div>
 

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -1,36 +1,36 @@
 # Claude Code Integration Example
 
-适用版本：`boss-agent-cli` 当前 CLI 契约（2026-04-13）
+Applies to the current `boss-agent-cli` CLI contract as of April 28, 2026.
 
-## 适用场景
+## Good fit when
 
-- 团队通过 skill 分发统一的求职能力
-- 希望 Agent 在规则文件里固定 BOSS 直聘操作顺序
-- 需要把 `boss` 命令当成稳定 shell 能力暴露给 Claude Code
+- your team distributes job-hunt capability through Skills
+- you want Claude Code rules to enforce a stable BOSS Zhipin workflow
+- you want `boss` exposed as a reliable shell capability for Claude Code
 
-## 最小接入流程
+## Minimal integration
 
-优先安装 skill：
+Preferred path: install the Skill.
 
 ```bash
 npx skills add can4hou6joeng4/boss-agent-cli
 ```
 
-如果你走规则文件方式，可以直接放入以下约束：
+If you prefer a rules-file workflow, you can add guidance like this:
 
 ```markdown
-当用户要求搜索职位、查看职位详情、打招呼或推进招聘沟通时：
-1. 先运行 boss schema
-2. 再运行 boss status
-3. 未登录时运行 boss login
-4. 搜索使用 boss search
-5. 查看详情使用 boss detail
-6. 执行动作使用 boss greet
-7. 招聘者场景使用 boss hr applications / candidates / reply / request-resume
-8. 只读取 stdout JSON，不解析 stderr
+When the user asks to search jobs, inspect job details, greet recruiters, or continue recruiter-side communication:
+1. Run `boss schema` first
+2. Then run `boss status`
+3. If not logged in, run `boss login`
+4. Use `boss search` for discovery
+5. Use `boss detail` for a full job view
+6. Use `boss greet` for the first outbound action
+7. In recruiter workflows, use `boss hr applications / candidates / reply / request-resume`
+8. Read stdout JSON only; do not parse stderr
 ```
 
-最小命令链路：
+Minimal candidate-side command chain:
 
 ```bash
 boss schema
@@ -40,7 +40,7 @@ boss detail <security_id>
 boss greet <security_id> <job_id>
 ```
 
-招聘者最小命令链路：
+Minimal recruiter-side command chain:
 
 ```bash
 boss schema
@@ -50,15 +50,15 @@ boss hr candidates "Golang"
 boss hr reply <friend_id> "你好"
 ```
 
-接入建议：
+Integration advice:
 
-- 把 `boss schema` 结果当成能力真源
-- 把 `boss detail` 返回结果拼回上下文，再决定是否 `boss greet`
-- 遇到 `ok=false` 时优先消费 `error.recovery_action`
+- treat `boss schema` as the source of truth for capabilities and arguments
+- feed `boss detail` output back into the context before deciding whether to call `boss greet`
+- when `ok=false`, prefer `error.recovery_action` before inventing your own retry logic
 
-## 失败恢复
+## Recovery flow
 
-推荐恢复顺序：
+Recommended order:
 
 ```bash
 boss doctor
@@ -67,8 +67,8 @@ boss login
 boss search "Golang" --city 广州
 ```
 
-常见恢复动作：
+Common recovery actions:
 
-- 登录失效：重新执行 `boss login`
-- 参数错误：回到 `boss schema` 或 `boss cities`
-- 环境异常：先跑 `boss doctor`，再决定是否继续 `boss greet`
+- login expired: run `boss login` again
+- invalid parameters: go back to `boss schema` or `boss cities`
+- environment issue: run `boss doctor` first, then decide whether it is safe to continue with `boss greet`

--- a/docs/integrations/codex.md
+++ b/docs/integrations/codex.md
@@ -1,30 +1,30 @@
 # Codex Integration Example
 
-适用版本：`boss-agent-cli` 当前 CLI 契约（2026-04-13）
+Applies to the current `boss-agent-cli` CLI contract as of April 28, 2026.
 
-## 适用场景
+## Good fit when
 
-- Agent 直接运行终端命令
-- 需要多步串联 `schema -> status -> search -> detail -> greet`
-- 需要把 stdout JSON 结果继续喂给后续决策
+- the agent runs terminal commands directly
+- you need a multi-step chain such as `schema -> status -> search -> detail -> greet`
+- you want stdout JSON to feed the next decision step programmatically
 
-## 最小接入流程
+## Minimal integration
 
-先让 Agent 遵守这条工作习惯：
+Teach the agent to follow this working pattern:
 
 ```text
-当任务涉及 BOSS 直聘搜索、查看详情、打招呼或推进候选流程时：
-1. 先运行 boss schema 获取能力与参数
-2. 再运行 boss status 检查登录态
-3. 未登录时执行 boss login，并提示用户完成扫码
-4. 搜索时优先调用 boss search
-5. 命中目标后调用 boss detail
-6. 需要主动触达时调用 boss greet
-7. 招聘者场景优先使用 boss hr applications / candidates / reply / request-resume
-8. 只解析 stdout JSON，ok=false 时读取 error.code 与 error.recovery_action
+When the task involves BOSS Zhipin search, detail inspection, greeting, or candidate workflow progression:
+1. Run `boss schema` first to get capabilities and arguments
+2. Run `boss status` to check authentication
+3. If not logged in, run `boss login` and tell the user to complete the QR flow if needed
+4. Use `boss search` for discovery
+5. Use `boss detail` after a promising hit
+6. Use `boss greet` when active outreach is appropriate
+7. In recruiter workflows, prefer `boss hr applications / candidates / reply / request-resume`
+8. Parse stdout JSON only; when `ok=false`, inspect `error.code` and `error.recovery_action`
 ```
 
-最小命令链路：
+Minimal candidate-side command chain:
 
 ```bash
 boss schema
@@ -34,7 +34,7 @@ boss detail <security_id>
 boss greet <security_id> <job_id>
 ```
 
-招聘者最小链路：
+Minimal recruiter-side chain:
 
 ```bash
 boss schema
@@ -44,17 +44,17 @@ boss hr candidates "Golang"
 boss hr reply <friend_id> "你好"
 ```
 
-推荐解析字段：
+Recommended fields to parse:
 
-- `ok`: 判断命令是否成功
-- `data`: 读取职位、详情或动作结果
-- `hints.next_actions`: 决定下一条命令
-- `error.code`: 做恢复分流
-- `error.recovery_action`: 告诉 Agent 如何修复
+- `ok`: success or failure
+- `data`: jobs, details, or action results
+- `hints.next_actions`: suggested next command
+- `error.code`: recovery routing
+- `error.recovery_action`: what the agent should do next
 
-## 失败恢复
+## Recovery flow
 
-优先按这个顺序恢复：
+Preferred order:
 
 ```bash
 boss doctor
@@ -63,8 +63,8 @@ boss login
 boss search "Golang" --city 广州
 ```
 
-常见分流：
+Common branches:
 
-- `AUTH_REQUIRED` / `AUTH_EXPIRED`: 重新执行 `boss login`
-- `INVALID_PARAM`: 回退到 `boss schema` 校验参数
-- `RATE_LIMITED`: 等待后重试，不要盲目连发 `boss greet`
+- `AUTH_REQUIRED` / `AUTH_EXPIRED`: run `boss login` again
+- `INVALID_PARAM`: return to `boss schema` and validate arguments
+- `RATE_LIMITED`: back off before retrying; do not spam `boss greet`

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -1,22 +1,22 @@
 # Cursor Integration Example
 
-适用版本：`boss-agent-cli` 当前 CLI 契约（2026-04-19）
+Applies to the current `boss-agent-cli` CLI contract as of April 28, 2026.
 
-Cursor 是基于 VS Code 的 AI 优先 IDE，Composer 模式的 Agent 可以直接执行终端命令，0.42+ 还支持 MCP 协议接入。本指引给两种接入方式：MCP 原生接入（推荐）和 Shell 命令接入（兜底）。
+Cursor is a VS Code-based AI-first IDE. Its Composer agent can run terminal commands directly, and Cursor 0.42+ can also attach MCP servers. This guide covers two options: native MCP integration (recommended) and shell-command integration (fallback).
 
-## 适用场景
+## Good fit when
 
-- 在 Cursor 里用 Composer Agent 推进完整求职链路
-- 希望 `boss` 命令以 MCP 工具形式暴露给 Cursor，而非依赖 terminal 脚本
-- 已经有 `.cursor/rules/` 规则体系，想追加 BOSS 直聘能力
+- you want Composer to drive the full job-hunt flow inside Cursor
+- you want `boss` exposed as MCP tools instead of pasted shell snippets
+- you already maintain `.cursor/rules/` and want to add BOSS Zhipin capability
 
-## 最小接入流程
+## Minimal integration
 
-Cursor 支持两种接入方式，按需二选一。
+Cursor supports two approaches. Use whichever fits your setup.
 
-### 方式一：MCP 服务接入（推荐）
+### Option 1: MCP server integration (recommended)
 
-在 Cursor 设置 → MCP 里添加一个 stdio 服务器，指向本仓库的 `mcp-server/server.py`：
+In Cursor Settings → MCP, add a stdio server that points to this repo's `mcp-server/server.py`:
 
 ```json
 {
@@ -35,30 +35,30 @@ Cursor 支持两种接入方式，按需二选一。
 }
 ```
 
-启用后 Composer 会自动看到 `boss_search` / `boss_detail` / `boss_greet` 等 43 个工具，直接在会话里调用即可。不需要额外粘贴 shell 命令。
+Once enabled, Composer will automatically discover `boss_search`, `boss_detail`, `boss_greet`, and the rest of the 49 MCP tools. No extra shell prompt glue is required.
 
-### 方式二：Shell 命令接入
+### Option 2: shell-command integration
 
-在 `.cursor/rules/boss-agent-cli.mdc` 里加入以下规则：
+Add a rule like this to `.cursor/rules/boss-agent-cli.mdc`:
 
 ```markdown
 ---
-description: BOSS 直聘求职能力
+description: BOSS Zhipin job-hunt capability
 globs:
 alwaysApply: false
 ---
 
-当用户要求搜索岗位 / 查看详情 / 打招呼 / 推进候选进度时：
-1. 先运行 `boss schema` 获取能力与参数
-2. 再运行 `boss status` 检查登录态
-3. 未登录时运行 `boss login`，提示用户扫码
-4. 搜索使用 `boss search <query> --city <city> --welfare <keywords>`
-5. 命中后用 `boss detail <security_id>` 看完整信息
-6. 执行动作用 `boss greet <security_id> <job_id>`
-7. 只读取 stdout JSON；`ok=false` 时读 `error.recovery_action`
+When the user asks to search jobs, inspect job details, greet recruiters, or continue a candidate workflow:
+1. Run `boss schema` first to learn the capability surface
+2. Then run `boss status` to check authentication
+3. If not logged in, run `boss login` and ask the user to scan if needed
+4. Use `boss search <query> --city <city> --welfare <keywords>` for discovery
+5. Use `boss detail <security_id>` to inspect a matching job
+6. Use `boss greet <security_id> <job_id>` when it is time to reach out
+7. Read stdout JSON only; when `ok=false`, inspect `error.recovery_action`
 ```
 
-最小命令链路：
+Minimal command chain:
 
 ```bash
 boss schema
@@ -68,17 +68,17 @@ boss detail <security_id>
 boss greet <security_id> <job_id>
 ```
 
-## 解析字段
+## Fields to parse
 
-- `ok`：判断命令是否成功
-- `data`：读取职位、详情或动作结果
-- `hints.next_actions`：决定下一条命令
-- `error.code`：做恢复分流
-- `error.recovery_action`：告诉 Agent 如何修复
+- `ok`: whether the command succeeded
+- `data`: jobs, details, or action results
+- `hints.next_actions`: suggested next command
+- `error.code`: recovery routing
+- `error.recovery_action`: how the agent should recover
 
-## 失败恢复
+## Recovery flow
 
-推荐恢复顺序：
+Recommended order:
 
 ```bash
 boss doctor
@@ -86,14 +86,14 @@ boss status
 boss login
 ```
 
-常见分流：
+Common branches:
 
-- `AUTH_REQUIRED` / `AUTH_EXPIRED`：重新执行 `boss login`
-- `INVALID_PARAM`：回退到 `boss schema` 校验参数名
-- `RATE_LIMITED`：等待后重试，不要盲目连发 `boss greet`
-- `ACCOUNT_RISK`：启动 CDP Chrome（`boss-chrome` alias），再重试
+- `AUTH_REQUIRED` / `AUTH_EXPIRED`: run `boss login` again
+- `INVALID_PARAM`: return to `boss schema` and validate parameter names
+- `RATE_LIMITED`: wait before retrying; do not spam `boss greet`
+- `ACCOUNT_RISK`: start a CDP Chrome session (for example via a `boss-chrome` alias), then retry
 
-## 进阶
+## Advanced ideas
 
-- 把 `boss ai interview-prep <jd>` / `boss ai chat-coach <chat>` 接入 Composer，让 Cursor 承担简历匹配与沟通辅导
-- 用 `boss digest --format md -o daily.md` 生成每日摘要，Cursor 侧边栏打开预览即可
+- Wire `boss ai interview-prep <jd>` and `boss ai chat-coach <chat>` into Composer for resume matching and communication coaching
+- Generate daily markdown reports with `boss digest --format md -o daily.md` and preview them directly in Cursor

--- a/docs/integrations/python-sdk.md
+++ b/docs/integrations/python-sdk.md
@@ -1,42 +1,42 @@
-# Python 直接集成（OpenAI / Claude SDK）
+# Python Direct Integration (OpenAI / Claude SDK)
 
-面向不走 MCP 通道的场景：在自己的 Python Agent 里直接调用 OpenAI Functions API 或 Claude Tool Use API，让大模型驱动 `boss-agent-cli`。
+Use this path when you do not want MCP in the loop. Your own Python agent can call the OpenAI Functions API or Claude Tool Use API directly, while `boss-agent-cli` remains the execution backend.
 
-## 适用场景
+## Good fit when
 
-- 自建 Agent 框架（LangGraph / LlamaIndex / 手写 Loop）
-- 想把 BOSS 求职能力嵌入到现有业务代码
-- 测试新模型对 34 个 CLI 工具的调度能力
-- CI/CD 里跑定时任务让 Agent 自动跟进投递
+- you run a custom agent framework (LangGraph, LlamaIndex, or a hand-written loop)
+- you want BOSS job-hunt capability embedded in existing business code
+- you want to test new models against the exported `boss` tool surface
+- you run scheduled follow-up tasks in CI/CD
 
-## 核心思路
+## Core idea
 
-`boss schema` 命令支持三种输出格式：
+`boss schema` supports three output formats:
 
-| `--format` | 输出结构 | 适用 SDK |
+| `--format` | Output shape | SDK target |
 |-----------|---------|---------|
-| `native`（默认） | 项目自定义 JSON 信封 | 手动解析 / MCP 转换 |
-| `openai-tools` | 符合 OpenAI Functions / Tools API | `openai` Python SDK |
-| `anthropic-tools` | 符合 Claude Tool Use API | `anthropic` Python SDK |
+| `native` (default) | project-specific JSON envelope | manual parsing / MCP conversion |
+| `openai-tools` | OpenAI Functions / Tools API compatible | `openai` Python SDK |
+| `anthropic-tools` | Claude Tool Use API compatible | `anthropic` Python SDK |
 
-后两种格式可直接喂给对应 SDK 的 `tools=` 参数，无需手写转换。
+The latter two can be passed directly into the relevant SDK's `tools=` parameter with no hand-written conversion layer.
 
-补充说明：
-- `native` schema 里每个命令都带有 `availability`，可用于在业务侧先做 `role/platform` 过滤
-- `openai-tools` / `anthropic-tools` 导出的 `description` 也会内嵌同一份可用性提示，方便模型直接感知边界
+Notes:
+- every command in the `native` schema includes `availability`, which lets your application pre-filter by `role` or `platform`
+- the exported `description` fields in `openai-tools` and `anthropic-tools` also carry the same availability hints so the model can see the boundary conditions directly
 
-## 最小 OpenAI 示例
+## Minimal OpenAI example
 
-`examples/openai_agent.py`：
+`examples/openai_agent.py`:
 
 ```python
-"""用 OpenAI GPT-4o 驱动 boss-agent-cli。
+"""Drive boss-agent-cli with OpenAI GPT-4o.
 
-运行：
+Run:
     pip install openai
     export OPENAI_API_KEY=sk-...
-    boss login  # 先确保已登录
-    python examples/openai_agent.py "找上海 30K 以上的 Python 后端"
+    boss login  # make sure auth is ready first
+    python examples/openai_agent.py "Find Python backend jobs in Shanghai above 30K"
 """
 import json
 import subprocess
@@ -44,7 +44,7 @@ import sys
 from openai import OpenAI
 
 def run_boss(*args):
-    """调用 boss CLI，返回解析后的 JSON 信封。"""
+    """Call the boss CLI and return the parsed JSON envelope."""
     result = subprocess.run(
         ["boss", "--json", *args],
         capture_output=True, text=True, timeout=120,
@@ -56,7 +56,7 @@ def run_boss(*args):
 
 
 def load_tools():
-    """拉 boss schema openai-tools 格式，直接喂给 SDK。"""
+    """Load boss schema in openai-tools format and feed it directly to the SDK."""
     out = subprocess.run(
         ["boss", "schema", "--format", "openai-tools"],
         capture_output=True, text=True,
@@ -68,11 +68,11 @@ def main(user_prompt: str):
     client = OpenAI()
     tools = load_tools()
     messages = [
-        {"role": "system", "content": "你是求职助手。通过 boss_* 工具帮用户操作 BOSS 直聘。每个工具的返回值是 JSON 信封，ok=false 时要告知用户。"},
+        {"role": "system", "content": "You are a job-hunt assistant. Use boss_* tools to operate BOSS Zhipin. Every tool returns a JSON envelope; if ok=false, explain the failure to the user."},
         {"role": "user", "content": user_prompt},
     ]
 
-    for _ in range(10):  # 最多 10 轮工具调用
+    for _ in range(10):  # at most 10 tool rounds
         resp = client.chat.completions.create(
             model="gpt-4o",
             messages=messages,
@@ -86,11 +86,11 @@ def main(user_prompt: str):
             return
 
         for call in msg.tool_calls:
-            # 工具名形如 "boss_search"；还原成 "search"
+            # Tool name looks like "boss_search"; convert back to CLI command name.
             cmd = call.function.name.replace("boss_", "").replace("_", "-")
             args = json.loads(call.function.arguments)
 
-            # 把 dict 参数拆成 CLI 参数
+            # Flatten dict arguments into CLI arguments.
             cli_args = [cmd]
             for key, value in args.items():
                 if key == "query" or (len(args) == 1 and isinstance(value, str)):
@@ -107,23 +107,23 @@ def main(user_prompt: str):
 
 
 if __name__ == "__main__":
-    main(sys.argv[1] if len(sys.argv) > 1 else "搜索北京的 Python 开发岗位")
+    main(sys.argv[1] if len(sys.argv) > 1 else "Search Python developer jobs in Beijing")
 ```
 
-运行：
+Run:
 
 ```bash
 export OPENAI_API_KEY=sk-...
 boss login
-python examples/openai_agent.py "搜上海 25K 以上的 Golang 岗位"
+python examples/openai_agent.py "Search Golang jobs in Shanghai above 25K"
 ```
 
-## 最小 Claude (Anthropic) 示例
+## Minimal Claude (Anthropic) example
 
 `examples/anthropic_agent.py`：
 
 ```python
-"""用 Claude Sonnet 4.6 驱动 boss-agent-cli。"""
+"""Drive boss-agent-cli with Claude Sonnet 4.6."""
 import json
 import subprocess
 import sys
@@ -154,7 +154,7 @@ def main(user_prompt: str):
         resp = client.messages.create(
             model="claude-sonnet-4-6",
             max_tokens=4096,
-            system="你是求职助手。通过 boss_* 工具帮用户操作 BOSS 直聘。",
+            system="You are a job-hunt assistant. Use boss_* tools to operate BOSS Zhipin.",
             tools=tools,
             messages=messages,
         )
@@ -193,21 +193,21 @@ def main(user_prompt: str):
 
 
 if __name__ == "__main__":
-    main(sys.argv[1] if len(sys.argv) > 1 else "搜索北京的 Python 开发岗位")
+    main(sys.argv[1] if len(sys.argv) > 1 else "Search Python developer jobs in Beijing")
 ```
 
-## 参数转换要点
+## Argument-mapping notes
 
-从 LLM 的 JSON 参数到 CLI 参数的映射约定：
+Recommended mapping from model JSON arguments to CLI arguments:
 
-| LLM 参数 | CLI 形式 | 示例 |
+| LLM argument | CLI form | Example |
 |---------|---------|------|
-| 位置参数（如 `query`） | 直接拼进 args 开头 | `boss search python` |
-| 下划线字段名（如 `job_id`） | 转 dash 作为 long option | `--job-id abc123` |
-| bool true | 作为 flag 加入 | `--dry-run` |
-| bool false | 省略（CLI 默认就是 false） | — |
+| positional argument (for example `query`) | append at the start of args | `boss search python` |
+| snake_case field (for example `job_id`) | convert to dashed long option | `--job-id abc123` |
+| bool `true` | include as a flag | `--dry-run` |
+| bool `false` | omit it (CLI defaults to false) | — |
 
-更健壮的参数转换器参考 `mcp-server/server.py` 的 `_build_args()` 函数，它已经覆盖了 34 个命令的完整转换逻辑，建议直接复用：
+For a more robust conversion path, reuse `_build_args()` in `mcp-server/server.py`. It already covers the full exported command surface and is a better choice than hand-maintained mappings:
 
 ```python
 sys.path.insert(0, "path/to/boss-agent-cli/mcp-server")
@@ -216,42 +216,42 @@ from server import _build_args
 cli_args = _build_args(call.function.name, args)
 ```
 
-## 错误处理建议
+## Error-handling advice
 
-boss CLI 的错误信封结构：
+boss CLI error envelope:
 
 ```json
 {
   "ok": false,
   "error": {
     "code": "AUTH_EXPIRED",
-    "message": "登录态已过期",
+    "message": "Session expired",
     "recoverable": true,
     "recovery_action": "boss login"
   }
 }
 ```
 
-让你的 Agent 识别 `recovery_action` 字段自动重试：
+Teach your agent to respect `recovery_action` and retry automatically when appropriate:
 
 ```python
 if not output["ok"]:
     err = output["error"]
     if err.get("recoverable") and err["code"] == "AUTH_EXPIRED":
-        run_boss("login")  # 自动重登
-        output = run_boss(*cli_args)  # 重试一次
+        run_boss("login")  # automatic re-login
+        output = run_boss(*cli_args)  # retry once
 ```
 
-## 环境依赖
+## Environment prerequisites
 
 - Python ≥ 3.10
-- `boss-agent-cli` 已 `uv tool install` 或 `pipx install`
-- 已跑过 `boss login` 确保登录态存在
-- OpenAI / Anthropic API key 按 SDK 标准环境变量设置
+- `boss-agent-cli` installed via `uv tool install` or `pipx install`
+- `boss login` already completed so a local session exists
+- OpenAI / Anthropic API keys configured via the standard SDK environment variables
 
-## 参考
+## References
 
-- [OpenAI Tools API 文档](https://platform.openai.com/docs/guides/function-calling)
-- [Anthropic Tool Use 文档](https://docs.claude.com/en/docs/build-with-claude/tool-use)
-- [boss schema --format 选项](../capability-matrix.md)
-- [MCP 集成方式（Claude Desktop / Cursor）](../../mcp-server/README.md)
+- [OpenAI Tools API docs](https://platform.openai.com/docs/guides/function-calling)
+- [Anthropic Tool Use docs](https://docs.claude.com/en/docs/build-with-claude/tool-use)
+- [`boss schema --format` options](../capability-matrix.md)
+- [MCP integration guide (Claude Desktop / Cursor)](../../mcp-server/README.md)

--- a/docs/integrations/shell-agent.md
+++ b/docs/integrations/shell-agent.md
@@ -1,29 +1,29 @@
 # Shell Agent Integration Example
 
-适用版本：`boss-agent-cli` 当前 CLI 契约（2026-04-13）
+Applies to the current `boss-agent-cli` CLI contract as of April 28, 2026.
 
-## 适用场景
+## Good fit when
 
-- 你的 Agent 框架只需要一个 shell/subprocess tool
-- 你希望把 `boss` 作为可复用外部命令挂到已有编排器
-- 你需要最通用、最少依赖的接入方式
+- your agent framework only needs a shell or subprocess tool
+- you want to expose `boss` as a reusable external command inside an existing orchestrator
+- you want the most universal, lowest-dependency integration path
 
-## 最小接入流程
+## Minimal integration
 
-核心原则：让宿主只负责“运行命令 + 解析 JSON”，不要自己重写 BOSS 直聘协议。
+Core rule: let the host do only two things, "run the command" and "parse JSON". Do not reimplement the BOSS Zhipin protocol inside the host.
 
-推荐包装流程：
+Recommended wrapper flow:
 
 ```text
-1. 运行 boss schema
-2. 运行 boss status
-3. 未登录时运行 boss login
-4. 运行 boss search
-5. 运行 boss detail
-6. 满足条件时运行 boss greet
+1. Run `boss schema`
+2. Run `boss status`
+3. If not logged in, run `boss login`
+4. Run `boss search`
+5. Run `boss detail`
+6. When the result is promising, run `boss greet`
 ```
 
-最小命令链路：
+Minimal command chain:
 
 ```bash
 boss schema
@@ -33,7 +33,7 @@ boss detail <security_id>
 boss greet <security_id> <job_id>
 ```
 
-如果宿主支持单函数包装，建议包装成：
+If the host supports a single wrapper function, use something like:
 
 ```python
 def run_boss(*args: str) -> dict:
@@ -41,11 +41,11 @@ def run_boss(*args: str) -> dict:
 	return json.loads(result.stdout)
 ```
 
-然后让上层只依赖返回的 JSON 信封字段。
+Then let the upper layer depend only on the returned JSON envelope.
 
-## 失败恢复
+## Recovery flow
 
-标准恢复顺序：
+Standard order:
 
 ```bash
 boss doctor
@@ -54,8 +54,8 @@ boss login
 boss search "Golang" --city 广州
 ```
 
-通用处理建议：
+General advice:
 
-- `ok=false` 时不要继续后续动作
-- `AUTH_REQUIRED` 时先恢复登录，再重试 `boss search`
-- `RATE_LIMITED` 时暂停，不要继续 `boss greet`
+- do not continue follow-up actions when `ok=false`
+- on `AUTH_REQUIRED`, restore login first and only then retry `boss search`
+- on `RATE_LIMITED`, pause instead of continuing with `boss greet`

--- a/docs/integrations/windsurf.md
+++ b/docs/integrations/windsurf.md
@@ -1,22 +1,22 @@
 # Windsurf Integration Example
 
-适用版本：`boss-agent-cli` 当前 CLI 契约（2026-04-19）
+Applies to the current `boss-agent-cli` CLI contract as of April 28, 2026.
 
-Windsurf 是 Codeium 发布的 agentic IDE，Cascade 面板是主力 Agent，支持 MCP 协议和项目级 `.windsurfrules`。本指引给两种接入方式：MCP 原生接入（推荐）和规则文件接入（兜底）。
+Windsurf is Codeium's agentic IDE. Cascade is the primary agent surface and supports both MCP servers and project-level `.windsurfrules`. This guide covers two options: native MCP integration (recommended) and rules-file integration (fallback).
 
-## 适用场景
+## Good fit when
 
-- 用 Cascade 跑完整求职链路，让 Agent 自主决定何时 search / detail / greet
-- 希望把 `boss` 能力以 MCP 工具形式注册，而非每次粘贴终端命令
-- 已有 `.windsurfrules` 项目规则，想追加 BOSS 直聘约束
+- you want Cascade to run the full job-hunt loop and decide when to search, inspect, and greet
+- you want `boss` registered as MCP tools instead of pasting terminal commands
+- you already have project rules in `.windsurfrules` and want to add BOSS Zhipin constraints
 
-## 最小接入流程
+## Minimal integration
 
-Windsurf 支持两种接入方式，按需二选一。
+Windsurf supports two approaches. Choose the one that fits your setup.
 
-### 方式一：MCP 服务接入（推荐）
+### Option 1: MCP server integration (recommended)
 
-在 Windsurf 设置 → Cascade → MCP Servers 里添加：
+In Windsurf Settings → Cascade → MCP Servers, add:
 
 ```json
 {
@@ -35,26 +35,26 @@ Windsurf 支持两种接入方式，按需二选一。
 }
 ```
 
-启用后 Cascade 会自动枚举 `boss_search` / `boss_detail` / `boss_greet` / `boss_ai_*` 等 43 个工具，无需额外提示词。
+Once enabled, Cascade will automatically enumerate `boss_search`, `boss_detail`, `boss_greet`, `boss_ai_*`, and the rest of the 49 MCP tools. No extra prompting glue is required.
 
-### 方式二：.windsurfrules 规则接入
+### Option 2: `.windsurfrules` integration
 
-在项目根目录 `.windsurfrules` 里追加：
+Append guidance like this to the project root `.windsurfrules`:
 
 ```markdown
-## BOSS 直聘求职能力
+## BOSS Zhipin job-hunt capability
 
-当任务涉及搜索岗位、查看职位详情、打招呼或推进求职进度时：
-1. 先运行 `boss schema` 获取能力和参数
-2. 再运行 `boss status` 检查登录态
-3. 未登录时运行 `boss login`，提示用户完成扫码
-4. 搜索使用 `boss search`，优先带 `--welfare` 精准筛选
-5. 命中后用 `boss detail <security_id>` 看完整信息
-6. 执行动作用 `boss greet <security_id> <job_id>`
-7. 只消费 stdout JSON；`ok=false` 时读 `error.recovery_action` 做恢复决策
+When the task involves job discovery, job-detail inspection, greeting, or candidate workflow progression:
+1. Run `boss schema` first to learn the capability surface and argument shapes
+2. Then run `boss status` to verify authentication
+3. If not logged in, run `boss login` and ask the user to scan if needed
+4. Use `boss search`, preferably with `--welfare` for precise filtering
+5. Use `boss detail <security_id>` once a hit looks promising
+6. Use `boss greet <security_id> <job_id>` for the outbound action
+7. Consume stdout JSON only; when `ok=false`, read `error.recovery_action` before retrying
 ```
 
-最小命令链路：
+Minimal command chain:
 
 ```bash
 boss schema
@@ -64,17 +64,17 @@ boss detail <security_id>
 boss greet <security_id> <job_id>
 ```
 
-## 解析字段
+## Fields to parse
 
-- `ok`：判断命令是否成功
-- `data`：读取职位、详情或动作结果
-- `hints.next_actions`：决定下一条命令
-- `error.code`：做恢复分流
-- `error.recovery_action`：告诉 Cascade 如何修复
+- `ok`: whether the command succeeded
+- `data`: jobs, details, or action results
+- `hints.next_actions`: suggested next command
+- `error.code`: recovery routing
+- `error.recovery_action`: how Cascade should recover
 
-## 失败恢复
+## Recovery flow
 
-推荐恢复顺序：
+Recommended order:
 
 ```bash
 boss doctor
@@ -82,14 +82,14 @@ boss status
 boss login
 ```
 
-常见分流：
+Common branches:
 
-- `AUTH_REQUIRED` / `AUTH_EXPIRED`：重新执行 `boss login`
-- `INVALID_PARAM`：回退到 `boss schema` 校验参数名
-- `RATE_LIMITED`：等待后重试，不要盲目连发 `boss greet`
-- `ACCOUNT_RISK`：启动 CDP Chrome（`boss-chrome` alias），再重试
+- `AUTH_REQUIRED` / `AUTH_EXPIRED`: run `boss login` again
+- `INVALID_PARAM`: return to `boss schema` and validate parameter names
+- `RATE_LIMITED`: wait before retrying; do not spam `boss greet`
+- `ACCOUNT_RISK`: start a CDP Chrome session (for example via a `boss-chrome` alias), then retry
 
-## 进阶
+## Advanced ideas
 
-- 把 `boss ai reply <message>` / `boss ai chat-coach <chat>` 接给 Cascade，让它在沟通过程中提供话术支持
-- 用 `boss digest --format md` 生成每日摘要，Cascade 预览面板直出飞书/邮件可用版
+- Hook `boss ai reply <message>` and `boss ai chat-coach <chat>` into Cascade so it can help with communication quality
+- Generate daily summaries with `boss digest --format md` and render them directly in the Windsurf preview panel

--- a/tests/test_agent_host_examples.py
+++ b/tests/test_agent_host_examples.py
@@ -37,9 +37,9 @@ def test_agent_host_index_links_all_examples():
 def test_agent_host_examples_cover_core_agent_loop():
 	for host_name, path in HOST_DOCS.items():
 		text = _read(path)
-		assert "## 适用场景" in text, host_name
-		assert "## 最小接入流程" in text, host_name
-		assert "## 失败恢复" in text, host_name
+		assert ("## 适用场景" in text or "## Good fit when" in text), host_name
+		assert ("## 最小接入流程" in text or "## Minimal integration" in text), host_name
+		assert ("## 失败恢复" in text or "## Recovery flow" in text), host_name
 		for command in REQUIRED_COMMANDS:
 			assert command in text, f"{host_name} missing {command}"
 


### PR DESCRIPTION
## Summary
- strengthen GitHub-internal English entry points by adding the README.en demo banner and roadmap link
- translate the English-facing integration docs so they read as actual English docs instead of mixed-language stubs
- update the agent-host example test to accept either Chinese or English section headings while still enforcing the same core workflow

## Verification
- `UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q tests/test_agent_host_examples.py tests/test_agent_docs.py`
