### PR TITLE
fix: 修正详情读取回执

### DIFF
--- a/src/boss_agent_cli/commands/detail.py
+++ b/src/boss_agent_cli/commands/detail.py
@@ -31,16 +31,26 @@ def detail_cmd(ctx: click.Context, security_id: str, lid: str, job_id: str) -> N
 				logger.info("从缓存命中 job_id，走 httpx 快速通道")
 
 		result = None
+		last_error: tuple[str, str] | None = None
 		if job_id:
 			try:
-				result = _detail_via_httpx(platform, security_id, job_id, data_dir)
+				result, last_error = _detail_via_httpx(platform, security_id, job_id, data_dir)
 			except Exception as e:
 				logger.info(f"httpx 快速通道失败（{e}），降级到浏览器通道")
 				result = None
 		if result is None:
-			result = _detail_via_browser(platform, security_id, lid, data_dir)
+			result, browser_error = _detail_via_browser(platform, security_id, lid, data_dir)
+			last_error = browser_error or last_error
 
 	if result is None:
+		if last_error:
+			handle_error_output(
+				ctx, "detail",
+				code=last_error[0],
+				message=last_error[1],
+				recoverable=False,
+			)
+			return
 		handle_error_output(
 			ctx, "detail",
 			code="JOB_NOT_FOUND",
@@ -60,16 +70,19 @@ def detail_cmd(ctx: click.Context, security_id: str, lid: str, job_id: str) -> N
 	)
 
 
-def _detail_via_httpx(platform: Platform, security_id: str, job_id: str, data_dir: Path) -> dict[str, Any] | None:
+def _detail_via_httpx(platform: Platform, security_id: str, job_id: str, data_dir: Path) -> tuple[dict[str, Any] | None, tuple[str, str] | None]:
 	"""快速通道：通过 httpx 获取职位详情（不需要浏览器）"""
 	raw = platform.job_detail(job_id)
+	if not platform.is_success(raw):
+		code, message = platform.parse_error(raw)
+		return None, (code, message or "职位详情获取失败")
 	platform_data = platform.unwrap_data(raw) or {}
 	job_info = platform_data.get("jobInfo", {})
 	boss_info = platform_data.get("bossInfo", {})
 	brand_info = platform_data.get("brandComInfo", {})
 
 	if not job_info:
-		return None
+		return None, None
 
 	with CacheStore(data_dir / "cache" / "boss_agent.db") as cache:
 		greeted = cache.is_greeted(security_id)
@@ -90,16 +103,19 @@ def _detail_via_httpx(platform: Platform, security_id: str, job_id: str, data_di
 		"boss_active": boss_info.get("activeTimeDesc", "离线"),
 		"security_id": security_id,
 		"greeted": greeted,
-	}
+	}, None
 
 
-def _detail_via_browser(platform: Platform, security_id: str, lid: str, data_dir: Path) -> dict[str, Any] | None:
+def _detail_via_browser(platform: Platform, security_id: str, lid: str, data_dir: Path) -> tuple[dict[str, Any] | None, tuple[str, str] | None]:
 	"""兜底通道：通过浏览器 job_card 获取职位详情"""
 	raw = platform.job_card(security_id, lid)
+	if not platform.is_success(raw):
+		code, message = platform.parse_error(raw)
+		return None, (code, message or "职位详情获取失败")
 	platform_data = platform.unwrap_data(raw) or {}
 	card = platform_data.get("jobCard", {})
 	if not card:
-		return None
+		return None, None
 
 	job_id = card.get("encryptJobId", "")
 
@@ -122,4 +138,4 @@ def _detail_via_browser(platform: Platform, security_id: str, lid: str, data_dir
 		"boss_active": card.get("activeTimeDesc", "离线"),
 		"security_id": security_id,
 		"greeted": greeted,
-	}
+	}, None

--- a/src/boss_agent_cli/commands/show.py
+++ b/src/boss_agent_cli/commands/show.py
@@ -46,6 +46,15 @@ def show_cmd(ctx: click.Context, index: int) -> None:
 	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	with get_platform_instance(ctx, auth) as platform:
 		raw = platform.job_card(security_id)
+		if not platform.is_success(raw):
+			code, message = platform.parse_error(raw)
+			handle_error_output(
+				ctx, "show",
+				code=code,
+				message=message or "职位详情获取失败",
+				recoverable=False,
+			)
+			return
 
 	platform_data = platform.unwrap_data(raw) or {}
 	card = platform_data.get("jobCard", {})

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -356,6 +356,23 @@ def test_detail_zhilian_hints_use_platform_specific_commands(mock_auth_cls, mock
 	assert parsed["hints"]["next_actions"][1] == "boss --platform zhilian search <query>"
 
 
+@patch("boss_agent_cli.commands.detail.CacheStore")
+@patch("boss_agent_cli.commands.detail.get_platform_instance")
+@patch("boss_agent_cli.commands.detail.AuthManager")
+def test_detail_reports_platform_error(mock_auth_cls, mock_client_cls, mock_cache_cls):
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.is_greeted.return_value = False
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.job_detail.return_value = {"code": 37, "message": "stoken expired"}
+	mock_client.parse_error.return_value = ("TOKEN_REFRESH_FAILED", "stoken expired")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["detail", "sec_001", "--job-id", "enc_001"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
+	assert parsed["error"]["message"] == "stoken expired"
+
+
 @patch("boss_agent_cli.commands.show.CacheStore")
 @patch("boss_agent_cli.commands.show.get_job_by_index")
 @patch("boss_agent_cli.commands.show.get_platform_instance")
@@ -386,6 +403,25 @@ def test_show_zhilian_hints_use_platform_specific_commands(mock_auth_cls, mock_c
 	parsed = json.loads(result.output)
 	assert parsed["hints"]["next_actions"][0] == "boss --platform zhilian greet sec_001 enc_001"
 	assert parsed["hints"]["next_actions"][1] == "boss --platform zhilian search <query>"
+
+
+@patch("boss_agent_cli.commands.show.CacheStore")
+@patch("boss_agent_cli.commands.show.get_job_by_index")
+@patch("boss_agent_cli.commands.show.get_platform_instance")
+@patch("boss_agent_cli.commands.show.AuthManager")
+def test_show_reports_platform_error(mock_auth_cls, mock_client_cls, mock_get_job_by_index, mock_cache_cls):
+	mock_get_job_by_index.return_value = {"security_id": "sec_001"}
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.is_greeted.return_value = False
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.job_card.return_value = {"code": 9, "message": "too fast"}
+	mock_client.parse_error.return_value = ("RATE_LIMITED", "too fast")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["show", "1"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "RATE_LIMITED"
+	assert parsed["error"]["message"] == "too fast"
 
 
 # ── me ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 摘要
- 修正 `detail` 在平台明确返回错误时误报职位不存在的问题，同时保留无内容时降级浏览器的既有行为
- 修正 `show` 在职位详情接口失败时仍回落为误导性结果的问题
- 补充失败路径测试，锁定 detail/show 的真实错误语义

## 验证
- UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q tests/test_new_commands.py tests/test_greet_detail_extended.py tests/test_coverage_second_sprint.py
- UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q