### PR TITLE
fix: 增强登录态可靠性

### DIFF
--- a/src/boss_agent_cli/auth/browser.py
+++ b/src/boss_agent_cli/auth/browser.py
@@ -98,44 +98,45 @@ def login_via_cdp(*, cdp_url: str | None = None, timeout: int = 120, platform: s
 	page = ctx.new_page()
 
 	try:
-		page.goto(
-			login_page_url,
-			wait_until="commit", timeout=_NAV_TIMEOUT_MS,
-		)
-	except Exception:
-		pass
+		try:
+			page.goto(
+				login_page_url,
+				wait_until="commit", timeout=_NAV_TIMEOUT_MS,
+			)
+		except Exception:
+			pass
 
-	print(f"[boss] 请在 Chrome 中扫码登录，等待中...（超时 {timeout}s）", file=sys.stderr)
+		print(f"[boss] 请在 Chrome 中扫码登录，等待中...（超时 {timeout}s）", file=sys.stderr)
 
-	for i in range(timeout):
-		time.sleep(1)
-		cookies = ctx.cookies()
-		success = [c for c in cookies if c["name"] == success_cookie and cookie_domain in c.get("domain", "")]
-		if success:
-			print("[boss] 检测到登录成功！", file=sys.stderr)
-			break
-		if i > 0 and i % 15 == 0:
-			print(f"[boss] 等待中... {i}s", file=sys.stderr)
-	else:
-		page.close()
-		pw.stop()
-		raise TimeoutError(f"CDP 扫码登录超时（{timeout}s）")
+		for i in range(timeout):
+			time.sleep(1)
+			cookies = ctx.cookies()
+			success = [c for c in cookies if c["name"] == success_cookie and cookie_domain in c.get("domain", "")]
+			if success:
+				print("[boss] 检测到登录成功！", file=sys.stderr)
+				break
+			if i > 0 and i % 15 == 0:
+				print(f"[boss] 等待中... {i}s", file=sys.stderr)
+		else:
+			raise TimeoutError(f"CDP 扫码登录超时（{timeout}s）")
 
-	try:
-		page.goto(home_url, wait_until="domcontentloaded", timeout=_NAV_TIMEOUT_MS)
-	except Exception:
-		pass
-	all_cookies = {c["name"]: c["value"] for c in ctx.cookies() if cookie_domain in c.get("domain", "")}
-	ua = page.evaluate("navigator.userAgent")
-	x_zp_client_id = _extract_zhilian_client_id(page) if platform == "zhilian" else ""
+		try:
+			page.goto(home_url, wait_until="domcontentloaded", timeout=_NAV_TIMEOUT_MS)
+		except Exception:
+			pass
+		all_cookies = {c["name"]: c["value"] for c in ctx.cookies() if cookie_domain in c.get("domain", "")}
+		ua = page.evaluate("navigator.userAgent")
+		x_zp_client_id = _extract_zhilian_client_id(page) if platform == "zhilian" else ""
 
-	page.close()
-	pw.stop()
-
-	result: dict[str, Any] = {"cookies": all_cookies, "stoken": "", "user_agent": ua}
-	if x_zp_client_id:
-		result["x_zp_client_id"] = x_zp_client_id
-	return result
+		result: dict[str, Any] = {"cookies": all_cookies, "stoken": "", "user_agent": ua}
+		if x_zp_client_id:
+			result["x_zp_client_id"] = x_zp_client_id
+		return result
+	finally:
+		try:
+			page.close()
+		finally:
+			pw.stop()
 
 
 def login_via_browser(*, timeout: int = 120, platform: str = "zhipin") -> dict[str, Any]:

--- a/src/boss_agent_cli/auth/manager.py
+++ b/src/boss_agent_cli/auth/manager.py
@@ -174,9 +174,9 @@ class AuthManager:
 						current["cookies"],
 						current.get("user_agent", ""),
 					)
-				current["stoken"] = new_stoken
-				self._store.save(current)
-				self._token = current
+				refreshed = {**current, "stoken": new_stoken}
+				self._store.save(refreshed)
+				self._token = refreshed
 			except Exception as e:
 				raise TokenRefreshFailed(f"Token 刷新失败: {e}") from e
 

--- a/src/boss_agent_cli/auth/token_store.py
+++ b/src/boss_agent_cli/auth/token_store.py
@@ -101,9 +101,12 @@ class TokenStore:
 		encrypted = self._session_path.read_bytes()
 		try:
 			plaintext = fernet.decrypt(encrypted)
-		except (InvalidToken, ValueError):
+			decoded = json.loads(plaintext)
+		except (InvalidToken, ValueError, TypeError, json.JSONDecodeError):
 			return None
-		return cast("dict[str, Any]", json.loads(plaintext))
+		if not isinstance(decoded, dict):
+			return None
+		return cast("dict[str, Any]", decoded)
 
 	def clear(self) -> None:
 		"""删除 session.enc 文件（保留 salt 供下次登录复用）"""

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+from cryptography.fernet import Fernet
+
 from boss_agent_cli.auth.token_store import TokenStore
 
 
@@ -30,6 +32,20 @@ def test_overwrite(tmp_path):
 def test_load_invalid_token_returns_none(tmp_path):
 	store = TokenStore(tmp_path)
 	(store._auth_dir / "session.enc").write_bytes(b"not-a-valid-fernet-token")
+	assert store.load() is None
+
+
+def test_load_malformed_decrypted_json_returns_none(tmp_path):
+	store = TokenStore(tmp_path)
+	fernet = Fernet(store._derive_key())
+	(store._auth_dir / "session.enc").write_bytes(fernet.encrypt(b"{not-json"))
+	assert store.load() is None
+
+
+def test_load_decrypted_non_dict_returns_none(tmp_path):
+	store = TokenStore(tmp_path)
+	fernet = Fernet(store._derive_key())
+	(store._auth_dir / "session.enc").write_bytes(fernet.encrypt(b'["not", "a", "dict"]'))
 	assert store.load() is None
 
 

--- a/tests/test_auth_browser.py
+++ b/tests/test_auth_browser.py
@@ -1,10 +1,13 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from boss_agent_cli.auth.browser import (
 	HOME_URL,
 	LOGIN_PAGE_URL,
 	_NAV_TIMEOUT_MS,
 	_NETWORKIDLE_GRACE_MS,
+	login_via_cdp,
 	login_via_browser,
 	refresh_stoken,
 )
@@ -19,6 +22,55 @@ def _mock_playwright_context(mock_browser: MagicMock) -> MagicMock:
 	mock_context_manager.__enter__ = MagicMock(return_value=mock_playwright)
 	mock_context_manager.__exit__ = MagicMock(return_value=False)
 	return mock_context_manager
+
+
+def _mock_cdp_playwright(mock_context: MagicMock) -> tuple[MagicMock, MagicMock, MagicMock]:
+	mock_page = MagicMock()
+	mock_context.new_page.return_value = mock_page
+
+	mock_browser = MagicMock()
+	mock_browser.contexts = [mock_context]
+
+	mock_playwright = MagicMock()
+	mock_playwright.chromium.connect_over_cdp.return_value = mock_browser
+
+	mock_launcher = MagicMock()
+	mock_launcher.start.return_value = mock_playwright
+	return mock_launcher, mock_playwright, mock_page
+
+
+@patch("boss_agent_cli.auth.browser.probe_cdp", return_value="ws://localhost/devtools/browser")
+@patch("boss_agent_cli.auth.browser.time.sleep", return_value=None)
+def test_login_via_cdp_stops_playwright_on_timeout(mock_sleep, mock_probe_cdp):
+	mock_context = MagicMock()
+	mock_context.cookies.return_value = []
+	mock_launcher, mock_playwright, mock_page = _mock_cdp_playwright(mock_context)
+
+	with patch("boss_agent_cli.auth.browser.sync_playwright", return_value=mock_launcher):
+		with pytest.raises(TimeoutError):
+			login_via_cdp(timeout=1)
+
+	mock_page.close.assert_called_once()
+	mock_playwright.stop.assert_called_once()
+
+
+@patch("boss_agent_cli.auth.browser.probe_cdp", return_value="ws://localhost/devtools/browser")
+@patch("boss_agent_cli.auth.browser.time.sleep", return_value=None)
+def test_login_via_cdp_stops_playwright_when_user_agent_extraction_fails(mock_sleep, mock_probe_cdp):
+	mock_context = MagicMock()
+	mock_context.cookies.side_effect = [
+		[{"name": "wt2", "value": "token", "domain": ".zhipin.com"}],
+		[{"name": "wt2", "value": "token", "domain": ".zhipin.com"}],
+	]
+	mock_launcher, mock_playwright, mock_page = _mock_cdp_playwright(mock_context)
+	mock_page.evaluate.side_effect = RuntimeError("user agent unavailable")
+
+	with patch("boss_agent_cli.auth.browser.sync_playwright", return_value=mock_launcher):
+		with pytest.raises(RuntimeError, match="user agent unavailable"):
+			login_via_cdp(timeout=1)
+
+	mock_page.close.assert_called_once()
+	mock_playwright.stop.assert_called_once()
 
 
 @patch("boss_agent_cli.auth.browser._extract_stoken", return_value="fresh-stoken")

--- a/tests/test_auth_manager_flow.py
+++ b/tests/test_auth_manager_flow.py
@@ -223,6 +223,35 @@ def test_force_refresh_prefers_cdp_and_persists_new_stoken(
 
 
 @patch("boss_agent_cli.auth.manager.TokenStore")
+@patch("boss_agent_cli.auth.manager.refresh_stoken")
+@patch("boss_agent_cli.auth.manager.refresh_stoken_via_cdp")
+@patch("boss_agent_cli.auth.manager.probe_cdp")
+def test_force_refresh_does_not_mutate_loaded_token_when_save_fails(
+	mock_probe_cdp,
+	mock_refresh_cdp,
+	mock_refresh_stoken,
+	mock_store_cls,
+	tmp_path,
+):
+	current = {"cookies": {"wt2": "cookie"}, "stoken": "old-token", "user_agent": "ua"}
+	store = _make_store(token=current)
+	store.save.side_effect = OSError("disk full")
+	mock_store_cls.return_value = store
+	mock_probe_cdp.return_value = False
+	mock_refresh_stoken.return_value = "new-token"
+
+	manager = AuthManager(tmp_path)
+
+	with pytest.raises(TokenRefreshFailed, match="Token 刷新失败"):
+		manager.force_refresh()
+
+	mock_refresh_cdp.assert_not_called()
+	mock_refresh_stoken.assert_called_once_with({"wt2": "cookie"}, "ua")
+	assert current["stoken"] == "old-token"
+	assert manager._token is None
+
+
+@patch("boss_agent_cli.auth.manager.TokenStore")
 @patch("boss_agent_cli.auth.manager.extract_cookies")
 def test_zhilian_force_refresh_prefers_browser_cookie_extract(mock_extract, mock_store_cls, tmp_path):
 	current = {"cookies": {"zp_token": "old"}, "user_agent": "ua"}

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -31,6 +31,36 @@ def test_schema_command():
 	assert "stdout" in parsed["data"]["conventions"]
 
 
+@patch("boss_agent_cli.commands.login.AuthManager")
+def test_login_cdp_connection_error_returns_json_envelope(mock_auth_cls):
+	mock_auth_cls.return_value.login.side_effect = ConnectionError("CDP 不可用")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["login", "--cdp"])
+	assert result.exit_code == 1
+	assert result.stderr == ""
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["command"] == "login"
+	assert parsed["error"]["code"] == "NETWORK_ERROR"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "boss-chrome 启动 Chrome 后重试"
+
+
+@patch("boss_agent_cli.commands.login.AuthManager")
+def test_login_timeout_returns_platform_aware_recovery_action(mock_auth_cls):
+	mock_auth_cls.return_value.login.side_effect = TimeoutError("扫码登录超时")
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--platform", "zhilian", "login"])
+	assert result.exit_code == 1
+	assert result.stderr == ""
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["command"] == "login"
+	assert parsed["error"]["code"] == "NETWORK_ERROR"
+	assert parsed["error"]["recoverable"] is True
+	assert parsed["error"]["recovery_action"] == "boss --platform zhilian login"
+
+
 @patch("boss_agent_cli.commands.status.AuthManager")
 def test_status_not_logged_in(mock_auth_cls):
 	mock_auth_cls.return_value.check_status.return_value = None


### PR DESCRIPTION
## Summary
- Harden TokenStore loading for malformed encrypted payloads and non-dict decrypted data.
- Prevent refresh save failures from mutating the current token before persistence succeeds.
- Ensure CDP login cleanup stops Playwright on timeout and credential extraction failures.
- Add command-level coverage for login failure JSON envelopes.

## Test Plan
- uv run pytest tests/ -q
- uv run mypy src/boss_agent_cli
- uv run ruff check src/ tests/
- uv run boss --help
- uv run boss schema --format native
- git diff --check

## Notes
- This PR stays focused on auth/browser/token reliability and does not change watch, pipeline, or apply behavior.
- Implemented with Subagent-Driven task split and controller verification.