### PR TITLE
docs: 补充英文架构与模型文档

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -151,7 +151,7 @@ Notes:
 - candidate-side `search / detail / recommend / user_info / greet / apply` are wired for `zhilian`
 - `boss --platform zhilian hr ...` is still intentionally rejected at runtime because recruiter support is not implemented yet
 
-Architecture notes: [docs/platform-abstraction.md](docs/platform-abstraction.md).
+Architecture notes: [docs/platform-abstraction.en.md](docs/platform-abstraction.en.md).
 
 ## 🤖 Agent Integration
 

--- a/docs/agent-hosts.en.md
+++ b/docs/agent-hosts.en.md
@@ -36,4 +36,4 @@ Current example baseline:
 
 ## Related docs
 
-- [Recommended models and entry points](integrations/ai-models.md) - current setup examples for Claude 4.7, GPT-5, DeepSeek-V3, Qwen3, and more
+- [Recommended models and entry points](integrations/ai-models.en.md) - current setup examples for Claude 4.7, GPT-5, DeepSeek-V3, Qwen3, and more

--- a/docs/integrations/ai-models.en.md
+++ b/docs/integrations/ai-models.en.md
@@ -1,0 +1,113 @@
+# Recommended AI Models and Providers
+
+The `boss ai` command group speaks an OpenAI-compatible protocol. This guide summarizes the recommended provider entry points and configuration examples for popular model families, so you can pick the latest or most practical option for your workflow. Updated on 2026-04-20.
+
+## Supported providers
+
+| Provider | Default `base_url` | Model coverage |
+|----------|--------------------|----------------|
+| `openai` | `https://api.openai.com/v1` | GPT-5, GPT-4.1, GPT-4o, and the o4 family |
+| `deepseek` | `https://api.deepseek.com/v1` | DeepSeek-V3 and DeepSeek-R1 |
+| `moonshot` | `https://api.moonshot.cn/v1` | Kimi K2 |
+| `openrouter` | `https://openrouter.ai/api/v1` | Aggregated access to Anthropic Claude, OpenAI, Google, Meta, and more |
+| `qwen` | `https://dashscope.aliyuncs.com/compatible-mode/v1` | Tongyi Qwen3 models |
+| `zhipu` | `https://open.bigmodel.cn/api/paas/v4` | GLM-4.6 and GLM-Z1 |
+| `siliconflow` | `https://api.siliconflow.cn/v1` | SiliconFlow aggregated inference |
+| `custom` | set manually with `--base-url` | LiteLLM, OneAPI, self-hosted proxies, and other compatible gateways |
+
+## Claude 4.7 / GPT-5 configuration examples
+
+### Claude 4.7 via OpenRouter
+
+OpenRouter wraps the Anthropic Messages API behind an OpenAI-compatible surface, which makes it the easiest way to plug Claude 4.7 into `boss ai` today:
+
+```bash
+boss ai config \
+  --provider openrouter \
+  --model anthropic/claude-opus-4.7 \
+  --api-key <OPENROUTER_KEY>
+```
+
+Other Claude variants include `anthropic/claude-sonnet-4.6` and `anthropic/claude-haiku-4.5`.
+
+### GPT-5 via OpenAI
+
+```bash
+boss ai config \
+  --provider openai \
+  --model gpt-5 \
+  --api-key <OPENAI_KEY>
+```
+
+### DeepSeek-V3
+
+```bash
+boss ai config \
+  --provider deepseek \
+  --model deepseek-chat \
+  --api-key <DEEPSEEK_KEY>
+```
+
+### Qwen3
+
+```bash
+boss ai config \
+  --provider qwen \
+  --model qwen3-max \
+  --api-key <DASHSCOPE_KEY>
+```
+
+### Zhipu GLM-4.6
+
+```bash
+boss ai config \
+  --provider zhipu \
+  --model glm-4.6 \
+  --api-key <ZHIPU_KEY>
+```
+
+### Self-hosted proxy via LiteLLM / OneAPI
+
+```bash
+boss ai config \
+  --provider custom \
+  --base-url https://your-proxy.example.com/v1 \
+  --model any-model-id \
+  --api-key <YOUR_KEY>
+```
+
+## How to choose
+
+| Scenario | Recommended setup |
+|----------|-------------------|
+| You want the strongest reasoning models | `openrouter` + `anthropic/claude-opus-4.7`, or `openai` + `gpt-5` |
+| You are cost-sensitive | `deepseek` + `deepseek-chat` |
+| You want mainland-China direct access without an extra proxy | `qwen`, `zhipu`, `deepseek`, or `moonshot` |
+| You want one key that spans many vendors | `openrouter` |
+| You already run your own compatible proxy | `custom` + `--base-url` |
+
+## Validate the configuration
+
+```bash
+# Inspect the current AI configuration
+boss ai config
+
+# Run a quick smoke test
+boss ai polish my-resume
+```
+
+Error codes you may see:
+
+- `AI_NOT_CONFIGURED`: provider, model, or API key is missing
+- `AI_API_ERROR`: the model API call failed, such as auth, network, or rate-limit issues
+- `AI_PARSE_ERROR`: the model returned JSON that does not match the expected schema, so retrying is usually enough
+
+## Related commands
+
+- `boss ai analyze-jd <jd>` - JD match analysis
+- `boss ai polish <resume>` - general resume polishing
+- `boss ai optimize <resume> --jd <jd>` - role-targeted resume optimization
+- `boss ai suggest <resume> --jd <jd>` - job-search improvement suggestions
+- `boss ai reply <message>` - draft replies for recruiter messages
+- `boss ai interview-prep <jd>` - mock interview question generation
+- `boss ai chat-coach <chat>` - chat coaching and guidance

--- a/docs/platform-abstraction.en.md
+++ b/docs/platform-abstraction.en.md
@@ -1,0 +1,219 @@
+# Platform Abstraction Design and Migration SOP
+
+> This document captures the reusable playbook distilled from Issue #129 Week 1. Use it when onboarding a new platform such as Lagou, Liepin, or any future recruitment source, or when repeating a similar refactor.
+
+## Why the platform abstraction exists
+
+**Core problem**: the original implementation had 30+ commands directly calling `with BossClient(...) as client:`. That implicit dependency made the cost of adding a second recruitment platform explode, because every new platform would have to re-implement request wiring across the full command surface.
+
+**Chosen abstraction boundary**: promote the idea of a "platform" to a first-class abstraction, instead of abstracting by API endpoint or auth flow. That keeps protocol differences such as response envelopes, error codes, and encryption fully encapsulated inside each platform implementation.
+
+## Platform ABC contract
+
+### 1. Basic metadata
+
+```python
+name: str            # "zhipin" / "zhilian" / ...
+display_name: str    # "BOSS Zhipin" / "Zhilian" / ...
+base_url: str
+```
+
+### 2. Response-envelope adapters
+
+Every platform must implement:
+
+```python
+def is_success(self, response: dict) -> bool
+def unwrap_data(self, response: dict) -> Any
+def parse_error(self, response: dict) -> tuple[str, str]  # (normalized error code, raw message)
+```
+
+Examples of platform-specific differences:
+- BOSS Zhipin: `code == 0` means success and the payload lives under `zpData`
+- Zhilian: `code == 200` means success and the payload lives under `data`
+- Raw platform errors are normalized into shared enums such as `AUTH_EXPIRED`, `RATE_LIMITED`, `ACCOUNT_RISK`, `TOKEN_REFRESH_FAILED`, and `UNKNOWN`
+
+### 3. P0 read-only capabilities
+
+These abstract methods are mandatory:
+
+```python
+@abstractmethod
+def search_jobs(self, query: str, **filters: Any) -> dict
+@abstractmethod
+def job_detail(self, job_id: str) -> dict
+@abstractmethod
+def recommend_jobs(self, page: int = 1) -> dict
+@abstractmethod
+def user_info(self) -> dict
+```
+
+### 4. P0+ / P1 / P2 capability tiers
+
+These default to `NotImplementedError` in the base class:
+
+```python
+# P0+: resume, application, history, interview, and chat read APIs
+def resume_baseinfo(self) -> dict
+def resume_expect(self) -> dict
+def deliver_list(self, page: int = 1) -> dict
+def job_card(self, security_id: str, lid: str = "") -> dict
+def interview_data(self) -> dict
+def job_history(self, page: int = 1) -> dict
+def chat_history(self, gid: str, security_id: str, page: int = 1, count: int = 20) -> dict
+def friend_label(self, friend_id: str, label_id: int, friend_source: int = 0, remove: bool = False) -> dict
+def exchange_contact(self, security_id: str, uid: str, friend_name: str, exchange_type: int = 1) -> dict
+
+# P1: write operations
+def greet(self, security_id: str, job_id: str, message: str = "") -> dict
+def apply(self, security_id: str, job_id: str, lid: str = "") -> dict
+
+# P2: conversation workflows
+def friend_list(self, page: int = 1) -> dict
+```
+
+### 5. Resource lifecycle
+
+```python
+def close(self) -> None                      # delegate to the underlying client.close()
+def __enter__(self) -> "Platform": ...
+def __exit__(self, ...) -> None: ...
+```
+
+## Command migration template
+
+**Key idea**: move the command layer from "use BossClient directly" to "call through the Platform abstraction", so command code no longer needs to know which platform it is talking to.
+
+### Before
+
+```python
+from boss_agent_cli.api.client import BossClient
+
+def cmd(ctx):
+    data_dir = ctx.obj["data_dir"]
+    logger = ctx.obj["logger"]
+    delay = ctx.obj["delay"]
+    cdp_url = ctx.obj.get("cdp_url")
+
+    auth = AuthManager(data_dir, logger=logger)
+    with BossClient(auth, delay=delay, cdp_url=cdp_url) as client:
+        result = client.search_jobs("Python", city="Guangzhou")
+```
+
+### After
+
+```python
+from boss_agent_cli.commands._platform import get_platform_instance
+
+def cmd(ctx):
+    data_dir = ctx.obj["data_dir"]
+    logger = ctx.obj["logger"]
+
+    auth = AuthManager(data_dir, logger=logger)
+    with get_platform_instance(ctx, auth) as platform:
+        result = platform.search_jobs("Python", city="Guangzhou")
+```
+
+**Net gain**: remove 3 lines of boilerplate (`delay`, `cdp_url`, and direct `BossClient` construction) while keeping the command call site stable.
+
+## Test mocking rule
+
+### Before
+
+```python
+@patch("boss_agent_cli.commands.X.BossClient")
+def test_something(mock_client_cls):
+    mock_client = _ctx_mock(mock_client_cls)
+    mock_client.search_jobs.return_value = {...}
+```
+
+### After
+
+```python
+@patch("boss_agent_cli.commands.X.get_platform_instance")
+def test_something(mock_get_platform):
+    mock_platform = _ctx_mock(mock_get_platform)
+    mock_platform.search_jobs.return_value = {...}
+```
+
+**Why**: patch the imported alias inside the command module, not the original source module. The patch target follows the command module's import path.
+
+### Batch replacement helper
+
+```bash
+for cmd in greet apply detail me recommend ...; do
+  sed -i '' "s/boss_agent_cli.commands.$cmd.BossClient/boss_agent_cli.commands.$cmd.get_platform_instance/g" tests/*.py
+done
+```
+
+## SOP for onboarding a new platform
+
+### Step 1: research note
+
+Create `docs/research/platforms/<name>.md` and cover the same seven areas used in [lagou.md](research/platforms/lagou.md):
+
+1. login flow
+2. core API endpoint inventory
+3. request signing or anti-bot mechanisms
+4. response structure
+5. CDP / browser-channel feasibility
+6. risk-control thresholds
+7. protocol-difference matrix compared to BOSS Zhipin
+
+### Step 2: register a stub
+
+```python
+# src/boss_agent_cli/platforms/<name>.py
+class MyPlatform(Platform):
+    name = "myname"
+    display_name = "My Platform"
+    base_url = "https://..."
+
+    def is_success(self, r): ...
+    def unwrap_data(self, r): ...
+    def parse_error(self, r): ...
+
+    # P0 / P1 / P2 methods all raise NotImplementedError("Planned for Week 2")
+```
+
+### Step 3: add it to `platforms/__init__.py`
+
+```python
+_REGISTRY: dict[str, type[Platform]] = {
+    "zhipin": BossPlatform,
+    "zhilian": ZhilianPlatform,
+    "myname": MyPlatform,
+}
+```
+
+### Step 4: contract tests in `tests/test_<name>_stub.py`
+
+Cover:
+- platform registry validation
+- basic metadata
+- response-envelope adaptation
+- stub behavior for each abstract method
+- CLI integration, such as `boss --platform <name> schema`
+
+### Step 5: real implementation rollout
+
+- Start with P0: `search`, `detail`, `recommend`, `user_info`
+- Then P1: `greet`, `apply`, if the platform needs them
+- Finally P2: conversation workflows as an optional later stage
+
+## Contract invariants
+
+These are breaking-change red lines for the platform abstraction:
+
+1. Keep the base-class signature `__init__(client: Any)` unchanged. Subclasses may narrow types but cannot add required parameters.
+2. Keep abstract-method signatures stable. Add new methods if needed, but do not mutate existing signatures.
+3. Error-code normalization must stay aligned with the shared error enums documented in `CLAUDE.md`.
+4. Preserve `with`-context semantics: `__exit__` must call `close()`.
+5. Python embedding exports must remain available through `from boss_agent_cli import ...` for `Platform`, `BossPlatform`, `ZhilianPlatform`, `get_platform`, and `list_platforms`.
+
+## References
+
+- [Issue #129 - Week 1 design and implementation](https://github.com/can4hou6joeng4/boss-agent-cli/issues/129)
+- The Zhilian candidate-side implementation is already merged into mainline through PR #157, PR #158, and follow-up fixes; recruiter-side support is still intentionally unavailable
+- [Issue #90 - Multi-platform API research](https://github.com/can4hou6joeng4/boss-agent-cli/issues/90)
+- PR #131 / #132 / #133 / #134 / #135 / #136 / #137 / #138 / #139 / #141 - the full Week 1 PR set

--- a/tests/test_agent_docs.py
+++ b/tests/test_agent_docs.py
@@ -123,10 +123,24 @@ def test_english_agent_docs_exist_and_are_linked_from_english_entrypoints():
 	readme_en = _read("README.en.md")
 	assert "[Agent Quickstart](docs/agent-quickstart.en.md)" in readme_en
 	assert "[Capability Matrix](docs/capability-matrix.en.md)" in readme_en
+	assert "[docs/platform-abstraction.en.md](docs/platform-abstraction.en.md)" in readme_en
 
 	python_sdk = _read("docs/integrations/python-sdk.md")
 	assert "[`boss schema --format` options](../capability-matrix.en.md)" in python_sdk
 	assert "[MCP integration guide (Claude Desktop / Cursor)](../../mcp-server/README.en.md)" in python_sdk
+
+	models_en = _read("docs/integrations/ai-models.en.md")
+	assert "# Recommended AI Models and Providers" in models_en
+	assert "## Supported providers" in models_en
+	assert "`openrouter`" in models_en
+	assert "`gpt-5`" in models_en
+
+	platform_en = _read("docs/platform-abstraction.en.md")
+	assert "# Platform Abstraction Design and Migration SOP" in platform_en
+	assert "## Why the platform abstraction exists" in platform_en
+	assert "## Contract invariants" in platform_en
+
+	assert "[Recommended models and entry points](integrations/ai-models.en.md)" in hosts
 
 
 def test_glama_metadata_exists_and_declares_owner():


### PR DESCRIPTION
## Summary
- add English companion docs for platform abstraction and AI model/provider recommendations
- update English entry links so README.en and agent host docs stay on the English path
- extend doc regression checks for the new English docs and links

## Verification
- UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q tests/test_agent_docs.py tests/test_agent_host_examples.py