### PR TITLE
fix: 修正聚合读取回执

### DIFF
--- a/src/boss_agent_cli/commands/digest.py
+++ b/src/boss_agent_cli/commands/digest.py
@@ -7,7 +7,7 @@ import click
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.digest import build_digest, render_digest_markdown
-from boss_agent_cli.display import handle_auth_errors, handle_output, render_message_panel
+from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_message_panel
 from boss_agent_cli.pipeline_state import build_pipeline_items, select_follow_up_candidates
 
 
@@ -35,9 +35,27 @@ def digest_cmd(ctx: click.Context, days_stale: int, now_ts_ms: int | None, outpu
 
 	with get_platform_instance(ctx, auth) as platform:
 		friend_resp = platform.friend_list(page=1)
+		if not platform.is_success(friend_resp):
+			code, message = platform.parse_error(friend_resp)
+			handle_error_output(
+				ctx, "digest",
+				code=code,
+				message=message or "沟通列表获取失败",
+				recoverable=False,
+			)
+			return
 		friend_data = platform.unwrap_data(friend_resp) or {}
 		chat_items = friend_data.get("result") or friend_data.get("friendList") or []
 		interview_resp = platform.interview_data()
+		if not platform.is_success(interview_resp):
+			code, message = platform.parse_error(interview_resp)
+			handle_error_output(
+				ctx, "digest",
+				code=code,
+				message=message or "面试列表获取失败",
+				recoverable=False,
+			)
+			return
 		interview_data = platform.unwrap_data(interview_resp) or {}
 		interview_items = interview_data.get("interviewList") or []
 

--- a/src/boss_agent_cli/commands/export.py
+++ b/src/boss_agent_cli/commands/export.py
@@ -8,7 +8,7 @@ import click
 from boss_agent_cli.api.models import JobItem
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_output, render_export_summary, render_job_table
+from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_export_summary, render_job_table
 
 
 @click.command("export")
@@ -34,6 +34,15 @@ def export_cmd(ctx: click.Context, query: str, city: str | None, salary: str | N
 		while len(all_items) < count and page <= max_pages:
 			logger.info(f"正在获取第 {page} 页...")
 			raw = platform.search_jobs(query, city=city, salary=salary, page=page)
+			if not platform.is_success(raw):
+				code, message = platform.parse_error(raw)
+				handle_error_output(
+					ctx, "export",
+					code=code,
+					message=message or "搜索结果获取失败",
+					recoverable=False,
+				)
+				return
 			platform_data = platform.unwrap_data(raw) or {}
 			job_list = platform_data.get("jobList", [])
 			if not job_list:

--- a/src/boss_agent_cli/commands/pipeline.py
+++ b/src/boss_agent_cli/commands/pipeline.py
@@ -5,7 +5,7 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_output, render_simple_list
+from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_simple_list
 from boss_agent_cli.pipeline_state import build_pipeline_items, select_follow_up_candidates
 
 
@@ -16,9 +16,27 @@ def _collect_pipeline_items(ctx: click.Context, *, now_ts_ms: int | None, stale_
 
 	with get_platform_instance(ctx, auth) as platform:
 		friend_resp = platform.friend_list(page=1)
+		if not platform.is_success(friend_resp):
+			code, message = platform.parse_error(friend_resp)
+			handle_error_output(
+				ctx, "pipeline",
+				code=code,
+				message=message or "沟通列表获取失败",
+				recoverable=False,
+			)
+			return []
 		friend_data = platform.unwrap_data(friend_resp) or {}
 		chat_items = friend_data.get("result") or friend_data.get("friendList") or []
 		interview_resp = platform.interview_data()
+		if not platform.is_success(interview_resp):
+			code, message = platform.parse_error(interview_resp)
+			handle_error_output(
+				ctx, "pipeline",
+				code=code,
+				message=message or "面试列表获取失败",
+				recoverable=False,
+			)
+			return []
 		interview_data = platform.unwrap_data(interview_resp) or {}
 		interview_items = interview_data.get("interviewList") or []
 

--- a/src/boss_agent_cli/commands/recommend.py
+++ b/src/boss_agent_cli/commands/recommend.py
@@ -4,7 +4,7 @@ from boss_agent_cli.api.models import JobItem
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.cache.store import CacheStore
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import handle_output, render_job_table, handle_auth_errors
+from boss_agent_cli.display import handle_error_output, handle_output, render_job_table, handle_auth_errors
 from boss_agent_cli.index_cache import try_save_index
 from boss_agent_cli.match_score import score_job_dict
 
@@ -29,9 +29,27 @@ def recommend_cmd(ctx: click.Context, page: int, with_score: bool) -> None:
 				except NotImplementedError:
 					expect_data = None
 				else:
+					if not platform.is_success(expect_resp):
+						code, message = platform.parse_error(expect_resp)
+						handle_error_output(
+							ctx, "recommend",
+							code=code,
+							message=message or "求职期望获取失败",
+							recoverable=False,
+						)
+						return
 					expect_data = platform.unwrap_data(expect_resp) or {}
 
 			raw = platform.recommend_jobs(page=page)
+			if not platform.is_success(raw):
+				code, message = platform.parse_error(raw)
+				handle_error_output(
+					ctx, "recommend",
+					code=code,
+					message=message or "推荐职位获取失败",
+					recoverable=False,
+				)
+				return
 			platform_data = platform.unwrap_data(raw) or {}
 			job_list = platform_data.get("jobList", [])
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -385,6 +385,40 @@ def test_recommend_supports_zhilian_style_data(mock_auth_cls, mock_client_cls, m
 	assert parsed["pagination"]["has_more"] is False
 
 
+@patch("boss_agent_cli.commands.recommend.CacheStore")
+@patch("boss_agent_cli.commands.recommend.get_platform_instance")
+@patch("boss_agent_cli.commands.recommend.AuthManager")
+def test_recommend_reports_recommend_jobs_error(mock_auth_cls, mock_client_cls, mock_cache_cls):
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.is_greeted.return_value = False
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.recommend_jobs.return_value = {"code": 9, "message": "too fast"}
+	mock_client.parse_error.return_value = ("RATE_LIMITED", "too fast")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["recommend"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "RATE_LIMITED"
+	assert parsed["error"]["message"] == "too fast"
+
+
+@patch("boss_agent_cli.commands.recommend.CacheStore")
+@patch("boss_agent_cli.commands.recommend.get_platform_instance")
+@patch("boss_agent_cli.commands.recommend.AuthManager")
+def test_recommend_with_score_reports_expect_error(mock_auth_cls, mock_client_cls, mock_cache_cls):
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.is_greeted.return_value = False
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.resume_expect.return_value = {"code": 37, "message": "stoken expired"}
+	mock_client.parse_error.return_value = ("TOKEN_REFRESH_FAILED", "stoken expired")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["recommend", "--with-score"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
+	assert parsed["error"]["message"] == "stoken expired"
+
+
 @patch("boss_agent_cli.commands.search.run_search_pipeline")
 @patch("boss_agent_cli.commands.search.CacheStore")
 @patch("boss_agent_cli.commands.search.AuthManager")
@@ -628,6 +662,20 @@ def test_export_supports_data_envelope(mock_auth_cls, mock_client_cls):
 	parsed = json.loads(result.output)
 	assert parsed["ok"] is True
 	assert parsed["data"]["jobs"][0]["company"] == "智联科技"
+
+
+@patch("boss_agent_cli.commands.export.get_platform_instance")
+@patch("boss_agent_cli.commands.export.AuthManager")
+def test_export_reports_search_error(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.search_jobs.return_value = {"code": 36, "message": "account risk"}
+	mock_client.parse_error.return_value = ("ACCOUNT_RISK", "account risk")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["export", "golang", "--count", "1"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "ACCOUNT_RISK"
+	assert parsed["error"]["message"] == "account risk"
 
 
 def _make_friend_item(name, brand, relation_type, last_ts):

--- a/tests/test_digest_command.py
+++ b/tests/test_digest_command.py
@@ -11,6 +11,7 @@ def _ctx_mock(mock_cls):
 	instance.__enter__ = lambda self: self
 	instance.__exit__ = lambda self, *a: None
 	instance.unwrap_data.side_effect = lambda response: response.get("zpData") if "zpData" in response else response.get("data")
+	instance.is_success.side_effect = lambda response: response.get("code", 0) in (0, 200)
 	return instance
 
 
@@ -153,3 +154,18 @@ def test_digest_format_json_default_unchanged(mock_auth_cls, mock_client_cls):
 	parsed = json.loads(result.output)
 	assert parsed["ok"] is True
 	assert "new_match_count" in parsed["data"]
+
+
+@patch("boss_agent_cli.commands.digest.get_platform_instance")
+@patch("boss_agent_cli.commands.digest.AuthManager")
+def test_digest_reports_interview_error(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = {"zpData": {"result": []}}
+	mock_client.interview_data.return_value = {"code": 36, "message": "account risk"}
+	mock_client.parse_error.return_value = ("ACCOUNT_RISK", "account risk")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "digest"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "ACCOUNT_RISK"
+	assert parsed["error"]["message"] == "account risk"

--- a/tests/test_export_extended.py
+++ b/tests/test_export_extended.py
@@ -17,6 +17,7 @@ def _ctx_mock(mock_cls):
 	instance.__enter__ = lambda self: self
 	instance.__exit__ = lambda self, *a: None
 	instance.unwrap_data.side_effect = lambda response: response.get("zpData") if "zpData" in response else response.get("data")
+	instance.is_success.side_effect = lambda response: response.get("code", 0) in (0, 200)
 	return instance
 
 

--- a/tests/test_pipeline_commands.py
+++ b/tests/test_pipeline_commands.py
@@ -11,6 +11,7 @@ def _ctx_mock(mock_cls):
 	instance.__enter__ = lambda self: self
 	instance.__exit__ = lambda self, *a: None
 	instance.unwrap_data.side_effect = lambda response: response.get("zpData") if "zpData" in response else response.get("data")
+	instance.is_success.side_effect = lambda response: response.get("code", 0) in (0, 200)
 	return instance
 
 
@@ -90,6 +91,20 @@ def test_follow_up_command_filters_actionable_items(mock_auth_cls, mock_client_c
 	assert "reply_needed" in stages
 	assert "follow_up" in stages
 	assert "interview" in stages
+
+
+@patch("boss_agent_cli.commands.pipeline.get_platform_instance")
+@patch("boss_agent_cli.commands.pipeline.AuthManager")
+def test_pipeline_reports_friend_list_error(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = {"code": 37, "message": "stoken expired"}
+	mock_client.parse_error.return_value = ("TOKEN_REFRESH_FAILED", "stoken expired")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "pipeline"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
+	assert parsed["error"]["message"] == "stoken expired"
 
 
 def test_pipeline_and_follow_up_are_exposed_in_schema():


### PR DESCRIPTION
## 摘要
- 修正 `pipeline`、`follow-up`、`digest`、`recommend`、`export` 在上游读取失败时仍返回空结果或误导性输出的问题
- 统一改为解析平台错误并输出 JSON 错误信封
- 补充失败路径测试，并为相关测试夹具补齐默认成功语义

## 验证
- UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q tests/test_pipeline_commands.py tests/test_digest_command.py tests/test_export_extended.py tests/test_commands.py
- UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q