### PR TITLE
fix: 修正招聘者职位状态回执

### DIFF
--- a/src/boss_agent_cli/commands/recruiter/jobs.py
+++ b/src/boss_agent_cli/commands/recruiter/jobs.py
@@ -3,7 +3,7 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._recruiter_platform import get_recruiter_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_output
+from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output
 
 
 @click.group("jobs")
@@ -39,7 +39,16 @@ def jobs_offline_cmd(ctx: click.Context, job_id: str) -> None:
 
 	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	with get_recruiter_platform_instance(ctx, auth) as platform:
-		platform.job_offline(job_id)
+		result = platform.job_offline(job_id)
+		if not platform.is_success(result):
+			code, message = platform.parse_error(result)
+			handle_error_output(
+				ctx, "recruiter-jobs-offline",
+				code=code,
+				message=message or "职位下线失败",
+				recoverable=False,
+			)
+			return
 		data = {"job_id": job_id, "message": "职位已下线"}
 		handle_output(ctx, "recruiter-jobs-offline", data)
 
@@ -55,6 +64,15 @@ def jobs_online_cmd(ctx: click.Context, job_id: str) -> None:
 
 	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	with get_recruiter_platform_instance(ctx, auth) as platform:
-		platform.job_online(job_id)
+		result = platform.job_online(job_id)
+		if not platform.is_success(result):
+			code, message = platform.parse_error(result)
+			handle_error_output(
+				ctx, "recruiter-jobs-online",
+				code=code,
+				message=message or "职位上线失败",
+				recoverable=False,
+			)
+			return
 		data = {"job_id": job_id, "message": "职位已上线"}
 		handle_output(ctx, "recruiter-jobs-online", data)

--- a/tests/test_recruiter_commands.py
+++ b/tests/test_recruiter_commands.py
@@ -82,6 +82,36 @@ def test_recruiter_jobs_list_supports_data_envelope(mock_auth_cls, mock_platform
 	assert parsed["data"]["jobList"][0]["jobName"] == "后端工程师"
 
 
+@patch("boss_agent_cli.commands.recruiter.jobs.get_recruiter_platform_instance")
+@patch("boss_agent_cli.commands.recruiter.jobs.AuthManager")
+def test_recruiter_jobs_offline_reports_error_when_platform_rejects(mock_auth_cls, mock_platform_cls):
+	mock_platform = _ctx_mock(mock_platform_cls)
+	mock_platform.job_offline.return_value = {"code": 37, "message": "stoken expired"}
+	mock_platform.is_success.return_value = False
+	mock_platform.parse_error.return_value = ("TOKEN_REFRESH_FAILED", "stoken expired")
+	result = _invoke("hr", "jobs", "offline", "enc-job-1")
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
+	assert parsed["error"]["message"] == "stoken expired"
+
+
+@patch("boss_agent_cli.commands.recruiter.jobs.get_recruiter_platform_instance")
+@patch("boss_agent_cli.commands.recruiter.jobs.AuthManager")
+def test_recruiter_jobs_online_reports_error_when_platform_rejects(mock_auth_cls, mock_platform_cls):
+	mock_platform = _ctx_mock(mock_platform_cls)
+	mock_platform.job_online.return_value = {"code": 9, "message": "too fast"}
+	mock_platform.is_success.return_value = False
+	mock_platform.parse_error.return_value = ("RATE_LIMITED", "too fast")
+	result = _invoke("hr", "jobs", "online", "enc-job-1")
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["error"]["code"] == "RATE_LIMITED"
+	assert parsed["error"]["message"] == "too fast"
+
+
 @patch("boss_agent_cli.commands.recruiter.resume.get_recruiter_platform_instance")
 @patch("boss_agent_cli.commands.recruiter.resume.AuthManager")
 def test_recruiter_resume_exchange_supports_data_envelope(mock_auth_cls, mock_platform_cls):


### PR DESCRIPTION
## Summary
- stop reporting recruiter job online/offline actions as success when the platform returns a failure envelope
- parse recruiter platform errors and emit JSON error envelopes for failed job state mutations
- add regression coverage for recruiter job online/offline failure cases

## Verification
- UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q tests/test_recruiter_commands.py