### PR TITLE
fix: 修正沟通写操作回执

### DIFF
--- a/src/boss_agent_cli/commands/exchange.py
+++ b/src/boss_agent_cli/commands/exchange.py
@@ -39,7 +39,16 @@ def exchange_cmd(ctx: click.Context, security_id: str, exchange_type: str) -> No
 			)
 			return
 
-		platform.exchange_contact(security_id, uid, friend_name, exchange_type=type_id)
+		resp = platform.exchange_contact(security_id, uid, friend_name, exchange_type=type_id)
+		if not platform.is_success(resp):
+			code, message = platform.parse_error(resp)
+			handle_error_output(
+				ctx, "exchange",
+				code=code,
+				message=message or f"{type_label}交换请求失败",
+				recoverable=False,
+			)
+			return
 
 		data = {
 			"security_id": security_id,

--- a/src/boss_agent_cli/commands/mark.py
+++ b/src/boss_agent_cli/commands/mark.py
@@ -64,7 +64,16 @@ def mark_cmd(ctx: click.Context, security_id: str, label: str, remove: bool) -> 
 			)
 			return
 
-		platform.friend_label(friend_id, label_id, friend_source, remove=remove)
+		resp = platform.friend_label(friend_id, label_id, friend_source, remove=remove)
+		if not platform.is_success(resp):
+			code, message = platform.parse_error(resp)
+			handle_error_output(
+				ctx, "mark",
+				code=code,
+				message=message or f"{action_text}标签失败",
+				recoverable=False,
+			)
+			return
 
 		data = {
 			"security_id": security_id,

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -140,6 +140,23 @@ def test_mark_remove_label(mock_auth_cls, mock_client_cls):
 
 @patch("boss_agent_cli.commands.mark.get_platform_instance")
 @patch("boss_agent_cli.commands.mark.AuthManager")
+def test_mark_reports_error_when_platform_rejects(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = _friend_list_response([_make_friend()])
+	mock_client.friend_label.return_value = {"code": 36, "message": "account risk"}
+	mock_client.is_success.return_value = False
+	mock_client.parse_error.return_value = ("ACCOUNT_RISK", "account risk")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["mark", "sec_001", "--label", "沟通中"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["error"]["code"] == "ACCOUNT_RISK"
+	assert parsed["error"]["message"] == "account risk"
+
+
+@patch("boss_agent_cli.commands.mark.get_platform_instance")
+@patch("boss_agent_cli.commands.mark.AuthManager")
 def test_mark_not_found(mock_auth_cls, mock_client_cls):
 	mock_client = _ctx_mock(mock_client_cls)
 	mock_client.friend_list.return_value = _friend_list_response([])
@@ -178,6 +195,23 @@ def test_exchange_wechat(mock_auth_cls, mock_client_cls):
 	assert result.exit_code == 0
 	parsed = json.loads(result.output)
 	assert "微信" in parsed["data"]["message"]
+
+
+@patch("boss_agent_cli.commands.exchange.get_platform_instance")
+@patch("boss_agent_cli.commands.exchange.AuthManager")
+def test_exchange_reports_error_when_platform_rejects(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = _friend_list_response([_make_friend()])
+	mock_client.exchange_contact.return_value = {"code": 9, "message": "too fast"}
+	mock_client.is_success.return_value = False
+	mock_client.parse_error.return_value = ("RATE_LIMITED", "too fast")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["exchange", "sec_001", "--type", "wechat"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["error"]["code"] == "RATE_LIMITED"
+	assert parsed["error"]["message"] == "too fast"
 
 
 # ── detail ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## 摘要
- 修正 `boss exchange` 和 `boss mark` 在平台拒绝写操作时仍返回成功回执的问题
- 统一改为解析平台错误并输出 JSON 错误信封
- 补充失败路径测试，防止再次出现假成功

## 验证
- UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q tests/test_new_commands.py
- UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q