### PR TITLE
refactor: 整理开发基础结构

### DIFF
--- a/src/boss_agent_cli/__init__.py
+++ b/src/boss_agent_cli/__init__.py
@@ -10,15 +10,40 @@ Public API 使用示例:
         result = client.search_jobs("Golang", city="广州")
 """
 
-from boss_agent_cli.ai.service import AIService, AIServiceError
-from boss_agent_cli.api.client import AccountRiskError, AuthError, BossClient
-from boss_agent_cli.api.models import JobDetail, JobItem
-from boss_agent_cli.auth.manager import AuthManager, AuthRequired, TokenRefreshFailed
-from boss_agent_cli.cache.store import CacheStore
-from boss_agent_cli.platforms import BossPlatform, Platform, ZhilianPlatform, get_platform, list_platforms
-from boss_agent_cli.resume.models import ResumeData, ResumeFile
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+	from boss_agent_cli.ai.service import AIService, AIServiceError
+	from boss_agent_cli.api.client import AccountRiskError, AuthError, BossClient
+	from boss_agent_cli.api.models import JobDetail, JobItem
+	from boss_agent_cli.auth.manager import AuthManager, AuthRequired, TokenRefreshFailed
+	from boss_agent_cli.cache.store import CacheStore
+	from boss_agent_cli.platforms import BossPlatform, Platform, ZhilianPlatform, get_platform, list_platforms
+	from boss_agent_cli.resume.models import ResumeData, ResumeFile
 
 __version__ = "1.11.0"
+
+_LAZY_EXPORT_MODULES = {
+	"AuthManager": "boss_agent_cli.auth.manager",
+	"AuthRequired": "boss_agent_cli.auth.manager",
+	"TokenRefreshFailed": "boss_agent_cli.auth.manager",
+	"BossClient": "boss_agent_cli.api.client",
+	"AuthError": "boss_agent_cli.api.client",
+	"AccountRiskError": "boss_agent_cli.api.client",
+	"JobItem": "boss_agent_cli.api.models",
+	"JobDetail": "boss_agent_cli.api.models",
+	"CacheStore": "boss_agent_cli.cache.store",
+	"AIService": "boss_agent_cli.ai.service",
+	"AIServiceError": "boss_agent_cli.ai.service",
+	"ResumeData": "boss_agent_cli.resume.models",
+	"ResumeFile": "boss_agent_cli.resume.models",
+	"Platform": "boss_agent_cli.platforms",
+	"BossPlatform": "boss_agent_cli.platforms",
+	"ZhilianPlatform": "boss_agent_cli.platforms",
+	"get_platform": "boss_agent_cli.platforms",
+	"list_platforms": "boss_agent_cli.platforms",
+}
 
 __all__ = [
 	# 版本
@@ -49,3 +74,15 @@ __all__ = [
 	"get_platform",
 	"list_platforms",
 ]
+
+
+def __getattr__(name: str) -> object:
+	"""Resolve package-level public API exports on first access."""
+	try:
+		module_name = _LAZY_EXPORT_MODULES[name]
+	except KeyError:
+		raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+
+	value = getattr(import_module(module_name), name)
+	globals()[name] = value
+	return value

--- a/src/boss_agent_cli/api/browser_client.py
+++ b/src/boss_agent_cli/api/browser_client.py
@@ -178,7 +178,10 @@ class BrowserSession:
 		import httpx
 		try:
 			resp = httpx.get(f"{http_url}/json/version", timeout=_CDP_PROBE_TIMEOUT)
-			return cast("str | None", resp.json().get("webSocketDebuggerUrl"))
+			payload = resp.json()
+			if not isinstance(payload, dict):
+				return None
+			return cast("str | None", payload.get("webSocketDebuggerUrl"))
 		except (httpx.HTTPError, ValueError, KeyError):
 			return None
 
@@ -322,9 +325,15 @@ class BrowserSession:
 		else:
 			# Headless 模式：关闭整个浏览器实例
 			if self._browser:
-				self._browser.close()
+				try:
+					self._browser.close()
+				except Exception:
+					pass
 		if self._pw:
-			self._pw.stop()
+			try:
+				self._pw.stop()
+			except Exception:
+				pass
 		self._started = False
 
 	def __enter__(self) -> "BrowserSession":

--- a/src/boss_agent_cli/commands/register.py
+++ b/src/boss_agent_cli/commands/register.py
@@ -1,0 +1,117 @@
+"""Click command registration helpers."""
+
+import click
+
+from boss_agent_cli.commands import (
+	ai_cmd,
+	apply,
+	chat,
+	chat_summary,
+	chatmsg,
+	cities,
+	clean,
+	config_cmd,
+	detail,
+	digest,
+	doctor,
+	exchange,
+	export,
+	greet,
+	history,
+	interviews,
+	login,
+	logout,
+	mark,
+	me,
+	pipeline,
+	preset,
+	recommend,
+	resume_cmd,
+	schema,
+	search,
+	shortlist,
+	show,
+	stats,
+	status,
+	watch,
+)
+from boss_agent_cli.commands.recruiter import applications as recruiter_applications
+from boss_agent_cli.commands.recruiter import candidates as recruiter_candidates
+from boss_agent_cli.commands.recruiter import chat as recruiter_chat
+from boss_agent_cli.commands.recruiter import jobs as recruiter_jobs
+from boss_agent_cli.commands.recruiter import reply as recruiter_reply
+from boss_agent_cli.commands.recruiter import request_resume as recruiter_request_resume
+from boss_agent_cli.commands.recruiter import resume as recruiter_resume
+from boss_agent_cli.display import handle_error_output
+from boss_agent_cli.platforms import list_recruiter_platforms
+
+
+def register_candidate_commands(cli: click.Group) -> None:
+	"""Register candidate and shared top-level commands."""
+	cli.add_command(schema.schema_cmd, "schema")
+	cli.add_command(login.login_cmd, "login")
+	cli.add_command(logout.logout_cmd, "logout")
+	cli.add_command(status.status_cmd, "status")
+	cli.add_command(doctor.doctor_cmd, "doctor")
+	cli.add_command(search.search_cmd, "search")
+	cli.add_command(detail.detail_cmd, "detail")
+	cli.add_command(greet.greet_cmd, "greet")
+	cli.add_command(greet.batch_greet_cmd, "batch-greet")
+	cli.add_command(recommend.recommend_cmd, "recommend")
+	cli.add_command(export.export_cmd, "export")
+	cli.add_command(cities.cities_cmd, "cities")
+	cli.add_command(me.me_cmd, "me")
+	cli.add_command(chat.chat_cmd, "chat")
+	cli.add_command(chatmsg.chatmsg_cmd, "chatmsg")
+	cli.add_command(chat_summary.chat_summary_cmd, "chat-summary")
+	cli.add_command(mark.mark_cmd, "mark")
+	cli.add_command(exchange.exchange_cmd, "exchange")
+	cli.add_command(interviews.interviews_cmd, "interviews")
+	cli.add_command(show.show_cmd, "show")
+	cli.add_command(history.history_cmd, "history")
+	cli.add_command(watch.watch_group, "watch")
+	cli.add_command(pipeline.pipeline_cmd, "pipeline")
+	cli.add_command(pipeline.follow_up_cmd, "follow-up")
+	cli.add_command(apply.apply_cmd, "apply")
+	cli.add_command(shortlist.shortlist_group, "shortlist")
+	cli.add_command(preset.preset_group, "preset")
+	cli.add_command(digest.digest_cmd, "digest")
+	cli.add_command(config_cmd.config_group, "config")
+	cli.add_command(clean.clean_cmd, "clean")
+	cli.add_command(resume_cmd.resume_group, "resume")
+	cli.add_command(ai_cmd.ai_group, "ai")
+	cli.add_command(stats.stats_cmd, "stats")
+
+
+@click.group("hr", help="招聘者模式快捷命令")
+@click.pass_context
+def hr_group(ctx: click.Context) -> None:
+	ctx.obj["role"] = "recruiter"
+	platform_name = ctx.obj.get("platform") or "zhipin"
+	recruiter_name = f"{platform_name}-recruiter"
+	supported = list_recruiter_platforms()
+	if recruiter_name not in supported:
+		handle_error_output(
+			ctx,
+			"hr",
+			code="INVALID_PARAM",
+			message=(
+				f"招聘者模式暂不支持平台 {platform_name!r}；"
+				f"当前仅支持: {', '.join(supported)}"
+			),
+			recoverable=True,
+			recovery_action="boss --platform zhipin hr ...",
+		)
+		raise SystemExit(1)
+
+
+def register_recruiter_commands(cli: click.Group) -> None:
+	"""Register recruiter shortcut commands."""
+	cli.add_command(hr_group, "hr")
+	hr_group.add_command(recruiter_applications.applications_cmd, "applications")
+	hr_group.add_command(recruiter_resume.resume_cmd, "resume")
+	hr_group.add_command(recruiter_chat.recruiter_chat_cmd, "chat")
+	hr_group.add_command(recruiter_jobs.jobs_group, "jobs")
+	hr_group.add_command(recruiter_candidates.candidates_cmd, "candidates")
+	hr_group.add_command(recruiter_reply.reply_cmd, "reply")
+	hr_group.add_command(recruiter_request_resume.request_resume_cmd, "request-resume")

--- a/src/boss_agent_cli/main.py
+++ b/src/boss_agent_cli/main.py
@@ -3,19 +3,11 @@ from pathlib import Path
 import click
 
 from boss_agent_cli import __version__
-from boss_agent_cli.commands import schema, login, logout, status, doctor, search, detail, greet, recommend, export, cities, me, chat, chatmsg, chat_summary, mark, exchange, interviews, show, history, watch, pipeline, apply, shortlist, preset, digest, config_cmd, clean, resume_cmd, ai_cmd, stats
-from boss_agent_cli.commands.recruiter import applications as recruiter_applications
-from boss_agent_cli.commands.recruiter import resume as recruiter_resume
-from boss_agent_cli.commands.recruiter import chat as recruiter_chat
-from boss_agent_cli.commands.recruiter import jobs as recruiter_jobs
-from boss_agent_cli.commands.recruiter import candidates as recruiter_candidates
-from boss_agent_cli.commands.recruiter import reply as recruiter_reply
-from boss_agent_cli.commands.recruiter import request_resume as recruiter_request_resume
+from boss_agent_cli.commands.register import register_candidate_commands, register_recruiter_commands
 from boss_agent_cli.config import load_config
-from boss_agent_cli.display import handle_error_output
 from boss_agent_cli.hooks import create_hook_bus
 from boss_agent_cli.output import Logger
-from boss_agent_cli.platforms import list_platforms, list_recruiter_platforms
+from boss_agent_cli.platforms import list_platforms
 
 
 @click.group(context_settings={"allow_interspersed_args": False})
@@ -64,67 +56,5 @@ def cli(ctx: click.Context, data_dir: str, delay: str | None, cdp_url: str | Non
 	ctx.obj["hooks"] = create_hook_bus()
 
 
-cli.add_command(schema.schema_cmd, "schema")
-cli.add_command(login.login_cmd, "login")
-cli.add_command(logout.logout_cmd, "logout")
-cli.add_command(status.status_cmd, "status")
-cli.add_command(doctor.doctor_cmd, "doctor")
-cli.add_command(search.search_cmd, "search")
-cli.add_command(detail.detail_cmd, "detail")
-cli.add_command(greet.greet_cmd, "greet")
-cli.add_command(greet.batch_greet_cmd, "batch-greet")
-cli.add_command(recommend.recommend_cmd, "recommend")
-cli.add_command(export.export_cmd, "export")
-cli.add_command(cities.cities_cmd, "cities")
-cli.add_command(me.me_cmd, "me")
-cli.add_command(chat.chat_cmd, "chat")
-cli.add_command(chatmsg.chatmsg_cmd, "chatmsg")
-cli.add_command(chat_summary.chat_summary_cmd, "chat-summary")
-cli.add_command(mark.mark_cmd, "mark")
-cli.add_command(exchange.exchange_cmd, "exchange")
-cli.add_command(interviews.interviews_cmd, "interviews")
-cli.add_command(show.show_cmd, "show")
-cli.add_command(history.history_cmd, "history")
-cli.add_command(watch.watch_group, "watch")
-cli.add_command(pipeline.pipeline_cmd, "pipeline")
-cli.add_command(pipeline.follow_up_cmd, "follow-up")
-cli.add_command(apply.apply_cmd, "apply")
-cli.add_command(shortlist.shortlist_group, "shortlist")
-cli.add_command(preset.preset_group, "preset")
-cli.add_command(digest.digest_cmd, "digest")
-cli.add_command(config_cmd.config_group, "config")
-cli.add_command(clean.clean_cmd, "clean")
-cli.add_command(resume_cmd.resume_group, "resume")
-cli.add_command(ai_cmd.ai_group, "ai")
-cli.add_command(stats.stats_cmd, "stats")
-
-# Recruiter shortcut: boss hr <subcommand>
-@click.group("hr", help="招聘者模式快捷命令")
-@click.pass_context
-def hr_group(ctx: click.Context) -> None:
-	ctx.obj["role"] = "recruiter"
-	platform_name = ctx.obj.get("platform") or "zhipin"
-	recruiter_name = f"{platform_name}-recruiter"
-	supported = list_recruiter_platforms()
-	if recruiter_name not in supported:
-		handle_error_output(
-			ctx,
-			"hr",
-			code="INVALID_PARAM",
-			message=(
-				f"招聘者模式暂不支持平台 {platform_name!r}；"
-				f"当前仅支持: {', '.join(supported)}"
-			),
-			recoverable=True,
-			recovery_action="boss --platform zhipin hr ...",
-		)
-		raise SystemExit(1)
-
-cli.add_command(hr_group, "hr")
-hr_group.add_command(recruiter_applications.applications_cmd, "applications")
-hr_group.add_command(recruiter_resume.resume_cmd, "resume")
-hr_group.add_command(recruiter_chat.recruiter_chat_cmd, "chat")
-hr_group.add_command(recruiter_jobs.jobs_group, "jobs")
-hr_group.add_command(recruiter_candidates.candidates_cmd, "candidates")
-hr_group.add_command(recruiter_reply.reply_cmd, "reply")
-hr_group.add_command(recruiter_request_resume.request_resume_cmd, "request-resume")
+register_candidate_commands(cli)
+register_recruiter_commands(cli)

--- a/tests/test_agent_docs.py
+++ b/tests/test_agent_docs.py
@@ -195,19 +195,17 @@ def test_pyproject_exposes_boss_mcp_script():
 
 
 def test_schema_main_and_modules_command_count_consistent():
-	"""防漂移：main.py 注册命令去掉 schema 自身后，应与 SCHEMA_DATA 完全一致。"""
-	import re
-
+	"""防漂移：Click 顶层命令去掉 schema 自身后，应与 SCHEMA_DATA 完全一致。"""
 	from boss_agent_cli.commands.schema import SCHEMA_DATA
+	from boss_agent_cli.main import cli
 
-	main_text = _read("src/boss_agent_cli/main.py")
-	registered = re.findall(r'cli\.add_command\([^,]+,\s*"([^"]+)"', main_text)
+	registered = list(cli.commands)
 	registered_set = set(registered) - {"schema"}
 
 	schema_set = set(SCHEMA_DATA["commands"].keys())
 
 	assert registered_set == schema_set, (
-		f"main.py 注册命令与 SCHEMA_DATA 不一致："
-		f"仅在 main: {registered_set - schema_set}，仅在 schema: {schema_set - registered_set}"
+		f"Click 顶层命令与 SCHEMA_DATA 不一致："
+		f"仅在 Click: {registered_set - schema_set}，仅在 schema: {schema_set - registered_set}"
 	)
-	assert len(registered) == len(set(registered)), "main.py 存在重复注册命令"
+	assert len(registered) == len(set(registered)), "Click 顶层命令存在重复注册"

--- a/tests/test_browser_client.py
+++ b/tests/test_browser_client.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, MagicMock
 import httpx
 
 from boss_agent_cli.api.browser_client import (
+	CDP_DEFAULT_URL,
 	HOME_URL,
 	_HEADLESS_NETWORKIDLE_GRACE_MS,
 	_NAV_TIMEOUT_MS,
@@ -29,6 +30,39 @@ def test_fetch_ws_url_success():
 def test_fetch_ws_url_failure():
 	with patch("httpx.get", side_effect=httpx.ConnectError("connection refused")):
 		ws = BrowserSession._fetch_ws_url("http://127.0.0.1:9222")
+		assert ws is None
+
+
+def test_fetch_ws_url_invalid_json_returns_none():
+	with patch("httpx.get") as mock_get:
+		mock_resp = MagicMock()
+		mock_resp.json.side_effect = ValueError("invalid json")
+		mock_get.return_value = mock_resp
+
+		ws = BrowserSession._fetch_ws_url("http://127.0.0.1:9222")
+
+		assert ws is None
+
+
+def test_fetch_ws_url_missing_websocket_debugger_url_returns_none():
+	with patch("httpx.get") as mock_get:
+		mock_resp = MagicMock()
+		mock_resp.json.return_value = {"Browser": "Chrome"}
+		mock_get.return_value = mock_resp
+
+		ws = BrowserSession._fetch_ws_url("http://127.0.0.1:9222")
+
+		assert ws is None
+
+
+def test_fetch_ws_url_non_object_json_returns_none():
+	with patch("httpx.get") as mock_get:
+		mock_resp = MagicMock()
+		mock_resp.json.return_value = ["not", "a", "devtools", "object"]
+		mock_get.return_value = mock_resp
+
+		ws = BrowserSession._fetch_ws_url("http://127.0.0.1:9222")
+
 		assert ws is None
 
 
@@ -93,6 +127,44 @@ def test_close_headless_mode_closes_browser():
 	session.close()
 
 	session._browser.close.assert_called_once()
+
+
+def test_close_is_idempotent_when_cdp_resources_are_partial_and_raise():
+	session = BrowserSession(cookies={}, user_agent="")
+	session._is_cdp = True
+	session._own_context = True
+	session._started = True
+	session._page = MagicMock()
+	session._context = MagicMock()
+	session._pw = MagicMock()
+	session._page.close.side_effect = RuntimeError("page already closed")
+	session._context.close.side_effect = RuntimeError("context already closed")
+	session._pw.stop.side_effect = RuntimeError("playwright already stopped")
+
+	session.close()
+	session.close()
+
+	assert session._started is False
+	assert session._page.close.call_count == 2
+	assert session._context.close.call_count == 2
+	assert session._pw.stop.call_count == 2
+
+
+def test_close_is_idempotent_when_headless_resources_are_partial_and_raise():
+	session = BrowserSession(cookies={}, user_agent="")
+	session._is_cdp = False
+	session._started = True
+	session._browser = MagicMock()
+	session._pw = MagicMock()
+	session._browser.close.side_effect = RuntimeError("browser already closed")
+	session._pw.stop.side_effect = RuntimeError("playwright already stopped")
+
+	session.close()
+	session.close()
+
+	assert session._started is False
+	assert session._browser.close.call_count == 2
+	assert session._pw.stop.call_count == 2
 
 
 def test_try_connect_reuses_existing_context():
@@ -179,3 +251,84 @@ def test_start_headless_tolerates_networkidle_timeout():
 		"headless 首页未进入 networkidle" in call.args[0]
 		for call in logger.info.call_args_list
 	)
+
+
+def test_ensure_started_falls_back_to_patchright_when_bridge_and_cdp_fail():
+	session = BrowserSession(cookies={}, user_agent="")
+	mock_pw = MagicMock()
+	sentinel = {"headless_started": False}
+
+	def mark_headless_started():
+		sentinel["headless_started"] = True
+		session._started = True
+
+	with (
+		patch.object(session, "_try_bridge", return_value=False) as mock_try_bridge,
+		patch("boss_agent_cli.api.browser_client.sync_playwright") as mock_sync_playwright,
+		patch.object(session, "_try_cdp", return_value=False) as mock_try_cdp,
+		patch.object(session, "_start_headless", side_effect=mark_headless_started) as mock_start_headless,
+	):
+		mock_sync_playwright.return_value.start.return_value = mock_pw
+
+		session._ensure_started()
+
+	assert sentinel["headless_started"] is True
+	assert session._started is True
+	assert session._pw is mock_pw
+	mock_try_bridge.assert_called_once()
+	mock_sync_playwright.assert_called_once()
+	mock_try_cdp.assert_called_once()
+	mock_start_headless.assert_called_once()
+
+
+def test_try_cdp_attempts_http_ws_and_devtools_urls_before_falling_back():
+	session = BrowserSession(cookies={}, user_agent="", cdp_url="http://127.0.0.1:9333")
+
+	with (
+		patch.object(session, "_try_connect", return_value=False) as mock_try_connect,
+		patch.object(BrowserSession, "_fetch_ws_url", side_effect=[None, "ws://127.0.0.1:9222/devtools/browser/default"]) as mock_fetch_ws_url,
+		patch.object(BrowserSession, "_read_devtools_active_port", return_value="ws://127.0.0.1:9222/devtools/browser/file") as mock_read_port,
+	):
+		result = session._try_cdp()
+
+	assert result is False
+	mock_read_port.assert_called_once()
+	assert [call.args[0] for call in mock_try_connect.call_args_list] == [
+		"http://127.0.0.1:9333",
+		CDP_DEFAULT_URL,
+		"ws://127.0.0.1:9222/devtools/browser/default",
+		"ws://127.0.0.1:9222/devtools/browser/file",
+	]
+	assert [call.args[0] for call in mock_fetch_ws_url.call_args_list] == [
+		"http://127.0.0.1:9333",
+		CDP_DEFAULT_URL,
+	]
+
+
+def test_request_returns_browser_evaluation_json_and_marks_throttle():
+	session = BrowserSession(cookies={}, user_agent="")
+	session._started = True
+	session._page = MagicMock()
+	session._throttle = MagicMock()
+	expected = {"code": 0, "zpData": {"jobs": []}}
+	session._page.evaluate.return_value = expected
+
+	result = session.request(
+		"POST",
+		"https://www.zhipin.com/wapi/zpgeek/search/joblist.json",
+		params={"query": "python", "page": 1},
+		data={"city": "101020100"},
+	)
+
+	assert result == expected
+	session._throttle.wait.assert_called_once()
+	session._throttle.mark.assert_called_once()
+	evaluate_script, evaluate_args = session._page.evaluate.call_args.args
+	assert "fetch(fetchUrl, options)" in evaluate_script
+	assert evaluate_args == {
+		"method": "POST",
+		"url": "https://www.zhipin.com/wapi/zpgeek/search/joblist.json",
+		"params": {"query": "python", "page": 1},
+		"data": {"city": "101020100"},
+		"referer": "https://www.zhipin.com/web/geek/job",
+	}

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -4,8 +4,11 @@
 任何改名 / 删除都会在这里被立即捕获。
 """
 import importlib
+import json
+import subprocess
+import sys
 
-import boss_agent_cli
+import pytest
 
 
 # ── __all__ 契约 ─────────────────────────────────────────
@@ -34,45 +37,80 @@ EXPECTED_EXPORTS = {
 }
 
 
-def test_all_is_defined():
+@pytest.fixture
+def boss_agent_cli():
+	return importlib.import_module("boss_agent_cli")
+
+
+def test_package_import_does_not_eagerly_import_browser_runtime():
+	probe = (
+		"import json, sys; "
+		"sys.modules.pop('patchright.sync_api', None); "
+		"import boss_agent_cli; "
+		"print(json.dumps({"
+		"'version': boss_agent_cli.__version__, "
+		"'patchright_loaded': 'patchright.sync_api' in sys.modules"
+		"}))"
+	)
+	result = subprocess.run(
+		[sys.executable, "-c", probe],
+		check=True,
+		capture_output=True,
+		text=True,
+	)
+	payload = json.loads(result.stdout)
+	assert payload["version"]
+	assert payload["patchright_loaded"] is False
+
+
+def test_all_is_defined(boss_agent_cli):
 	assert hasattr(boss_agent_cli, "__all__")
 	assert isinstance(boss_agent_cli.__all__, list)
 
 
-def test_all_matches_expected_exports():
+def test_all_matches_expected_exports(boss_agent_cli):
 	assert set(boss_agent_cli.__all__) == EXPECTED_EXPORTS
 
 
-def test_every_export_is_actually_importable():
+def test_every_export_is_actually_importable(boss_agent_cli):
 	"""__all__ 里声明的每个名字都能真的从包里 import 到。"""
 	for name in boss_agent_cli.__all__:
 		assert hasattr(boss_agent_cli, name), f"{name} declared in __all__ but not exported"
 
 
+def test_lazy_export_is_cached_after_first_access(boss_agent_cli):
+	assert boss_agent_cli.AuthManager is boss_agent_cli.AuthManager
+
+
+def test_unknown_package_attribute_raises_attribute_error(boss_agent_cli):
+	with pytest.raises(AttributeError, match="no attribute 'MissingExport'"):
+		getattr(boss_agent_cli, "MissingExport")
+
+
 # ── 关键类型的身份一致性 ──────────────────────────────────
 
 
-def test_auth_manager_identity():
+def test_auth_manager_identity(boss_agent_cli):
 	from boss_agent_cli.auth.manager import AuthManager as OriginalAuthManager
 	assert boss_agent_cli.AuthManager is OriginalAuthManager
 
 
-def test_boss_client_identity():
+def test_boss_client_identity(boss_agent_cli):
 	from boss_agent_cli.api.client import BossClient as OriginalBossClient
 	assert boss_agent_cli.BossClient is OriginalBossClient
 
 
-def test_cache_store_identity():
+def test_cache_store_identity(boss_agent_cli):
 	from boss_agent_cli.cache.store import CacheStore as OriginalCacheStore
 	assert boss_agent_cli.CacheStore is OriginalCacheStore
 
 
-def test_job_item_identity():
+def test_job_item_identity(boss_agent_cli):
 	from boss_agent_cli.api.models import JobItem as OriginalJobItem
 	assert boss_agent_cli.JobItem is OriginalJobItem
 
 
-def test_ai_service_identity():
+def test_ai_service_identity(boss_agent_cli):
 	from boss_agent_cli.ai.service import AIService as OriginalAIService
 	assert boss_agent_cli.AIService is OriginalAIService
 
@@ -80,30 +118,30 @@ def test_ai_service_identity():
 # ── 异常继承关系 ──────────────────────────────────────────
 
 
-def test_auth_required_is_exception():
+def test_auth_required_is_exception(boss_agent_cli):
 	assert issubclass(boss_agent_cli.AuthRequired, Exception)
 
 
-def test_token_refresh_failed_is_exception():
+def test_token_refresh_failed_is_exception(boss_agent_cli):
 	assert issubclass(boss_agent_cli.TokenRefreshFailed, Exception)
 
 
-def test_auth_error_is_exception():
+def test_auth_error_is_exception(boss_agent_cli):
 	assert issubclass(boss_agent_cli.AuthError, Exception)
 
 
-def test_account_risk_error_is_exception():
+def test_account_risk_error_is_exception(boss_agent_cli):
 	assert issubclass(boss_agent_cli.AccountRiskError, Exception)
 
 
-def test_ai_service_error_is_exception():
+def test_ai_service_error_is_exception(boss_agent_cli):
 	assert issubclass(boss_agent_cli.AIServiceError, Exception)
 
 
 # ── 平台抽象 ──────────────────────────────────────────────
 
 
-def test_platform_is_abstract():
+def test_platform_is_abstract(boss_agent_cli):
 	assert inspect_abstract(boss_agent_cli.Platform)
 
 
@@ -111,22 +149,22 @@ def inspect_abstract(cls: type) -> bool:
 	return bool(getattr(cls, "__abstractmethods__", set()))
 
 
-def test_boss_platform_subclasses_platform():
+def test_boss_platform_subclasses_platform(boss_agent_cli):
 	assert issubclass(boss_agent_cli.BossPlatform, boss_agent_cli.Platform)
 
 
-def test_get_platform_returns_boss_by_default():
+def test_get_platform_returns_boss_by_default(boss_agent_cli):
 	assert boss_agent_cli.get_platform("zhipin") is boss_agent_cli.BossPlatform
 
 
-def test_list_platforms_contains_zhipin():
+def test_list_platforms_contains_zhipin(boss_agent_cli):
 	assert "zhipin" in boss_agent_cli.list_platforms()
 
 
 # ── 版本格式 ──────────────────────────────────────────────
 
 
-def test_version_is_semver_string():
+def test_version_is_semver_string(boss_agent_cli):
 	version = boss_agent_cli.__version__
 	assert isinstance(version, str)
 	parts = version.split(".")
@@ -151,7 +189,7 @@ def test_py_typed_marker_exists():
 # ── 包级 docstring ────────────────────────────────────────
 
 
-def test_package_has_docstring():
+def test_package_has_docstring(boss_agent_cli):
 	"""提供给 help(boss_agent_cli) 的入口说明。"""
 	assert boss_agent_cli.__doc__ is not None
 	assert len(boss_agent_cli.__doc__.strip()) > 0


### PR DESCRIPTION
## Summary
- Reduce package import side effects by lazily resolving public API exports.
- Split Click command registration out of main.py into a dedicated registration module.
- Add browser client error-path coverage and harden cleanup/WebSocket lookup behavior.

## Test Plan
- uv run pytest tests/ -q
- uv run mypy src/boss_agent_cli
- uv run ruff check src/
- uv run boss --help
- uv run boss schema --format native
- git diff --check

## Notes
- This PR intentionally excludes the README badge policy branch so the review scope stays focused on runtime structure and tests.
- Final code review found no blocking issues.