### PR TITLE
fix: 修正候选人能力边界回执

### DIFF
--- a/src/boss_agent_cli/commands/detail.py
+++ b/src/boss_agent_cli/commands/detail.py
@@ -121,8 +121,8 @@ def _detail_via_browser(platform: Platform, security_id: str, lid: str, data_dir
 	"""兜底通道：通过浏览器 job_card 获取职位详情"""
 	try:
 		raw = platform.job_card(security_id, lid)
-	except NotImplementedError as exc:
-		return None, ("NOT_SUPPORTED", str(exc) or "当前平台不支持职位详情兜底能力")
+	except NotImplementedError:
+		return None, ("NOT_SUPPORTED", "当前平台暂不支持 detail 浏览器兜底，请提供 --job-id 或切换平台后重试")
 	if not platform.is_success(raw):
 		code, message = platform.parse_error(raw)
 		return None, (code, message or "职位详情获取失败")

--- a/src/boss_agent_cli/commands/me.py
+++ b/src/boss_agent_cli/commands/me.py
@@ -54,11 +54,11 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 					logger.info("获取简历基本信息...")
 				try:
 					resp = platform.resume_baseinfo()
-				except NotImplementedError as exc:
+				except NotImplementedError:
 					handle_error_output(
 						ctx, "me",
 						code="NOT_SUPPORTED",
-						message=str(exc) or "当前平台不支持简历基本信息能力",
+						message="当前平台暂不支持简历基本信息查询，请改用 --section user 或切换平台后重试",
 						recoverable=True,
 						recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
 					)
@@ -82,11 +82,11 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 					logger.info("获取求职期望...")
 				try:
 					resp = platform.resume_expect()
-				except NotImplementedError as exc:
+				except NotImplementedError:
 					handle_error_output(
 						ctx, "me",
 						code="NOT_SUPPORTED",
-						message=str(exc) or "当前平台不支持求职期望能力",
+						message="当前平台暂不支持求职期望查询，请改用 --section user 或切换平台后重试",
 						recoverable=True,
 						recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
 					)
@@ -110,11 +110,11 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 					logger.info("获取投递记录...")
 				try:
 					resp = platform.deliver_list(page=deliver_page)
-				except NotImplementedError as exc:
+				except NotImplementedError:
 					handle_error_output(
 						ctx, "me",
 						code="NOT_SUPPORTED",
-						message=str(exc) or "当前平台不支持投递记录能力",
+						message="当前平台暂不支持投递记录查询，请切换平台后重试",
 						recoverable=True,
 						recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
 					)

--- a/src/boss_agent_cli/commands/recommend.py
+++ b/src/boss_agent_cli/commands/recommend.py
@@ -28,11 +28,11 @@ def recommend_cmd(ctx: click.Context, page: int, with_score: bool) -> None:
 			if with_score:
 				try:
 					expect_resp = platform.resume_expect()
-				except NotImplementedError as exc:
+				except NotImplementedError:
 					handle_error_output(
 						ctx, "recommend",
 						code="NOT_SUPPORTED",
-						message=str(exc) or "当前平台不支持求职期望能力",
+						message="当前平台暂不支持带期望加权的推荐评分，请去掉 --with-score 或切换平台后重试",
 						recoverable=True,
 						recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
 					)

--- a/src/boss_agent_cli/commands/show.py
+++ b/src/boss_agent_cli/commands/show.py
@@ -49,11 +49,11 @@ def show_cmd(ctx: click.Context, index: int) -> None:
 	with get_platform_instance(ctx, auth) as platform:
 		try:
 			raw = platform.job_card(security_id)
-		except NotImplementedError as exc:
+		except NotImplementedError:
 			handle_error_output(
 				ctx, "show",
 				code="NOT_SUPPORTED",
-				message=str(exc) or "当前平台不支持职位详情能力",
+				message="当前平台暂不支持按编号查看职位详情，请改用 detail <security_id> --job-id <job_id> 或切换平台后重试",
 				recoverable=True,
 				recovery_action=NOT_SUPPORTED_RECOVERY_ACTION,
 			)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -437,7 +437,7 @@ def test_recommend_with_score_reports_not_supported(mock_auth_cls, mock_client_c
 	assert result.exit_code == 1
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "NOT_SUPPORTED"
-	assert parsed["error"]["message"] == "当前平台不支持求职期望能力"
+	assert parsed["error"]["message"] == "当前平台暂不支持带期望加权的推荐评分，请去掉 --with-score 或切换平台后重试"
 	assert parsed["error"]["recoverable"] is True
 	assert parsed["error"]["recovery_action"] == "切换平台或调整命令参数后重试"
 	mock_client.recommend_jobs.assert_not_called()

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -633,7 +633,7 @@ def test_detail_reports_not_supported_when_browser_fallback_missing(mock_auth_cl
 	assert result.exit_code == 1
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "NOT_SUPPORTED"
-	assert parsed["error"]["message"] == "job_card is not supported"
+	assert parsed["error"]["message"] == "当前平台暂不支持 detail 浏览器兜底，请提供 --job-id 或切换平台后重试"
 	assert parsed["error"]["recoverable"] is True
 	assert parsed["error"]["recovery_action"] == "切换平台或调整命令参数后重试"
 
@@ -727,7 +727,7 @@ def test_show_reports_not_supported_when_job_card_missing(mock_auth_cls, mock_cl
 	assert result.exit_code == 1
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "NOT_SUPPORTED"
-	assert parsed["error"]["message"] == "job_card is not supported"
+	assert parsed["error"]["message"] == "当前平台暂不支持按编号查看职位详情，请改用 detail <security_id> --job-id <job_id> 或切换平台后重试"
 	assert parsed["error"]["recoverable"] is True
 	assert parsed["error"]["recovery_action"] == "切换平台或调整命令参数后重试"
 

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -803,7 +803,9 @@ def test_me_resume_reports_not_supported(mock_auth_cls, mock_client_cls):
 	assert result.exit_code == 1
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "NOT_SUPPORTED"
-	assert parsed["error"]["message"] == "resume_baseinfo is not supported"
+	assert parsed["error"]["message"] == "当前平台暂不支持简历基本信息查询，请改用 --section user 或切换平台后重试"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "切换平台或调整命令参数后重试"
 
 
 @patch("boss_agent_cli.commands.me.get_platform_instance")
@@ -816,7 +818,7 @@ def test_me_expect_reports_not_supported(mock_auth_cls, mock_client_cls):
 	assert result.exit_code == 1
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "NOT_SUPPORTED"
-	assert parsed["error"]["message"] == "resume_expect is not supported"
+	assert parsed["error"]["message"] == "当前平台暂不支持求职期望查询，请改用 --section user 或切换平台后重试"
 	assert parsed["error"]["recoverable"] is True
 	assert parsed["error"]["recovery_action"] == "切换平台或调整命令参数后重试"
 
@@ -831,7 +833,9 @@ def test_me_deliver_reports_not_supported(mock_auth_cls, mock_client_cls):
 	assert result.exit_code == 1
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "NOT_SUPPORTED"
-	assert parsed["error"]["message"] == "deliver_list is not supported"
+	assert parsed["error"]["message"] == "当前平台暂不支持投递记录查询，请切换平台后重试"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "切换平台或调整命令参数后重试"
 
 
 @patch("boss_agent_cli.commands.me.get_platform_instance")
@@ -846,7 +850,7 @@ def test_me_default_sequence_stops_on_expect_not_supported(mock_auth_cls, mock_c
 	assert result.exit_code == 1
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "NOT_SUPPORTED"
-	assert parsed["error"]["message"] == "resume_expect is not supported"
+	assert parsed["error"]["message"] == "当前平台暂不支持求职期望查询，请改用 --section user 或切换平台后重试"
 	assert parsed["error"]["recoverable"] is True
 	assert parsed["error"]["recovery_action"] == "切换平台或调整命令参数后重试"
 	mock_client.user_info.assert_called_once_with()


### PR DESCRIPTION
## 摘要
- 修正 detail 和 show 在 job_card 不支持时的 NOT_SUPPORTED 能力边界回执
- 修正 me 在 resume/expect/deliver section 不支持时的显式能力边界提示
- 修正 recommend --with-score 对 resume_expect 的显式依赖提示，避免静默降级

## 验证
- env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q
- env UV_CACHE_DIR=/tmp/boss-agent-cli-uv-cache uv run pytest -q tests/test_new_commands.py tests/test_commands.py