### PR TITLE
fix: 统一候选人错误回执契约

### DIFF
--- a/src/boss_agent_cli/commands/chat.py
+++ b/src/boss_agent_cli/commands/chat.py
@@ -12,7 +12,7 @@ from boss_agent_cli.commands.chat_utils import (
 	RELATION_LABELS, FROM_FILTER, MSG_STATUS_LABELS,
 	sanitize_csv_cell, escape_md_cell,
 )
-from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, login_action_for_ctx, render_simple_list
+from boss_agent_cli.display import error_contract_for_code, handle_auth_errors, handle_error_output, handle_output, login_action_for_ctx, render_simple_list
 
 NOT_SUPPORTED_RECOVERY_ACTION = "切换平台或调整命令参数后重试"
 
@@ -68,11 +68,13 @@ def chat_cmd(ctx: click.Context, page: int, from_who: str | None, days: int | No
 			return
 		if not platform.is_success(resp):
 			code, message = platform.parse_error(resp)
+			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "chat",
 				code=code,
 				message=message or "沟通列表获取失败",
-				recoverable=False,
+				recoverable=recoverable,
+				recovery_action=recovery_action,
 			)
 			return
 		platform_data = platform.unwrap_data(resp) or {}

--- a/src/boss_agent_cli/commands/chat.py
+++ b/src/boss_agent_cli/commands/chat.py
@@ -14,6 +14,8 @@ from boss_agent_cli.commands.chat_utils import (
 )
 from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, login_action_for_ctx, render_simple_list
 
+NOT_SUPPORTED_RECOVERY_ACTION = "切换平台或调整命令参数后重试"
+
 # 向后兼容别名（旧测试引用 chat._sanitize_csv_cell 等）
 _RELATION_LABELS = RELATION_LABELS
 _FROM_FILTER = FROM_FILTER
@@ -53,7 +55,17 @@ def chat_cmd(ctx: click.Context, page: int, from_who: str | None, days: int | No
 		return
 
 	with get_platform_instance(ctx, auth) as platform:
-		resp = platform.friend_list(page=page)
+		try:
+			resp = platform.friend_list(page=page)
+		except NotImplementedError as exc:
+			handle_error_output(
+				ctx, "chat",
+				code="NOT_SUPPORTED",
+				message=str(exc) or "当前平台不支持沟通列表能力",
+				recoverable=True,
+				recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
+			)
+			return
 		if not platform.is_success(resp):
 			code, message = platform.parse_error(resp)
 			handle_error_output(

--- a/src/boss_agent_cli/commands/chatmsg.py
+++ b/src/boss_agent_cli/commands/chatmsg.py
@@ -5,7 +5,9 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import boss_command_for_ctx, handle_auth_errors, handle_error_output, handle_output, render_simple_list
+from boss_agent_cli.display import boss_command_for_ctx, error_contract_for_code, handle_auth_errors, handle_error_output, handle_output, render_simple_list
+
+NOT_SUPPORTED_RECOVERY_ACTION = "切换平台或调整命令参数后重试"
 
 _MSG_TYPE_MAP = {
 	1: "文本", 2: "图片", 3: "招呼", 4: "简历", 5: "系统",
@@ -26,14 +28,26 @@ def chatmsg_cmd(ctx: click.Context, security_id: str, page: int, count: int) -> 
 	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 
 	with get_platform_instance(ctx, auth) as platform:
-		friends_resp = platform.friend_list(page=1)
+		try:
+			friends_resp = platform.friend_list(page=1)
+		except NotImplementedError as exc:
+			handle_error_output(
+				ctx, "chatmsg",
+				code="NOT_SUPPORTED",
+				message=str(exc) or "当前平台不支持沟通列表能力",
+				recoverable=True,
+				recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
+			)
+			return
 		if not platform.is_success(friends_resp):
 			code, message = platform.parse_error(friends_resp)
+			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "chatmsg",
 				code=code,
 				message=message or "沟通列表获取失败",
-				recoverable=False,
+				recoverable=recoverable,
+				recovery_action=recovery_action,
 			)
 			return
 		platform_data = platform.unwrap_data(friends_resp) or {}
@@ -55,14 +69,26 @@ def chatmsg_cmd(ctx: click.Context, security_id: str, page: int, count: int) -> 
 			)
 			return
 
-		resp = platform.chat_history(gid, security_id, page=page, count=count)
+		try:
+			resp = platform.chat_history(gid, security_id, page=page, count=count)
+		except NotImplementedError as exc:
+			handle_error_output(
+				ctx, "chatmsg",
+				code="NOT_SUPPORTED",
+				message=str(exc) or "当前平台不支持聊天记录能力",
+				recoverable=True,
+				recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
+			)
+			return
 		if not platform.is_success(resp):
 			code, message = platform.parse_error(resp)
+			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "chatmsg",
 				code=code,
 				message=message or "聊天记录获取失败",
-				recoverable=False,
+				recoverable=recoverable,
+				recovery_action=recovery_action,
 			)
 			return
 		msg_data = platform.unwrap_data(resp) or {}

--- a/src/boss_agent_cli/commands/detail.py
+++ b/src/boss_agent_cli/commands/detail.py
@@ -40,7 +40,8 @@ def detail_cmd(ctx: click.Context, security_id: str, lid: str, job_id: str) -> N
 				result = None
 		if result is None:
 			result, browser_error = _detail_via_browser(platform, security_id, lid, data_dir)
-			last_error = browser_error or last_error
+			if browser_error and (last_error is None or browser_error[0] != "NOT_SUPPORTED"):
+				last_error = browser_error
 
 	if result is None:
 		if last_error:

--- a/src/boss_agent_cli/commands/detail.py
+++ b/src/boss_agent_cli/commands/detail.py
@@ -9,6 +9,8 @@ from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import boss_command_for_ctx, handle_auth_errors, handle_error_output, handle_output, render_job_detail
 from boss_agent_cli.platforms import Platform
 
+NOT_SUPPORTED_RECOVERY_ACTION = "切换平台或调整命令参数后重试"
+
 
 @click.command("detail")
 @click.argument("security_id")
@@ -45,11 +47,13 @@ def detail_cmd(ctx: click.Context, security_id: str, lid: str, job_id: str) -> N
 
 	if result is None:
 		if last_error:
+			recoverable = last_error[0] == "NOT_SUPPORTED"
 			handle_error_output(
 				ctx, "detail",
 				code=last_error[0],
 				message=last_error[1],
-				recoverable=False,
+				recoverable=recoverable,
+				recovery_action=NOT_SUPPORTED_RECOVERY_ACTION if recoverable else None,
 			)
 			return
 		handle_error_output(

--- a/src/boss_agent_cli/commands/detail.py
+++ b/src/boss_agent_cli/commands/detail.py
@@ -108,7 +108,10 @@ def _detail_via_httpx(platform: Platform, security_id: str, job_id: str, data_di
 
 def _detail_via_browser(platform: Platform, security_id: str, lid: str, data_dir: Path) -> tuple[dict[str, Any] | None, tuple[str, str] | None]:
 	"""兜底通道：通过浏览器 job_card 获取职位详情"""
-	raw = platform.job_card(security_id, lid)
+	try:
+		raw = platform.job_card(security_id, lid)
+	except NotImplementedError as exc:
+		return None, ("NOT_SUPPORTED", str(exc) or "当前平台不支持职位详情兜底能力")
 	if not platform.is_success(raw):
 		code, message = platform.parse_error(raw)
 		return None, (code, message or "职位详情获取失败")

--- a/src/boss_agent_cli/commands/exchange.py
+++ b/src/boss_agent_cli/commands/exchange.py
@@ -2,7 +2,9 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_message_panel
+from boss_agent_cli.display import boss_command_for_ctx, error_contract_for_code, handle_auth_errors, handle_error_output, handle_output, render_message_panel
+
+NOT_SUPPORTED_RECOVERY_ACTION = "切换平台或调整命令参数后重试"
 
 
 @click.command("exchange")
@@ -20,14 +22,26 @@ def exchange_cmd(ctx: click.Context, security_id: str, exchange_type: str) -> No
 	type_label = "微信" if exchange_type == "wechat" else "手机号"
 
 	with get_platform_instance(ctx, auth) as platform:
-		friends_resp = platform.friend_list(page=1)
+		try:
+			friends_resp = platform.friend_list(page=1)
+		except NotImplementedError as exc:
+			handle_error_output(
+				ctx, "exchange",
+				code="NOT_SUPPORTED",
+				message=str(exc) or "当前平台不支持沟通列表能力",
+				recoverable=True,
+				recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
+			)
+			return
 		if not platform.is_success(friends_resp):
 			code, message = platform.parse_error(friends_resp)
+			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "exchange",
 				code=code,
 				message=message or "沟通列表获取失败",
-				recoverable=False,
+				recoverable=recoverable,
+				recovery_action=recovery_action,
 			)
 			return
 		friend_data = platform.unwrap_data(friends_resp) or {}
@@ -48,14 +62,26 @@ def exchange_cmd(ctx: click.Context, security_id: str, exchange_type: str) -> No
 			)
 			return
 
-		resp = platform.exchange_contact(security_id, uid, friend_name, exchange_type=type_id)
+		try:
+			resp = platform.exchange_contact(security_id, uid, friend_name, exchange_type=type_id)
+		except NotImplementedError as exc:
+			handle_error_output(
+				ctx, "exchange",
+				code="NOT_SUPPORTED",
+				message=str(exc) or f"当前平台不支持{type_label}交换能力",
+				recoverable=True,
+				recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
+			)
+			return
 		if not platform.is_success(resp):
 			code, message = platform.parse_error(resp)
+			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "exchange",
 				code=code,
 				message=message or f"{type_label}交换请求失败",
-				recoverable=False,
+				recoverable=recoverable,
+				recovery_action=recovery_action,
 			)
 			return
 
@@ -69,7 +95,7 @@ def exchange_cmd(ctx: click.Context, security_id: str, exchange_type: str) -> No
 			ctx, "exchange", data,
 			render=lambda d: render_message_panel(d, title="exchange"),
 			hints={"next_actions": [
-				"boss chat — 返回沟通列表",
-				f"boss chatmsg {security_id} — 查看聊天记录",
+				f"{boss_command_for_ctx(ctx, 'chat')} — 返回沟通列表",
+				f"{boss_command_for_ctx(ctx, f'chatmsg {security_id}')} — 查看聊天记录",
 			]},
 		)

--- a/src/boss_agent_cli/commands/history.py
+++ b/src/boss_agent_cli/commands/history.py
@@ -5,6 +5,8 @@ from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import boss_command_for_ctx, handle_auth_errors, handle_error_output, handle_output, render_job_table
 
+NOT_SUPPORTED_RECOVERY_ACTION = "切换平台或调整命令参数后重试"
+
 
 @click.command("history")
 @click.option("--page", default=1, help="页码")
@@ -17,7 +19,17 @@ def history_cmd(ctx: click.Context, page: int) -> None:
 
 	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	with get_platform_instance(ctx, auth) as platform:
-		raw = platform.job_history(page)
+		try:
+			raw = platform.job_history(page)
+		except NotImplementedError as exc:
+			handle_error_output(
+				ctx, "history",
+				code="NOT_SUPPORTED",
+				message=str(exc) or "当前平台不支持浏览历史能力",
+				recoverable=True,
+				recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
+			)
+			return
 		if not platform.is_success(raw):
 			code, message = platform.parse_error(raw)
 			handle_error_output(

--- a/src/boss_agent_cli/commands/history.py
+++ b/src/boss_agent_cli/commands/history.py
@@ -3,7 +3,7 @@ import click
 from boss_agent_cli.api.models import JobItem
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import boss_command_for_ctx, handle_auth_errors, handle_error_output, handle_output, render_job_table
+from boss_agent_cli.display import boss_command_for_ctx, error_contract_for_code, handle_auth_errors, handle_error_output, handle_output, render_job_table
 
 NOT_SUPPORTED_RECOVERY_ACTION = "切换平台或调整命令参数后重试"
 
@@ -32,11 +32,13 @@ def history_cmd(ctx: click.Context, page: int) -> None:
 			return
 		if not platform.is_success(raw):
 			code, message = platform.parse_error(raw)
+			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "history",
 				code=code,
 				message=message or "浏览历史获取失败",
-				recoverable=False,
+				recoverable=recoverable,
+				recovery_action=recovery_action,
 			)
 			return
 		platform_data = platform.unwrap_data(raw) or {}

--- a/src/boss_agent_cli/commands/interviews.py
+++ b/src/boss_agent_cli/commands/interviews.py
@@ -5,6 +5,8 @@ from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, login_action_for_ctx, render_simple_list
 from typing import Any
 
+NOT_SUPPORTED_RECOVERY_ACTION = "切换平台或调整命令参数后重试"
+
 
 @click.command("interviews")
 @click.pass_context
@@ -27,7 +29,17 @@ def interviews_cmd(ctx: click.Context) -> None:
 		return
 
 	with get_platform_instance(ctx, auth) as platform:
-		raw = platform.interview_data()
+		try:
+			raw = platform.interview_data()
+		except NotImplementedError as exc:
+			handle_error_output(
+				ctx, "interviews",
+				code="NOT_SUPPORTED",
+				message=str(exc) or "当前平台不支持面试邀请能力",
+				recoverable=True,
+				recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
+			)
+			return
 		if not platform.is_success(raw):
 			code, message = platform.parse_error(raw)
 			handle_error_output(

--- a/src/boss_agent_cli/commands/interviews.py
+++ b/src/boss_agent_cli/commands/interviews.py
@@ -2,7 +2,7 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, login_action_for_ctx, render_simple_list
+from boss_agent_cli.display import boss_command_for_ctx, error_contract_for_code, handle_auth_errors, handle_error_output, handle_output, login_action_for_ctx, render_simple_list
 from typing import Any
 
 NOT_SUPPORTED_RECOVERY_ACTION = "切换平台或调整命令参数后重试"
@@ -42,11 +42,13 @@ def interviews_cmd(ctx: click.Context) -> None:
 			return
 		if not platform.is_success(raw):
 			code, message = platform.parse_error(raw)
+			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "interviews",
 				code=code,
 				message=message or "面试邀请获取失败",
-				recoverable=False,
+				recoverable=recoverable,
+				recovery_action=recovery_action,
 			)
 			return
 		platform_data = platform.unwrap_data(raw) or {}
@@ -79,5 +81,5 @@ def interviews_cmd(ctx: click.Context) -> None:
 	handle_output(
 		ctx, "interviews", items,
 		render=_render,
-		hints={"next_actions": ["boss detail <job_id>"]},
+		hints={"next_actions": [boss_command_for_ctx(ctx, "search <query>")]},
 	)

--- a/src/boss_agent_cli/commands/mark.py
+++ b/src/boss_agent_cli/commands/mark.py
@@ -2,7 +2,9 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_message_panel
+from boss_agent_cli.display import boss_command_for_ctx, error_contract_for_code, handle_auth_errors, handle_error_output, handle_output, render_message_panel
+
+NOT_SUPPORTED_RECOVERY_ACTION = "切换平台或调整命令参数后重试"
 
 _LABEL_MAP = {
 	"新招呼": 1, "沟通中": 2, "已约面": 3, "已获取简历": 4,
@@ -43,14 +45,26 @@ def mark_cmd(ctx: click.Context, security_id: str, label: str, remove: bool) -> 
 	action_text = "移除" if remove else "添加"
 
 	with get_platform_instance(ctx, auth) as platform:
-		friends_resp = platform.friend_list(page=1)
+		try:
+			friends_resp = platform.friend_list(page=1)
+		except NotImplementedError as exc:
+			handle_error_output(
+				ctx, "mark",
+				code="NOT_SUPPORTED",
+				message=str(exc) or "当前平台不支持沟通列表能力",
+				recoverable=True,
+				recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
+			)
+			return
 		if not platform.is_success(friends_resp):
 			code, message = platform.parse_error(friends_resp)
+			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "mark",
 				code=code,
 				message=message or "沟通列表获取失败",
-				recoverable=False,
+				recoverable=recoverable,
+				recovery_action=recovery_action,
 			)
 			return
 		friend_data = platform.unwrap_data(friends_resp) or {}
@@ -73,14 +87,26 @@ def mark_cmd(ctx: click.Context, security_id: str, label: str, remove: bool) -> 
 			)
 			return
 
-		resp = platform.friend_label(friend_id, label_id, friend_source, remove=remove)
+		try:
+			resp = platform.friend_label(friend_id, label_id, friend_source, remove=remove)
+		except NotImplementedError as exc:
+			handle_error_output(
+				ctx, "mark",
+				code="NOT_SUPPORTED",
+				message=str(exc) or "当前平台不支持联系人标签能力",
+				recoverable=True,
+				recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
+			)
+			return
 		if not platform.is_success(resp):
 			code, message = platform.parse_error(resp)
+			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "mark",
 				code=code,
 				message=message or f"{action_text}标签失败",
-				recoverable=False,
+				recoverable=recoverable,
+				recovery_action=recovery_action,
 			)
 			return
 
@@ -95,6 +121,6 @@ def mark_cmd(ctx: click.Context, security_id: str, label: str, remove: bool) -> 
 			ctx, "mark", data,
 			render=lambda d: render_message_panel(d, title="mark"),
 			hints={"next_actions": [
-				"boss chat — 返回沟通列表",
+				f"{boss_command_for_ctx(ctx, 'chat')} — 返回沟通列表",
 			]},
 		)

--- a/src/boss_agent_cli/commands/me.py
+++ b/src/boss_agent_cli/commands/me.py
@@ -48,7 +48,16 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 			if "resume" in sections:
 				if logger:
 					logger.info("获取简历基本信息...")
-				resp = platform.resume_baseinfo()
+				try:
+					resp = platform.resume_baseinfo()
+				except NotImplementedError as exc:
+					handle_error_output(
+						ctx, "me",
+						code="NOT_SUPPORTED",
+						message=str(exc) or "当前平台不支持简历基本信息能力",
+						recoverable=False,
+					)
+					return
 				if not platform.is_success(resp):
 					code, message = platform.parse_error(resp)
 					handle_error_output(
@@ -64,7 +73,16 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 			if "expect" in sections:
 				if logger:
 					logger.info("获取求职期望...")
-				resp = platform.resume_expect()
+				try:
+					resp = platform.resume_expect()
+				except NotImplementedError as exc:
+					handle_error_output(
+						ctx, "me",
+						code="NOT_SUPPORTED",
+						message=str(exc) or "当前平台不支持求职期望能力",
+						recoverable=False,
+					)
+					return
 				if not platform.is_success(resp):
 					code, message = platform.parse_error(resp)
 					handle_error_output(
@@ -80,7 +98,16 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 			if "deliver" in sections:
 				if logger:
 					logger.info("获取投递记录...")
-				resp = platform.deliver_list(page=deliver_page)
+				try:
+					resp = platform.deliver_list(page=deliver_page)
+				except NotImplementedError as exc:
+					handle_error_output(
+						ctx, "me",
+						code="NOT_SUPPORTED",
+						message=str(exc) or "当前平台不支持投递记录能力",
+						recoverable=False,
+					)
+					return
 				if not platform.is_success(resp):
 					code, message = platform.parse_error(resp)
 					handle_error_output(

--- a/src/boss_agent_cli/commands/me.py
+++ b/src/boss_agent_cli/commands/me.py
@@ -5,6 +5,8 @@ from boss_agent_cli.auth.manager import AuthManager, AuthRequired, TokenRefreshF
 from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import boss_command_for_ctx, handle_error_output, handle_output, login_action_for_ctx, render_sectioned_record
 
+NOT_SUPPORTED_RECOVERY_ACTION = "切换平台或调整命令参数后重试"
+
 
 @click.command("me")
 @click.option("--section", default=None, type=click.Choice(["user", "resume", "expect", "deliver"]),
@@ -55,7 +57,8 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 						ctx, "me",
 						code="NOT_SUPPORTED",
 						message=str(exc) or "当前平台不支持简历基本信息能力",
-						recoverable=False,
+						recoverable=True,
+						recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
 					)
 					return
 				if not platform.is_success(resp):
@@ -80,7 +83,8 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 						ctx, "me",
 						code="NOT_SUPPORTED",
 						message=str(exc) or "当前平台不支持求职期望能力",
-						recoverable=False,
+						recoverable=True,
+						recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
 					)
 					return
 				if not platform.is_success(resp):
@@ -105,7 +109,8 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 						ctx, "me",
 						code="NOT_SUPPORTED",
 						message=str(exc) or "当前平台不支持投递记录能力",
-						recoverable=False,
+						recoverable=True,
+						recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
 					)
 					return
 				if not platform.is_success(resp):

--- a/src/boss_agent_cli/commands/recommend.py
+++ b/src/boss_agent_cli/commands/recommend.py
@@ -8,6 +8,8 @@ from boss_agent_cli.display import handle_error_output, handle_output, render_jo
 from boss_agent_cli.index_cache import try_save_index
 from boss_agent_cli.match_score import score_job_dict
 
+NOT_SUPPORTED_RECOVERY_ACTION = "切换平台或调整命令参数后重试"
+
 
 @click.command("recommend")
 @click.option("--page", default=1, type=int, help="页码")
@@ -26,8 +28,15 @@ def recommend_cmd(ctx: click.Context, page: int, with_score: bool) -> None:
 			if with_score:
 				try:
 					expect_resp = platform.resume_expect()
-				except NotImplementedError:
-					expect_data = None
+				except NotImplementedError as exc:
+					handle_error_output(
+						ctx, "recommend",
+						code="NOT_SUPPORTED",
+						message=str(exc) or "当前平台不支持求职期望能力",
+						recoverable=True,
+						recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
+					)
+					return
 				else:
 					if not platform.is_success(expect_resp):
 						code, message = platform.parse_error(expect_resp)

--- a/src/boss_agent_cli/commands/show.py
+++ b/src/boss_agent_cli/commands/show.py
@@ -45,7 +45,16 @@ def show_cmd(ctx: click.Context, index: int) -> None:
 
 	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	with get_platform_instance(ctx, auth) as platform:
-		raw = platform.job_card(security_id)
+		try:
+			raw = platform.job_card(security_id)
+		except NotImplementedError as exc:
+			handle_error_output(
+				ctx, "show",
+				code="NOT_SUPPORTED",
+				message=str(exc) or "当前平台不支持职位详情能力",
+				recoverable=False,
+			)
+			return
 		if not platform.is_success(raw):
 			code, message = platform.parse_error(raw)
 			handle_error_output(

--- a/src/boss_agent_cli/commands/show.py
+++ b/src/boss_agent_cli/commands/show.py
@@ -6,6 +6,8 @@ from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import boss_command_for_ctx, handle_auth_errors, handle_error_output, handle_output, render_job_detail
 from boss_agent_cli.index_cache import get_index_info, get_job_by_index
 
+NOT_SUPPORTED_RECOVERY_ACTION = "切换平台或调整命令参数后重试"
+
 
 @click.command("show")
 @click.argument("index", type=int)
@@ -52,7 +54,8 @@ def show_cmd(ctx: click.Context, index: int) -> None:
 				ctx, "show",
 				code="NOT_SUPPORTED",
 				message=str(exc) or "当前平台不支持职位详情能力",
-				recoverable=False,
+				recoverable=True,
+				recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
 			)
 			return
 		if not platform.is_success(raw):

--- a/src/boss_agent_cli/display.py
+++ b/src/boss_agent_cli/display.py
@@ -32,6 +32,25 @@ def login_action_for_ctx(ctx: Any) -> str:
 	return boss_command_for_ctx(ctx, "login")
 
 
+def error_contract_for_code(
+	code: str,
+	*,
+	fallback_recoverable: bool = False,
+	fallback_recovery_action: str | None = None,
+) -> tuple[bool, str | None]:
+	"""Return recoverability metadata for a known error code."""
+	from boss_agent_cli.commands.schema import SCHEMA_DATA
+
+	error_codes = SCHEMA_DATA.get("error_codes", {})
+	spec = error_codes.get(code, {}) if isinstance(error_codes, dict) else {}
+	if not isinstance(spec, dict):
+		spec = {}
+	return (
+		bool(spec.get("recoverable", fallback_recoverable)),
+		spec.get("recovery_action", fallback_recovery_action),
+	)
+
+
 def is_json_mode(ctx) -> bool:
 	"""Check if --json flag is set or stdout is piped (non-TTY)."""
 	force_json = ctx.obj.get("json_output", False) if ctx and ctx.obj else False

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -810,6 +810,8 @@ def test_chat_reports_friend_list_error(mock_auth_cls, mock_client_cls):
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
 	assert parsed["error"]["message"] == "stoken expired"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "boss login"
 
 
 @patch("boss_agent_cli.commands.chat.get_platform_instance")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -814,6 +814,22 @@ def test_chat_reports_friend_list_error(mock_auth_cls, mock_client_cls):
 
 @patch("boss_agent_cli.commands.chat.get_platform_instance")
 @patch("boss_agent_cli.commands.chat.AuthManager")
+def test_chat_reports_not_supported_when_friend_list_missing(mock_auth_cls, mock_client_cls):
+	mock_auth_cls.return_value.check_status.return_value = {"cookies": {}}
+	_ctx_mock(mock_client_cls)
+	mock_client_cls.return_value.friend_list.side_effect = NotImplementedError("friend_list is not supported")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chat"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "NOT_SUPPORTED"
+	assert parsed["error"]["message"] == "friend_list is not supported"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "切换平台或调整命令参数后重试"
+
+
+@patch("boss_agent_cli.commands.chat.get_platform_instance")
+@patch("boss_agent_cli.commands.chat.AuthManager")
 def test_chat_export_md(mock_auth_cls, mock_client_cls, tmp_path):
 	"""--export md 导出包含 security_id 和 diff 摘要"""
 	import time

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -420,6 +420,50 @@ def test_recommend_with_score_reports_expect_error(mock_auth_cls, mock_client_cl
 	assert parsed["error"]["message"] == "stoken expired"
 
 
+@patch("boss_agent_cli.commands.recommend.CacheStore")
+@patch("boss_agent_cli.commands.recommend.get_platform_instance")
+@patch("boss_agent_cli.commands.recommend.AuthManager")
+def test_recommend_with_score_reports_not_supported(mock_auth_cls, mock_client_cls, mock_cache_cls):
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.is_greeted.return_value = False
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.resume_expect.side_effect = NotImplementedError("当前平台不支持求职期望能力")
+	mock_client.recommend_jobs.return_value = {
+		"zpData": {
+			"hasMore": False,
+			"jobList": [
+				{
+					"encryptJobId": "j1",
+					"jobName": "Go 开发",
+					"brandName": "TestCo",
+					"salaryDesc": "20-30K",
+					"cityName": "广州",
+					"areaDistrict": "天河区",
+					"jobExperience": "3-5年",
+					"jobDegree": "本科",
+					"skills": ["Golang"],
+					"welfareList": ["双休"],
+					"brandIndustry": "互联网",
+					"brandScaleName": "100-499人",
+					"brandStageName": "A轮",
+					"bossName": "李",
+					"bossTitle": "HR",
+					"bossOnline": True,
+					"securityId": "sec_r1",
+				},
+			],
+		},
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["recommend", "--with-score"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "NOT_SUPPORTED"
+	assert parsed["error"]["message"] == "当前平台不支持求职期望能力"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "切换平台或调整命令参数后重试"
+
+
 @patch("boss_agent_cli.commands.search.run_search_pipeline")
 @patch("boss_agent_cli.commands.search.CacheStore")
 @patch("boss_agent_cli.commands.search.AuthManager")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -428,32 +428,6 @@ def test_recommend_with_score_reports_not_supported(mock_auth_cls, mock_client_c
 	mock_cache.is_greeted.return_value = False
 	mock_client = _ctx_mock(mock_client_cls)
 	mock_client.resume_expect.side_effect = NotImplementedError("当前平台不支持求职期望能力")
-	mock_client.recommend_jobs.return_value = {
-		"zpData": {
-			"hasMore": False,
-			"jobList": [
-				{
-					"encryptJobId": "j1",
-					"jobName": "Go 开发",
-					"brandName": "TestCo",
-					"salaryDesc": "20-30K",
-					"cityName": "广州",
-					"areaDistrict": "天河区",
-					"jobExperience": "3-5年",
-					"jobDegree": "本科",
-					"skills": ["Golang"],
-					"welfareList": ["双休"],
-					"brandIndustry": "互联网",
-					"brandScaleName": "100-499人",
-					"brandStageName": "A轮",
-					"bossName": "李",
-					"bossTitle": "HR",
-					"bossOnline": True,
-					"securityId": "sec_r1",
-				},
-			],
-		},
-	}
 	runner = CliRunner()
 	result = runner.invoke(cli, ["recommend", "--with-score"])
 	assert result.exit_code == 1
@@ -462,6 +436,7 @@ def test_recommend_with_score_reports_not_supported(mock_auth_cls, mock_client_c
 	assert parsed["error"]["message"] == "当前平台不支持求职期望能力"
 	assert parsed["error"]["recoverable"] is True
 	assert parsed["error"]["recovery_action"] == "切换平台或调整命令参数后重试"
+	mock_client.recommend_jobs.assert_not_called()
 
 
 @patch("boss_agent_cli.commands.search.run_search_pipeline")

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -373,6 +373,23 @@ def test_detail_reports_platform_error(mock_auth_cls, mock_client_cls, mock_cach
 	assert parsed["error"]["message"] == "stoken expired"
 
 
+@patch("boss_agent_cli.commands.detail.CacheStore")
+@patch("boss_agent_cli.commands.detail.get_platform_instance")
+@patch("boss_agent_cli.commands.detail.AuthManager")
+def test_detail_reports_not_supported_when_browser_fallback_missing(mock_auth_cls, mock_client_cls, mock_cache_cls):
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.is_greeted.return_value = False
+	mock_cache.get_job_id.return_value = ""
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.job_card.side_effect = NotImplementedError("job_card is not supported")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["detail", "sec_001"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "NOT_SUPPORTED"
+	assert parsed["error"]["message"] == "job_card is not supported"
+
+
 @patch("boss_agent_cli.commands.show.CacheStore")
 @patch("boss_agent_cli.commands.show.get_job_by_index")
 @patch("boss_agent_cli.commands.show.get_platform_instance")
@@ -422,6 +439,24 @@ def test_show_reports_platform_error(mock_auth_cls, mock_client_cls, mock_get_jo
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "RATE_LIMITED"
 	assert parsed["error"]["message"] == "too fast"
+
+
+@patch("boss_agent_cli.commands.show.CacheStore")
+@patch("boss_agent_cli.commands.show.get_job_by_index")
+@patch("boss_agent_cli.commands.show.get_platform_instance")
+@patch("boss_agent_cli.commands.show.AuthManager")
+def test_show_reports_not_supported_when_job_card_missing(mock_auth_cls, mock_client_cls, mock_get_job_by_index, mock_cache_cls):
+	mock_get_job_by_index.return_value = {"security_id": "sec_001"}
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.is_greeted.return_value = False
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.job_card.side_effect = NotImplementedError("job_card is not supported")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["show", "1"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "NOT_SUPPORTED"
+	assert parsed["error"]["message"] == "job_card is not supported"
 
 
 # ── me ───────────────────────────────────────────────────────────────

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -537,6 +537,45 @@ def test_me_reports_user_info_error(mock_auth_cls, mock_client_cls):
 	assert parsed["error"]["message"] == "stoken expired"
 
 
+@patch("boss_agent_cli.commands.me.get_platform_instance")
+@patch("boss_agent_cli.commands.me.AuthManager")
+def test_me_resume_reports_not_supported(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.resume_baseinfo.side_effect = NotImplementedError("resume_baseinfo is not supported")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["me", "--section", "resume"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "NOT_SUPPORTED"
+	assert parsed["error"]["message"] == "resume_baseinfo is not supported"
+
+
+@patch("boss_agent_cli.commands.me.get_platform_instance")
+@patch("boss_agent_cli.commands.me.AuthManager")
+def test_me_expect_reports_not_supported(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.resume_expect.side_effect = NotImplementedError("resume_expect is not supported")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["me", "--section", "expect"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "NOT_SUPPORTED"
+	assert parsed["error"]["message"] == "resume_expect is not supported"
+
+
+@patch("boss_agent_cli.commands.me.get_platform_instance")
+@patch("boss_agent_cli.commands.me.AuthManager")
+def test_me_deliver_reports_not_supported(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.deliver_list.side_effect = NotImplementedError("deliver_list is not supported")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["me", "--section", "deliver"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "NOT_SUPPORTED"
+	assert parsed["error"]["message"] == "deliver_list is not supported"
+
+
 # ── history ──────────────────────────────────────────────────────────
 
 

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -123,6 +123,8 @@ def test_chatmsg_reports_friend_list_error(mock_auth_cls, mock_client_cls):
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
 	assert parsed["error"]["message"] == "stoken expired"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "boss login"
 
 
 @patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
@@ -139,6 +141,39 @@ def test_chatmsg_reports_chat_history_error(mock_auth_cls, mock_client_cls):
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "RATE_LIMITED"
 	assert parsed["error"]["message"] == "too fast"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "等待后重试"
+
+
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
+@patch("boss_agent_cli.commands.chatmsg.AuthManager")
+def test_chatmsg_reports_not_supported_when_friend_list_missing(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.side_effect = NotImplementedError("friend_list is not supported")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chatmsg", "sec_001"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "NOT_SUPPORTED"
+	assert parsed["error"]["message"] == "friend_list is not supported"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "切换平台或调整命令参数后重试"
+
+
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
+@patch("boss_agent_cli.commands.chatmsg.AuthManager")
+def test_chatmsg_reports_not_supported_when_chat_history_missing(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = _friend_list_response([_make_friend()])
+	mock_client.chat_history.side_effect = NotImplementedError("chat_history is not supported")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chatmsg", "sec_001"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "NOT_SUPPORTED"
+	assert parsed["error"]["message"] == "chat_history is not supported"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "切换平台或调整命令参数后重试"
 
 
 # ── mark ─────────────────────────────────────────────────────────────
@@ -173,6 +208,19 @@ def test_mark_remove_label(mock_auth_cls, mock_client_cls):
 
 @patch("boss_agent_cli.commands.mark.get_platform_instance")
 @patch("boss_agent_cli.commands.mark.AuthManager")
+def test_mark_zhilian_hints_use_platform_specific_commands(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = {"code": 200, "data": {"result": [_make_friend()]}}
+	mock_client.friend_label.return_value = {"code": 200, "data": {}}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--platform", "zhilian", "mark", "sec_001", "--label", "沟通中"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["hints"]["next_actions"][0] == "boss --platform zhilian chat — 返回沟通列表"
+
+
+@patch("boss_agent_cli.commands.mark.get_platform_instance")
+@patch("boss_agent_cli.commands.mark.AuthManager")
 def test_mark_reports_error_when_platform_rejects(mock_auth_cls, mock_client_cls):
 	mock_client = _ctx_mock(mock_client_cls)
 	mock_client.friend_list.return_value = _friend_list_response([_make_friend()])
@@ -186,6 +234,8 @@ def test_mark_reports_error_when_platform_rejects(mock_auth_cls, mock_client_cls
 	assert parsed["ok"] is False
 	assert parsed["error"]["code"] == "ACCOUNT_RISK"
 	assert parsed["error"]["message"] == "account risk"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "启动 CDP Chrome 重试，或联系客服"
 
 
 @patch("boss_agent_cli.commands.mark.get_platform_instance")
@@ -202,6 +252,8 @@ def test_mark_reports_friend_list_error(mock_auth_cls, mock_client_cls):
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
 	assert parsed["error"]["message"] == "stoken expired"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "boss login"
 
 
 @patch("boss_agent_cli.commands.mark.get_platform_instance")
@@ -214,6 +266,37 @@ def test_mark_not_found(mock_auth_cls, mock_client_cls):
 	assert result.exit_code == 1
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "JOB_NOT_FOUND"
+
+
+@patch("boss_agent_cli.commands.mark.get_platform_instance")
+@patch("boss_agent_cli.commands.mark.AuthManager")
+def test_mark_reports_not_supported_when_friend_list_missing(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.side_effect = NotImplementedError("friend_list is not supported")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["mark", "sec_001", "--label", "沟通中"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "NOT_SUPPORTED"
+	assert parsed["error"]["message"] == "friend_list is not supported"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "切换平台或调整命令参数后重试"
+
+
+@patch("boss_agent_cli.commands.mark.get_platform_instance")
+@patch("boss_agent_cli.commands.mark.AuthManager")
+def test_mark_reports_not_supported_when_friend_label_missing(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = _friend_list_response([_make_friend()])
+	mock_client.friend_label.side_effect = NotImplementedError("friend_label is not supported")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["mark", "sec_001", "--label", "沟通中"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "NOT_SUPPORTED"
+	assert parsed["error"]["message"] == "friend_label is not supported"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "切换平台或调整命令参数后重试"
 
 
 # ── exchange ─────────────────────────────────────────────────────────
@@ -248,6 +331,20 @@ def test_exchange_wechat(mock_auth_cls, mock_client_cls):
 
 @patch("boss_agent_cli.commands.exchange.get_platform_instance")
 @patch("boss_agent_cli.commands.exchange.AuthManager")
+def test_exchange_zhilian_hints_use_platform_specific_commands(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = {"code": 200, "data": {"result": [_make_friend()]}}
+	mock_client.exchange_contact.return_value = {"code": 200, "data": {}}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--platform", "zhilian", "exchange", "sec_001", "--type", "wechat"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["hints"]["next_actions"][0] == "boss --platform zhilian chat — 返回沟通列表"
+	assert parsed["hints"]["next_actions"][1] == "boss --platform zhilian chatmsg sec_001 — 查看聊天记录"
+
+
+@patch("boss_agent_cli.commands.exchange.get_platform_instance")
+@patch("boss_agent_cli.commands.exchange.AuthManager")
 def test_exchange_reports_error_when_platform_rejects(mock_auth_cls, mock_client_cls):
 	mock_client = _ctx_mock(mock_client_cls)
 	mock_client.friend_list.return_value = _friend_list_response([_make_friend()])
@@ -261,6 +358,8 @@ def test_exchange_reports_error_when_platform_rejects(mock_auth_cls, mock_client
 	assert parsed["ok"] is False
 	assert parsed["error"]["code"] == "RATE_LIMITED"
 	assert parsed["error"]["message"] == "too fast"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "等待后重试"
 
 
 @patch("boss_agent_cli.commands.exchange.get_platform_instance")
@@ -277,6 +376,39 @@ def test_exchange_reports_friend_list_error(mock_auth_cls, mock_client_cls):
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "ACCOUNT_RISK"
 	assert parsed["error"]["message"] == "account risk"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "启动 CDP Chrome 重试，或联系客服"
+
+
+@patch("boss_agent_cli.commands.exchange.get_platform_instance")
+@patch("boss_agent_cli.commands.exchange.AuthManager")
+def test_exchange_reports_not_supported_when_friend_list_missing(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.side_effect = NotImplementedError("friend_list is not supported")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["exchange", "sec_001"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "NOT_SUPPORTED"
+	assert parsed["error"]["message"] == "friend_list is not supported"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "切换平台或调整命令参数后重试"
+
+
+@patch("boss_agent_cli.commands.exchange.get_platform_instance")
+@patch("boss_agent_cli.commands.exchange.AuthManager")
+def test_exchange_reports_not_supported_when_exchange_contact_missing(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = _friend_list_response([_make_friend()])
+	mock_client.exchange_contact.side_effect = NotImplementedError("exchange_contact is not supported")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["exchange", "sec_001"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "NOT_SUPPORTED"
+	assert parsed["error"]["message"] == "exchange_contact is not supported"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "切换平台或调整命令参数后重试"
 
 
 # ── detail ───────────────────────────────────────────────────────────
@@ -388,6 +520,8 @@ def test_detail_reports_not_supported_when_browser_fallback_missing(mock_auth_cl
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "NOT_SUPPORTED"
 	assert parsed["error"]["message"] == "job_card is not supported"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "切换平台或调整命令参数后重试"
 
 
 @patch("boss_agent_cli.commands.detail.CacheStore")
@@ -476,6 +610,8 @@ def test_show_reports_not_supported_when_job_card_missing(mock_auth_cls, mock_cl
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "NOT_SUPPORTED"
 	assert parsed["error"]["message"] == "job_card is not supported"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "切换平台或调整命令参数后重试"
 
 
 # ── me ───────────────────────────────────────────────────────────────
@@ -687,6 +823,8 @@ def test_history_reports_platform_error(mock_auth_cls, mock_client_cls):
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "RATE_LIMITED"
 	assert parsed["error"]["message"] == "too fast"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "等待后重试"
 
 
 @patch("boss_agent_cli.commands.history.get_platform_instance")
@@ -721,6 +859,7 @@ def test_interviews_success(mock_auth_cls, mock_client_cls):
 	assert result.exit_code == 0
 	parsed = json.loads(result.output)
 	assert parsed["ok"] is True
+	assert parsed["hints"]["next_actions"][0] == "boss search <query>"
 
 
 @patch("boss_agent_cli.commands.interviews.get_platform_instance")
@@ -738,6 +877,7 @@ def test_interviews_supports_zhilian_style_data(mock_auth_cls, mock_client_cls):
 	assert result.exit_code == 0
 	parsed = json.loads(result.output)
 	assert parsed["data"][0]["jobName"] == "测试岗位"
+	assert parsed["hints"]["next_actions"][0] == "boss search <query>"
 
 
 @patch("boss_agent_cli.commands.interviews.get_platform_instance")
@@ -753,6 +893,8 @@ def test_interviews_reports_platform_error(mock_auth_cls, mock_client_cls):
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "ACCOUNT_RISK"
 	assert parsed["error"]["message"] == "account risk"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "启动 CDP Chrome 重试，或联系客服"
 
 
 @patch("boss_agent_cli.commands.interviews.get_platform_instance")

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -561,6 +561,8 @@ def test_me_expect_reports_not_supported(mock_auth_cls, mock_client_cls):
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "NOT_SUPPORTED"
 	assert parsed["error"]["message"] == "resume_expect is not supported"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "切换平台或调整命令参数后重试"
 
 
 @patch("boss_agent_cli.commands.me.get_platform_instance")
@@ -574,6 +576,27 @@ def test_me_deliver_reports_not_supported(mock_auth_cls, mock_client_cls):
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "NOT_SUPPORTED"
 	assert parsed["error"]["message"] == "deliver_list is not supported"
+
+
+@patch("boss_agent_cli.commands.me.get_platform_instance")
+@patch("boss_agent_cli.commands.me.AuthManager")
+def test_me_default_sequence_stops_on_expect_not_supported(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.user_info.return_value = {"code": 0, "zpData": {"name": "测试用户"}}
+	mock_client.resume_baseinfo.return_value = {"code": 0, "zpData": {"degree": "本科"}}
+	mock_client.resume_expect.side_effect = NotImplementedError("resume_expect is not supported")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["me"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "NOT_SUPPORTED"
+	assert parsed["error"]["message"] == "resume_expect is not supported"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "切换平台或调整命令参数后重试"
+	mock_client.user_info.assert_called_once_with()
+	mock_client.resume_baseinfo.assert_called_once_with()
+	mock_client.resume_expect.assert_called_once_with()
+	mock_client.deliver_list.assert_not_called()
 
 
 # ── history ──────────────────────────────────────────────────────────

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -390,6 +390,25 @@ def test_detail_reports_not_supported_when_browser_fallback_missing(mock_auth_cl
 	assert parsed["error"]["message"] == "job_card is not supported"
 
 
+@patch("boss_agent_cli.commands.detail.CacheStore")
+@patch("boss_agent_cli.commands.detail.get_platform_instance")
+@patch("boss_agent_cli.commands.detail.AuthManager")
+def test_detail_preserves_httpx_platform_error_when_browser_fallback_not_supported(mock_auth_cls, mock_client_cls, mock_cache_cls):
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.is_greeted.return_value = False
+	mock_cache.get_job_id.return_value = "enc_cached_001"
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.job_detail.return_value = {"code": 9, "message": "too fast"}
+	mock_client.parse_error.return_value = ("RATE_LIMITED", "too fast")
+	mock_client.job_card.side_effect = NotImplementedError("job_card is not supported")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["detail", "sec_001"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "RATE_LIMITED"
+	assert parsed["error"]["message"] == "too fast"
+
+
 @patch("boss_agent_cli.commands.show.CacheStore")
 @patch("boss_agent_cli.commands.show.get_job_by_index")
 @patch("boss_agent_cli.commands.show.get_platform_instance")

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -689,6 +689,21 @@ def test_history_reports_platform_error(mock_auth_cls, mock_client_cls):
 	assert parsed["error"]["message"] == "too fast"
 
 
+@patch("boss_agent_cli.commands.history.get_platform_instance")
+@patch("boss_agent_cli.commands.history.AuthManager")
+def test_history_reports_not_supported_when_job_history_missing(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.job_history.side_effect = NotImplementedError("job_history is not supported")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["history"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "NOT_SUPPORTED"
+	assert parsed["error"]["message"] == "job_history is not supported"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "切换平台或调整命令参数后重试"
+
+
 # ── interviews ───────────────────────────────────────────────────────
 
 
@@ -738,6 +753,22 @@ def test_interviews_reports_platform_error(mock_auth_cls, mock_client_cls):
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "ACCOUNT_RISK"
 	assert parsed["error"]["message"] == "account risk"
+
+
+@patch("boss_agent_cli.commands.interviews.get_platform_instance")
+@patch("boss_agent_cli.commands.interviews.AuthManager")
+def test_interviews_reports_not_supported_when_interview_data_missing(mock_auth_cls, mock_client_cls):
+	mock_auth_cls.return_value.check_status.return_value = {"cookies": {"zp_token": "x"}}
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.interview_data.side_effect = NotImplementedError("interview_data is not supported")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["interviews"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "NOT_SUPPORTED"
+	assert parsed["error"]["message"] == "interview_data is not supported"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "切换平台或调整命令参数后重试"
 
 
 @patch("boss_agent_cli.commands.chat_summary.get_platform_instance")


### PR DESCRIPTION
## 摘要
- 为 candidate 侧剩余可选 platform method 缺失路径统一返回 `NOT_SUPPORTED`，不再被装饰器误报成 `NETWORK_ERROR`
- 让相关平台错误分支按 schema 透出 `recoverable` / `recovery_action`，并修正 `interviews` 的下一步提示
- 补齐 detail/show/chat/chatmsg/mark/exchange/history/interviews 的契约测试与平台感知提示测试

## 验证
- `env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q tests/test_commands.py -k 'chat'`
- `env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q tests/test_new_commands.py -k 'chatmsg or mark or exchange or history or interviews or detail or show'`
- `env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q`
