### PR TITLE
fix: 修正搜索流水线读取回执

### DIFF
--- a/src/boss_agent_cli/commands/search.py
+++ b/src/boss_agent_cli/commands/search.py
@@ -17,6 +17,7 @@ from boss_agent_cli.index_cache import try_save_index
 from boss_agent_cli.match_score import score_job_dict
 from boss_agent_cli.search_filters import (
 	SearchFilterCriteria,
+	SearchPipelinePlatformError,
 	resolve_welfare_keywords,
 	run_search_pipeline,
 )
@@ -110,13 +111,22 @@ def search_cmd(ctx: click.Context, query: str, preset: str | None, city: str | N
 		auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 		with get_platform_instance(ctx, auth) as platform:
 			max_pages = 5 if welfare_conditions else 1
-			pipeline_result = run_search_pipeline(
-				platform, cache, logger,
-				criteria=criteria,
-				start_page=page,
-				max_pages=max_pages,
-				welfare_conditions=welfare_conditions,
-			)
+			try:
+				pipeline_result = run_search_pipeline(
+					platform, cache, logger,
+					criteria=criteria,
+					start_page=page,
+					max_pages=max_pages,
+					welfare_conditions=welfare_conditions,
+				)
+			except SearchPipelinePlatformError as exc:
+				handle_error_output(
+					ctx, "search",
+					code=exc.code,
+					message=exc.message or "搜索结果获取失败",
+					recoverable=False,
+				)
+				return
 			items = pipeline_result.items
 			if with_score:
 				items = [score_job_dict(item, criteria=criteria, expect_data=None) for item in items]

--- a/src/boss_agent_cli/commands/watch.py
+++ b/src/boss_agent_cli/commands/watch.py
@@ -11,7 +11,7 @@ from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.cache.store import CacheStore
 from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output
-from boss_agent_cli.search_filters import SearchFilterCriteria, resolve_welfare_keywords, run_search_pipeline
+from boss_agent_cli.search_filters import SearchFilterCriteria, SearchPipelinePlatformError, resolve_welfare_keywords, run_search_pipeline
 
 
 def _parse_watch_filters(
@@ -149,15 +149,24 @@ def watch_run_cmd(ctx: click.Context, name: str) -> None:
 		)
 		auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 		with get_platform_instance(ctx, auth) as platform:
-			pipeline_result = run_search_pipeline(
-				platform,
-				cache,
-				logger,
-				criteria=criteria,
-				start_page=1,
-				max_pages=5 if welfare_conditions else 1,
-				welfare_conditions=welfare_conditions,
-			)
+			try:
+				pipeline_result = run_search_pipeline(
+					platform,
+					cache,
+					logger,
+					criteria=criteria,
+					start_page=1,
+					max_pages=5 if welfare_conditions else 1,
+					welfare_conditions=welfare_conditions,
+				)
+			except SearchPipelinePlatformError as exc:
+				handle_error_output(
+					ctx, "watch",
+					code=exc.code,
+					message=exc.message or "搜索结果获取失败",
+					recoverable=False,
+				)
+				return
 		watch_result = cache.record_watch_results(name, pipeline_result.items)
 		handle_output(
 			ctx,

--- a/src/boss_agent_cli/search_filters.py
+++ b/src/boss_agent_cli/search_filters.py
@@ -119,6 +119,13 @@ class SearchPipelineResult:
 	stats: SearchPipelineStats = field(default_factory=SearchPipelineStats)
 
 
+class SearchPipelinePlatformError(Exception):
+	def __init__(self, code: str, message: str):
+		self.code = code
+		self.message = message
+		super().__init__(message)
+
+
 # ── List-page prefilter ─────────────────────────────────────────────
 
 def prefilter_job(raw_item: dict[str, Any], criteria: SearchFilterCriteria) -> tuple[bool, list[str]]:
@@ -272,6 +279,9 @@ def run_search_pipeline(
 			stage=criteria.stage, job_type=criteria.job_type,
 			page=current_page,
 		)
+		if not client.is_success(raw):
+			code, message = client.parse_error(raw)
+			raise SearchPipelinePlatformError(code, message or "搜索结果获取失败")
 		zp_data = raw.get("zpData", {})
 		job_list = zp_data.get("jobList", [])
 		last_page_scanned = current_page

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,9 +1,10 @@
 import json
-from unittest.mock import patch, MagicMock
 from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
 
 from click.testing import CliRunner
 from boss_agent_cli.main import cli
+from boss_agent_cli.search_filters import SearchPipelinePlatformError
 
 
 def _ctx_mock(mock_cls):
@@ -1275,3 +1276,22 @@ def test_search_account_risk_returns_error(mock_client_cls, mock_auth_cls, mock_
 	assert parsed["error"]["recoverable"] is True
 	assert "Chrome" in parsed["error"]["recovery_action"]
 	assert parsed["hints"]["next_actions"]
+
+
+@patch("boss_agent_cli.commands.search.run_search_pipeline")
+@patch("boss_agent_cli.commands.search.CacheStore")
+@patch("boss_agent_cli.commands.search.AuthManager")
+@patch("boss_agent_cli.commands.search.get_platform_instance")
+def test_search_reports_pipeline_platform_error(mock_client_cls, mock_auth_cls, mock_cache_cls, mock_pipeline):
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.get_search.return_value = None
+	_ctx_mock(mock_client_cls)
+	mock_pipeline.side_effect = SearchPipelinePlatformError("UPSTREAM_ERROR", "service unavailable")
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["search", "golang"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["error"]["code"] == "UPSTREAM_ERROR"
+	assert parsed["error"]["message"] == "service unavailable"

--- a/tests/test_search_pipeline.py
+++ b/tests/test_search_pipeline.py
@@ -1,4 +1,6 @@
-from boss_agent_cli.search_filters import SearchFilterCriteria, resolve_welfare_keywords, run_search_pipeline
+import pytest
+
+from boss_agent_cli.search_filters import SearchFilterCriteria, SearchPipelinePlatformError, resolve_welfare_keywords, run_search_pipeline
 
 
 class FakeLogger:
@@ -27,6 +29,12 @@ class FakeClient:
 	def search_jobs(self, query: str, **filters):
 		self.search_calls.append({"query": query, "filters": filters})
 		return self.pages.pop(0)
+
+	def is_success(self, response: dict) -> bool:
+		return response.get("code", 0) in (0, 200)
+
+	def parse_error(self, response: dict) -> tuple[str, str]:
+		return response.get("error_code", "UNKNOWN"), response.get("message", "")
 
 	def job_card(self, security_id: str, lid: str = ""):
 		self.detail_calls.append((security_id, lid))
@@ -202,3 +210,21 @@ def test_pipeline_respects_max_pages_even_when_has_more():
 	assert len(result.items) == 1
 	assert result.last_page == 1
 	assert result.has_more is True
+
+
+def test_pipeline_reports_platform_error():
+	client = FakeClient(
+		pages=[{"code": 500, "message": "service unavailable", "error_code": "UPSTREAM_ERROR"}],
+		descriptions={},
+	)
+
+	with pytest.raises(SearchPipelinePlatformError) as exc_info:
+		run_search_pipeline(
+			client,
+			FakeCache(),
+			FakeLogger(),
+			criteria=SearchFilterCriteria(query="python"),
+		)
+
+	assert exc_info.value.code == "UPSTREAM_ERROR"
+	assert exc_info.value.message == "service unavailable"

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -67,6 +67,7 @@ def test_watch_add_list_remove(tmp_path):
 @patch("boss_agent_cli.commands.watch.AuthManager")
 def test_watch_run_marks_only_new_items(mock_auth_cls, mock_client_cls, tmp_path):
 	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.is_success.return_value = True
 	mock_client.search_jobs.return_value = {
 		"zpData": {
 			"hasMore": False,
@@ -94,6 +95,31 @@ def test_watch_run_marks_only_new_items(mock_auth_cls, mock_client_cls, tmp_path
 	assert second.exit_code == 0
 	second_parsed = json.loads(second.output)
 	assert second_parsed["data"]["new_count"] == 0
+
+
+@patch("boss_agent_cli.commands.watch.get_platform_instance")
+@patch("boss_agent_cli.commands.watch.AuthManager")
+def test_watch_run_reports_platform_error(mock_auth_cls, mock_client_cls, tmp_path):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.is_success.return_value = False
+	mock_client.parse_error.return_value = ("UPSTREAM_ERROR", "service unavailable")
+	mock_client.search_jobs.return_value = {"code": 500, "message": "service unavailable"}
+
+	runner = CliRunner()
+	runner.invoke(
+		cli,
+		[
+			"--data-dir", str(tmp_path),
+			"--json",
+			"watch", "add", "golang-gz", "golang",
+		],
+	)
+
+	result = runner.invoke(cli, ["--data-dir", str(tmp_path), "--json", "watch", "run", "golang-gz"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["error"]["code"] == "UPSTREAM_ERROR"
 
 
 def test_watch_schema_is_exposed():


### PR DESCRIPTION
## 摘要
- 为公共 `run_search_pipeline(...)` 增加平台失败检测与错误上抛
- 让 `search` / `watch run` 在搜索接口明确失败时返回真实错误信封
- 补充搜索流水线、search 命令、watch 命令的错误回执测试

## 验证
- `UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q tests/test_search_pipeline.py tests/test_watch.py tests/test_commands.py`
- `UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q`