### PR TITLE
fix: 收口联系人分页与错误契约

### DIFF
--- a/src/boss_agent_cli/commands/chat_summary.py
+++ b/src/boss_agent_cli/commands/chat_summary.py
@@ -3,7 +3,7 @@ import click
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.chat_summary import summarize_messages
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.commands.contact_lookup import find_friend_by_security_id
+from boss_agent_cli.commands.contact_lookup import FriendLookupLimitExceeded, find_friend_by_security_id
 from boss_agent_cli.display import boss_command_for_ctx, error_contract_for_code, handle_auth_errors, handle_error_output, handle_output, render_message_panel
 
 NOT_SUPPORTED_RECOVERY_ACTION = "切换平台或调整命令参数后重试"
@@ -31,6 +31,16 @@ def chat_summary_cmd(ctx: click.Context, security_id: str, page: int, count: int
 				message=str(exc) or "当前平台不支持沟通列表能力",
 				recoverable=True,
 				recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
+			)
+			return
+		except FriendLookupLimitExceeded as exc:
+			handle_error_output(
+				ctx,
+				"chat-summary",
+				code="NETWORK_ERROR",
+				message=str(exc),
+				recoverable=True,
+				recovery_action="重试",
 			)
 			return
 		if friends_error is not None:

--- a/src/boss_agent_cli/commands/chat_summary.py
+++ b/src/boss_agent_cli/commands/chat_summary.py
@@ -3,7 +3,10 @@ import click
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.chat_summary import summarize_messages
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import boss_command_for_ctx, handle_auth_errors, handle_error_output, handle_output, render_message_panel
+from boss_agent_cli.commands.contact_lookup import find_friend_by_security_id
+from boss_agent_cli.display import boss_command_for_ctx, error_contract_for_code, handle_auth_errors, handle_error_output, handle_output, render_message_panel
+
+NOT_SUPPORTED_RECOVERY_ACTION = "切换平台或调整命令参数后重试"
 
 
 @click.command("chat-summary")
@@ -18,29 +21,31 @@ def chat_summary_cmd(ctx: click.Context, security_id: str, page: int, count: int
 	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 
 	with get_platform_instance(ctx, auth) as platform:
-		friends_resp = platform.friend_list(page=1)
-		if not platform.is_success(friends_resp):
-			code, message = platform.parse_error(friends_resp)
+		try:
+			friend_item, friends_error = find_friend_by_security_id(platform, security_id)
+		except NotImplementedError as exc:
+			handle_error_output(
+				ctx,
+				"chat-summary",
+				code="NOT_SUPPORTED",
+				message=str(exc) or "当前平台不支持沟通列表能力",
+				recoverable=True,
+				recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
+			)
+			return
+		if friends_error is not None:
+			code, message = platform.parse_error(friends_error)
+			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx,
 				"chat-summary",
 				code=code,
 				message=message or "沟通列表获取失败",
-				recoverable=False,
+				recoverable=recoverable,
+				recovery_action=recovery_action,
 			)
 			return
-		friends_data = platform.unwrap_data(friends_resp) or {}
-		items = friends_data.get("result") or friends_data.get("friendList") or []
-
-		gid = None
-		friend_name = "-"
-		for item in items:
-			if item.get("securityId") == security_id:
-				gid = str(item.get("uid", ""))
-				friend_name = item.get("name") or "-"
-				break
-
-		if not gid:
+		if friend_item is None:
 			handle_error_output(
 				ctx,
 				"chat-summary",
@@ -48,16 +53,31 @@ def chat_summary_cmd(ctx: click.Context, security_id: str, page: int, count: int
 				message=f"未在沟通列表中找到 security_id={security_id}",
 			)
 			return
+		gid = str(friend_item.get("uid", ""))
+		friend_name = friend_item.get("name") or "-"
 
-		resp = platform.chat_history(gid, security_id, page=page, count=count)
+		try:
+			resp = platform.chat_history(gid, security_id, page=page, count=count)
+		except NotImplementedError as exc:
+			handle_error_output(
+				ctx,
+				"chat-summary",
+				code="NOT_SUPPORTED",
+				message=str(exc) or "当前平台不支持聊天记录能力",
+				recoverable=True,
+				recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
+			)
+			return
 		if not platform.is_success(resp):
 			code, message = platform.parse_error(resp)
+			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx,
 				"chat-summary",
 				code=code,
 				message=message or "聊天记录获取失败",
-				recoverable=False,
+				recoverable=recoverable,
+				recovery_action=recovery_action,
 			)
 			return
 		msg_data = platform.unwrap_data(resp) or {}

--- a/src/boss_agent_cli/commands/chatmsg.py
+++ b/src/boss_agent_cli/commands/chatmsg.py
@@ -4,6 +4,7 @@ from typing import Any
 import click
 
 from boss_agent_cli.auth.manager import AuthManager
+from boss_agent_cli.commands.contact_lookup import find_friend_by_security_id
 from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import boss_command_for_ctx, error_contract_for_code, handle_auth_errors, handle_error_output, handle_output, render_simple_list
 
@@ -29,7 +30,7 @@ def chatmsg_cmd(ctx: click.Context, security_id: str, page: int, count: int) -> 
 
 	with get_platform_instance(ctx, auth) as platform:
 		try:
-			friends_resp = platform.friend_list(page=1)
+			friend_item, friends_error = find_friend_by_security_id(platform, security_id)
 		except NotImplementedError as exc:
 			handle_error_output(
 				ctx, "chatmsg",
@@ -39,8 +40,8 @@ def chatmsg_cmd(ctx: click.Context, security_id: str, page: int, count: int) -> 
 				recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
 			)
 			return
-		if not platform.is_success(friends_resp):
-			code, message = platform.parse_error(friends_resp)
+		if friends_error is not None:
+			code, message = platform.parse_error(friends_error)
 			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "chatmsg",
@@ -50,24 +51,15 @@ def chatmsg_cmd(ctx: click.Context, security_id: str, page: int, count: int) -> 
 				recovery_action=recovery_action,
 			)
 			return
-		platform_data = platform.unwrap_data(friends_resp) or {}
-		items = platform_data.get("result") or platform_data.get("friendList") or []
-
-		gid = None
-		friend_name = None
-		for item in items:
-			if item.get("securityId") == security_id:
-				gid = str(item.get("uid", ""))
-				friend_name = item.get("name") or "-"
-				break
-
-		if not gid:
+		if friend_item is None:
 			handle_error_output(
 				ctx, "chatmsg",
 				code="JOB_NOT_FOUND",
 				message=f"未在沟通列表中找到 security_id={security_id}，请确认该联系人存在",
 			)
 			return
+		gid = str(friend_item.get("uid", ""))
+		friend_name = friend_item.get("name") or "-"
 
 		try:
 			resp = platform.chat_history(gid, security_id, page=page, count=count)

--- a/src/boss_agent_cli/commands/chatmsg.py
+++ b/src/boss_agent_cli/commands/chatmsg.py
@@ -4,7 +4,7 @@ from typing import Any
 import click
 
 from boss_agent_cli.auth.manager import AuthManager
-from boss_agent_cli.commands.contact_lookup import find_friend_by_security_id
+from boss_agent_cli.commands.contact_lookup import FriendLookupLimitExceeded, find_friend_by_security_id
 from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import boss_command_for_ctx, error_contract_for_code, handle_auth_errors, handle_error_output, handle_output, render_simple_list
 
@@ -38,6 +38,15 @@ def chatmsg_cmd(ctx: click.Context, security_id: str, page: int, count: int) -> 
 				message=str(exc) or "当前平台不支持沟通列表能力",
 				recoverable=True,
 				recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
+			)
+			return
+		except FriendLookupLimitExceeded as exc:
+			handle_error_output(
+				ctx, "chatmsg",
+				code="NETWORK_ERROR",
+				message=str(exc),
+				recoverable=True,
+				recovery_action="重试",
 			)
 			return
 		if friends_error is not None:

--- a/src/boss_agent_cli/commands/contact_lookup.py
+++ b/src/boss_agent_cli/commands/contact_lookup.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+
+def find_friend_by_security_id(
+	platform: Any,
+	security_id: str,
+	*,
+	start_page: int = 1,
+	max_pages: int = 50,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+	"""分页遍历沟通列表，按 security_id 查找联系人。
+
+	返回 (friend_item, error_response)：
+	- 找到联系人：返回 (item, None)
+	- 平台返回失败响应：返回 (None, raw_response)
+	- 遍历完成仍未找到：返回 (None, None)
+	"""
+	page = start_page
+	for _ in range(max_pages):
+		resp = platform.friend_list(page=page)
+		if not platform.is_success(resp):
+			return None, resp
+
+		platform_data = platform.unwrap_data(resp) or {}
+		items = platform_data.get("result") or platform_data.get("friendList") or []
+		for item in items:
+			if item.get("securityId") == security_id:
+				return item, None
+
+		has_more = platform_data.get("hasMore")
+		if not items or has_more is False:
+			break
+		page += 1
+
+	return None, None

--- a/src/boss_agent_cli/commands/contact_lookup.py
+++ b/src/boss_agent_cli/commands/contact_lookup.py
@@ -1,6 +1,10 @@
 from typing import Any
 
 
+class FriendLookupLimitExceeded(RuntimeError):
+	"""Raised when paginated friend lookup cannot prove completion safely."""
+
+
 def find_friend_by_security_id(
 	platform: Any,
 	security_id: str,
@@ -16,6 +20,8 @@ def find_friend_by_security_id(
 	- 遍历完成仍未找到：返回 (None, None)
 	"""
 	page = start_page
+	terminated = False
+	seen_signatures: set[tuple[str, ...]] = set()
 	for _ in range(max_pages):
 		resp = platform.friend_list(page=page)
 		if not platform.is_success(resp):
@@ -27,9 +33,18 @@ def find_friend_by_security_id(
 			if item.get("securityId") == security_id:
 				return item, None
 
+		signature = tuple(str(item.get("securityId", "")) for item in items if isinstance(item, dict))
+		if signature in seen_signatures:
+			terminated = True
+			break
+		seen_signatures.add(signature)
+
 		has_more = platform_data.get("hasMore")
 		if not items or has_more is False:
+			terminated = True
 			break
 		page += 1
 
+	if not terminated:
+		raise FriendLookupLimitExceeded("沟通列表分页遍历超过上限，未能确认联系人是否存在，请重试")
 	return None, None

--- a/src/boss_agent_cli/commands/detail.py
+++ b/src/boss_agent_cli/commands/detail.py
@@ -47,6 +47,8 @@ def detail_cmd(ctx: click.Context, security_id: str, lid: str, job_id: str) -> N
 
 	if result is None:
 		if last_error:
+			recoverable: bool
+			recovery_action: str | None
 			if last_error[0] == "NOT_SUPPORTED":
 				recoverable = True
 				recovery_action = NOT_SUPPORTED_RECOVERY_ACTION

--- a/src/boss_agent_cli/commands/detail.py
+++ b/src/boss_agent_cli/commands/detail.py
@@ -6,7 +6,7 @@ import click
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.cache.store import CacheStore
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import boss_command_for_ctx, handle_auth_errors, handle_error_output, handle_output, render_job_detail
+from boss_agent_cli.display import boss_command_for_ctx, error_contract_for_code, handle_auth_errors, handle_error_output, handle_output, render_job_detail
 from boss_agent_cli.platforms import Platform
 
 NOT_SUPPORTED_RECOVERY_ACTION = "切换平台或调整命令参数后重试"
@@ -47,13 +47,17 @@ def detail_cmd(ctx: click.Context, security_id: str, lid: str, job_id: str) -> N
 
 	if result is None:
 		if last_error:
-			recoverable = last_error[0] == "NOT_SUPPORTED"
+			if last_error[0] == "NOT_SUPPORTED":
+				recoverable = True
+				recovery_action = NOT_SUPPORTED_RECOVERY_ACTION
+			else:
+				recoverable, recovery_action = error_contract_for_code(last_error[0])
 			handle_error_output(
 				ctx, "detail",
 				code=last_error[0],
 				message=last_error[1],
 				recoverable=recoverable,
-				recovery_action=NOT_SUPPORTED_RECOVERY_ACTION if recoverable else None,
+				recovery_action=recovery_action,
 			)
 			return
 		handle_error_output(

--- a/src/boss_agent_cli/commands/digest.py
+++ b/src/boss_agent_cli/commands/digest.py
@@ -7,7 +7,7 @@ import click
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.digest import build_digest, render_digest_markdown
-from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_message_panel
+from boss_agent_cli.display import error_contract_for_code, handle_auth_errors, handle_error_output, handle_output, render_message_panel
 from boss_agent_cli.pipeline_state import build_pipeline_items, select_follow_up_candidates
 
 
@@ -37,11 +37,13 @@ def digest_cmd(ctx: click.Context, days_stale: int, now_ts_ms: int | None, outpu
 		friend_resp = platform.friend_list(page=1)
 		if not platform.is_success(friend_resp):
 			code, message = platform.parse_error(friend_resp)
+			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "digest",
 				code=code,
 				message=message or "沟通列表获取失败",
-				recoverable=False,
+				recoverable=recoverable,
+				recovery_action=recovery_action,
 			)
 			return
 		friend_data = platform.unwrap_data(friend_resp) or {}
@@ -49,11 +51,13 @@ def digest_cmd(ctx: click.Context, days_stale: int, now_ts_ms: int | None, outpu
 		interview_resp = platform.interview_data()
 		if not platform.is_success(interview_resp):
 			code, message = platform.parse_error(interview_resp)
+			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "digest",
 				code=code,
 				message=message or "面试列表获取失败",
-				recoverable=False,
+				recoverable=recoverable,
+				recovery_action=recovery_action,
 			)
 			return
 		interview_data = platform.unwrap_data(interview_resp) or {}

--- a/src/boss_agent_cli/commands/exchange.py
+++ b/src/boss_agent_cli/commands/exchange.py
@@ -2,6 +2,7 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._platform import get_platform_instance
+from boss_agent_cli.commands.contact_lookup import find_friend_by_security_id
 from boss_agent_cli.display import boss_command_for_ctx, error_contract_for_code, handle_auth_errors, handle_error_output, handle_output, render_message_panel
 
 NOT_SUPPORTED_RECOVERY_ACTION = "切换平台或调整命令参数后重试"
@@ -23,7 +24,7 @@ def exchange_cmd(ctx: click.Context, security_id: str, exchange_type: str) -> No
 
 	with get_platform_instance(ctx, auth) as platform:
 		try:
-			friends_resp = platform.friend_list(page=1)
+			friend_item, friends_error = find_friend_by_security_id(platform, security_id)
 		except NotImplementedError as exc:
 			handle_error_output(
 				ctx, "exchange",
@@ -33,8 +34,8 @@ def exchange_cmd(ctx: click.Context, security_id: str, exchange_type: str) -> No
 				recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
 			)
 			return
-		if not platform.is_success(friends_resp):
-			code, message = platform.parse_error(friends_resp)
+		if friends_error is not None:
+			code, message = platform.parse_error(friends_error)
 			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "exchange",
@@ -44,23 +45,14 @@ def exchange_cmd(ctx: click.Context, security_id: str, exchange_type: str) -> No
 				recovery_action=recovery_action,
 			)
 			return
-		friend_data = platform.unwrap_data(friends_resp) or {}
-		items = friend_data.get("result") or friend_data.get("friendList") or []
-
-		uid = None
-		friend_name: str = "-"
-		for item in items:
-			if item.get("securityId") == security_id:
-				uid = str(item.get("uid", ""))
-				friend_name = item.get("name") or "-"
-				break
-
-		if not uid:
+		if friend_item is None:
 			handle_error_output(
 				ctx, "exchange", code="JOB_NOT_FOUND",
 				message=f"未在沟通列表中找到 security_id={security_id}",
 			)
 			return
+		uid = str(friend_item.get("uid", ""))
+		friend_name: str = friend_item.get("name") or "-"
 
 		try:
 			resp = platform.exchange_contact(security_id, uid, friend_name, exchange_type=type_id)

--- a/src/boss_agent_cli/commands/exchange.py
+++ b/src/boss_agent_cli/commands/exchange.py
@@ -2,7 +2,7 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.commands.contact_lookup import find_friend_by_security_id
+from boss_agent_cli.commands.contact_lookup import FriendLookupLimitExceeded, find_friend_by_security_id
 from boss_agent_cli.display import boss_command_for_ctx, error_contract_for_code, handle_auth_errors, handle_error_output, handle_output, render_message_panel
 
 NOT_SUPPORTED_RECOVERY_ACTION = "切换平台或调整命令参数后重试"
@@ -32,6 +32,15 @@ def exchange_cmd(ctx: click.Context, security_id: str, exchange_type: str) -> No
 				message=str(exc) or "当前平台不支持沟通列表能力",
 				recoverable=True,
 				recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
+			)
+			return
+		except FriendLookupLimitExceeded as exc:
+			handle_error_output(
+				ctx, "exchange",
+				code="NETWORK_ERROR",
+				message=str(exc),
+				recoverable=True,
+				recovery_action="重试",
 			)
 			return
 		if friends_error is not None:

--- a/src/boss_agent_cli/commands/mark.py
+++ b/src/boss_agent_cli/commands/mark.py
@@ -2,6 +2,7 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._platform import get_platform_instance
+from boss_agent_cli.commands.contact_lookup import find_friend_by_security_id
 from boss_agent_cli.display import boss_command_for_ctx, error_contract_for_code, handle_auth_errors, handle_error_output, handle_output, render_message_panel
 
 NOT_SUPPORTED_RECOVERY_ACTION = "切换平台或调整命令参数后重试"
@@ -46,7 +47,7 @@ def mark_cmd(ctx: click.Context, security_id: str, label: str, remove: bool) -> 
 
 	with get_platform_instance(ctx, auth) as platform:
 		try:
-			friends_resp = platform.friend_list(page=1)
+			friend_item, friends_error = find_friend_by_security_id(platform, security_id)
 		except NotImplementedError as exc:
 			handle_error_output(
 				ctx, "mark",
@@ -56,8 +57,8 @@ def mark_cmd(ctx: click.Context, security_id: str, label: str, remove: bool) -> 
 				recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
 			)
 			return
-		if not platform.is_success(friends_resp):
-			code, message = platform.parse_error(friends_resp)
+		if friends_error is not None:
+			code, message = platform.parse_error(friends_error)
 			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "mark",
@@ -67,25 +68,15 @@ def mark_cmd(ctx: click.Context, security_id: str, label: str, remove: bool) -> 
 				recovery_action=recovery_action,
 			)
 			return
-		friend_data = platform.unwrap_data(friends_resp) or {}
-		items = friend_data.get("result") or friend_data.get("friendList") or []
-
-		friend_id = None
-		friend_source = 0
-		friend_name = None
-		for item in items:
-			if item.get("securityId") == security_id:
-				friend_id = str(item.get("uid", ""))
-				friend_source = item.get("friendSource", 0)
-				friend_name = item.get("name") or "-"
-				break
-
-		if not friend_id:
+		if friend_item is None:
 			handle_error_output(
 				ctx, "mark", code="JOB_NOT_FOUND",
 				message=f"未在沟通列表中找到 security_id={security_id}",
 			)
 			return
+		friend_id = str(friend_item.get("uid", ""))
+		friend_source = friend_item.get("friendSource", 0)
+		friend_name = friend_item.get("name") or "-"
 
 		try:
 			resp = platform.friend_label(friend_id, label_id, friend_source, remove=remove)

--- a/src/boss_agent_cli/commands/mark.py
+++ b/src/boss_agent_cli/commands/mark.py
@@ -2,7 +2,7 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.commands.contact_lookup import find_friend_by_security_id
+from boss_agent_cli.commands.contact_lookup import FriendLookupLimitExceeded, find_friend_by_security_id
 from boss_agent_cli.display import boss_command_for_ctx, error_contract_for_code, handle_auth_errors, handle_error_output, handle_output, render_message_panel
 
 NOT_SUPPORTED_RECOVERY_ACTION = "切换平台或调整命令参数后重试"
@@ -55,6 +55,15 @@ def mark_cmd(ctx: click.Context, security_id: str, label: str, remove: bool) -> 
 				message=str(exc) or "当前平台不支持沟通列表能力",
 				recoverable=True,
 				recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
+			)
+			return
+		except FriendLookupLimitExceeded as exc:
+			handle_error_output(
+				ctx, "mark",
+				code="NETWORK_ERROR",
+				message=str(exc),
+				recoverable=True,
+				recovery_action="重试",
 			)
 			return
 		if friends_error is not None:

--- a/src/boss_agent_cli/commands/me.py
+++ b/src/boss_agent_cli/commands/me.py
@@ -3,7 +3,7 @@ import click
 from boss_agent_cli.api.client import AuthError
 from boss_agent_cli.auth.manager import AuthManager, AuthRequired, TokenRefreshFailed
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import boss_command_for_ctx, handle_error_output, handle_output, login_action_for_ctx, render_sectioned_record
+from boss_agent_cli.display import boss_command_for_ctx, error_contract_for_code, handle_error_output, handle_output, login_action_for_ctx, render_sectioned_record
 
 NOT_SUPPORTED_RECOVERY_ACTION = "切换平台或调整命令参数后重试"
 
@@ -31,11 +31,13 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 				resp = platform.user_info()
 				if not platform.is_success(resp):
 					code, message = platform.parse_error(resp)
+					recoverable, recovery_action = error_contract_for_code(code)
 					handle_error_output(
 						ctx, "me",
 						code=code,
 						message=message or "用户基本信息获取失败",
-						recoverable=False,
+						recoverable=recoverable,
+						recovery_action=recovery_action,
 					)
 					return
 				zp_data = platform.unwrap_data(resp) or {}
@@ -63,11 +65,13 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 					return
 				if not platform.is_success(resp):
 					code, message = platform.parse_error(resp)
+					recoverable, recovery_action = error_contract_for_code(code)
 					handle_error_output(
 						ctx, "me",
 						code=code,
 						message=message or "简历基本信息获取失败",
-						recoverable=False,
+						recoverable=recoverable,
+						recovery_action=recovery_action,
 					)
 					return
 				zp_data = platform.unwrap_data(resp) or {}
@@ -89,11 +93,13 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 					return
 				if not platform.is_success(resp):
 					code, message = platform.parse_error(resp)
+					recoverable, recovery_action = error_contract_for_code(code)
 					handle_error_output(
 						ctx, "me",
 						code=code,
 						message=message or "求职期望获取失败",
-						recoverable=False,
+						recoverable=recoverable,
+						recovery_action=recovery_action,
 					)
 					return
 				zp_data = platform.unwrap_data(resp) or {}
@@ -115,11 +121,13 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 					return
 				if not platform.is_success(resp):
 					code, message = platform.parse_error(resp)
+					recoverable, recovery_action = error_contract_for_code(code)
 					handle_error_output(
 						ctx, "me",
 						code=code,
 						message=message or "投递记录获取失败",
-						recoverable=False,
+						recoverable=recoverable,
+						recovery_action=recovery_action,
 					)
 					return
 				zp_data = platform.unwrap_data(resp) or {}

--- a/src/boss_agent_cli/commands/pipeline.py
+++ b/src/boss_agent_cli/commands/pipeline.py
@@ -5,7 +5,7 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_simple_list
+from boss_agent_cli.display import error_contract_for_code, handle_auth_errors, handle_error_output, handle_output, render_simple_list
 from boss_agent_cli.pipeline_state import build_pipeline_items, select_follow_up_candidates
 
 
@@ -18,11 +18,13 @@ def _collect_pipeline_items(ctx: click.Context, *, now_ts_ms: int | None, stale_
 		friend_resp = platform.friend_list(page=1)
 		if not platform.is_success(friend_resp):
 			code, message = platform.parse_error(friend_resp)
+			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "pipeline",
 				code=code,
 				message=message or "沟通列表获取失败",
-				recoverable=False,
+				recoverable=recoverable,
+				recovery_action=recovery_action,
 			)
 			return []
 		friend_data = platform.unwrap_data(friend_resp) or {}
@@ -30,11 +32,13 @@ def _collect_pipeline_items(ctx: click.Context, *, now_ts_ms: int | None, stale_
 		interview_resp = platform.interview_data()
 		if not platform.is_success(interview_resp):
 			code, message = platform.parse_error(interview_resp)
+			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "pipeline",
 				code=code,
 				message=message or "面试列表获取失败",
-				recoverable=False,
+				recoverable=recoverable,
+				recovery_action=recovery_action,
 			)
 			return []
 		interview_data = platform.unwrap_data(interview_resp) or {}

--- a/src/boss_agent_cli/commands/recommend.py
+++ b/src/boss_agent_cli/commands/recommend.py
@@ -4,7 +4,7 @@ from boss_agent_cli.api.models import JobItem
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.cache.store import CacheStore
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import handle_error_output, handle_output, render_job_table, handle_auth_errors
+from boss_agent_cli.display import error_contract_for_code, handle_auth_errors, handle_error_output, handle_output, render_job_table
 from boss_agent_cli.index_cache import try_save_index
 from boss_agent_cli.match_score import score_job_dict
 
@@ -40,11 +40,13 @@ def recommend_cmd(ctx: click.Context, page: int, with_score: bool) -> None:
 				else:
 					if not platform.is_success(expect_resp):
 						code, message = platform.parse_error(expect_resp)
+						recoverable, recovery_action = error_contract_for_code(code)
 						handle_error_output(
 							ctx, "recommend",
 							code=code,
 							message=message or "求职期望获取失败",
-							recoverable=False,
+							recoverable=recoverable,
+							recovery_action=recovery_action,
 						)
 						return
 					expect_data = platform.unwrap_data(expect_resp) or {}
@@ -52,11 +54,13 @@ def recommend_cmd(ctx: click.Context, page: int, with_score: bool) -> None:
 			raw = platform.recommend_jobs(page=page)
 			if not platform.is_success(raw):
 				code, message = platform.parse_error(raw)
+				recoverable, recovery_action = error_contract_for_code(code)
 				handle_error_output(
 					ctx, "recommend",
 					code=code,
 					message=message or "推荐职位获取失败",
-					recoverable=False,
+					recoverable=recoverable,
+					recovery_action=recovery_action,
 				)
 				return
 			platform_data = platform.unwrap_data(raw) or {}

--- a/src/boss_agent_cli/commands/show.py
+++ b/src/boss_agent_cli/commands/show.py
@@ -3,7 +3,7 @@ import click
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.cache.store import CacheStore
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import boss_command_for_ctx, handle_auth_errors, handle_error_output, handle_output, render_job_detail
+from boss_agent_cli.display import boss_command_for_ctx, error_contract_for_code, handle_auth_errors, handle_error_output, handle_output, render_job_detail
 from boss_agent_cli.index_cache import get_index_info, get_job_by_index
 
 NOT_SUPPORTED_RECOVERY_ACTION = "切换平台或调整命令参数后重试"
@@ -60,11 +60,13 @@ def show_cmd(ctx: click.Context, index: int) -> None:
 			return
 		if not platform.is_success(raw):
 			code, message = platform.parse_error(raw)
+			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "show",
 				code=code,
 				message=message or "职位详情获取失败",
-				recoverable=False,
+				recoverable=recoverable,
+				recovery_action=recovery_action,
 			)
 			return
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1211,6 +1211,45 @@ def test_chat_summary_supports_data_envelope(mock_auth_cls, mock_client_cls):
 	assert parsed["data"]["security_id"] == "sec_张HR"
 
 
+@patch("boss_agent_cli.commands.chat_summary.get_platform_instance")
+@patch("boss_agent_cli.commands.chat_summary.AuthManager")
+def test_chat_summary_finds_contact_on_second_page(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.side_effect = [
+		{"code": 200, "data": {"result": [_make_friend_item("其他HR", "别家公司", 1, 1700000000000) | {"securityId": "sec_other", "uid": 99999}]}},
+		{"code": 200, "data": {"result": [_make_friend_item("张HR", "智联科技", 1, 1700000000000) | {"uid": 12345}]}},
+	]
+	mock_client.chat_history.return_value = {
+		"code": 200,
+		"data": {
+			"messages": [
+				{"from": {"uid": 12345, "name": "张HR"}, "text": "您好", "type": 1, "time": 1700000000000},
+				{"from": {"uid": 88888, "name": "我"}, "text": "第二页摘要", "type": 1, "time": 1700000001000},
+			],
+		},
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "--platform", "zhilian", "chat-summary", "sec_张HR"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["security_id"] == "sec_张HR"
+	assert mock_client.friend_list.call_args_list[0].kwargs == {"page": 1}
+	assert mock_client.friend_list.call_args_list[1].kwargs == {"page": 2}
+
+
+@patch("boss_agent_cli.commands.chat_summary.get_platform_instance")
+@patch("boss_agent_cli.commands.chat_summary.AuthManager")
+def test_chat_summary_not_found_keeps_job_not_found(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = {"code": 200, "data": {"result": []}}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "--platform", "zhilian", "chat-summary", "sec_missing"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "JOB_NOT_FOUND"
+
+
 @patch("boss_agent_cli.commands.pipeline.get_platform_instance")
 @patch("boss_agent_cli.commands.pipeline.AuthManager")
 def test_pipeline_supports_data_envelope(mock_auth_cls, mock_client_cls):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -401,6 +401,8 @@ def test_recommend_reports_recommend_jobs_error(mock_auth_cls, mock_client_cls, 
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "RATE_LIMITED"
 	assert parsed["error"]["message"] == "too fast"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "等待后重试"
 
 
 @patch("boss_agent_cli.commands.recommend.CacheStore")
@@ -418,6 +420,8 @@ def test_recommend_with_score_reports_expect_error(mock_auth_cls, mock_client_cl
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
 	assert parsed["error"]["message"] == "stoken expired"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "boss login"
 
 
 @patch("boss_agent_cli.commands.recommend.CacheStore")
@@ -1250,6 +1254,21 @@ def test_chat_summary_not_found_keeps_job_not_found(mock_auth_cls, mock_client_c
 	assert parsed["error"]["code"] == "JOB_NOT_FOUND"
 
 
+@patch("boss_agent_cli.commands.chat_summary.get_platform_instance")
+@patch("boss_agent_cli.commands.chat_summary.AuthManager")
+def test_chat_summary_not_found_after_second_page_keeps_job_not_found(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.side_effect = [
+		{"code": 200, "data": {"result": [_make_friend_item("其他HR", "别家公司", 1, 1700000000000) | {"securityId": "sec_other", "uid": 99999}]}},
+		{"code": 200, "data": {"result": [], "hasMore": False}},
+	]
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "--platform", "zhilian", "chat-summary", "sec_missing"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "JOB_NOT_FOUND"
+
+
 @patch("boss_agent_cli.commands.pipeline.get_platform_instance")
 @patch("boss_agent_cli.commands.pipeline.AuthManager")
 def test_pipeline_supports_data_envelope(mock_auth_cls, mock_client_cls):
@@ -1290,6 +1309,39 @@ def test_pipeline_supports_data_envelope(mock_auth_cls, mock_client_cls):
 	assert len(parsed["data"]) >= 1
 
 
+@patch("boss_agent_cli.commands.pipeline.get_platform_instance")
+@patch("boss_agent_cli.commands.pipeline.AuthManager")
+def test_pipeline_reports_friend_list_error_contract(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = {"code": 37, "message": "stoken expired"}
+	mock_client.parse_error.return_value = ("TOKEN_REFRESH_FAILED", "stoken expired")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "pipeline"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
+	assert parsed["error"]["message"] == "stoken expired"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "boss login"
+
+
+@patch("boss_agent_cli.commands.pipeline.get_platform_instance")
+@patch("boss_agent_cli.commands.pipeline.AuthManager")
+def test_pipeline_reports_interview_error_contract(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = {"code": 0, "zpData": {"result": []}}
+	mock_client.interview_data.return_value = {"code": 9, "message": "too fast"}
+	mock_client.parse_error.return_value = ("RATE_LIMITED", "too fast")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "pipeline"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "RATE_LIMITED"
+	assert parsed["error"]["message"] == "too fast"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "等待后重试"
+
+
 @patch("boss_agent_cli.commands.digest.get_platform_instance")
 @patch("boss_agent_cli.commands.digest.AuthManager")
 def test_digest_supports_data_envelope(mock_auth_cls, mock_client_cls):
@@ -1324,6 +1376,39 @@ def test_digest_supports_data_envelope(mock_auth_cls, mock_client_cls):
 	parsed = json.loads(result.output)
 	assert parsed["ok"] is True
 	assert "follow_ups" in parsed["data"]
+
+
+@patch("boss_agent_cli.commands.digest.get_platform_instance")
+@patch("boss_agent_cli.commands.digest.AuthManager")
+def test_digest_reports_friend_list_error_contract(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = {"code": 37, "message": "stoken expired"}
+	mock_client.parse_error.return_value = ("TOKEN_REFRESH_FAILED", "stoken expired")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "digest"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
+	assert parsed["error"]["message"] == "stoken expired"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "boss login"
+
+
+@patch("boss_agent_cli.commands.digest.get_platform_instance")
+@patch("boss_agent_cli.commands.digest.AuthManager")
+def test_digest_reports_interview_error_contract(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.return_value = {"code": 0, "zpData": {"result": []}}
+	mock_client.interview_data.return_value = {"code": 9, "message": "too fast"}
+	mock_client.parse_error.return_value = ("RATE_LIMITED", "too fast")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "digest"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "RATE_LIMITED"
+	assert parsed["error"]["message"] == "too fast"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "等待后重试"
 
 
 @patch("boss_agent_cli.commands.search.run_search_pipeline")

--- a/tests/test_contact_lookup.py
+++ b/tests/test_contact_lookup.py
@@ -1,0 +1,43 @@
+from types import SimpleNamespace
+
+import pytest
+
+from boss_agent_cli.commands.contact_lookup import FriendLookupLimitExceeded, find_friend_by_security_id
+
+
+def test_find_friend_by_security_id_returns_none_after_terminal_second_page():
+	pages = [
+		{"zpData": {"result": [{"securityId": "sec_other"}], "friendList": [{"securityId": "sec_other"}]}},
+		{"zpData": {"result": [], "friendList": [], "hasMore": False}},
+	]
+	index = {"value": 0}
+
+	def friend_list(*, page):
+		response = pages[index["value"]]
+		index["value"] += 1
+		return response
+
+	platform = SimpleNamespace(
+		friend_list=friend_list,
+		is_success=lambda response: response.get("code", 0) in (0, 200),
+		unwrap_data=lambda response: response.get("zpData") if "zpData" in response else response.get("data"),
+	)
+
+	friend_item, error_response = find_friend_by_security_id(platform, "sec_missing")
+
+	assert friend_item is None
+	assert error_response is None
+
+
+def test_find_friend_by_security_id_raises_when_pagination_cap_reached_without_terminal_signal():
+	def friend_list(*, page):
+		return {"zpData": {"result": [{"securityId": f"sec_{page}"}], "friendList": [{"securityId": f"sec_{page}"}], "hasMore": True}}
+
+	platform = SimpleNamespace(
+		friend_list=friend_list,
+		is_success=lambda response: True,
+		unwrap_data=lambda response: response["zpData"],
+	)
+
+	with pytest.raises(FriendLookupLimitExceeded):
+		find_friend_by_security_id(platform, "sec_missing", max_pages=2)

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -41,8 +41,8 @@ def test_chatmsg_success(mock_auth_cls, mock_client_cls):
 	mock_client.chat_history.return_value = {
 		"zpData": {
 			"messages": [
-				{"from": {"uid": 99, "name": "张HR"}, "type": 1, "text": "你好", "time": 1700000000000},
-				{"from": {"uid": 12345, "name": "我"}, "type": 1, "text": "谢谢", "time": 1700000001000},
+				{"from": {"uid": 12345, "name": "张HR"}, "type": 1, "text": "你好", "time": 1700000000000},
+				{"from": {"uid": 99, "name": "我"}, "type": 1, "text": "谢谢", "time": 1700000001000},
 			],
 		},
 	}
@@ -52,6 +52,8 @@ def test_chatmsg_success(mock_auth_cls, mock_client_cls):
 	parsed = json.loads(result.output)
 	assert parsed["ok"] is True
 	assert len(parsed["data"]) == 2
+	assert parsed["data"][0]["from"] == "张HR"
+	assert parsed["data"][1]["from"] == "我"
 	assert parsed["data"][0]["text"] == "你好"
 
 
@@ -66,7 +68,7 @@ def test_chatmsg_finds_contact_on_second_page(mock_auth_cls, mock_client_cls):
 	mock_client.chat_history.return_value = {
 		"zpData": {
 			"messages": [
-				{"from": {"uid": 99, "name": "张HR"}, "type": 1, "text": "第二页找到你了", "time": 1700000000000},
+				{"from": {"uid": 12345, "name": "张HR"}, "type": 1, "text": "第二页找到你了", "time": 1700000000000},
 			],
 		},
 	}
@@ -75,6 +77,7 @@ def test_chatmsg_finds_contact_on_second_page(mock_auth_cls, mock_client_cls):
 	assert result.exit_code == 0
 	parsed = json.loads(result.output)
 	assert parsed["ok"] is True
+	assert parsed["data"][0]["from"] == "张HR"
 	assert parsed["data"][0]["text"] == "第二页找到你了"
 	assert mock_client.friend_list.call_args_list[0].kwargs == {"page": 1}
 	assert mock_client.friend_list.call_args_list[1].kwargs == {"page": 2}
@@ -94,6 +97,21 @@ def test_chatmsg_not_found(mock_auth_cls, mock_client_cls):
 
 @patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
 @patch("boss_agent_cli.commands.chatmsg.AuthManager")
+def test_chatmsg_not_found_after_second_page_keeps_job_not_found(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.side_effect = [
+		_friend_list_response([_make_friend(sid="sec_other", uid=999)]),
+		{"zpData": {"result": [], "friendList": [], "hasMore": False}},
+	]
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chatmsg", "sec_nonexistent"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "JOB_NOT_FOUND"
+
+
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
+@patch("boss_agent_cli.commands.chatmsg.AuthManager")
 def test_chatmsg_supports_data_envelope(mock_auth_cls, mock_client_cls):
 	mock_client = _ctx_mock(mock_client_cls)
 	mock_client.friend_list.return_value = {"code": 200, "data": {"result": [_make_friend()]}}
@@ -101,7 +119,7 @@ def test_chatmsg_supports_data_envelope(mock_auth_cls, mock_client_cls):
 		"code": 200,
 		"data": {
 			"messages": [
-				{"from": {"uid": 99, "name": "张HR"}, "type": 1, "text": "智联你好", "time": 1700000000000},
+				{"from": {"uid": 12345, "name": "张HR"}, "type": 1, "text": "智联你好", "time": 1700000000000},
 			],
 		},
 	}
@@ -110,6 +128,7 @@ def test_chatmsg_supports_data_envelope(mock_auth_cls, mock_client_cls):
 	assert result.exit_code == 0
 	parsed = json.loads(result.output)
 	assert parsed["ok"] is True
+	assert parsed["data"][0]["from"] == "张HR"
 	assert parsed["data"][0]["text"] == "智联你好"
 
 
@@ -122,7 +141,7 @@ def test_chatmsg_zhilian_hints_use_platform_specific_commands(mock_auth_cls, moc
 		"code": 200,
 		"data": {
 			"messages": [
-				{"from": {"uid": 99, "name": "张HR"}, "type": 1, "text": "智联你好", "time": 1700000000000},
+				{"from": {"uid": 12345, "name": "张HR"}, "type": 1, "text": "智联你好", "time": 1700000000000},
 			],
 		},
 	}
@@ -314,6 +333,21 @@ def test_mark_not_found(mock_auth_cls, mock_client_cls):
 
 @patch("boss_agent_cli.commands.mark.get_platform_instance")
 @patch("boss_agent_cli.commands.mark.AuthManager")
+def test_mark_not_found_after_second_page_keeps_job_not_found(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.side_effect = [
+		_friend_list_response([_make_friend(sid="sec_other", uid=999)]),
+		{"zpData": {"result": [], "friendList": [], "hasMore": False}},
+	]
+	runner = CliRunner()
+	result = runner.invoke(cli, ["mark", "sec_none", "--label", "收藏"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "JOB_NOT_FOUND"
+
+
+@patch("boss_agent_cli.commands.mark.get_platform_instance")
+@patch("boss_agent_cli.commands.mark.AuthManager")
 def test_mark_reports_not_supported_when_friend_list_missing(mock_auth_cls, mock_client_cls):
 	mock_client = _ctx_mock(mock_client_cls)
 	mock_client.friend_list.side_effect = NotImplementedError("friend_list is not supported")
@@ -377,6 +411,21 @@ def test_exchange_finds_contact_on_second_page(mock_auth_cls, mock_client_cls):
 	assert parsed["data"]["name"] == "张HR"
 	assert mock_client.friend_list.call_args_list[0].kwargs == {"page": 1}
 	assert mock_client.friend_list.call_args_list[1].kwargs == {"page": 2}
+
+
+@patch("boss_agent_cli.commands.exchange.get_platform_instance")
+@patch("boss_agent_cli.commands.exchange.AuthManager")
+def test_exchange_not_found_after_second_page_keeps_job_not_found(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.side_effect = [
+		_friend_list_response([_make_friend(sid="sec_other", uid=999)]),
+		{"zpData": {"result": [], "friendList": [], "hasMore": False}},
+	]
+	runner = CliRunner()
+	result = runner.invoke(cli, ["exchange", "sec_none"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "JOB_NOT_FOUND"
 
 
 @patch("boss_agent_cli.commands.exchange.get_platform_instance")
@@ -566,6 +615,8 @@ def test_detail_reports_platform_error(mock_auth_cls, mock_client_cls, mock_cach
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
 	assert parsed["error"]["message"] == "stoken expired"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "boss login"
 
 
 @patch("boss_agent_cli.commands.detail.CacheStore")
@@ -604,6 +655,8 @@ def test_detail_preserves_httpx_platform_error_when_browser_fallback_not_support
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "RATE_LIMITED"
 	assert parsed["error"]["message"] == "too fast"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "等待后重试"
 
 
 @patch("boss_agent_cli.commands.show.CacheStore")
@@ -655,6 +708,8 @@ def test_show_reports_platform_error(mock_auth_cls, mock_client_cls, mock_get_jo
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "RATE_LIMITED"
 	assert parsed["error"]["message"] == "too fast"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "等待后重试"
 
 
 @patch("boss_agent_cli.commands.show.CacheStore")
@@ -734,6 +789,8 @@ def test_me_reports_user_info_error(mock_auth_cls, mock_client_cls):
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
 	assert parsed["error"]["message"] == "stoken expired"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "boss login"
 
 
 @patch("boss_agent_cli.commands.me.get_platform_instance")

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -57,6 +57,31 @@ def test_chatmsg_success(mock_auth_cls, mock_client_cls):
 
 @patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
 @patch("boss_agent_cli.commands.chatmsg.AuthManager")
+def test_chatmsg_finds_contact_on_second_page(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.side_effect = [
+		_friend_list_response([_make_friend(sid="sec_other", uid=999)]),
+		_friend_list_response([_make_friend()]),
+	]
+	mock_client.chat_history.return_value = {
+		"zpData": {
+			"messages": [
+				{"from": {"uid": 99, "name": "张HR"}, "type": 1, "text": "第二页找到你了", "time": 1700000000000},
+			],
+		},
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chatmsg", "sec_001"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"][0]["text"] == "第二页找到你了"
+	assert mock_client.friend_list.call_args_list[0].kwargs == {"page": 1}
+	assert mock_client.friend_list.call_args_list[1].kwargs == {"page": 2}
+
+
+@patch("boss_agent_cli.commands.chatmsg.get_platform_instance")
+@patch("boss_agent_cli.commands.chatmsg.AuthManager")
 def test_chatmsg_not_found(mock_auth_cls, mock_client_cls):
 	mock_client = _ctx_mock(mock_client_cls)
 	mock_client.friend_list.return_value = _friend_list_response([])
@@ -195,6 +220,25 @@ def test_mark_add_label(mock_auth_cls, mock_client_cls):
 
 @patch("boss_agent_cli.commands.mark.get_platform_instance")
 @patch("boss_agent_cli.commands.mark.AuthManager")
+def test_mark_finds_contact_on_second_page(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.side_effect = [
+		_friend_list_response([_make_friend(sid="sec_other", uid=999)]),
+		_friend_list_response([_make_friend()]),
+	]
+	mock_client.friend_label.return_value = {"code": 0, "zpData": {}}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["mark", "sec_001", "--label", "沟通中"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["name"] == "张HR"
+	assert mock_client.friend_list.call_args_list[0].kwargs == {"page": 1}
+	assert mock_client.friend_list.call_args_list[1].kwargs == {"page": 2}
+
+
+@patch("boss_agent_cli.commands.mark.get_platform_instance")
+@patch("boss_agent_cli.commands.mark.AuthManager")
 def test_mark_remove_label(mock_auth_cls, mock_client_cls):
 	mock_client = _ctx_mock(mock_client_cls)
 	mock_client.friend_list.return_value = _friend_list_response([_make_friend()])
@@ -314,6 +358,25 @@ def test_exchange_phone(mock_auth_cls, mock_client_cls):
 	parsed = json.loads(result.output)
 	assert parsed["ok"] is True
 	assert "手机号" in parsed["data"]["message"]
+
+
+@patch("boss_agent_cli.commands.exchange.get_platform_instance")
+@patch("boss_agent_cli.commands.exchange.AuthManager")
+def test_exchange_finds_contact_on_second_page(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.side_effect = [
+		_friend_list_response([_make_friend(sid="sec_other", uid=999)]),
+		_friend_list_response([_make_friend()]),
+	]
+	mock_client.exchange_contact.return_value = {"code": 0, "zpData": {}}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["exchange", "sec_001"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["name"] == "张HR"
+	assert mock_client.friend_list.call_args_list[0].kwargs == {"page": 1}
+	assert mock_client.friend_list.call_args_list[1].kwargs == {"page": 2}
 
 
 @patch("boss_agent_cli.commands.exchange.get_platform_instance")


### PR DESCRIPTION
## 摘要
- 为联系人类命令补分页查找 helper，避免只查 `friend_list(page=1)` 带来的误判
- 将 candidate 侧剩余 `parse_error` 出口统一接入 `error_contract_for_code`，对齐 schema 的 `recoverable` / `recovery_action`
- 补齐第二页命中、第二页未命中、分页上限与关键错误契约测试

## 验证
- `env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q tests/test_contact_lookup.py tests/test_new_commands.py -k 'chatmsg or mark or exchange' tests/test_commands.py -k 'chat_summary'`
- `env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q tests/test_new_commands.py -k 'detail or show or me or history or interviews'`
- `env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q tests/test_commands.py -k 'recommend or pipeline or digest'`
- `env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q`
