### PR TITLE
fix: 收平招聘者错误契约

### DIFF
--- a/docs/superpowers/plans/2026-04-29-recruiter-error-contract-completion.md
+++ b/docs/superpowers/plans/2026-04-29-recruiter-error-contract-completion.md
@@ -1,0 +1,42 @@
+# Recruiter Error Contract Completion Plan
+
+**Date:** 2026-04-29
+**Branch:** `feat/recruiter-error-contract-completion`
+**Goal:** 收平 recruiter 侧剩余没有接入 schema error contract 的两个命令，让平台错误继续保留真实 `code/message`，同时补齐 `recoverable` 与 `recovery_action`。
+
+## Scope
+
+### In Scope
+
+- `src/boss_agent_cli/commands/recruiter/candidates.py`
+- `src/boss_agent_cli/commands/recruiter/reply.py`
+- `tests/test_recruiter_commands.py`
+
+### Out Of Scope
+
+- recruiter 侧新增分页能力
+- recruiter 侧成功路径数据结构调整
+- candidate 侧其他命令重构
+
+## Task 1: `recruiter-candidates` 错误契约统一
+
+- 平台返回错误时，继续使用 `parse_error()` 的真实 `code/message`
+- 同步从 `schema.error_codes` 派生 `recoverable` 与 `recovery_action`
+
+## Task 2: `recruiter-reply` 错误契约统一
+
+- 平台返回错误时，继续使用 `parse_error()` 的真实 `code/message`
+- 同步从 `schema.error_codes` 派生 `recoverable` 与 `recovery_action`
+
+## Task 3: 验证
+
+至少执行：
+
+- `env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q tests/test_recruiter_commands.py`
+- 如需要，再补跑：
+  - `env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q`
+
+## Delivery Notes
+
+- 保持为一个可独立审查的小 PR
+- commit message 遵循：`fix: 中文描述`

--- a/src/boss_agent_cli/commands/recruiter/candidates.py
+++ b/src/boss_agent_cli/commands/recruiter/candidates.py
@@ -3,7 +3,7 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._recruiter_platform import get_recruiter_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output
+from boss_agent_cli.display import error_contract_for_code, handle_auth_errors, handle_error_output, handle_output
 
 
 @click.command("candidates")
@@ -28,11 +28,13 @@ def candidates_cmd(ctx: click.Context, query: str, city: str | None, job_id: str
 		)
 		if not platform.is_success(result):
 			code, message = platform.parse_error(result)
+			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "recruiter-candidates",
 				code=code,
 				message=message or "候选人搜索失败",
-				recoverable=False,
+				recoverable=recoverable,
+				recovery_action=recovery_action,
 			)
 			return
 		data = platform.unwrap_data(result) or {}

--- a/src/boss_agent_cli/commands/recruiter/reply.py
+++ b/src/boss_agent_cli/commands/recruiter/reply.py
@@ -3,7 +3,7 @@ import click
 
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._recruiter_platform import get_recruiter_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output
+from boss_agent_cli.display import error_contract_for_code, handle_auth_errors, handle_error_output, handle_output
 
 
 @click.command("reply")
@@ -21,11 +21,13 @@ def reply_cmd(ctx: click.Context, friend_id: int, message: str) -> None:
 		result = platform.send_message(friend_id, message)
 		if not platform.is_success(result):
 			code, error_message = platform.parse_error(result)
+			recoverable, recovery_action = error_contract_for_code(code)
 			handle_error_output(
 				ctx, "recruiter-reply",
 				code=code,
 				message=error_message or "消息发送失败",
-				recoverable=False,
+				recoverable=recoverable,
+				recovery_action=recovery_action,
 			)
 			return
 		data = {

--- a/tests/test_recruiter_commands.py
+++ b/tests/test_recruiter_commands.py
@@ -54,8 +54,13 @@ def test_recruiter_candidates_reports_error_when_platform_rejects(mock_auth_cls,
 	result = _invoke("hr", "candidates", "python")
 	assert result.exit_code == 1
 	parsed = json.loads(result.output)
-	assert parsed["error"]["code"] == "RATE_LIMITED"
-	assert parsed["error"]["message"] == "too fast"
+	_assert_error_contract(
+		parsed,
+		code="RATE_LIMITED",
+		message="too fast",
+		recoverable=True,
+		recovery_action="等待后重试",
+	)
 
 
 @patch("boss_agent_cli.commands.recruiter.chat.get_recruiter_platform_instance")
@@ -294,8 +299,13 @@ def test_recruiter_reply_reports_error_when_platform_rejects(mock_auth_cls, mock
 	assert result.exit_code == 1
 	parsed = json.loads(result.output)
 	assert parsed["ok"] is False
-	assert parsed["error"]["code"] == "RATE_LIMITED"
-	assert parsed["error"]["message"] == "too fast"
+	_assert_error_contract(
+		parsed,
+		code="RATE_LIMITED",
+		message="too fast",
+		recoverable=True,
+		recovery_action="等待后重试",
+	)
 
 
 @patch("boss_agent_cli.commands.recruiter.request_resume.get_recruiter_platform_instance")


### PR DESCRIPTION
## Summary
- unify recruiter candidates/reply platform error paths with schema error contract metadata
- preserve existing parse_error code/message truthfulness while filling recoverable and recovery_action
- extend recruiter command tests to assert the full error envelope for these commands

## Review
- review depth: quick
- scope: on target
- hard stops: 0 found

## Test Plan
- env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q tests/test_recruiter_commands.py
- env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q