### PR TITLE
fix: 修正核心读取回执

### DIFF
--- a/src/boss_agent_cli/commands/history.py
+++ b/src/boss_agent_cli/commands/history.py
@@ -3,7 +3,7 @@ import click
 from boss_agent_cli.api.models import JobItem
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import boss_command_for_ctx, handle_auth_errors, handle_output, render_job_table
+from boss_agent_cli.display import boss_command_for_ctx, handle_auth_errors, handle_error_output, handle_output, render_job_table
 
 
 @click.command("history")
@@ -18,6 +18,15 @@ def history_cmd(ctx: click.Context, page: int) -> None:
 	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	with get_platform_instance(ctx, auth) as platform:
 		raw = platform.job_history(page)
+		if not platform.is_success(raw):
+			code, message = platform.parse_error(raw)
+			handle_error_output(
+				ctx, "history",
+				code=code,
+				message=message or "浏览历史获取失败",
+				recoverable=False,
+			)
+			return
 		platform_data = platform.unwrap_data(raw) or {}
 		job_list = platform_data.get("jobList", [])
 

--- a/src/boss_agent_cli/commands/interviews.py
+++ b/src/boss_agent_cli/commands/interviews.py
@@ -28,6 +28,15 @@ def interviews_cmd(ctx: click.Context) -> None:
 
 	with get_platform_instance(ctx, auth) as platform:
 		raw = platform.interview_data()
+		if not platform.is_success(raw):
+			code, message = platform.parse_error(raw)
+			handle_error_output(
+				ctx, "interviews",
+				code=code,
+				message=message or "面试邀请获取失败",
+				recoverable=False,
+			)
+			return
 		platform_data = platform.unwrap_data(raw) or {}
 		interview_list = platform_data.get("interviewList", [])
 

--- a/src/boss_agent_cli/commands/me.py
+++ b/src/boss_agent_cli/commands/me.py
@@ -27,6 +27,15 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 				if logger:
 					logger.info("获取用户基本信息...")
 				resp = platform.user_info()
+				if not platform.is_success(resp):
+					code, message = platform.parse_error(resp)
+					handle_error_output(
+						ctx, "me",
+						code=code,
+						message=message or "用户基本信息获取失败",
+						recoverable=False,
+					)
+					return
 				zp_data = platform.unwrap_data(resp) or {}
 				result["user"] = {
 					"name": zp_data.get("name", ""),
@@ -40,6 +49,15 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 				if logger:
 					logger.info("获取简历基本信息...")
 				resp = platform.resume_baseinfo()
+				if not platform.is_success(resp):
+					code, message = platform.parse_error(resp)
+					handle_error_output(
+						ctx, "me",
+						code=code,
+						message=message or "简历基本信息获取失败",
+						recoverable=False,
+					)
+					return
 				zp_data = platform.unwrap_data(resp) or {}
 				result["resume"] = zp_data
 
@@ -47,6 +65,15 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 				if logger:
 					logger.info("获取求职期望...")
 				resp = platform.resume_expect()
+				if not platform.is_success(resp):
+					code, message = platform.parse_error(resp)
+					handle_error_output(
+						ctx, "me",
+						code=code,
+						message=message or "求职期望获取失败",
+						recoverable=False,
+					)
+					return
 				zp_data = platform.unwrap_data(resp) or {}
 				result["expect"] = zp_data
 
@@ -54,6 +81,15 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 				if logger:
 					logger.info("获取投递记录...")
 				resp = platform.deliver_list(page=deliver_page)
+				if not platform.is_success(resp):
+					code, message = platform.parse_error(resp)
+					handle_error_output(
+						ctx, "me",
+						code=code,
+						message=message or "投递记录获取失败",
+						recoverable=False,
+					)
+					return
 				zp_data = platform.unwrap_data(resp) or {}
 				result["deliver"] = zp_data
 

--- a/src/boss_agent_cli/commands/status.py
+++ b/src/boss_agent_cli/commands/status.py
@@ -27,6 +27,16 @@ def status_cmd(ctx: click.Context) -> None:
 
 	with get_platform_instance(ctx, auth) as platform:
 		info = platform.user_info()
+		if not platform.is_success(info):
+			code, message = platform.parse_error(info)
+			handle_error_output(
+				ctx,
+				"status",
+				code=code,
+				message=message or "用户信息获取失败",
+				recoverable=False,
+			)
+			return
 		user_info = platform.unwrap_data(info) or {}
 		user_name = user_info.get("name", "未知用户")
 		data = {

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -59,6 +59,7 @@ def test_status_logged_in_happy_path(mock_auth_cls, mock_client_cls):
 	mock_client = mock_client_cls.return_value
 	mock_client.__enter__ = lambda self: self
 	mock_client.__exit__ = lambda self, *a: None
+	mock_client.is_success.return_value = True
 	mock_client.user_info.return_value = {"zpData": {"name": "张三"}}
 	mock_client.unwrap_data.return_value = {"name": "张三"}
 
@@ -79,6 +80,7 @@ def test_status_logged_in_unknown_user(mock_auth_cls, mock_client_cls):
 	mock_client = mock_client_cls.return_value
 	mock_client.__enter__ = lambda self: self
 	mock_client.__exit__ = lambda self, *a: None
+	mock_client.is_success.return_value = True
 	mock_client.user_info.return_value = {"zpData": {}}
 	mock_client.unwrap_data.return_value = {}
 
@@ -87,6 +89,24 @@ def test_status_logged_in_unknown_user(mock_auth_cls, mock_client_cls):
 	assert result.exit_code == 0
 	parsed = json.loads(result.output)
 	assert parsed["data"]["user_name"] == "未知用户"
+
+
+@patch("boss_agent_cli.commands.status.get_platform_instance")
+@patch("boss_agent_cli.commands.status.AuthManager")
+def test_status_reports_user_info_error(mock_auth_cls, mock_client_cls):
+	mock_auth_cls.return_value.check_status.return_value = {"cookies": {"wt2": "x"}}
+	mock_client = mock_client_cls.return_value
+	mock_client.__enter__ = lambda self: self
+	mock_client.__exit__ = lambda self, *a: None
+	mock_client.is_success.return_value = False
+	mock_client.user_info.return_value = {"code": 37, "message": "stoken expired"}
+	mock_client.parse_error.return_value = ("TOKEN_REFRESH_FAILED", "stoken expired")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "status"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
+	assert parsed["error"]["message"] == "stoken expired"
 
 
 @patch("boss_agent_cli.commands.search.CacheStore")

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -433,6 +433,20 @@ def test_me_zhilian_hints_use_platform_specific_commands(mock_auth_cls, mock_cli
 	assert parsed["hints"]["next_actions"][1] == "boss --platform zhilian recommend"
 
 
+@patch("boss_agent_cli.commands.me.get_platform_instance")
+@patch("boss_agent_cli.commands.me.AuthManager")
+def test_me_reports_user_info_error(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.user_info.return_value = {"code": 37, "message": "stoken expired"}
+	mock_client.parse_error.return_value = ("TOKEN_REFRESH_FAILED", "stoken expired")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["me", "--section", "user"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
+	assert parsed["error"]["message"] == "stoken expired"
+
+
 # ── history ──────────────────────────────────────────────────────────
 
 
@@ -509,6 +523,20 @@ def test_history_zhilian_hints_use_platform_specific_commands(mock_auth_cls, moc
 	assert parsed["hints"]["next_actions"][2] == "使用 boss --platform zhilian history --page 2 查看下一页"
 
 
+@patch("boss_agent_cli.commands.history.get_platform_instance")
+@patch("boss_agent_cli.commands.history.AuthManager")
+def test_history_reports_platform_error(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.job_history.return_value = {"code": 9, "message": "too fast"}
+	mock_client.parse_error.return_value = ("RATE_LIMITED", "too fast")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["history"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "RATE_LIMITED"
+	assert parsed["error"]["message"] == "too fast"
+
+
 # ── interviews ───────────────────────────────────────────────────────
 
 
@@ -543,6 +571,21 @@ def test_interviews_supports_zhilian_style_data(mock_auth_cls, mock_client_cls):
 	assert result.exit_code == 0
 	parsed = json.loads(result.output)
 	assert parsed["data"][0]["jobName"] == "测试岗位"
+
+
+@patch("boss_agent_cli.commands.interviews.get_platform_instance")
+@patch("boss_agent_cli.commands.interviews.AuthManager")
+def test_interviews_reports_platform_error(mock_auth_cls, mock_client_cls):
+	mock_auth_cls.return_value.check_status.return_value = {"cookies": {"zp_token": "x"}}
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.interview_data.return_value = {"code": 36, "message": "account risk"}
+	mock_client.parse_error.return_value = ("ACCOUNT_RISK", "account risk")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["interviews"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "ACCOUNT_RISK"
+	assert parsed["error"]["message"] == "account risk"
 
 
 @patch("boss_agent_cli.commands.chat_summary.get_platform_instance")


### PR DESCRIPTION
## 摘要
- 修正 `status`、`me`、`history`、`interviews` 在平台读取失败时仍返回误导性空数据的问题
- 统一改为解析平台错误并输出 JSON 错误信封
- 补充失败路径测试，锁定登录态、个人信息、浏览历史、面试列表的错误语义

## 验证
- UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q tests/test_commands.py tests/test_new_commands.py tests/test_coverage_second_sprint.py
- UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q