### PR TITLE
fix: 修正福利筛选平台回执

### DIFF
--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -734,6 +734,11 @@ SCHEMA_DATA = {
 			"recoverable": False,
 			"recovery_action": "修正参数",
 		},
+		"NOT_SUPPORTED": {
+			"message": "当前平台暂不支持该能力",
+			"recoverable": True,
+			"recovery_action": "切换平台或调整命令参数后重试",
+		},
 		"RESUME_NOT_FOUND": {
 			"message": "简历不存在",
 			"recoverable": False,

--- a/src/boss_agent_cli/search_filters.py
+++ b/src/boss_agent_cli/search_filters.py
@@ -203,6 +203,11 @@ def _fetch_and_check(client: Any, welfare_conditions: list[tuple[str, list[str]]
 			code, message = client.parse_error(card_raw)
 			raise SearchPipelinePlatformError(code, message or "职位详情获取失败")
 		desc = card_raw.get("zpData", {}).get("jobCard", {}).get("postDescription", "")
+	except NotImplementedError:
+		raise SearchPipelinePlatformError(
+			"NOT_SUPPORTED",
+			"当前平台暂不支持福利详情筛选，请去掉 --welfare 后重试",
+		)
 	except (OSError, KeyError, TypeError):
 		desc = ""
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1295,3 +1295,47 @@ def test_search_reports_pipeline_platform_error(mock_client_cls, mock_auth_cls, 
 	assert parsed["ok"] is False
 	assert parsed["error"]["code"] == "UPSTREAM_ERROR"
 	assert parsed["error"]["message"] == "service unavailable"
+
+
+@patch("boss_agent_cli.commands.search.CacheStore")
+@patch("boss_agent_cli.commands.search.AuthManager")
+@patch("boss_agent_cli.commands.search.get_platform_instance")
+def test_search_reports_welfare_not_supported(mock_client_cls, mock_auth_cls, mock_cache_cls):
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.get_search.return_value = None
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.search_jobs.return_value = {
+		"code": 0,
+		"zpData": {
+			"hasMore": False,
+			"jobList": [
+				{
+					"encryptJobId": "j1",
+					"jobName": "Go 开发",
+					"brandName": "TestCo",
+					"salaryDesc": "20K",
+					"cityName": "广州",
+					"areaDistrict": "天河区",
+					"jobExperience": "3-5年",
+					"jobDegree": "本科",
+					"skills": ["Golang"],
+					"welfareList": [],
+					"brandIndustry": "互联网",
+					"brandScaleName": "100-499人",
+					"brandStageName": "A轮",
+					"bossName": "李",
+					"bossTitle": "HR",
+					"bossOnline": True,
+					"securityId": "sec_001",
+				},
+			],
+		},
+	}
+	mock_client.job_card.side_effect = NotImplementedError("unsupported")
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["search", "golang", "--welfare", "双休"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["error"]["code"] == "NOT_SUPPORTED"

--- a/tests/test_schema_contract.py
+++ b/tests/test_schema_contract.py
@@ -102,6 +102,7 @@ def test_schema_error_codes_cover_all_used_codes():
 		"GREET_LIMIT",
 		"NETWORK_ERROR",
 		"INVALID_PARAM",
+		"NOT_SUPPORTED",
 		"HOOK_BLOCKED",
 	}
 

--- a/tests/test_search_pipeline.py
+++ b/tests/test_search_pipeline.py
@@ -251,3 +251,23 @@ def test_pipeline_reports_detail_platform_error():
 
 	assert exc_info.value.code == "DETAIL_ERROR"
 	assert exc_info.value.message == "detail unavailable"
+
+
+def test_pipeline_reports_welfare_not_supported():
+	client = FakeClient(
+		pages=[{"zpData": {"hasMore": False, "jobList": [_make_job_raw(security_id="sec-1", job_id="job-1")]}}],
+		descriptions={},
+	)
+	client.job_card = lambda security_id, lid="": (_ for _ in ()).throw(NotImplementedError("unsupported"))
+
+	with pytest.raises(SearchPipelinePlatformError) as exc_info:
+		run_search_pipeline(
+			client,
+			FakeCache(),
+			FakeLogger(),
+			criteria=SearchFilterCriteria(query="python"),
+			welfare_conditions=_welfare_conditions(),
+		)
+
+	assert exc_info.value.code == "NOT_SUPPORTED"
+	assert "不支持福利详情筛选" in exc_info.value.message

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -155,6 +155,38 @@ def test_watch_run_reports_detail_platform_error(mock_auth_cls, mock_client_cls,
 	assert parsed["error"]["code"] == "DETAIL_ERROR"
 
 
+@patch("boss_agent_cli.commands.watch.get_platform_instance")
+@patch("boss_agent_cli.commands.watch.AuthManager")
+def test_watch_run_reports_welfare_not_supported(mock_auth_cls, mock_client_cls, tmp_path):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.is_success.side_effect = lambda response: response.get("code", 0) in (0, 200)
+	mock_client.search_jobs.return_value = {
+		"code": 0,
+		"zpData": {
+			"hasMore": False,
+			"jobList": [_job("sec-1", "job-1", title="Go 开发") | {"welfareList": []}],
+		},
+	}
+	mock_client.job_card.side_effect = NotImplementedError("unsupported")
+
+	runner = CliRunner()
+	runner.invoke(
+		cli,
+		[
+			"--data-dir", str(tmp_path),
+			"--json",
+			"watch", "add", "golang-gz", "golang",
+			"--welfare", "双休",
+		],
+	)
+
+	result = runner.invoke(cli, ["--data-dir", str(tmp_path), "--json", "watch", "run", "golang-gz"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["error"]["code"] == "NOT_SUPPORTED"
+
+
 def test_watch_schema_is_exposed():
 	runner = CliRunner()
 	result = runner.invoke(cli, ["schema"])


### PR DESCRIPTION
## 摘要
- 当平台不支持 `job_card` 时，福利筛选不再静默返回空结果
- 新增 `NOT_SUPPORTED` 错误码，并在 schema 中公开声明
- 补充搜索流水线、search、watch 和 schema 合约测试

## 验证
- `UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q tests/test_search_pipeline.py tests/test_watch.py tests/test_commands.py tests/test_schema_contract.py`
- `UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q`