### PR TITLE
fix: 修正招聘者读取回执

### DIFF
--- a/src/boss_agent_cli/commands/recruiter/applications.py
+++ b/src/boss_agent_cli/commands/recruiter/applications.py
@@ -3,7 +3,7 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._recruiter_platform import get_recruiter_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_output
+from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output
 
 
 @click.command("applications")
@@ -20,6 +20,15 @@ def applications_cmd(ctx: click.Context, job_id: str | None, label_id: int, page
 	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	with get_recruiter_platform_instance(ctx, auth) as platform:
 		result = platform.friend_list(page=page, label_id=label_id, job_id=job_id)
+		if not platform.is_success(result):
+			code, message = platform.parse_error(result)
+			handle_error_output(
+				ctx, "recruiter-applications",
+				code=code,
+				message=message or "投递申请列表获取失败",
+				recoverable=False,
+			)
+			return
 		data = platform.unwrap_data(result) or {}
 		handle_output(
 			ctx, "recruiter-applications", data,

--- a/src/boss_agent_cli/commands/recruiter/candidates.py
+++ b/src/boss_agent_cli/commands/recruiter/candidates.py
@@ -3,7 +3,7 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._recruiter_platform import get_recruiter_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_output
+from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output
 
 
 @click.command("candidates")
@@ -26,6 +26,15 @@ def candidates_cmd(ctx: click.Context, query: str, city: str | None, job_id: str
 			query, city=city, page=page, job_id=job_id,
 			experience=experience, degree=degree,
 		)
+		if not platform.is_success(result):
+			code, message = platform.parse_error(result)
+			handle_error_output(
+				ctx, "recruiter-candidates",
+				code=code,
+				message=message or "候选人搜索失败",
+				recoverable=False,
+			)
+			return
 		data = platform.unwrap_data(result) or {}
 		handle_output(
 			ctx, "recruiter-candidates", data,

--- a/src/boss_agent_cli/commands/recruiter/chat.py
+++ b/src/boss_agent_cli/commands/recruiter/chat.py
@@ -3,7 +3,7 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._recruiter_platform import get_recruiter_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_output
+from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output
 
 
 @click.command("chat")
@@ -20,6 +20,15 @@ def recruiter_chat_cmd(ctx: click.Context, page: int, job_id: str | None, label_
 	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	with get_recruiter_platform_instance(ctx, auth) as platform:
 		result = platform.friend_list(page=page, label_id=label_id, job_id=job_id)
+		if not platform.is_success(result):
+			code, message = platform.parse_error(result)
+			handle_error_output(
+				ctx, "recruiter-chat",
+				code=code,
+				message=message or "沟通列表获取失败",
+				recoverable=False,
+			)
+			return
 		data = platform.unwrap_data(result) or {}
 		handle_output(
 			ctx, "recruiter-chat", data,

--- a/src/boss_agent_cli/commands/recruiter/jobs.py
+++ b/src/boss_agent_cli/commands/recruiter/jobs.py
@@ -24,6 +24,15 @@ def jobs_list_cmd(ctx: click.Context) -> None:
 	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	with get_recruiter_platform_instance(ctx, auth) as platform:
 		result = platform.list_jobs()
+		if not platform.is_success(result):
+			code, message = platform.parse_error(result)
+			handle_error_output(
+				ctx, "recruiter-jobs-list",
+				code=code,
+				message=message or "职位列表获取失败",
+				recoverable=False,
+			)
+			return
 		data = platform.unwrap_data(result) or {}
 		handle_output(ctx, "recruiter-jobs-list", data)
 

--- a/src/boss_agent_cli/commands/recruiter/resume.py
+++ b/src/boss_agent_cli/commands/recruiter/resume.py
@@ -47,6 +47,15 @@ def resume_cmd(ctx: click.Context, geek_id: str, job_id: str, security_id: str |
 			data["message"] = "联系方式交换请求已发送"
 		elif security_id and job_id:
 			result = platform.view_geek(geek_id, job_id, security_id=security_id)
+			if not platform.is_success(result):
+				code, message = platform.parse_error(result)
+				handle_error_output(
+					ctx, "recruiter-resume",
+					code=code,
+					message=message or "候选人简历获取失败",
+					recoverable=False,
+				)
+				return
 			data = result if show_raw else parse_resume(result)
 		else:
 			handle_error_output(

--- a/tests/test_recruiter_commands.py
+++ b/tests/test_recruiter_commands.py
@@ -12,6 +12,7 @@ def _ctx_mock(mock_cls):
 	instance.__enter__ = lambda self: self
 	instance.__exit__ = lambda self, *a: None
 	instance.unwrap_data.side_effect = lambda response: response.get("zpData") if "zpData" in response else response.get("data")
+	instance.is_success.side_effect = lambda response: response.get("code", 0) in (0, 200)
 	return instance
 
 
@@ -37,6 +38,19 @@ def test_recruiter_candidates_supports_data_envelope(mock_auth_cls, mock_platfor
 	assert parsed["hints"]["next_actions"][1] == "boss hr chat — 查看沟通"
 
 
+@patch("boss_agent_cli.commands.recruiter.candidates.get_recruiter_platform_instance")
+@patch("boss_agent_cli.commands.recruiter.candidates.AuthManager")
+def test_recruiter_candidates_reports_error_when_platform_rejects(mock_auth_cls, mock_platform_cls):
+	mock_platform = _ctx_mock(mock_platform_cls)
+	mock_platform.search_geeks.return_value = {"code": 9, "message": "too fast"}
+	mock_platform.parse_error.return_value = ("RATE_LIMITED", "too fast")
+	result = _invoke("hr", "candidates", "python")
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "RATE_LIMITED"
+	assert parsed["error"]["message"] == "too fast"
+
+
 @patch("boss_agent_cli.commands.recruiter.chat.get_recruiter_platform_instance")
 @patch("boss_agent_cli.commands.recruiter.chat.AuthManager")
 def test_recruiter_chat_supports_data_envelope(mock_auth_cls, mock_platform_cls):
@@ -50,6 +64,19 @@ def test_recruiter_chat_supports_data_envelope(mock_auth_cls, mock_platform_cls)
 	parsed = json.loads(result.output)
 	assert parsed["data"]["friendList"][0]["name"] == "候选人B"
 	assert parsed["hints"]["next_actions"][0] == "boss hr resume <geek_id> --job-id <id> --security-id <id> — 查看候选人简历"
+
+
+@patch("boss_agent_cli.commands.recruiter.chat.get_recruiter_platform_instance")
+@patch("boss_agent_cli.commands.recruiter.chat.AuthManager")
+def test_recruiter_chat_reports_error_when_platform_rejects(mock_auth_cls, mock_platform_cls):
+	mock_platform = _ctx_mock(mock_platform_cls)
+	mock_platform.friend_list.return_value = {"code": 37, "message": "stoken expired"}
+	mock_platform.parse_error.return_value = ("TOKEN_REFRESH_FAILED", "stoken expired")
+	result = _invoke("hr", "chat")
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
+	assert parsed["error"]["message"] == "stoken expired"
 
 
 @patch("boss_agent_cli.commands.recruiter.applications.get_recruiter_platform_instance")
@@ -68,6 +95,19 @@ def test_recruiter_applications_supports_data_envelope(mock_auth_cls, mock_platf
 	assert parsed["hints"]["next_actions"][1] == "boss hr chat — 查看沟通列表"
 
 
+@patch("boss_agent_cli.commands.recruiter.applications.get_recruiter_platform_instance")
+@patch("boss_agent_cli.commands.recruiter.applications.AuthManager")
+def test_recruiter_applications_reports_error_when_platform_rejects(mock_auth_cls, mock_platform_cls):
+	mock_platform = _ctx_mock(mock_platform_cls)
+	mock_platform.friend_list.return_value = {"code": 36, "message": "account risk"}
+	mock_platform.parse_error.return_value = ("ACCOUNT_RISK", "account risk")
+	result = _invoke("hr", "applications")
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "ACCOUNT_RISK"
+	assert parsed["error"]["message"] == "account risk"
+
+
 @patch("boss_agent_cli.commands.recruiter.jobs.get_recruiter_platform_instance")
 @patch("boss_agent_cli.commands.recruiter.jobs.AuthManager")
 def test_recruiter_jobs_list_supports_data_envelope(mock_auth_cls, mock_platform_cls):
@@ -80,6 +120,19 @@ def test_recruiter_jobs_list_supports_data_envelope(mock_auth_cls, mock_platform
 	assert result.exit_code == 0
 	parsed = json.loads(result.output)
 	assert parsed["data"]["jobList"][0]["jobName"] == "后端工程师"
+
+
+@patch("boss_agent_cli.commands.recruiter.jobs.get_recruiter_platform_instance")
+@patch("boss_agent_cli.commands.recruiter.jobs.AuthManager")
+def test_recruiter_jobs_list_reports_error_when_platform_rejects(mock_auth_cls, mock_platform_cls):
+	mock_platform = _ctx_mock(mock_platform_cls)
+	mock_platform.list_jobs.return_value = {"code": 9, "message": "too fast"}
+	mock_platform.parse_error.return_value = ("RATE_LIMITED", "too fast")
+	result = _invoke("hr", "jobs", "list")
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "RATE_LIMITED"
+	assert parsed["error"]["message"] == "too fast"
 
 
 @patch("boss_agent_cli.commands.recruiter.jobs.get_recruiter_platform_instance")
@@ -173,6 +226,19 @@ def test_recruiter_resume_parse_supports_data_envelope(mock_auth_cls, mock_platf
 	assert parsed["data"]["basic"]["name"] == "张三"
 	assert parsed["data"]["expectation"]["position"] == "后端工程师"
 	assert parsed["hints"]["next_actions"][0] == "boss hr applications — 返回候选人列表"
+
+
+@patch("boss_agent_cli.commands.recruiter.resume.get_recruiter_platform_instance")
+@patch("boss_agent_cli.commands.recruiter.resume.AuthManager")
+def test_recruiter_resume_parse_reports_error_when_platform_rejects(mock_auth_cls, mock_platform_cls):
+	mock_platform = _ctx_mock(mock_platform_cls)
+	mock_platform.view_geek.return_value = {"code": 37, "message": "stoken expired"}
+	mock_platform.parse_error.return_value = ("TOKEN_REFRESH_FAILED", "stoken expired")
+	result = _invoke("hr", "resume", "geek-1", "--job-id", "job-1", "--security-id", "sec-1")
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
+	assert parsed["error"]["message"] == "stoken expired"
 
 
 @patch("boss_agent_cli.commands.recruiter.reply.get_recruiter_platform_instance")


### PR DESCRIPTION
## 摘要
- 修正 recruiter 侧 `applications`、`chat`、`candidates`、`jobs list`、`resume` 在平台读取失败时仍返回空数据的问题
- 统一改为解析平台错误并输出 JSON 错误信封
- 补充失败路径测试，并为 recruiter mock 补齐默认成功语义

## 验证
- UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q tests/test_recruiter_commands.py
- UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q