### PR TITLE
test: 完善真实流烟测框架

### DIFF
--- a/docs/smoke-testing.md
+++ b/docs/smoke-testing.md
@@ -1,36 +1,95 @@
 # Smoke Testing
 
-`scripts/smoke_p0.py` provides a minimal structured smoke harness for the current P0 golden path.
+`scripts/smoke_p0.py` is a gated real-flow smoke harness for the read-only P0 path.
 
-By default it targets `zhipin`. Set `BOSS_SMOKE_PLATFORM=zhilian` to run the same P0 shape against the Zhilian candidate path and have each step automatically prepend `--platform zhilian`.
+It is intentionally manual-first. Do not run it automatically against a real account in public CI.
 
 ## Covered Steps
 
-- `doctor`
-- `status`
-- `search`
-- `detail`
+- `doctor`: validates local environment and login prerequisites.
+- `status`: validates that the local encrypted login state can be read and used.
+- `search`: validates a minimal job discovery query.
+- `detail`: validates a known job detail lookup entrypoint.
+
+## Environment Controls
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `BOSS_SMOKE_PLATFORM` | `zhipin` | Platform adapter to test. Use `zhilian` for the Zhilian candidate path. |
+| `BOSS_SMOKE_QUERY` | `golang` | Query used by the `search` step. Required for live search confidence. |
+| `BOSS_SMOKE_SECURITY_ID` | `demo-security-id` | Security ID used by the `detail` step. Use a fresh value from a recent search result. |
+| `BOSS_SMOKE_TIMEOUT` | `30` | Per-command timeout in seconds. |
+| `BOSS_SMOKE_DRY_RUN` | unset | Set to `1`, `true`, or `yes` to print planned steps without executing commands. |
+
+## Safe Local Usage
+
+Dry run:
+
+```bash
+BOSS_SMOKE_DRY_RUN=1 uv run python scripts/smoke_p0.py
+```
+
+Zhipin live read-only smoke:
+
+```bash
+BOSS_SMOKE_QUERY=golang \
+BOSS_SMOKE_SECURITY_ID=<security_id_from_recent_search> \
+uv run python scripts/smoke_p0.py
+```
+
+Zhilian live read-only smoke:
+
+```bash
+BOSS_SMOKE_PLATFORM=zhilian \
+BOSS_SMOKE_QUERY=java \
+BOSS_SMOKE_SECURITY_ID=<security_id_from_recent_search> \
+uv run python scripts/smoke_p0.py
+```
 
 ## Output Shape
 
-The script prints JSON describing each step:
+The script prints one JSON object:
 
-- `name`
-- `purpose`
-- `platform`
-- `preconditions`
-- `failure_classification`
-- `command`
-- `status`
+```json
+{
+  "steps": [
+    {
+      "name": "status",
+      "purpose": "验证本地登录态是否存在且可读取",
+      "platform": "zhipin",
+      "preconditions": ["command:boss"],
+      "failure_classification": "env_error",
+      "command": ["boss", "status"],
+      "status": "pass",
+      "ok": true,
+      "error_code": null,
+      "recovery_action": null,
+      "returncode": 0,
+      "detail": ""
+    }
+  ]
+}
+```
 
 ## Status Meanings
 
-- `pass`: command ran successfully
-- `env_error`: required local setup is missing
-- `command_error`: command executed but the smoke path failed
+- `pass`: command returned a valid JSON envelope with `ok=true`.
+- `env_error`: required local setup is missing, or an auth/environment command returned `ok=false`.
+- `command_error`: command returned a valid JSON envelope with `ok=false`.
+- `contract_error`: stdout was not a valid boss JSON envelope.
+- `timeout`: command exceeded `BOSS_SMOKE_TIMEOUT`.
+- `dry_run`: command was intentionally not executed.
+
+## Privacy And CI Policy
+
+- 不提交真实 Cookie、token、security_id、联系人姓名、公司名称或原始 stdout 到仓库。
+- Use fresh local values for `BOSS_SMOKE_SECURITY_ID`; do not commit them into scripts or docs.
+- Public CI should run unit tests for the smoke harness, not live platform smoke.
+- Private/manual CI may run smoke only with an explicitly provisioned account and redacted logs.
 
 ## Intended Use
 
-- local pre-release validation
-- manual debugging checkpoints
-- future CI-safe smoke expansion
+- local pre-release validation;
+- manual debugging checkpoints;
+- release-candidate verification;
+- future private CI smoke expansion.

--- a/docs/smoke-testing.md
+++ b/docs/smoke-testing.md
@@ -84,6 +84,7 @@ The script prints one JSON object:
 
 - 不提交真实 Cookie、token、security_id、联系人姓名、公司名称或原始 stdout 到仓库。
 - Use fresh local values for `BOSS_SMOKE_SECURITY_ID`; do not commit them into scripts or docs.
+- Smoke output redacts the `detail` command argument so live `security_id` values are not printed by the harness.
 - Public CI should run unit tests for the smoke harness, not live platform smoke.
 - Private/manual CI may run smoke only with an explicitly provisioned account and redacted logs.
 

--- a/scripts/smoke_p0.py
+++ b/scripts/smoke_p0.py
@@ -87,10 +87,18 @@ DEFAULT_STEPS = build_default_steps()
 
 
 class SmokeRunner:
-	def __init__(self, steps: list[SmokeStep], *, run_command=None, timeout_seconds: int = 30):
+	def __init__(
+		self,
+		steps: list[SmokeStep],
+		*,
+		run_command=None,
+		timeout_seconds: int = 30,
+		dry_run: bool = False,
+	):
 		self.steps = steps
 		self._run_command = run_command or self._default_run_command
 		self._timeout_seconds = timeout_seconds
+		self._dry_run = dry_run
 
 	def _default_run_command(self, command, cwd, capture_output, text, timeout, check):
 		completed = subprocess.run(
@@ -125,36 +133,40 @@ class SmokeRunner:
 			recovery_action = None
 			returncode = None
 			if status is None:
-				try:
-					completed = self._run_command(
-						step.command,
-						cwd=ROOT,
-						capture_output=True,
-						text=True,
-						timeout=self._timeout_seconds,
-						check=False,
-					)
-					returncode = completed.returncode
-					payload, contract_error = parse_envelope(completed.stdout)
-					if contract_error:
-						status = "contract_error"
-						detail = contract_error
-					else:
-						ok = payload["ok"]
-						if ok:
-							status = "pass"
+				if self._dry_run:
+					status = "dry_run"
+					detail = "command not executed"
+				else:
+					try:
+						completed = self._run_command(
+							step.command,
+							cwd=ROOT,
+							capture_output=True,
+							text=True,
+							timeout=self._timeout_seconds,
+							check=False,
+						)
+						returncode = completed.returncode
+						payload, contract_error = parse_envelope(completed.stdout)
+						if contract_error:
+							status = "contract_error"
+							detail = contract_error
 						else:
-							status = step.failure_classification
-							error = payload.get("error") or {}
-							error_code = error.get("code")
-							recovery_action = error.get("recovery_action")
-							detail = error.get("message") or ""
-				except subprocess.TimeoutExpired:
-					status = "timeout"
-					detail = f"command exceeded {self._timeout_seconds}s"
-				except OSError as e:
-					status = "env_error"
-					detail = str(e)
+							ok = payload["ok"]
+							if ok:
+								status = "pass"
+							else:
+								status = step.failure_classification
+								error = payload.get("error") or {}
+								error_code = error.get("code")
+								recovery_action = error.get("recovery_action")
+								detail = error.get("message") or ""
+					except subprocess.TimeoutExpired:
+						status = "timeout"
+						detail = f"command exceeded {self._timeout_seconds}s"
+					except OSError as e:
+						status = "env_error"
+						detail = str(e)
 			results.append(
 				{
 					"name": step.name,
@@ -178,7 +190,13 @@ def main() -> None:
 	platform = os.environ.get("BOSS_SMOKE_PLATFORM", "zhipin").strip() or "zhipin"
 	query = os.environ.get("BOSS_SMOKE_QUERY", "golang").strip() or "golang"
 	security_id = os.environ.get("BOSS_SMOKE_SECURITY_ID", "demo-security-id").strip() or "demo-security-id"
-	runner = SmokeRunner(build_default_steps(platform, query=query, security_id=security_id))
+	timeout_seconds = int(os.environ.get("BOSS_SMOKE_TIMEOUT", "30"))
+	dry_run = os.environ.get("BOSS_SMOKE_DRY_RUN", "").strip() in {"1", "true", "yes"}
+	runner = SmokeRunner(
+		build_default_steps(platform, query=query, security_id=security_id),
+		timeout_seconds=timeout_seconds,
+		dry_run=dry_run,
+	)
 	print(json.dumps(runner.run(), ensure_ascii=False))
 
 

--- a/scripts/smoke_p0.py
+++ b/scripts/smoke_p0.py
@@ -18,7 +18,12 @@ class SmokeStep:
 	command: list[str]
 
 
-def build_default_steps(platform: str = "zhipin") -> list[SmokeStep]:
+def build_default_steps(
+	platform: str = "zhipin",
+	*,
+	query: str = "golang",
+	security_id: str = "demo-security-id",
+) -> list[SmokeStep]:
 	platform_args = ["--platform", platform] if platform != "zhipin" else []
 	return [
 		SmokeStep(
@@ -43,7 +48,7 @@ def build_default_steps(platform: str = "zhipin") -> list[SmokeStep]:
 			purpose="验证最小职位发现路径可执行",
 			preconditions=["command:boss", "env:BOSS_SMOKE_QUERY"],
 			failure_classification="command_error",
-			command=["boss", *platform_args, "search", "golang"],
+			command=["boss", *platform_args, "search", query],
 		),
 		SmokeStep(
 			name="detail",
@@ -51,7 +56,7 @@ def build_default_steps(platform: str = "zhipin") -> list[SmokeStep]:
 			purpose="验证职位详情路径具备可测试入口",
 			preconditions=["command:boss", "env:BOSS_SMOKE_SECURITY_ID"],
 			failure_classification="command_error",
-			command=["boss", *platform_args, "detail", "demo-security-id"],
+			command=["boss", *platform_args, "detail", security_id],
 		),
 	]
 
@@ -100,9 +105,11 @@ class SmokeRunner:
 		return {"steps": results}
 
 
-def main():
+def main() -> None:
 	platform = os.environ.get("BOSS_SMOKE_PLATFORM", "zhipin").strip() or "zhipin"
-	runner = SmokeRunner(build_default_steps(platform))
+	query = os.environ.get("BOSS_SMOKE_QUERY", "golang").strip() or "golang"
+	security_id = os.environ.get("BOSS_SMOKE_SECURITY_ID", "demo-security-id").strip() or "demo-security-id"
+	runner = SmokeRunner(build_default_steps(platform, query=query, security_id=security_id))
 	print(json.dumps(runner.run(), ensure_ascii=False))
 
 

--- a/scripts/smoke_p0.py
+++ b/scripts/smoke_p0.py
@@ -126,17 +126,18 @@ class SmokeRunner:
 	def run(self) -> dict:
 		results = []
 		for step in self.steps:
-			status = self._check_preconditions(step)
+			status = None
 			detail = ""
 			ok = None
 			error_code = None
 			recovery_action = None
 			returncode = None
-			if status is None:
-				if self._dry_run:
-					status = "dry_run"
-					detail = "command not executed"
-				else:
+			if self._dry_run:
+				status = "dry_run"
+				detail = "command not executed"
+			else:
+				status = self._check_preconditions(step)
+				if status is None:
 					try:
 						completed = self._run_command(
 							step.command,

--- a/scripts/smoke_p0.py
+++ b/scripts/smoke_p0.py
@@ -18,6 +18,13 @@ class SmokeStep:
 	command: list[str]
 
 
+@dataclass(frozen=True)
+class CommandResult:
+	returncode: int
+	stdout: str
+	stderr: str
+
+
 def build_default_steps(
 	platform: str = "zhipin",
 	*,
@@ -61,12 +68,44 @@ def build_default_steps(
 	]
 
 
+def parse_envelope(stdout: str) -> tuple[dict | None, str | None]:
+	try:
+		payload = json.loads(stdout.strip())
+	except json.JSONDecodeError:
+		return None, "stdout was not a JSON envelope"
+	required = {"ok", "schema_version", "command", "data", "pagination", "error", "hints"}
+	if not isinstance(payload, dict) or set(payload) != required:
+		return None, "stdout JSON did not match the envelope shape"
+	if payload.get("schema_version") != "1.0":
+		return None, "stdout envelope schema_version was not 1.0"
+	if not isinstance(payload.get("ok"), bool):
+		return None, "stdout envelope ok was not a boolean"
+	return payload, None
+
+
 DEFAULT_STEPS = build_default_steps()
 
 
 class SmokeRunner:
-	def __init__(self, steps: list[SmokeStep]):
+	def __init__(self, steps: list[SmokeStep], *, run_command=None, timeout_seconds: int = 30):
 		self.steps = steps
+		self._run_command = run_command or self._default_run_command
+		self._timeout_seconds = timeout_seconds
+
+	def _default_run_command(self, command, cwd, capture_output, text, timeout, check):
+		completed = subprocess.run(
+			command,
+			check=check,
+			cwd=cwd,
+			capture_output=capture_output,
+			text=text,
+			timeout=timeout,
+		)
+		return CommandResult(
+			returncode=completed.returncode,
+			stdout=completed.stdout,
+			stderr=completed.stderr,
+		)
 
 	def _check_preconditions(self, step: SmokeStep) -> str | None:
 		for item in step.preconditions:
@@ -80,26 +119,56 @@ class SmokeRunner:
 		results = []
 		for step in self.steps:
 			status = self._check_preconditions(step)
+			detail = ""
+			ok = None
+			error_code = None
+			recovery_action = None
+			returncode = None
 			if status is None:
 				try:
-					subprocess.run(
+					completed = self._run_command(
 						step.command,
-						check=True,
 						cwd=ROOT,
-						stdout=subprocess.DEVNULL,
-						stderr=subprocess.DEVNULL,
+						capture_output=True,
+						text=True,
+						timeout=self._timeout_seconds,
+						check=False,
 					)
-					status = "pass"
-				except Exception:
-					status = step.failure_classification
+					returncode = completed.returncode
+					payload, contract_error = parse_envelope(completed.stdout)
+					if contract_error:
+						status = "contract_error"
+						detail = contract_error
+					else:
+						ok = payload["ok"]
+						if ok:
+							status = "pass"
+						else:
+							status = step.failure_classification
+							error = payload.get("error") or {}
+							error_code = error.get("code")
+							recovery_action = error.get("recovery_action")
+							detail = error.get("message") or ""
+				except subprocess.TimeoutExpired:
+					status = "timeout"
+					detail = f"command exceeded {self._timeout_seconds}s"
+				except OSError as e:
+					status = "env_error"
+					detail = str(e)
 			results.append(
 				{
 					"name": step.name,
 					"purpose": step.purpose,
+					"platform": step.platform,
 					"preconditions": step.preconditions,
 					"failure_classification": step.failure_classification,
 					"command": step.command,
 					"status": status,
+					"ok": ok,
+					"error_code": error_code,
+					"recovery_action": recovery_action,
+					"returncode": returncode,
+					"detail": detail,
 				}
 			)
 		return {"steps": results}

--- a/scripts/smoke_p0.py
+++ b/scripts/smoke_p0.py
@@ -83,6 +83,27 @@ def parse_envelope(stdout: str) -> tuple[dict | None, str | None]:
 	return payload, None
 
 
+def validate_envelope_result(payload: dict, returncode: int) -> str | None:
+	ok = payload["ok"]
+	expected_returncode = 0 if ok else 1
+	if returncode != expected_returncode:
+		return "stdout envelope ok did not match process exit code"
+	if not ok:
+		error = payload.get("error")
+		required = {"code", "recoverable", "recovery_action"}
+		if not isinstance(error, dict) or not required.issubset(error):
+			return "stdout envelope error did not match the error shape"
+		if not isinstance(error.get("code"), str) or not isinstance(error.get("recoverable"), bool):
+			return "stdout envelope error did not match the error shape"
+	return None
+
+
+def reported_command(step: SmokeStep) -> list[str]:
+	if step.name == "detail" and step.command:
+		return [*step.command[:-1], "<redacted>"]
+	return step.command
+
+
 DEFAULT_STEPS = build_default_steps()
 
 
@@ -154,7 +175,11 @@ class SmokeRunner:
 							detail = contract_error
 						else:
 							ok = payload["ok"]
-							if ok:
+							result_error = validate_envelope_result(payload, returncode)
+							if result_error:
+								status = "contract_error"
+								detail = result_error
+							elif ok:
 								status = "pass"
 							else:
 								status = step.failure_classification
@@ -175,7 +200,7 @@ class SmokeRunner:
 					"platform": step.platform,
 					"preconditions": step.preconditions,
 					"failure_classification": step.failure_classification,
-					"command": step.command,
+					"command": reported_command(step),
 					"status": status,
 					"ok": ok,
 					"error_code": error_code,

--- a/tests/test_smoke_p0.py
+++ b/tests/test_smoke_p0.py
@@ -84,6 +84,13 @@ def test_smoke_runner_distinguishes_step_failure_types():
 	module = importlib.util.module_from_spec(spec)
 	spec.loader.exec_module(module)
 
+	def fake_run(command, cwd, capture_output, text, timeout, check):
+		return module.CommandResult(
+			returncode=0,
+			stdout='{"ok": true, "schema_version": "1.0", "command": "doctor", "data": {}, "pagination": null, "error": null, "hints": null}',
+			stderr="",
+		)
+
 	runner = module.SmokeRunner(
 		steps=[
 			module.SmokeStep(
@@ -102,10 +109,76 @@ def test_smoke_runner_distinguishes_step_failure_types():
 				failure_classification="env_error",
 				command=["echo", "skip"],
 			),
-		]
+		],
+		run_command=fake_run,
 	)
 
 	results = runner.run()
 	statuses = {item["name"]: item["status"] for item in results["steps"]}
 	assert statuses["ok"] == "pass"
 	assert statuses["missing"] == "env_error"
+
+
+def test_smoke_runner_marks_non_json_stdout_as_contract_error():
+	spec = importlib.util.spec_from_file_location("smoke_p0", SMOKE_SCRIPT)
+	assert spec is not None and spec.loader is not None
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+
+	def fake_run(command, cwd, capture_output, text, timeout, check):
+		return module.CommandResult(returncode=0, stdout="not json", stderr="")
+
+	runner = module.SmokeRunner(
+		steps=[
+			module.SmokeStep(
+				name="schema",
+				platform="zhipin",
+				purpose="contract",
+				preconditions=["command:boss"],
+				failure_classification="command_error",
+				command=["boss", "schema"],
+			),
+		],
+		run_command=fake_run,
+	)
+
+	results = runner.run()
+	step = results["steps"][0]
+	assert step["status"] == "contract_error"
+	assert step["ok"] is None
+	assert "stdout was not a JSON envelope" in step["detail"]
+
+
+def test_smoke_runner_marks_ok_false_envelope_as_command_error():
+	spec = importlib.util.spec_from_file_location("smoke_p0", SMOKE_SCRIPT)
+	assert spec is not None and spec.loader is not None
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+
+	def fake_run(command, cwd, capture_output, text, timeout, check):
+		return module.CommandResult(
+			returncode=1,
+			stdout='{"ok": false, "schema_version": "1.0", "command": "status", "data": null, "pagination": null, "error": {"code": "AUTH_REQUIRED", "message": "未登录", "recoverable": true, "recovery_action": "boss login"}, "hints": null}',
+			stderr="",
+		)
+
+	runner = module.SmokeRunner(
+		steps=[
+			module.SmokeStep(
+				name="status",
+				platform="zhipin",
+				purpose="auth",
+				preconditions=["command:boss"],
+				failure_classification="env_error",
+				command=["boss", "status"],
+			),
+		],
+		run_command=fake_run,
+	)
+
+	results = runner.run()
+	step = results["steps"][0]
+	assert step["status"] == "env_error"
+	assert step["ok"] is False
+	assert step["error_code"] == "AUTH_REQUIRED"
+	assert step["recovery_action"] == "boss login"

--- a/tests/test_smoke_p0.py
+++ b/tests/test_smoke_p0.py
@@ -245,3 +245,17 @@ def test_smoke_runner_dry_run_does_not_execute_commands():
 	assert calls == []
 	assert results["steps"][0]["status"] == "dry_run"
 	assert results["steps"][0]["detail"] == "command not executed"
+
+
+def test_smoke_docs_describe_env_controls_and_failure_classes():
+	content = (ROOT / "docs" / "smoke-testing.md").read_text(encoding="utf-8")
+
+	assert "BOSS_SMOKE_PLATFORM" in content
+	assert "BOSS_SMOKE_QUERY" in content
+	assert "BOSS_SMOKE_SECURITY_ID" in content
+	assert "BOSS_SMOKE_TIMEOUT" in content
+	assert "BOSS_SMOKE_DRY_RUN" in content
+	assert "contract_error" in content
+	assert "timeout" in content
+	assert "dry_run" in content
+	assert "不提交真实 Cookie" in content

--- a/tests/test_smoke_p0.py
+++ b/tests/test_smoke_p0.py
@@ -182,3 +182,66 @@ def test_smoke_runner_marks_ok_false_envelope_as_command_error():
 	assert step["ok"] is False
 	assert step["error_code"] == "AUTH_REQUIRED"
 	assert step["recovery_action"] == "boss login"
+
+
+def test_smoke_runner_marks_timeout():
+	spec = importlib.util.spec_from_file_location("smoke_p0", SMOKE_SCRIPT)
+	assert spec is not None and spec.loader is not None
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+
+	def fake_timeout(command, cwd, capture_output, text, timeout, check):
+		raise module.subprocess.TimeoutExpired(command, timeout)
+
+	runner = module.SmokeRunner(
+		steps=[
+			module.SmokeStep(
+				name="search",
+				platform="zhipin",
+				purpose="timeout",
+				preconditions=["command:boss"],
+				failure_classification="command_error",
+				command=["boss", "search", "golang"],
+			),
+		],
+		run_command=fake_timeout,
+		timeout_seconds=7,
+	)
+
+	results = runner.run()
+	step = results["steps"][0]
+	assert step["status"] == "timeout"
+	assert step["detail"] == "command exceeded 7s"
+
+
+def test_smoke_runner_dry_run_does_not_execute_commands():
+	spec = importlib.util.spec_from_file_location("smoke_p0", SMOKE_SCRIPT)
+	assert spec is not None and spec.loader is not None
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+
+	calls = []
+
+	def fake_run(command, cwd, capture_output, text, timeout, check):
+		calls.append(command)
+		return module.CommandResult(returncode=0, stdout="{}", stderr="")
+
+	runner = module.SmokeRunner(
+		steps=[
+			module.SmokeStep(
+				name="doctor",
+				platform="zhipin",
+				purpose="dry",
+				preconditions=["command:boss"],
+				failure_classification="env_error",
+				command=["boss", "doctor"],
+			),
+		],
+		run_command=fake_run,
+		dry_run=True,
+	)
+
+	results = runner.run()
+	assert calls == []
+	assert results["steps"][0]["status"] == "dry_run"
+	assert results["steps"][0]["detail"] == "command not executed"

--- a/tests/test_smoke_p0.py
+++ b/tests/test_smoke_p0.py
@@ -247,6 +247,40 @@ def test_smoke_runner_dry_run_does_not_execute_commands():
 	assert results["steps"][0]["detail"] == "command not executed"
 
 
+def test_smoke_runner_dry_run_bypasses_live_env_preconditions(monkeypatch):
+	spec = importlib.util.spec_from_file_location("smoke_p0", SMOKE_SCRIPT)
+	assert spec is not None and spec.loader is not None
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+
+	monkeypatch.delenv("BOSS_SMOKE_QUERY", raising=False)
+	calls = []
+
+	def fake_run(command, cwd, capture_output, text, timeout, check):
+		calls.append(command)
+		return module.CommandResult(returncode=0, stdout="{}", stderr="")
+
+	runner = module.SmokeRunner(
+		steps=[
+			module.SmokeStep(
+				name="search",
+				platform="zhipin",
+				purpose="dry",
+				preconditions=["command:boss", "env:BOSS_SMOKE_QUERY"],
+				failure_classification="command_error",
+				command=["boss", "search", "golang"],
+			),
+		],
+		run_command=fake_run,
+		dry_run=True,
+	)
+
+	results = runner.run()
+	assert calls == []
+	assert results["steps"][0]["status"] == "dry_run"
+	assert results["steps"][0]["detail"] == "command not executed"
+
+
 def test_smoke_docs_describe_env_controls_and_failure_classes():
 	content = (ROOT / "docs" / "smoke-testing.md").read_text(encoding="utf-8")
 

--- a/tests/test_smoke_p0.py
+++ b/tests/test_smoke_p0.py
@@ -37,11 +37,45 @@ def test_smoke_script_can_build_zhilian_steps():
 	module = importlib.util.module_from_spec(spec)
 	spec.loader.exec_module(module)
 
-	steps = module.build_default_steps("zhilian")
+	steps = module.build_default_steps("zhilian", query="golang", security_id="demo-security-id")
 	assert [step.name for step in steps] == ["doctor", "status", "search", "detail"]
 	assert all(step.platform == "zhilian" for step in steps)
 	assert steps[0].command == ["boss", "--platform", "zhilian", "doctor"]
 	assert steps[1].command == ["boss", "--platform", "zhilian", "status"]
+
+
+def test_smoke_steps_use_configured_query_and_security_id():
+	spec = importlib.util.spec_from_file_location("smoke_p0", SMOKE_SCRIPT)
+	assert spec is not None and spec.loader is not None
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+
+	steps = module.build_default_steps(
+		"zhipin",
+		query="python",
+		security_id="real-security-id",
+	)
+
+	commands = {step.name: step.command for step in steps}
+	assert commands["search"] == ["boss", "search", "python"]
+	assert commands["detail"] == ["boss", "detail", "real-security-id"]
+
+
+def test_smoke_steps_use_configured_zhilian_query_and_security_id():
+	spec = importlib.util.spec_from_file_location("smoke_p0", SMOKE_SCRIPT)
+	assert spec is not None and spec.loader is not None
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+
+	steps = module.build_default_steps(
+		"zhilian",
+		query="java",
+		security_id="zhilian-security-id",
+	)
+
+	commands = {step.name: step.command for step in steps}
+	assert commands["search"] == ["boss", "--platform", "zhilian", "search", "java"]
+	assert commands["detail"] == ["boss", "--platform", "zhilian", "detail", "zhilian-security-id"]
 
 
 def test_smoke_runner_distinguishes_step_failure_types():

--- a/tests/test_smoke_p0.py
+++ b/tests/test_smoke_p0.py
@@ -184,6 +184,139 @@ def test_smoke_runner_marks_ok_false_envelope_as_command_error():
 	assert step["recovery_action"] == "boss login"
 
 
+def test_smoke_runner_redacts_detail_security_id_from_reported_command():
+	spec = importlib.util.spec_from_file_location("smoke_p0", SMOKE_SCRIPT)
+	assert spec is not None and spec.loader is not None
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+
+	def fake_run(command, cwd, capture_output, text, timeout, check):
+		return module.CommandResult(
+			returncode=0,
+			stdout='{"ok": true, "schema_version": "1.0", "command": "detail", "data": {}, "pagination": null, "error": null, "hints": null}',
+			stderr="",
+		)
+
+	runner = module.SmokeRunner(
+		steps=[
+			module.SmokeStep(
+				name="detail",
+				platform="zhipin",
+				purpose="privacy",
+				preconditions=["command:boss"],
+				failure_classification="command_error",
+				command=["boss", "detail", "real-security-id"],
+			),
+		],
+		run_command=fake_run,
+	)
+
+	step = runner.run()["steps"][0]
+	assert step["status"] == "pass"
+	assert step["command"] == ["boss", "detail", "<redacted>"]
+
+
+def test_smoke_runner_marks_exit_code_ok_mismatch_as_contract_error():
+	spec = importlib.util.spec_from_file_location("smoke_p0", SMOKE_SCRIPT)
+	assert spec is not None and spec.loader is not None
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+
+	def fake_run(command, cwd, capture_output, text, timeout, check):
+		return module.CommandResult(
+			returncode=1,
+			stdout='{"ok": true, "schema_version": "1.0", "command": "status", "data": {}, "pagination": null, "error": null, "hints": null}',
+			stderr="",
+		)
+
+	runner = module.SmokeRunner(
+		steps=[
+			module.SmokeStep(
+				name="status",
+				platform="zhipin",
+				purpose="contract",
+				preconditions=["command:boss"],
+				failure_classification="env_error",
+				command=["boss", "status"],
+			),
+		],
+		run_command=fake_run,
+	)
+
+	step = runner.run()["steps"][0]
+	assert step["status"] == "contract_error"
+	assert step["ok"] is True
+	assert step["returncode"] == 1
+	assert step["detail"] == "stdout envelope ok did not match process exit code"
+
+
+def test_smoke_runner_marks_ok_false_exit_zero_as_contract_error():
+	spec = importlib.util.spec_from_file_location("smoke_p0", SMOKE_SCRIPT)
+	assert spec is not None and spec.loader is not None
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+
+	def fake_run(command, cwd, capture_output, text, timeout, check):
+		return module.CommandResult(
+			returncode=0,
+			stdout='{"ok": false, "schema_version": "1.0", "command": "status", "data": null, "pagination": null, "error": {"code": "AUTH_REQUIRED", "message": "未登录", "recoverable": true, "recovery_action": "boss login"}, "hints": null}',
+			stderr="",
+		)
+
+	runner = module.SmokeRunner(
+		steps=[
+			module.SmokeStep(
+				name="status",
+				platform="zhipin",
+				purpose="contract",
+				preconditions=["command:boss"],
+				failure_classification="env_error",
+				command=["boss", "status"],
+			),
+		],
+		run_command=fake_run,
+	)
+
+	step = runner.run()["steps"][0]
+	assert step["status"] == "contract_error"
+	assert step["ok"] is False
+	assert step["returncode"] == 0
+	assert step["detail"] == "stdout envelope ok did not match process exit code"
+
+
+def test_smoke_runner_marks_missing_error_fields_as_contract_error():
+	spec = importlib.util.spec_from_file_location("smoke_p0", SMOKE_SCRIPT)
+	assert spec is not None and spec.loader is not None
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+
+	def fake_run(command, cwd, capture_output, text, timeout, check):
+		return module.CommandResult(
+			returncode=1,
+			stdout='{"ok": false, "schema_version": "1.0", "command": "status", "data": null, "pagination": null, "error": {"message": "未登录"}, "hints": null}',
+			stderr="",
+		)
+
+	runner = module.SmokeRunner(
+		steps=[
+			module.SmokeStep(
+				name="status",
+				platform="zhipin",
+				purpose="contract",
+				preconditions=["command:boss"],
+				failure_classification="env_error",
+				command=["boss", "status"],
+			),
+		],
+		run_command=fake_run,
+	)
+
+	step = runner.run()["steps"][0]
+	assert step["status"] == "contract_error"
+	assert step["ok"] is False
+	assert step["detail"] == "stdout envelope error did not match the error shape"
+
+
 def test_smoke_runner_marks_timeout():
 	spec = importlib.util.spec_from_file_location("smoke_p0", SMOKE_SCRIPT)
 	assert spec is not None and spec.loader is not None


### PR DESCRIPTION
## Summary
- Make the P0 smoke harness use explicit query/security-id environment values.
- Parse boss JSON envelopes and classify contract, command, environment, timeout, and dry-run outcomes.
- Add per-command timeout and dry-run controls for safe local verification.
- Redact live detail security IDs from smoke output and validate CLI exit-code/error-envelope invariants.
- Expand smoke testing documentation and regression tests.

## Test Plan
- uv run pytest tests/test_smoke_p0.py -q
- BOSS_SMOKE_DRY_RUN=1 uv run python scripts/smoke_p0.py
- uv run pytest tests/ -q
- uv run mypy src/boss_agent_cli
- uv run ruff check src/ tests/
- uv run boss --help
- uv run boss schema --format native
- git diff --check

## Notes
- This PR does not run live smoke in public CI.
- This PR does not store or introduce real cookies, tokens, security IDs, contacts, or company names.
- The smoke report redacts the live `detail` command security ID as `<redacted>`.