### PR TITLE
fix: 修正福利详情回执

### DIFF
--- a/src/boss_agent_cli/search_filters.py
+++ b/src/boss_agent_cli/search_filters.py
@@ -199,6 +199,9 @@ def _fetch_and_check(client: Any, welfare_conditions: list[tuple[str, list[str]]
 			raw_item.get("securityId", ""),
 			raw_item.get("lid", ""),
 		)
+		if not client.is_success(card_raw):
+			code, message = client.parse_error(card_raw)
+			raise SearchPipelinePlatformError(code, message or "职位详情获取失败")
 		desc = card_raw.get("zpData", {}).get("jobCard", {}).get("postDescription", "")
 	except (OSError, KeyError, TypeError):
 		desc = ""
@@ -241,6 +244,9 @@ def _check_details_parallel(
 					logger.info(f"  ✅ {company} - {title}（详情匹配）")
 				else:
 					logger.info(f"  ❌ {company} - {title}")
+			except SearchPipelinePlatformError:
+				logger.info(f"  ❌ {company} - {title}（详情接口失败）")
+				raise
 			except Exception:
 				logger.info(f"  ❌ {company} - {title}（查询失败）")
 

--- a/tests/test_search_pipeline.py
+++ b/tests/test_search_pipeline.py
@@ -41,6 +41,8 @@ class FakeClient:
 		value = self.descriptions[security_id]
 		if isinstance(value, Exception):
 			raise value
+		if isinstance(value, dict):
+			return value
 		return {"zpData": {"jobCard": {"postDescription": value}}}
 
 
@@ -228,3 +230,24 @@ def test_pipeline_reports_platform_error():
 
 	assert exc_info.value.code == "UPSTREAM_ERROR"
 	assert exc_info.value.message == "service unavailable"
+
+
+def test_pipeline_reports_detail_platform_error():
+	client = FakeClient(
+		pages=[{"zpData": {"hasMore": False, "jobList": [_make_job_raw(security_id="sec-1", job_id="job-1")]}}],
+		descriptions={
+			"sec-1": {"code": 500, "message": "detail unavailable", "error_code": "DETAIL_ERROR"},
+		},
+	)
+
+	with pytest.raises(SearchPipelinePlatformError) as exc_info:
+		run_search_pipeline(
+			client,
+			FakeCache(),
+			FakeLogger(),
+			criteria=SearchFilterCriteria(query="python"),
+			welfare_conditions=_welfare_conditions(),
+		)
+
+	assert exc_info.value.code == "DETAIL_ERROR"
+	assert exc_info.value.message == "detail unavailable"

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -122,6 +122,39 @@ def test_watch_run_reports_platform_error(mock_auth_cls, mock_client_cls, tmp_pa
 	assert parsed["error"]["code"] == "UPSTREAM_ERROR"
 
 
+@patch("boss_agent_cli.commands.watch.get_platform_instance")
+@patch("boss_agent_cli.commands.watch.AuthManager")
+def test_watch_run_reports_detail_platform_error(mock_auth_cls, mock_client_cls, tmp_path):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.is_success.side_effect = lambda response: response.get("code", 0) in (0, 200)
+	mock_client.parse_error.side_effect = lambda response: (response.get("error_code", "UNKNOWN"), response.get("message", ""))
+	mock_client.search_jobs.return_value = {
+		"code": 0,
+		"zpData": {
+			"hasMore": False,
+			"jobList": [_job("sec-1", "job-1", title="Go 开发") | {"welfareList": []}],
+		},
+	}
+	mock_client.job_card.return_value = {"code": 500, "message": "detail unavailable", "error_code": "DETAIL_ERROR"}
+
+	runner = CliRunner()
+	runner.invoke(
+		cli,
+		[
+			"--data-dir", str(tmp_path),
+			"--json",
+			"watch", "add", "golang-gz", "golang",
+			"--welfare", "双休",
+		],
+	)
+
+	result = runner.invoke(cli, ["--data-dir", str(tmp_path), "--json", "watch", "run", "golang-gz"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["error"]["code"] == "DETAIL_ERROR"
+
+
 def test_watch_schema_is_exposed():
 	runner = CliRunner()
 	result = runner.invoke(cli, ["schema"])


### PR DESCRIPTION
## 摘要
- 让福利筛选详情回退中的 `job_card` 显式失败不再被伪装成未命中
- 保留网络抖动等非显式平台失败的宽容降级行为
- 补充搜索流水线与 watch 命令的福利详情失败回执测试

## 验证
- `UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q tests/test_search_pipeline.py tests/test_watch.py`
- `UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q`