### PR TITLE
fix: 补齐分页聚合与招聘者错误契约

### DIFF
--- a/src/boss_agent_cli/commands/digest.py
+++ b/src/boss_agent_cli/commands/digest.py
@@ -6,6 +6,7 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._platform import get_platform_instance
+from boss_agent_cli.commands.friend_list_pages import collect_friend_list_items
 from boss_agent_cli.digest import build_digest, render_digest_markdown
 from boss_agent_cli.display import error_contract_for_code, handle_auth_errors, handle_error_output, handle_output, render_message_panel
 from boss_agent_cli.pipeline_state import build_pipeline_items, select_follow_up_candidates
@@ -34,9 +35,9 @@ def digest_cmd(ctx: click.Context, days_stale: int, now_ts_ms: int | None, outpu
 	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 
 	with get_platform_instance(ctx, auth) as platform:
-		friend_resp = platform.friend_list(page=1)
-		if not platform.is_success(friend_resp):
-			code, message = platform.parse_error(friend_resp)
+		chat_items, friend_error = collect_friend_list_items(platform)
+		if friend_error is not None:
+			code, message = platform.parse_error(friend_error)
 			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "digest",
@@ -46,8 +47,6 @@ def digest_cmd(ctx: click.Context, days_stale: int, now_ts_ms: int | None, outpu
 				recovery_action=recovery_action,
 			)
 			return
-		friend_data = platform.unwrap_data(friend_resp) or {}
-		chat_items = friend_data.get("result") or friend_data.get("friendList") or []
 		interview_resp = platform.interview_data()
 		if not platform.is_success(interview_resp):
 			code, message = platform.parse_error(interview_resp)

--- a/src/boss_agent_cli/commands/friend_list_pages.py
+++ b/src/boss_agent_cli/commands/friend_list_pages.py
@@ -1,0 +1,43 @@
+from typing import Any
+
+
+MAX_FRIEND_LIST_PAGES = 50
+
+
+def collect_friend_list_items(
+	platform: Any,
+	*,
+	start_page: int = 1,
+	max_pages: int = MAX_FRIEND_LIST_PAGES,
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+	"""安全聚合多页沟通列表，保留原始顺序。
+
+	返回 (items, error_response)：
+	- 成功聚合：([items...], None)
+	- 任一页平台失败：([], raw_response)
+	"""
+	items: list[dict[str, Any]] = []
+	page = start_page
+	seen_signatures: set[tuple[str, ...]] = set()
+
+	for _ in range(max_pages):
+		resp = platform.friend_list(page=page)
+		if not platform.is_success(resp):
+			return [], resp
+
+		platform_data = platform.unwrap_data(resp) or {}
+		page_items = platform_data.get("result") or platform_data.get("friendList") or []
+		if not page_items:
+			break
+
+		signature = tuple(str(item.get("securityId", "")) for item in page_items if isinstance(item, dict))
+		if signature in seen_signatures:
+			break
+		seen_signatures.add(signature)
+		items.extend(page_items)
+
+		if platform_data.get("hasMore") is False:
+			break
+		page += 1
+
+	return items, None

--- a/src/boss_agent_cli/commands/pipeline.py
+++ b/src/boss_agent_cli/commands/pipeline.py
@@ -4,37 +4,36 @@ from typing import Any
 import click
 
 from boss_agent_cli.auth.manager import AuthManager
+from boss_agent_cli.commands.friend_list_pages import collect_friend_list_items
 from boss_agent_cli.commands._platform import get_platform_instance
 from boss_agent_cli.display import error_contract_for_code, handle_auth_errors, handle_error_output, handle_output, render_simple_list
 from boss_agent_cli.pipeline_state import build_pipeline_items, select_follow_up_candidates
 
 
-def _collect_pipeline_items(ctx: click.Context, *, now_ts_ms: int | None, stale_days: int) -> list[dict[str, Any]]:
+def _collect_pipeline_items(ctx: click.Context, *, command_name: str, now_ts_ms: int | None, stale_days: int) -> list[dict[str, Any]]:
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
 	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 
 	with get_platform_instance(ctx, auth) as platform:
-		friend_resp = platform.friend_list(page=1)
-		if not platform.is_success(friend_resp):
-			code, message = platform.parse_error(friend_resp)
+		chat_items, friend_error = collect_friend_list_items(platform)
+		if friend_error is not None:
+			code, message = platform.parse_error(friend_error)
 			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
-				ctx, "pipeline",
+				ctx, command_name,
 				code=code,
 				message=message or "沟通列表获取失败",
 				recoverable=recoverable,
 				recovery_action=recovery_action,
 			)
 			return []
-		friend_data = platform.unwrap_data(friend_resp) or {}
-		chat_items = friend_data.get("result") or friend_data.get("friendList") or []
 		interview_resp = platform.interview_data()
 		if not platform.is_success(interview_resp):
 			code, message = platform.parse_error(interview_resp)
 			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
-				ctx, "pipeline",
+				ctx, command_name,
 				code=code,
 				message=message or "面试列表获取失败",
 				recoverable=recoverable,
@@ -74,7 +73,7 @@ def _render_pipeline(data: list[dict[str, Any]], title: str) -> None:
 @click.pass_context
 @handle_auth_errors("pipeline")
 def pipeline_cmd(ctx: click.Context, days_stale: int, now_ts_ms: int | None) -> None:
-	items = _collect_pipeline_items(ctx, now_ts_ms=now_ts_ms, stale_days=days_stale)
+	items = _collect_pipeline_items(ctx, command_name="pipeline", now_ts_ms=now_ts_ms, stale_days=days_stale)
 	handle_output(
 		ctx,
 		"pipeline",
@@ -90,7 +89,7 @@ def pipeline_cmd(ctx: click.Context, days_stale: int, now_ts_ms: int | None) -> 
 @click.pass_context
 @handle_auth_errors("follow-up")
 def follow_up_cmd(ctx: click.Context, days_stale: int, now_ts_ms: int | None) -> None:
-	items = _collect_pipeline_items(ctx, now_ts_ms=now_ts_ms, stale_days=days_stale)
+	items = _collect_pipeline_items(ctx, command_name="follow-up", now_ts_ms=now_ts_ms, stale_days=days_stale)
 	candidates = select_follow_up_candidates(items)
 	handle_output(
 		ctx,

--- a/src/boss_agent_cli/commands/recruiter/applications.py
+++ b/src/boss_agent_cli/commands/recruiter/applications.py
@@ -3,7 +3,7 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._recruiter_platform import get_recruiter_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output
+from boss_agent_cli.display import error_contract_for_code, handle_auth_errors, handle_error_output, handle_output
 
 
 @click.command("applications")
@@ -22,11 +22,13 @@ def applications_cmd(ctx: click.Context, job_id: str | None, label_id: int, page
 		result = platform.friend_list(page=page, label_id=label_id, job_id=job_id)
 		if not platform.is_success(result):
 			code, message = platform.parse_error(result)
+			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "recruiter-applications",
 				code=code,
 				message=message or "投递申请列表获取失败",
-				recoverable=False,
+				recoverable=recoverable,
+				recovery_action=recovery_action,
 			)
 			return
 		data = platform.unwrap_data(result) or {}

--- a/src/boss_agent_cli/commands/recruiter/chat.py
+++ b/src/boss_agent_cli/commands/recruiter/chat.py
@@ -3,7 +3,7 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._recruiter_platform import get_recruiter_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output
+from boss_agent_cli.display import error_contract_for_code, handle_auth_errors, handle_error_output, handle_output
 
 
 @click.command("chat")
@@ -22,11 +22,13 @@ def recruiter_chat_cmd(ctx: click.Context, page: int, job_id: str | None, label_
 		result = platform.friend_list(page=page, label_id=label_id, job_id=job_id)
 		if not platform.is_success(result):
 			code, message = platform.parse_error(result)
+			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "recruiter-chat",
 				code=code,
 				message=message or "沟通列表获取失败",
-				recoverable=False,
+				recoverable=recoverable,
+				recovery_action=recovery_action,
 			)
 			return
 		data = platform.unwrap_data(result) or {}

--- a/src/boss_agent_cli/commands/recruiter/jobs.py
+++ b/src/boss_agent_cli/commands/recruiter/jobs.py
@@ -3,7 +3,7 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._recruiter_platform import get_recruiter_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output
+from boss_agent_cli.display import error_contract_for_code, handle_auth_errors, handle_error_output, handle_output
 
 
 @click.group("jobs")
@@ -26,11 +26,13 @@ def jobs_list_cmd(ctx: click.Context) -> None:
 		result = platform.list_jobs()
 		if not platform.is_success(result):
 			code, message = platform.parse_error(result)
+			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "recruiter-jobs-list",
 				code=code,
 				message=message or "职位列表获取失败",
-				recoverable=False,
+				recoverable=recoverable,
+				recovery_action=recovery_action,
 			)
 			return
 		data = platform.unwrap_data(result) or {}
@@ -51,11 +53,13 @@ def jobs_offline_cmd(ctx: click.Context, job_id: str) -> None:
 		result = platform.job_offline(job_id)
 		if not platform.is_success(result):
 			code, message = platform.parse_error(result)
+			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "recruiter-jobs-offline",
 				code=code,
 				message=message or "职位下线失败",
-				recoverable=False,
+				recoverable=recoverable,
+				recovery_action=recovery_action,
 			)
 			return
 		data = {"job_id": job_id, "message": "职位已下线"}
@@ -76,11 +80,13 @@ def jobs_online_cmd(ctx: click.Context, job_id: str) -> None:
 		result = platform.job_online(job_id)
 		if not platform.is_success(result):
 			code, message = platform.parse_error(result)
+			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "recruiter-jobs-online",
 				code=code,
 				message=message or "职位上线失败",
-				recoverable=False,
+				recoverable=recoverable,
+				recovery_action=recovery_action,
 			)
 			return
 		data = {"job_id": job_id, "message": "职位已上线"}

--- a/src/boss_agent_cli/commands/recruiter/request_resume.py
+++ b/src/boss_agent_cli/commands/recruiter/request_resume.py
@@ -3,7 +3,7 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._recruiter_platform import get_recruiter_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output
+from boss_agent_cli.display import error_contract_for_code, handle_auth_errors, handle_error_output, handle_output
 
 
 @click.command("request-resume")
@@ -22,11 +22,13 @@ def request_resume_cmd(ctx: click.Context, friend_id: int, job_id: int) -> None:
 		result = platform.exchange_request(3, friend_id, job_id, friend_id)
 		if not platform.is_success(result):
 			code, error_message = platform.parse_error(result)
+			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "recruiter-request-resume",
 				code=code,
 				message=error_message or "附件简历请求失败",
-				recoverable=False,
+				recoverable=recoverable,
+				recovery_action=recovery_action,
 			)
 			return
 		data = {

--- a/src/boss_agent_cli/commands/recruiter/resume.py
+++ b/src/boss_agent_cli/commands/recruiter/resume.py
@@ -4,7 +4,7 @@ import click
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._recruiter_platform import get_recruiter_platform_instance
 from boss_agent_cli.commands.recruiter.resume_parser import parse_resume
-from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output
+from boss_agent_cli.display import error_contract_for_code, handle_auth_errors, handle_error_output, handle_output
 
 
 @click.command("resume")
@@ -36,11 +36,13 @@ def resume_cmd(ctx: click.Context, geek_id: str, job_id: str, security_id: str |
 			result = platform.exchange_request(1, uid, int(job_id), gid)
 			if not platform.is_success(result):
 				code, message = platform.parse_error(result)
+				recoverable, recovery_action = error_contract_for_code(code)
 				handle_error_output(
 					ctx, "recruiter-resume",
 					code=code,
 					message=message or "联系方式交换请求失败",
-					recoverable=False,
+					recoverable=recoverable,
+					recovery_action=recovery_action,
 				)
 				return
 			data = platform.unwrap_data(result) or {}
@@ -49,11 +51,13 @@ def resume_cmd(ctx: click.Context, geek_id: str, job_id: str, security_id: str |
 			result = platform.view_geek(geek_id, job_id, security_id=security_id)
 			if not platform.is_success(result):
 				code, message = platform.parse_error(result)
+				recoverable, recovery_action = error_contract_for_code(code)
 				handle_error_output(
 					ctx, "recruiter-resume",
 					code=code,
 					message=message or "候选人简历获取失败",
-					recoverable=False,
+					recoverable=recoverable,
+					recovery_action=recovery_action,
 				)
 				return
 			data = result if show_raw else parse_resume(result)

--- a/tests/test_digest_command.py
+++ b/tests/test_digest_command.py
@@ -62,6 +62,66 @@ def test_digest_command_returns_structured_sections(mock_auth_cls, mock_client_c
 	assert parsed["data"]["interview_count"] == 1
 
 
+@patch("boss_agent_cli.commands.digest.get_platform_instance")
+@patch("boss_agent_cli.commands.digest.AuthManager")
+def test_digest_aggregates_second_page_matches(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.side_effect = [
+		{
+			"zpData": {
+				"result": [
+					{
+						"name": "张HR",
+						"securityId": "sec_1",
+						"uid": 99,
+						"title": "HR",
+						"brandName": "TestCo",
+						"friendSource": 0,
+						"encryptJobId": "job_1",
+						"lastMsg": "请尽快回复",
+						"lastTS": 1700000001000,
+						"unreadMsgCount": 1,
+						"relationType": 1,
+						"lastMessageInfo": {"status": 1},
+					},
+				],
+			},
+		},
+		{
+			"zpData": {
+				"result": [
+					{
+						"name": "李HR",
+						"securityId": "sec_2",
+						"uid": 100,
+						"title": "HRBP",
+						"brandName": "PageTwo Inc",
+						"friendSource": 0,
+						"encryptJobId": "job_2",
+						"lastMsg": "第二页待回复",
+						"lastTS": 1700000002000,
+						"unreadMsgCount": 1,
+						"relationType": 1,
+						"lastMessageInfo": {"status": 1},
+					},
+				],
+			},
+		},
+		{"zpData": {"result": []}},
+	]
+	mock_client.interview_data.return_value = {"zpData": {"interviewList": []}}
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "digest"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	companies = {item["company"] for item in parsed["data"]["new_matches"]}
+	assert "TestCo" in companies
+	assert "PageTwo Inc" in companies
+	assert parsed["data"]["new_match_count"] == 2
+
+
 def test_digest_is_exposed_in_schema():
 	runner = CliRunner()
 	result = runner.invoke(cli, ["schema"])
@@ -169,3 +229,39 @@ def test_digest_reports_interview_error(mock_auth_cls, mock_client_cls):
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "ACCOUNT_RISK"
 	assert parsed["error"]["message"] == "account risk"
+
+
+@patch("boss_agent_cli.commands.digest.get_platform_instance")
+@patch("boss_agent_cli.commands.digest.AuthManager")
+def test_digest_reports_second_page_friend_list_error(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.side_effect = [
+		{
+			"zpData": {
+				"result": [
+					{
+						"name": "张HR",
+						"securityId": "sec_1",
+						"uid": 99,
+						"title": "HR",
+						"brandName": "TestCo",
+						"friendSource": 0,
+						"encryptJobId": "job_1",
+						"lastMsg": "请尽快回复",
+						"lastTS": 1700000001000,
+						"unreadMsgCount": 1,
+						"relationType": 1,
+						"lastMessageInfo": {"status": 1},
+					},
+				],
+			},
+		},
+		{"code": 37, "message": "stoken expired"},
+	]
+	mock_client.parse_error.return_value = ("TOKEN_REFRESH_FAILED", "stoken expired")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "digest"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
+	assert parsed["error"]["message"] == "stoken expired"

--- a/tests/test_pipeline_commands.py
+++ b/tests/test_pipeline_commands.py
@@ -95,9 +95,50 @@ def test_follow_up_command_filters_actionable_items(mock_auth_cls, mock_client_c
 
 @patch("boss_agent_cli.commands.pipeline.get_platform_instance")
 @patch("boss_agent_cli.commands.pipeline.AuthManager")
+def test_follow_up_command_aggregates_items_from_second_page(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.side_effect = [
+		_friend_list_response([_chat_item(unread=1, security_id="sec_001", job_id="job_001")]),
+		_friend_list_response([_chat_item(unread=0, security_id="sec_page2", job_id="job_page2", last_ts=1700000000000)]),
+		_friend_list_response([]),
+	]
+	mock_client.interview_data.return_value = {"zpData": {"interviewList": []}}
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "follow-up", "--now-ts-ms", str(1700000000000 + 5 * 24 * 3600 * 1000)])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	security_ids = {item["security_id"] for item in parsed["data"]}
+	assert "sec_001" in security_ids
+	assert "sec_page2" in security_ids
+	assert mock_client.friend_list.call_args_list[0].kwargs == {"page": 1}
+	assert mock_client.friend_list.call_args_list[1].kwargs == {"page": 2}
+	assert mock_client.friend_list.call_args_list[2].kwargs == {"page": 3}
+
+
+@patch("boss_agent_cli.commands.pipeline.get_platform_instance")
+@patch("boss_agent_cli.commands.pipeline.AuthManager")
 def test_pipeline_reports_friend_list_error(mock_auth_cls, mock_client_cls):
 	mock_client = _ctx_mock(mock_client_cls)
 	mock_client.friend_list.return_value = {"code": 37, "message": "stoken expired"}
+	mock_client.parse_error.return_value = ("TOKEN_REFRESH_FAILED", "stoken expired")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "pipeline"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
+	assert parsed["error"]["message"] == "stoken expired"
+
+
+@patch("boss_agent_cli.commands.pipeline.get_platform_instance")
+@patch("boss_agent_cli.commands.pipeline.AuthManager")
+def test_pipeline_reports_second_page_friend_list_error(mock_auth_cls, mock_client_cls):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.friend_list.side_effect = [
+		_friend_list_response([_chat_item(unread=1)]),
+		{"code": 37, "message": "stoken expired"},
+	]
 	mock_client.parse_error.return_value = ("TOKEN_REFRESH_FAILED", "stoken expired")
 	runner = CliRunner()
 	result = runner.invoke(cli, ["--json", "pipeline"])

--- a/tests/test_recruiter_commands.py
+++ b/tests/test_recruiter_commands.py
@@ -21,6 +21,13 @@ def _invoke(*args):
 	return runner.invoke(cli, ["--role", "recruiter", *args])
 
 
+def _assert_error_contract(parsed: dict, *, code: str, message: str, recoverable: bool, recovery_action: str | None) -> None:
+	assert parsed["error"]["code"] == code
+	assert parsed["error"]["message"] == message
+	assert parsed["error"]["recoverable"] is recoverable
+	assert parsed["error"]["recovery_action"] == recovery_action
+
+
 @patch("boss_agent_cli.commands.recruiter.candidates.get_recruiter_platform_instance")
 @patch("boss_agent_cli.commands.recruiter.candidates.AuthManager")
 def test_recruiter_candidates_supports_data_envelope(mock_auth_cls, mock_platform_cls):
@@ -75,8 +82,13 @@ def test_recruiter_chat_reports_error_when_platform_rejects(mock_auth_cls, mock_
 	result = _invoke("hr", "chat")
 	assert result.exit_code == 1
 	parsed = json.loads(result.output)
-	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
-	assert parsed["error"]["message"] == "stoken expired"
+	_assert_error_contract(
+		parsed,
+		code="TOKEN_REFRESH_FAILED",
+		message="stoken expired",
+		recoverable=True,
+		recovery_action="boss login",
+	)
 
 
 @patch("boss_agent_cli.commands.recruiter.applications.get_recruiter_platform_instance")
@@ -104,8 +116,13 @@ def test_recruiter_applications_reports_error_when_platform_rejects(mock_auth_cl
 	result = _invoke("hr", "applications")
 	assert result.exit_code == 1
 	parsed = json.loads(result.output)
-	assert parsed["error"]["code"] == "ACCOUNT_RISK"
-	assert parsed["error"]["message"] == "account risk"
+	_assert_error_contract(
+		parsed,
+		code="ACCOUNT_RISK",
+		message="account risk",
+		recoverable=True,
+		recovery_action="启动 CDP Chrome 重试，或联系客服",
+	)
 
 
 @patch("boss_agent_cli.commands.recruiter.jobs.get_recruiter_platform_instance")
@@ -131,8 +148,13 @@ def test_recruiter_jobs_list_reports_error_when_platform_rejects(mock_auth_cls, 
 	result = _invoke("hr", "jobs", "list")
 	assert result.exit_code == 1
 	parsed = json.loads(result.output)
-	assert parsed["error"]["code"] == "RATE_LIMITED"
-	assert parsed["error"]["message"] == "too fast"
+	_assert_error_contract(
+		parsed,
+		code="RATE_LIMITED",
+		message="too fast",
+		recoverable=True,
+		recovery_action="等待后重试",
+	)
 
 
 @patch("boss_agent_cli.commands.recruiter.jobs.get_recruiter_platform_instance")
@@ -146,8 +168,13 @@ def test_recruiter_jobs_offline_reports_error_when_platform_rejects(mock_auth_cl
 	assert result.exit_code == 1
 	parsed = json.loads(result.output)
 	assert parsed["ok"] is False
-	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
-	assert parsed["error"]["message"] == "stoken expired"
+	_assert_error_contract(
+		parsed,
+		code="TOKEN_REFRESH_FAILED",
+		message="stoken expired",
+		recoverable=True,
+		recovery_action="boss login",
+	)
 
 
 @patch("boss_agent_cli.commands.recruiter.jobs.get_recruiter_platform_instance")
@@ -161,8 +188,13 @@ def test_recruiter_jobs_online_reports_error_when_platform_rejects(mock_auth_cls
 	assert result.exit_code == 1
 	parsed = json.loads(result.output)
 	assert parsed["ok"] is False
-	assert parsed["error"]["code"] == "RATE_LIMITED"
-	assert parsed["error"]["message"] == "too fast"
+	_assert_error_contract(
+		parsed,
+		code="RATE_LIMITED",
+		message="too fast",
+		recoverable=True,
+		recovery_action="等待后重试",
+	)
 
 
 @patch("boss_agent_cli.commands.recruiter.resume.get_recruiter_platform_instance")
@@ -192,8 +224,13 @@ def test_recruiter_resume_exchange_reports_error_when_platform_rejects(mock_auth
 	assert result.exit_code == 1
 	parsed = json.loads(result.output)
 	assert parsed["ok"] is False
-	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
-	assert parsed["error"]["message"] == "stoken expired"
+	_assert_error_contract(
+		parsed,
+		code="TOKEN_REFRESH_FAILED",
+		message="stoken expired",
+		recoverable=True,
+		recovery_action="boss login",
+	)
 
 
 @patch("boss_agent_cli.commands.recruiter.resume.get_recruiter_platform_instance")
@@ -237,8 +274,13 @@ def test_recruiter_resume_parse_reports_error_when_platform_rejects(mock_auth_cl
 	result = _invoke("hr", "resume", "geek-1", "--job-id", "job-1", "--security-id", "sec-1")
 	assert result.exit_code == 1
 	parsed = json.loads(result.output)
-	assert parsed["error"]["code"] == "TOKEN_REFRESH_FAILED"
-	assert parsed["error"]["message"] == "stoken expired"
+	_assert_error_contract(
+		parsed,
+		code="TOKEN_REFRESH_FAILED",
+		message="stoken expired",
+		recoverable=True,
+		recovery_action="boss login",
+	)
 
 
 @patch("boss_agent_cli.commands.recruiter.reply.get_recruiter_platform_instance")
@@ -267,8 +309,13 @@ def test_recruiter_request_resume_reports_error_when_platform_rejects(mock_auth_
 	assert result.exit_code == 1
 	parsed = json.loads(result.output)
 	assert parsed["ok"] is False
-	assert parsed["error"]["code"] == "ACCOUNT_RISK"
-	assert parsed["error"]["message"] == "account risk"
+	_assert_error_contract(
+		parsed,
+		code="ACCOUNT_RISK",
+		message="account risk",
+		recoverable=True,
+		recovery_action="启动 CDP Chrome 重试，或联系客服",
+	)
 
 
 def test_parse_resume_accepts_data_envelope():


### PR DESCRIPTION
## Summary
- add a shared friend-list pagination helper for pipeline, follow-up, and digest
- aggregate multi-page chat items so pipeline and digest no longer stop at page 1
- align recruiter platform error responses with schema recoverability contracts and extend tests

## Testing
- env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q tests/test_pipeline_commands.py tests/test_digest_command.py tests/test_recruiter_commands.py
- env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run mypy src/boss_agent_cli
- env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q