### PR TITLE
fix: 修正招聘者提示命令

### DIFF
--- a/src/boss_agent_cli/commands/recruiter/applications.py
+++ b/src/boss_agent_cli/commands/recruiter/applications.py
@@ -24,7 +24,7 @@ def applications_cmd(ctx: click.Context, job_id: str | None, label_id: int, page
 		handle_output(
 			ctx, "recruiter-applications", data,
 			hints={"next_actions": [
-				"boss --role recruiter recruiter resume <geek_id> --job-id <id> --security-id <id> — 查看候选人简历",
-				"boss --role recruiter recruiter chat — 查看沟通列表",
+				"boss hr resume <geek_id> --job-id <id> --security-id <id> — 查看候选人简历",
+				"boss hr chat — 查看沟通列表",
 			]},
 		)

--- a/src/boss_agent_cli/commands/recruiter/candidates.py
+++ b/src/boss_agent_cli/commands/recruiter/candidates.py
@@ -30,7 +30,7 @@ def candidates_cmd(ctx: click.Context, query: str, city: str | None, job_id: str
 		handle_output(
 			ctx, "recruiter-candidates", data,
 			hints={"next_actions": [
-				"boss --role recruiter recruiter resume <geek_id> --job-id <id> --security-id <id> — 查看简历",
-				"boss --role recruiter recruiter chat — 查看沟通",
+				"boss hr resume <geek_id> --job-id <id> --security-id <id> — 查看简历",
+				"boss hr chat — 查看沟通",
 			]},
 		)

--- a/src/boss_agent_cli/commands/recruiter/chat.py
+++ b/src/boss_agent_cli/commands/recruiter/chat.py
@@ -24,6 +24,6 @@ def recruiter_chat_cmd(ctx: click.Context, page: int, job_id: str | None, label_
 		handle_output(
 			ctx, "recruiter-chat", data,
 			hints={"next_actions": [
-				"boss --role recruiter recruiter resume <geek_id> --job-id <id> --security-id <id> — 查看候选人简历",
+				"boss hr resume <geek_id> --job-id <id> --security-id <id> — 查看候选人简历",
 			]},
 		)

--- a/src/boss_agent_cli/commands/recruiter/resume.py
+++ b/src/boss_agent_cli/commands/recruiter/resume.py
@@ -51,6 +51,6 @@ def resume_cmd(ctx: click.Context, geek_id: str, job_id: str, security_id: str |
 		handle_output(
 			ctx, "recruiter-resume", data,
 			hints={"next_actions": [
-				"boss --role recruiter recruiter applications — 返回候选人列表",
+				"boss hr applications — 返回候选人列表",
 			]},
 		)

--- a/tests/test_recruiter_commands.py
+++ b/tests/test_recruiter_commands.py
@@ -33,6 +33,8 @@ def test_recruiter_candidates_supports_data_envelope(mock_auth_cls, mock_platfor
 	parsed = json.loads(result.output)
 	assert parsed["ok"] is True
 	assert parsed["data"]["geekList"][0]["name"] == "候选人A"
+	assert parsed["hints"]["next_actions"][0] == "boss hr resume <geek_id> --job-id <id> --security-id <id> — 查看简历"
+	assert parsed["hints"]["next_actions"][1] == "boss hr chat — 查看沟通"
 
 
 @patch("boss_agent_cli.commands.recruiter.chat.get_recruiter_platform_instance")
@@ -47,6 +49,7 @@ def test_recruiter_chat_supports_data_envelope(mock_auth_cls, mock_platform_cls)
 	assert result.exit_code == 0
 	parsed = json.loads(result.output)
 	assert parsed["data"]["friendList"][0]["name"] == "候选人B"
+	assert parsed["hints"]["next_actions"][0] == "boss hr resume <geek_id> --job-id <id> --security-id <id> — 查看候选人简历"
 
 
 @patch("boss_agent_cli.commands.recruiter.applications.get_recruiter_platform_instance")
@@ -61,6 +64,8 @@ def test_recruiter_applications_supports_data_envelope(mock_auth_cls, mock_platf
 	assert result.exit_code == 0
 	parsed = json.loads(result.output)
 	assert parsed["data"]["friendList"][0]["name"] == "候选人C"
+	assert parsed["hints"]["next_actions"][0] == "boss hr resume <geek_id> --job-id <id> --security-id <id> — 查看候选人简历"
+	assert parsed["hints"]["next_actions"][1] == "boss hr chat — 查看沟通列表"
 
 
 @patch("boss_agent_cli.commands.recruiter.jobs.get_recruiter_platform_instance")
@@ -90,6 +95,7 @@ def test_recruiter_resume_exchange_supports_data_envelope(mock_auth_cls, mock_pl
 	parsed = json.loads(result.output)
 	assert parsed["data"]["exchangeStatus"] == "sent"
 	assert "联系方式交换请求已发送" == parsed["data"]["message"]
+	assert parsed["hints"]["next_actions"][0] == "boss hr applications — 返回候选人列表"
 
 
 @patch("boss_agent_cli.commands.recruiter.resume.get_recruiter_platform_instance")
@@ -121,6 +127,7 @@ def test_recruiter_resume_parse_supports_data_envelope(mock_auth_cls, mock_platf
 	parsed = json.loads(result.output)
 	assert parsed["data"]["basic"]["name"] == "张三"
 	assert parsed["data"]["expectation"]["position"] == "后端工程师"
+	assert parsed["hints"]["next_actions"][0] == "boss hr applications — 返回候选人列表"
 
 
 def test_parse_resume_accepts_data_envelope():


### PR DESCRIPTION
## Summary
- replace invalid recruiter hint commands like `boss --role recruiter recruiter ...` with executable `boss hr ...` commands
- fix next-action hints for recruiter applications, candidates, chat, and resume flows
- add regression assertions so recruiter command hints stay runnable

## Verification
- UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q tests/test_recruiter_commands.py
- rg -n "boss --role recruiter recruiter" src tests docs README.md README.en.md