### PR TITLE
docs: 补充英文 Agent 与 MCP 文档

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -182,7 +182,7 @@ jobs = json.loads(result.stdout)["data"]["items"]
 }
 ```
 
-See [Agent Quickstart](docs/agent-quickstart.md) and [Capability Matrix](docs/capability-matrix.md) for the full picture.
+See [Agent Quickstart](docs/agent-quickstart.en.md) and [Capability Matrix](docs/capability-matrix.en.md) for the full picture.
 
 ## 📚 Commands
 

--- a/docs/agent-hosts.en.md
+++ b/docs/agent-hosts.en.md
@@ -1,0 +1,39 @@
+# Agent Host Examples
+
+An index of the smallest useful integration examples for each agent host, so `boss-agent-cli` feels copy-pasteable instead of protocol archaeology.
+
+Current example baseline:
+- Discover capabilities via `boss schema`
+- Verify login state with `boss status`
+- Complete the minimal action loop with `boss search` / `boss detail` / `boss greet`
+- Parse `ok`, `data`, `error.code`, and `error.recovery_action` from the JSON envelope
+
+## Example list
+
+| Host | Good fit when | Example |
+|---|---|---|
+| Codex | You want to orchestrate shell commands and parse JSON directly inside the terminal | [Codex](integrations/codex.md) |
+| Claude Code | You prefer skills or rule files to drive job-search actions | [Claude Code](integrations/claude-code.md) |
+| Cursor | You use Composer Agent with MCP or `.cursor/rules` | [Cursor](integrations/cursor.md) |
+| Windsurf | You use Cascade Agent with MCP or `.windsurfrules` | [Windsurf](integrations/windsurf.md) |
+| Shell Agent | You have any shell-capable agent framework or a homegrown orchestrator | [Shell Agent](integrations/shell-agent.md) |
+| Python SDK | You want business code, LangGraph, or a custom agent to call model SDKs directly | [Python SDK](integrations/python-sdk.md) |
+
+## Picking the right host
+
+- Choose `Codex` when the agent already has reliable terminal access and multi-step tool execution
+- Choose `Claude Code` when your workflow is driven by distributed skills and rule files
+- In Cursor or Windsurf, enable the MCP server first and start from the host-specific guide
+- Choose `Shell Agent` for your own orchestrator or any framework that can run shell tools
+- Choose `Python SDK` when the agent logic lives inside Python code and needs direct OpenAI or Claude SDK tool wiring
+
+## Shared integration rules
+
+1. Always start a new integration by running `boss schema`; do not hardcode the command table.
+2. Treat the JSON envelope on `stdout` as the source of truth for success and failure; never parse `stderr`.
+3. Use `boss doctor`, `boss login`, and `boss status` as the common recovery entry points.
+4. When the user mentions benefits or welfare requirements, map them to `--welfare` first.
+
+## Related docs
+
+- [Recommended models and entry points](integrations/ai-models.md) - current setup examples for Claude 4.7, GPT-5, DeepSeek-V3, Qwen3, and more

--- a/docs/agent-quickstart.en.md
+++ b/docs/agent-quickstart.en.md
@@ -1,0 +1,89 @@
+# Agent Quickstart
+
+The shortest path for an AI agent to get productive with `boss-agent-cli`: discover capabilities first, then complete a search-to-action loop. Recruiter workflows use the same JSON contract through `boss hr`.
+
+## 1) Install and prepare the environment
+
+```bash
+# Recommended options (pick one)
+uv tool install boss-agent-cli   # uv: fast, isolated
+pipx install boss-agent-cli      # pipx: isolated
+pip install boss-agent-cli       # pip
+
+# Install the browser used during login
+patchright install chromium
+
+# Run diagnostics and log in
+boss doctor
+boss login
+boss status
+```
+
+Success criteria:
+- `boss doctor` returns `ok=true`
+- `boss status` returns the current authenticated session
+- If you are using `zhilian`, pass the platform explicitly: `boss --platform zhilian doctor && boss --platform zhilian login`
+
+If you plan to wire the CLI into an agent host instead of running commands manually in a terminal, start with [Agent Host Examples](agent-hosts.en.md).
+
+## 2) Complete the minimal agent loop in three steps
+
+```bash
+# Step 1: fetch the self-described capability schema
+boss schema
+
+# Step 2: search and narrow down target jobs
+boss search "Golang" --city 广州 --welfare "双休,五险一金"
+
+# Step 3: inspect details and take action
+boss detail <security_id>
+boss greet <security_id> <job_id>
+```
+
+Parsing contract:
+- Read JSON envelopes from `stdout` only
+- `ok=true` means success; when `ok=false`, inspect `error.code` and `error.recovery_action`
+- `boss schema` also returns `supported_platforms`, `supported_recruiter_platforms`, and per-command `availability`, so agents can route tools by `role/platform`
+
+### Minimal recruiter loop
+
+If your agent operates for recruiters or hiring teams, use `boss hr` directly:
+
+```bash
+# Step 1: discover capabilities
+boss schema
+
+# Step 2: access recruiter-side workflows
+boss hr applications
+boss hr candidates "Golang"
+
+# Step 3: contact candidates
+boss hr reply <friend_id> "你好，方便聊一下岗位吗？"
+boss hr request-resume <friend_id> --job-id <job_id>
+```
+
+Recommended usage:
+- Treat the `hr` command group returned by `boss schema` as the source of truth for recruiter capabilities
+- `boss hr <subcommand>` switches to recruiter mode automatically, so you do not need to infer `--role` yourself
+- Candidate-side and recruiter-side commands share the same `stdout JSON / stderr logs` contract
+- `hr` currently supports `zhipin-recruiter` only; if the active platform is `zhilian`, recruiter commands are rejected intentionally
+
+## 3) Recovery flow and troubleshooting
+
+Recommended sequence:
+
+```bash
+boss doctor
+boss logout
+boss login
+boss status
+```
+
+Common recovery actions:
+- `AUTH_REQUIRED` / `AUTH_EXPIRED` / `TOKEN_REFRESH_FAILED`: run `boss login` again
+- `RATE_LIMITED`: wait and retry
+- `INVALID_PARAM`: correct the input parameters, such as city, welfare filters, or page number
+
+Further reading:
+- [Agent Host Examples](agent-hosts.en.md)
+- [Capability Matrix](capability-matrix.en.md)

--- a/docs/capability-matrix.en.md
+++ b/docs/capability-matrix.en.md
@@ -1,0 +1,107 @@
+# Capability Matrix
+
+Use this matrix to keep CLI, skills, and MCP integrations aligned across different agent entry points.
+
+## Auth and environment
+
+| Capability | CLI command | Login required | Transport |
+|---|---|---|---|
+| Protocol discovery | `boss schema` | No | Local |
+| Log in | `boss login` | No | Browser |
+| Log out | `boss logout` | No | Local |
+| Session status | `boss status` | Yes | httpx |
+| Environment diagnostics | `boss doctor` | No | Hybrid |
+| Config management | `boss config` | No | Local |
+| Cache cleanup | `boss clean` | No | Local |
+
+## Job discovery
+
+| Capability | CLI command | Login required | Transport |
+|---|---|---|---|
+| Job search | `boss search` | Yes | Browser |
+| Personalized recommendations | `boss recommend` | Yes | Browser |
+| Job detail | `boss detail` | Yes | httpx first, browser fallback |
+| Show by index | `boss show` | No | Local cache |
+| City catalog | `boss cities` | No | httpx |
+| Browsing history | `boss history` | Yes | httpx |
+
+## Candidate actions
+
+| Capability | CLI command | Login required | Transport |
+|---|---|---|---|
+| Greet a recruiter | `boss greet` | Yes | Browser |
+| Batch greet after search | `boss batch-greet` | Yes | Browser |
+| Apply or start the conversation | `boss apply` | Yes | Browser |
+| Export results | `boss export` | Yes | Browser |
+
+## Conversation management
+
+| Capability | CLI command | Login required | Transport |
+|---|---|---|---|
+| Conversation list | `boss chat` | Yes | httpx |
+| Message history | `boss chatmsg` | Yes | httpx |
+| Conversation summary | `boss chat-summary` | Yes | httpx |
+| Contact labels | `boss mark` | Yes | httpx |
+| Contact exchange | `boss exchange` | Yes | httpx |
+| Interview invites | `boss interviews` | Yes | httpx |
+
+## Workflow management
+
+| Capability | CLI command | Login required | Transport |
+|---|---|---|---|
+| Pipeline view | `boss pipeline` | Yes | httpx |
+| Follow-up filtering | `boss follow-up` | Yes | httpx |
+| Daily digest | `boss digest` | Yes | httpx |
+| Incremental watch | `boss watch` | Yes | Browser |
+| Search presets | `boss preset` | No | Local |
+| Shortlist management | `boss shortlist` | No | Local |
+
+## User profile
+
+| Capability | CLI command | Login required | Transport |
+|---|---|---|---|
+| My profile | `boss me` | Yes | httpx |
+
+## Resume management
+
+| Capability | CLI command | Login required | Transport |
+|---|---|---|---|
+| Local resume management | `boss resume` | Depends | Local (`init` can bootstrap from the online profile) |
+
+## AI capabilities
+
+| Capability | CLI command | Login required | Transport |
+|---|---|---|---|
+| AI configuration | `boss ai config` | No | Local |
+| JD match analysis | `boss ai analyze-jd` | No | AI service |
+| Resume polishing | `boss ai polish` | No | AI service |
+| Role-targeted optimization | `boss ai optimize` | No | AI service |
+| Resume improvement suggestions | `boss ai suggest` | No | AI service |
+| Draft chat replies | `boss ai reply` | No | AI service |
+| Mock interview prep | `boss ai interview-prep` | No | AI service |
+| Chat coaching | `boss ai chat-coach` | No | AI service |
+
+## Data insights
+
+| Capability | CLI command | Login required | Transport |
+|---|---|---|---|
+| Application funnel stats | `boss stats` | No | Local |
+
+## Recruiter workflow
+
+| Capability | CLI command | Login required | Transport |
+|---|---|---|---|
+| Application inbox | `boss hr applications` | Yes | httpx |
+| Candidate search | `boss hr candidates` | Yes | httpx |
+| Recruiter chat list | `boss hr chat` | Yes | httpx |
+| Online resume view | `boss hr resume` | Yes | httpx |
+| Reply to candidate | `boss hr reply` | Yes | httpx |
+| Request attached resume | `boss hr request-resume` | Yes | httpx |
+| Job listing and online/offline operations | `boss hr jobs` | Yes | httpx |
+
+Notes:
+- **Transport**: `httpx` means a direct API call, `Browser` means a CDP/patchright flow for actions that need a real browser fingerprint, and `AI service` means a third-party model API.
+- For CLI-first integrations, prefer `boss schema` for capability discovery and parameter validation; the schema exposes both `supported_platforms` and `supported_recruiter_platforms`.
+- Current platform coverage: `zhipin` supports both candidate and recruiter workflows; `zhilian` already supports candidate-side login plus read/write actions, while the recruiter side is still unavailable.
+- Current auth posture: `zhipin` keeps the four-tier fallback login chain; `zhilian` now supports the candidate-side browser login foundation (Cookie / CDP / browser fallback), while recruiter auth is not implemented yet.
+- Use `boss schema` as the source of truth: it currently exposes 33 top-level commands, with 7 first-level recruiter subcommands under `hr`, while `ai` and `resume` remain command-group entries.

--- a/docs/integrations/python-sdk.md
+++ b/docs/integrations/python-sdk.md
@@ -253,5 +253,5 @@ if not output["ok"]:
 
 - [OpenAI Tools API docs](https://platform.openai.com/docs/guides/function-calling)
 - [Anthropic Tool Use docs](https://docs.claude.com/en/docs/build-with-claude/tool-use)
-- [`boss schema --format` options](../capability-matrix.md)
-- [MCP integration guide (Claude Desktop / Cursor)](../../mcp-server/README.md)
+- [`boss schema --format` options](../capability-matrix.en.md)
+- [MCP integration guide (Claude Desktop / Cursor)](../../mcp-server/README.en.md)

--- a/mcp-server/README.en.md
+++ b/mcp-server/README.en.md
@@ -1,0 +1,201 @@
+# boss-agent-cli MCP Server
+
+Expose `boss-agent-cli` as MCP tools for clients such as Claude Desktop, Cursor, and other MCP-compatible hosts.
+
+Related docs:
+- [Agent Quickstart](../docs/agent-quickstart.en.md)
+- [Capability Matrix](../docs/capability-matrix.en.md)
+
+## Install
+
+```bash
+# 1. Install the boss CLI
+uv tool install boss-agent-cli
+patchright install chromium
+
+# 2. Install the MCP extra and expose the MCP entry point
+uv tool install "boss-agent-cli[mcp]"
+```
+
+## Configure Claude Desktop
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "boss-agent-cli": {
+      "command": "boss-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+## Configure Cursor
+
+Add the server in Cursor Settings -> MCP Servers:
+
+```json
+{
+  "boss-agent-cli": {
+    "command": "boss-mcp",
+    "args": []
+  }
+}
+```
+
+## Available tools
+
+The current MCP server exposes **49 tools**, covering candidate workflows, AI assistance, and recruiter-side `hr` operations.
+
+### Auth and environment
+
+| Tool | Description |
+|------|-------------|
+| `boss_status` | Check the current authenticated session |
+| `boss_doctor` | Run environment diagnostics |
+| `boss_config` | View or update configuration |
+| `boss_clean` | Remove stale cache and temp files |
+
+### Job discovery
+
+| Tool | Description |
+|------|-------------|
+| `boss_search` | Search jobs with city, salary, and welfare filters |
+| `boss_recommend` | Get personalized recommendations |
+| `boss_detail` | Fetch job details |
+| `boss_show` | Open a job from the previous search result by index |
+| `boss_cities` | List supported cities |
+| `boss_history` | Read browsing history |
+
+### Candidate actions
+
+| Tool | Description |
+|------|-------------|
+| `boss_greet` | Greet a recruiter |
+| `boss_batch_greet` | Greet multiple recruiters from a search result |
+| `boss_apply` | Apply or start the conversation immediately |
+
+### Conversation management
+
+| Tool | Description |
+|------|-------------|
+| `boss_chat` | Conversation list |
+| `boss_chatmsg` | Chat message history |
+| `boss_chat_summary` | Conversation summary and next-step suggestions |
+| `boss_mark` | Manage contact labels |
+| `boss_exchange` | Exchange contact information |
+| `boss_interviews` | List interview invitations |
+
+### Workflow management
+
+| Tool | Description |
+|------|-------------|
+| `boss_pipeline` | Candidate pipeline view |
+| `boss_follow_up` | Follow-up filtering |
+| `boss_digest` | Daily digest |
+
+### User profile
+
+| Tool | Description |
+|------|-------------|
+| `boss_me` | User profile, resume, intent, and application history |
+
+### Recruiter workflow
+
+| Tool | Description |
+|------|-------------|
+| `boss_hr_applications` | View candidate applications |
+| `boss_hr_candidates` | Search candidates |
+| `boss_hr_chat` | Recruiter conversation list |
+| `boss_hr_resume` | View online candidate resumes |
+| `boss_hr_reply` | Reply to a candidate |
+| `boss_hr_request_resume` | Request an attached resume from a candidate |
+| `boss_hr_jobs` | Manage job listings and online/offline state |
+
+## Example prompt
+
+After configuration, you can say this directly in Claude Desktop:
+
+> "Help me search for Golang roles in Guangzhou with 双休 and 五险一金."
+
+Claude will call `boss_search` automatically and show the result.
+
+## Transports
+
+### stdio (default, already supported)
+
+Claude Desktop, Cursor, Codex, and similar hosts connect over stdin/stdout by default. The `claude_desktop_config.json` example above uses stdio mode.
+
+```bash
+boss-mcp
+```
+
+### SSE
+
+For hosts or custom orchestrators that still prefer the traditional MCP SSE transport:
+
+```bash
+boss-mcp --transport sse --host 127.0.0.1 --port 8765
+```
+
+Default paths:
+- SSE handshake: `/sse`
+- Message endpoint: `/messages/`
+
+Custom paths:
+
+```bash
+boss-mcp --transport sse --port 8765 --sse-path /events --message-path /inbox
+```
+
+### HTTP streaming
+
+For hosts that support the newer MCP streamable HTTP transport:
+
+```bash
+boss-mcp --transport http --host 127.0.0.1 --port 8765
+```
+
+Default path:
+- HTTP streaming: `/mcp`
+
+Custom path:
+
+```bash
+boss-mcp --transport http --port 8765 --path /rpc
+```
+
+**Design constraints**:
+- `stdio` remains the default behavior so existing integrations do not break
+- HTTP transports bind to `127.0.0.1` by default; exposing them remotely requires an explicit `--host 0.0.0.0`
+- Authentication and TLS are not built in; add them via a reverse proxy such as nginx, Caddy, or Cloudflare Tunnel when needed
+
+## Other agent hosts
+
+This MCP server focuses on stdio, SSE, and streamable HTTP. If your agent framework does not support MCP directly, use `boss schema` to generate host-native tool definitions:
+
+```bash
+# OpenAI Functions / Tools API (GPT-4 / GPT-5)
+boss schema --format openai-tools
+
+# Anthropic Tool Use (Claude API)
+boss schema --format anthropic-tools
+```
+
+Then feed the `data.tools` array from stdout into the corresponding SDK.
+
+## Contributing
+
+You are welcome to pick up tasks labeled `good first issue` or `help wanted` in the [Issue Tracker](https://github.com/can4hou6joeng4/boss-agent-cli/issues).
+
+Development environment:
+
+```bash
+cd boss-agent-cli
+uv sync --all-extras
+uv run pytest tests/test_mcp_server.py -v  # 65 tests covering tool schema + arg construction
+```
+
+Style rule: tabs for indentation, and `uv run ruff check src/ tests/` must pass.

--- a/tests/test_agent_docs.py
+++ b/tests/test_agent_docs.py
@@ -95,6 +95,40 @@ def test_readme_en_mentions_current_mcp_tool_count():
 	assert f"MCP server with {tool_count} tools" in content
 
 
+def test_english_agent_docs_exist_and_are_linked_from_english_entrypoints():
+	quickstart = _read("docs/agent-quickstart.en.md")
+	assert "# Agent Quickstart" in quickstart
+	assert "## 1) Install and prepare the environment" in quickstart
+	assert "## 2) Complete the minimal agent loop in three steps" in quickstart
+	assert "## 3) Recovery flow and troubleshooting" in quickstart
+	assert "[Capability Matrix](capability-matrix.en.md)" in quickstart
+
+	hosts = _read("docs/agent-hosts.en.md")
+	assert "# Agent Host Examples" in hosts
+	assert "[Codex](integrations/codex.md)" in hosts
+	assert "[Python SDK](integrations/python-sdk.md)" in hosts
+
+	matrix = _read("docs/capability-matrix.en.md")
+	assert "# Capability Matrix" in matrix
+	assert "| Capability | CLI command | Login required | Transport |" in matrix
+	assert "`boss schema`" in matrix
+	assert "`boss hr candidates`" in matrix
+	assert "33 top-level commands" in matrix
+	assert "7 first-level recruiter subcommands" in matrix
+
+	mcp_readme = _read("mcp-server/README.en.md")
+	assert "[Agent Quickstart](../docs/agent-quickstart.en.md)" in mcp_readme
+	assert "[Capability Matrix](../docs/capability-matrix.en.md)" in mcp_readme
+
+	readme_en = _read("README.en.md")
+	assert "[Agent Quickstart](docs/agent-quickstart.en.md)" in readme_en
+	assert "[Capability Matrix](docs/capability-matrix.en.md)" in readme_en
+
+	python_sdk = _read("docs/integrations/python-sdk.md")
+	assert "[`boss schema --format` options](../capability-matrix.en.md)" in python_sdk
+	assert "[MCP integration guide (Claude Desktop / Cursor)](../../mcp-server/README.en.md)" in python_sdk
+
+
 def test_glama_metadata_exists_and_declares_owner():
 	content = json.loads(_read("glama.json"))
 	assert content["$schema"] == "https://glama.ai/mcp/schemas/server.json"


### PR DESCRIPTION
## Summary
- add English companion docs for agent quickstart, host examples, capability matrix, and MCP server usage
- point English-facing entry links to the new English docs
- add regression checks for the English doc links and sections

## Verification
- UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q tests/test_agent_docs.py tests/test_agent_host_examples.py