### PR TITLE
fix: 修正沟通读取回执

### DIFF
--- a/src/boss_agent_cli/commands/chat.py
+++ b/src/boss_agent_cli/commands/chat.py
@@ -54,6 +54,15 @@ def chat_cmd(ctx: click.Context, page: int, from_who: str | None, days: int | No
 
 	with get_platform_instance(ctx, auth) as platform:
 		resp = platform.friend_list(page=page)
+		if not platform.is_success(resp):
+			code, message = platform.parse_error(resp)
+			handle_error_output(
+				ctx, "chat",
+				code=code,
+				message=message or "沟通列表获取失败",
+				recoverable=False,
+			)
+			return
 		platform_data = platform.unwrap_data(resp) or {}
 		items = platform_data.get("result") or platform_data.get("friendList") or []
 

--- a/src/boss_agent_cli/commands/chat_summary.py
+++ b/src/boss_agent_cli/commands/chat_summary.py
@@ -19,6 +19,16 @@ def chat_summary_cmd(ctx: click.Context, security_id: str, page: int, count: int
 
 	with get_platform_instance(ctx, auth) as platform:
 		friends_resp = platform.friend_list(page=1)
+		if not platform.is_success(friends_resp):
+			code, message = platform.parse_error(friends_resp)
+			handle_error_output(
+				ctx,
+				"chat-summary",
+				code=code,
+				message=message or "沟通列表获取失败",
+				recoverable=False,
+			)
+			return
 		friends_data = platform.unwrap_data(friends_resp) or {}
 		items = friends_data.get("result") or friends_data.get("friendList") or []
 
@@ -40,6 +50,16 @@ def chat_summary_cmd(ctx: click.Context, security_id: str, page: int, count: int
 			return
 
 		resp = platform.chat_history(gid, security_id, page=page, count=count)
+		if not platform.is_success(resp):
+			code, message = platform.parse_error(resp)
+			handle_error_output(
+				ctx,
+				"chat-summary",
+				code=code,
+				message=message or "聊天记录获取失败",
+				recoverable=False,
+			)
+			return
 		msg_data = platform.unwrap_data(resp) or {}
 		messages = msg_data.get("messages") or msg_data.get("historyMsgList") or []
 		summary = summarize_messages(messages, friend_uid=gid)

--- a/src/boss_agent_cli/commands/chatmsg.py
+++ b/src/boss_agent_cli/commands/chatmsg.py
@@ -27,6 +27,15 @@ def chatmsg_cmd(ctx: click.Context, security_id: str, page: int, count: int) -> 
 
 	with get_platform_instance(ctx, auth) as platform:
 		friends_resp = platform.friend_list(page=1)
+		if not platform.is_success(friends_resp):
+			code, message = platform.parse_error(friends_resp)
+			handle_error_output(
+				ctx, "chatmsg",
+				code=code,
+				message=message or "沟通列表获取失败",
+				recoverable=False,
+			)
+			return
 		platform_data = platform.unwrap_data(friends_resp) or {}
 		items = platform_data.get("result") or platform_data.get("friendList") or []
 
@@ -47,6 +56,15 @@ def chatmsg_cmd(ctx: click.Context, security_id: str, page: int, count: int) -> 
 			return
 
 		resp = platform.chat_history(gid, security_id, page=page, count=count)
+		if not platform.is_success(resp):
+			code, message = platform.parse_error(resp)
+			handle_error_output(
+				ctx, "chatmsg",
+				code=code,
+				message=message or "聊天记录获取失败",
+				recoverable=False,
+			)
+			return
 		msg_data = platform.unwrap_data(resp) or {}
 		messages = msg_data.get("messages") or msg_data.get("historyMsgList") or []
 

--- a/src/boss_agent_cli/commands/exchange.py
+++ b/src/boss_agent_cli/commands/exchange.py
@@ -21,6 +21,15 @@ def exchange_cmd(ctx: click.Context, security_id: str, exchange_type: str) -> No
 
 	with get_platform_instance(ctx, auth) as platform:
 		friends_resp = platform.friend_list(page=1)
+		if not platform.is_success(friends_resp):
+			code, message = platform.parse_error(friends_resp)
+			handle_error_output(
+				ctx, "exchange",
+				code=code,
+				message=message or "沟通列表获取失败",
+				recoverable=False,
+			)
+			return
 		friend_data = platform.unwrap_data(friends_resp) or {}
 		items = friend_data.get("result") or friend_data.get("friendList") or []
 

--- a/src/boss_agent_cli/commands/mark.py
+++ b/src/boss_agent_cli/commands/mark.py
@@ -44,6 +44,15 @@ def mark_cmd(ctx: click.Context, security_id: str, label: str, remove: bool) -> 
 
 	with get_platform_instance(ctx, auth) as platform:
 		friends_resp = platform.friend_list(page=1)
+		if not platform.is_success(friends_resp):
+			code, message = platform.parse_error(friends_resp)
+			handle_error_output(
+				ctx, "mark",
+				code=code,
+				message=message or "沟通列表获取失败",
+				recoverable=False,
+			)
+			return
 		friend_data = platform.unwrap_data(friends_resp) or {}
 		items = friend_data.get("result") or friend_data.get("friendList") or []
 

--- a/tests/test_chat_summary_command.py
+++ b/tests/test_chat_summary_command.py
@@ -11,6 +11,7 @@ def _ctx_mock(mock_cls):
 	instance.__enter__ = lambda self: self
 	instance.__exit__ = lambda self, *a: None
 	instance.unwrap_data.side_effect = lambda response: response.get("zpData") if "zpData" in response else response.get("data")
+	instance.is_success.side_effect = lambda response: response.get("code", 0) in (0, 200)
 	return instance
 
 
@@ -55,6 +56,35 @@ def test_chat_summary_command_success(mock_auth_cls, mock_client_cls):
 	assert parsed["ok"] is True
 	assert parsed["data"]["stage"] == "reply_needed"
 	assert parsed["data"]["security_id"] == "sec_001"
+
+
+@patch("boss_agent_cli.commands.chat_summary.get_platform_instance")
+@patch("boss_agent_cli.commands.chat_summary.AuthManager")
+def test_chat_summary_reports_chat_history_error(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = _friend_list_response([_friend()])
+	mock_client.chat_history.return_value = {"code": 9, "message": "too fast"}
+	mock_client.parse_error.return_value = ("RATE_LIMITED", "too fast")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "chat-summary", "sec_001"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "RATE_LIMITED"
+	assert parsed["error"]["message"] == "too fast"
+
+
+@patch("boss_agent_cli.commands.chat_summary.get_platform_instance")
+@patch("boss_agent_cli.commands.chat_summary.AuthManager")
+def test_chat_summary_reports_friend_list_error(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = {"code": 37, "message": "stoken expired"}
+	mock_client.parse_error.return_value = ("TOKEN_REFRESH_FAILED", "stoken expired")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "chat-summary", "sec_001"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
+	assert parsed["error"]["message"] == "stoken expired"
 
 
 def test_chat_summary_is_exposed_in_schema():

--- a/tests/test_chatmsg_extended.py
+++ b/tests/test_chatmsg_extended.py
@@ -13,6 +13,7 @@ def _ctx_mock(mock_cls):
 	instance.__enter__ = lambda self: self
 	instance.__exit__ = lambda self, *a: None
 	instance.unwrap_data.side_effect = lambda response: response.get("zpData") if "zpData" in response else response.get("data")
+	instance.is_success.side_effect = lambda response: response.get("code", 0) in (0, 200)
 	return instance
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -12,6 +12,7 @@ def _ctx_mock(mock_cls):
 	instance.__enter__ = lambda self: self
 	instance.__exit__ = lambda self, *a: None
 	instance.unwrap_data.side_effect = lambda response: response.get("zpData") if "zpData" in response else response.get("data")
+	instance.is_success.side_effect = lambda response: response.get("code", 0) in (0, 200)
 	return instance
 
 
@@ -706,6 +707,21 @@ def test_chat_combined_filter(mock_auth_cls, mock_client_cls):
 	assert len(parsed["data"]) == 1
 	assert parsed["data"][0]["brand_name"] == "阿里"
 	assert parsed["data"][0]["initiated_by"] == "对方主动"
+
+
+@patch("boss_agent_cli.commands.chat.get_platform_instance")
+@patch("boss_agent_cli.commands.chat.AuthManager")
+def test_chat_reports_friend_list_error(mock_auth_cls, mock_client_cls):
+	mock_auth_cls.return_value.check_status.return_value = {"cookies": {}}
+	_ctx_mock(mock_client_cls)
+	mock_client_cls.return_value.friend_list.return_value = {"code": 37, "message": "stoken expired"}
+	mock_client_cls.return_value.parse_error.return_value = ("TOKEN_REFRESH_FAILED", "stoken expired")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chat"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
+	assert parsed["error"]["message"] == "stoken expired"
 
 
 @patch("boss_agent_cli.commands.chat.get_platform_instance")

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -11,6 +11,7 @@ def _ctx_mock(mock_cls):
 	instance.__enter__ = lambda self: self
 	instance.__exit__ = lambda self, *a: None
 	instance.unwrap_data.side_effect = lambda response: response.get("zpData") if "zpData" in response else response.get("data")
+	instance.is_success.side_effect = lambda response: response.get("code", 0) in (0, 200)
 	return instance
 
 
@@ -108,6 +109,38 @@ def test_chatmsg_zhilian_hints_use_platform_specific_commands(mock_auth_cls, moc
 	assert parsed["hints"]["next_actions"][1] == "boss --platform zhilian detail sec_001 — 查看职位详情"
 
 
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
+@patch("boss_agent_cli.commands.chatmsg.AuthManager")
+def test_chatmsg_reports_friend_list_error(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = {"code": 37, "message": "stoken expired"}
+	mock_client.is_success.side_effect = None
+	mock_client.is_success.return_value = False
+	mock_client.parse_error.return_value = ("TOKEN_REFRESH_FAILED", "stoken expired")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chatmsg", "sec_001"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
+	assert parsed["error"]["message"] == "stoken expired"
+
+
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
+@patch("boss_agent_cli.commands.chatmsg.AuthManager")
+def test_chatmsg_reports_chat_history_error(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = _friend_list_response([_make_friend()])
+	mock_client.chat_history.return_value = {"code": 9, "message": "too fast"}
+	mock_client.is_success.side_effect = lambda response: response.get("code", 0) in (0, 200)
+	mock_client.parse_error.return_value = ("RATE_LIMITED", "too fast")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chatmsg", "sec_001"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "RATE_LIMITED"
+	assert parsed["error"]["message"] == "too fast"
+
+
 # ── mark ─────────────────────────────────────────────────────────────
 
 
@@ -153,6 +186,22 @@ def test_mark_reports_error_when_platform_rejects(mock_auth_cls, mock_client_cls
 	assert parsed["ok"] is False
 	assert parsed["error"]["code"] == "ACCOUNT_RISK"
 	assert parsed["error"]["message"] == "account risk"
+
+
+@patch("boss_agent_cli.commands.mark.get_platform_instance")
+@patch("boss_agent_cli.commands.mark.AuthManager")
+def test_mark_reports_friend_list_error(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = {"code": 37, "message": "stoken expired"}
+	mock_client.is_success.side_effect = None
+	mock_client.is_success.return_value = False
+	mock_client.parse_error.return_value = ("TOKEN_REFRESH_FAILED", "stoken expired")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["mark", "sec_001", "--label", "沟通中"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
+	assert parsed["error"]["message"] == "stoken expired"
 
 
 @patch("boss_agent_cli.commands.mark.get_platform_instance")
@@ -212,6 +261,22 @@ def test_exchange_reports_error_when_platform_rejects(mock_auth_cls, mock_client
 	assert parsed["ok"] is False
 	assert parsed["error"]["code"] == "RATE_LIMITED"
 	assert parsed["error"]["message"] == "too fast"
+
+
+@patch("boss_agent_cli.commands.exchange.get_platform_instance")
+@patch("boss_agent_cli.commands.exchange.AuthManager")
+def test_exchange_reports_friend_list_error(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = {"code": 36, "message": "account risk"}
+	mock_client.is_success.side_effect = None
+	mock_client.is_success.return_value = False
+	mock_client.parse_error.return_value = ("ACCOUNT_RISK", "account risk")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["exchange", "sec_001"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "ACCOUNT_RISK"
+	assert parsed["error"]["message"] == "account risk"
 
 
 # ── detail ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## 摘要
- 修正 `chat`、`chatmsg`、`chat-summary` 在列表或聊天记录读取失败时仍返回空数据或误导性结果的问题
- 修正 `mark`、`exchange` 在前置沟通列表读取失败时误报未找到的问题
- 补充失败路径测试，并统一测试 mock 的默认成功语义

## 验证
- UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q tests/test_commands.py tests/test_chat_summary_command.py tests/test_new_commands.py tests/test_chatmsg_extended.py
- UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q