### PR TITLE
fix: 修正招聘者写操作回执

### DIFF
--- a/src/boss_agent_cli/commands/recruiter/reply.py
+++ b/src/boss_agent_cli/commands/recruiter/reply.py
@@ -3,7 +3,7 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._recruiter_platform import get_recruiter_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_output
+from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output
 
 
 @click.command("reply")
@@ -19,10 +19,19 @@ def reply_cmd(ctx: click.Context, friend_id: int, message: str) -> None:
 	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	with get_recruiter_platform_instance(ctx, auth) as platform:
 		result = platform.send_message(friend_id, message)
+		if not platform.is_success(result):
+			code, error_message = platform.parse_error(result)
+			handle_error_output(
+				ctx, "recruiter-reply",
+				code=code,
+				message=error_message or "消息发送失败",
+				recoverable=False,
+			)
+			return
 		data = {
 			"friend_id": friend_id,
 			"message": message,
-			"sent": platform.is_success(result),
+			"sent": True,
 		}
 		handle_output(
 			ctx, "recruiter-reply", data,

--- a/src/boss_agent_cli/commands/recruiter/request_resume.py
+++ b/src/boss_agent_cli/commands/recruiter/request_resume.py
@@ -3,7 +3,7 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._recruiter_platform import get_recruiter_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_output
+from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output
 
 
 @click.command("request-resume")
@@ -20,11 +20,20 @@ def request_resume_cmd(ctx: click.Context, friend_id: int, job_id: int) -> None:
 	with get_recruiter_platform_instance(ctx, auth) as platform:
 		# friend_id 就是 uid，gid 也设为 uid
 		result = platform.exchange_request(3, friend_id, job_id, friend_id)
+		if not platform.is_success(result):
+			code, error_message = platform.parse_error(result)
+			handle_error_output(
+				ctx, "recruiter-request-resume",
+				code=code,
+				message=error_message or "附件简历请求失败",
+				recoverable=False,
+			)
+			return
 		data = {
 			"friend_id": friend_id,
 			"job_id": job_id,
-			"requested": platform.is_success(result),
-			"message": "附件简历请求已发送" if platform.is_success(result) else "请求失败，可能已请求过或权限不足",
+			"requested": True,
+			"message": "附件简历请求已发送",
 		}
 		handle_output(
 			ctx, "recruiter-request-resume", data,

--- a/src/boss_agent_cli/commands/recruiter/resume.py
+++ b/src/boss_agent_cli/commands/recruiter/resume.py
@@ -34,6 +34,15 @@ def resume_cmd(ctx: click.Context, geek_id: str, job_id: str, security_id: str |
 				)
 				return
 			result = platform.exchange_request(1, uid, int(job_id), gid)
+			if not platform.is_success(result):
+				code, message = platform.parse_error(result)
+				handle_error_output(
+					ctx, "recruiter-resume",
+					code=code,
+					message=message or "联系方式交换请求失败",
+					recoverable=False,
+				)
+				return
 			data = platform.unwrap_data(result) or {}
 			data["message"] = "联系方式交换请求已发送"
 		elif security_id and job_id:

--- a/tests/test_recruiter_commands.py
+++ b/tests/test_recruiter_commands.py
@@ -130,6 +130,21 @@ def test_recruiter_resume_exchange_supports_data_envelope(mock_auth_cls, mock_pl
 
 @patch("boss_agent_cli.commands.recruiter.resume.get_recruiter_platform_instance")
 @patch("boss_agent_cli.commands.recruiter.resume.AuthManager")
+def test_recruiter_resume_exchange_reports_error_when_platform_rejects(mock_auth_cls, mock_platform_cls):
+	mock_platform = _ctx_mock(mock_platform_cls)
+	mock_platform.exchange_request.return_value = {"code": 37, "message": "stoken expired"}
+	mock_platform.is_success.return_value = False
+	mock_platform.parse_error.return_value = ("TOKEN_REFRESH_FAILED", "stoken expired")
+	result = _invoke("hr", "resume", "geek-1", "--exchange", "--uid", "1", "--gid", "2", "--job-id", "3")
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
+	assert parsed["error"]["message"] == "stoken expired"
+
+
+@patch("boss_agent_cli.commands.recruiter.resume.get_recruiter_platform_instance")
+@patch("boss_agent_cli.commands.recruiter.resume.AuthManager")
 def test_recruiter_resume_parse_supports_data_envelope(mock_auth_cls, mock_platform_cls):
 	mock_platform = _ctx_mock(mock_platform_cls)
 	mock_platform.view_geek.return_value = {
@@ -158,6 +173,36 @@ def test_recruiter_resume_parse_supports_data_envelope(mock_auth_cls, mock_platf
 	assert parsed["data"]["basic"]["name"] == "张三"
 	assert parsed["data"]["expectation"]["position"] == "后端工程师"
 	assert parsed["hints"]["next_actions"][0] == "boss hr applications — 返回候选人列表"
+
+
+@patch("boss_agent_cli.commands.recruiter.reply.get_recruiter_platform_instance")
+@patch("boss_agent_cli.commands.recruiter.reply.AuthManager")
+def test_recruiter_reply_reports_error_when_platform_rejects(mock_auth_cls, mock_platform_cls):
+	mock_platform = _ctx_mock(mock_platform_cls)
+	mock_platform.send_message.return_value = {"code": 9, "message": "too fast"}
+	mock_platform.is_success.return_value = False
+	mock_platform.parse_error.return_value = ("RATE_LIMITED", "too fast")
+	result = _invoke("hr", "reply", "123", "你好")
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["error"]["code"] == "RATE_LIMITED"
+	assert parsed["error"]["message"] == "too fast"
+
+
+@patch("boss_agent_cli.commands.recruiter.request_resume.get_recruiter_platform_instance")
+@patch("boss_agent_cli.commands.recruiter.request_resume.AuthManager")
+def test_recruiter_request_resume_reports_error_when_platform_rejects(mock_auth_cls, mock_platform_cls):
+	mock_platform = _ctx_mock(mock_platform_cls)
+	mock_platform.exchange_request.return_value = {"code": 36, "message": "account risk"}
+	mock_platform.is_success.return_value = False
+	mock_platform.parse_error.return_value = ("ACCOUNT_RISK", "account risk")
+	result = _invoke("hr", "request-resume", "123", "--job-id", "88")
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["error"]["code"] == "ACCOUNT_RISK"
+	assert parsed["error"]["message"] == "account risk"
 
 
 def test_parse_resume_accepts_data_envelope():


### PR DESCRIPTION
## 摘要
- 修正招聘者 reply、request-resume、resume --exchange 在平台失败时仍返回成功回执的问题
- 统一改为解析平台错误并输出 JSON 错误信封
- 补充对应失败路径测试，避免再次出现假成功

## 验证
- UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q tests/test_recruiter_commands.py
- UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q