### PR TITLE
docs: 完善开源项目治理文档

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -79,6 +79,48 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: platform
+    attributes:
+      label: 招聘平台 / Platform
+      options:
+        - zhipin
+        - zhilian
+        - unknown
+    validations:
+      required: true
+
+  - type: dropdown
+    id: role
+    attributes:
+      label: 角色 / Role
+      options:
+        - candidate
+        - recruiter
+        - unknown
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: redaction
+    attributes:
+      label: 脱敏确认 / Redaction
+      options:
+        - label: 我已移除 Token / 密码 / Cookie / security_id / 手机号 / 微信 / 真实账号信息
+          required: true
+
+  - type: dropdown
+    id: platform_drift
+    attributes:
+      label: 是否疑似平台漂移 / Possible platform drift
+      description: 如果 mock/本地契约正常但真实平台命令失败，请选择“是”
+      options:
+        - 否
+        - 是
+        - 不确定
+    validations:
+      required: true
+
   - type: input
     id: os_version
     attributes:

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,7 +1,7 @@
 name: 📚 Documentation / 文档改进
 description: 报告文档错误、过时内容或改进建议
 title: "[Docs] "
-labels: ["documentation", "triage"]
+labels: ["documentation", "triage", "docs-parity"]
 body:
   - type: textarea
     id: location
@@ -42,3 +42,12 @@ body:
         - 翻译（中英不一致）
     validations:
       required: true
+
+  - type: checkboxes
+    id: docs_parity
+    attributes:
+      label: 中英文同步 / Docs parity
+      options:
+        - label: 如果修改 README.md，也需要检查 README.en.md
+        - label: 如果修改中文 docs，也需要检查对应英文 docs
+        - label: 如确认无需同步，请在 Issue 中说明原因

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -55,6 +55,40 @@ body:
         boss stats --format html -o report.html
         # 生成自包含 HTML 漏斗报表
 
+  - type: dropdown
+    id: platform
+    attributes:
+      label: 目标平台 / Target platform
+      options:
+        - zhipin
+        - zhilian
+        - all platforms
+        - not platform-specific
+    validations:
+      required: true
+
+  - type: dropdown
+    id: role
+    attributes:
+      label: 目标角色 / Target role
+      options:
+        - candidate
+        - recruiter
+        - both
+        - not role-specific
+    validations:
+      required: true
+
+  - type: textarea
+    id: agent_contract
+    attributes:
+      label: Agent 契约影响
+      description: 描述期望的 JSON 信封字段、schema 暴露方式、错误码或 MCP/Skill 影响
+      placeholder: |
+        - 新命令会出现在 boss schema --format native
+        - stdout 仍只输出 JSON 信封
+        - 失败错误码为 NOT_SUPPORTED
+
   - type: textarea
     id: alternatives
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -57,7 +57,7 @@ Closes #
 
 ## 安全与规范 / Safety & Convention
 
-- [ ] commit message 格式: `type: 中文描述`（或英文等价）
+- [ ] commit message 格式: `type: 中文描述`
 - [ ] 无敏感信息（Token / 密码 / Cookie / security_id / 手机号 / 微信 / 真实账号）
 - [ ] 如涉及 Cookie、CDP、patchright、请求频率或真实账号，已阅读 `docs/platform-risk.md`
 - [ ] 如涉及发布流程，已阅读 `docs/maintainer/release-checklist.md`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,8 +40,11 @@ Closes #
 
 - [ ] `uv run pytest tests/ -q` 全部通过
 - [ ] `uv run ruff check src/ tests/` 无报错
+- [ ] `uv run mypy src/boss_agent_cli` 无报错
+- [ ] `uv run boss --help` 可加载
+- [ ] `uv run boss schema --format native` 返回合法 JSON 信封
 - [ ] 新增/修改的功能已有对应测试覆盖
-- [ ] 本地跑过涉及命令（如有可粘贴输出）
+- [ ] 本地跑过涉及命令（如有可粘贴已脱敏输出）
 
 ## 文档与契约 / Docs & Contracts
 
@@ -55,5 +58,7 @@ Closes #
 ## 安全与规范 / Safety & Convention
 
 - [ ] commit message 格式: `type: 中文描述`（或英文等价）
-- [ ] 无敏感信息（Token / 密码 / Cookie / 真实账号）
+- [ ] 无敏感信息（Token / 密码 / Cookie / security_id / 手机号 / 微信 / 真实账号）
+- [ ] 如涉及 Cookie、CDP、patchright、请求频率或真实账号，已阅读 `docs/platform-risk.md`
+- [ ] 如涉及发布流程，已阅读 `docs/maintainer/release-checklist.md`
 - [ ] 无新增外部 CDN / script 依赖（HTML 报表类特别注意）

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,18 +17,6 @@ name: Docs
       - ".github/workflows/docs.yml"
   pull_request:
     branches: [master]
-    paths:
-      - "README.md"
-      - "README.en.md"
-      - "CONTRIBUTING.md"
-      - "CONTRIBUTING.en.md"
-      - "SECURITY.md"
-      - "docs/**"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/PULL_REQUEST_TEMPLATE.md"
-      - "tests/test_agent_docs.py"
-      - "tests/test_open_source_docs.py"
-      - ".github/workflows/docs.yml"
   workflow_dispatch:
 
 concurrency:
@@ -56,4 +44,12 @@ jobs:
         run: uv run pytest tests/test_agent_docs.py tests/test_open_source_docs.py -q
 
       - name: Check whitespace
-        run: git diff --check
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+            git diff --check "origin/${{ github.base_ref }}...HEAD"
+          elif git rev-parse --verify HEAD^ >/dev/null 2>&1; then
+            git diff --check HEAD^...HEAD
+          else
+            git diff --check
+          fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,6 @@
 name: Docs
 
-on:
+"on":
   push:
     branches: [master]
     paths:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,59 @@
+name: Docs
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "README.md"
+      - "README.en.md"
+      - "CONTRIBUTING.md"
+      - "CONTRIBUTING.en.md"
+      - "SECURITY.md"
+      - "docs/**"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/PULL_REQUEST_TEMPLATE.md"
+      - "tests/test_agent_docs.py"
+      - "tests/test_open_source_docs.py"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    branches: [master]
+    paths:
+      - "README.md"
+      - "README.en.md"
+      - "CONTRIBUTING.md"
+      - "CONTRIBUTING.en.md"
+      - "SECURITY.md"
+      - "docs/**"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/PULL_REQUEST_TEMPLATE.md"
+      - "tests/test_agent_docs.py"
+      - "tests/test_open_source_docs.py"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run docs checks
+        run: uv run pytest tests/test_agent_docs.py tests/test_open_source_docs.py -q
+
+      - name: Check whitespace
+        run: git diff --check

--- a/CONTRIBUTING.en.md
+++ b/CONTRIBUTING.en.md
@@ -18,16 +18,37 @@ uv run pre-commit install
 
 Python **≥ 3.10** is required. We use [`uv`](https://github.com/astral-sh/uv) for dependency management — `uv sync --all-extras` installs runtime + dev deps in a local `.venv`.
 
-## Coding Conventions
+## Coding Standards
 
-- **Indentation:** tabs (not spaces) — enforced by `ruff format`
-- **Python version:** 3.10+, use `X | Y` union syntax (no `Optional[X]`)
-- **Type checking:** `uv run mypy src/boss_agent_cli` — enforced as a blocking CI gate. All new code must pass mypy.
-- **Commit messages:** `type: 中文描述` — the description is written in Chinese even if the code/comments are in English. Valid types: `feat / fix / refactor / docs / test / chore / perf / ci`
+- Python source indentation uses **tabs**.
+- `indent-width = 4` in `pyproject.toml` is the formatter display width. It does not mean Python files should switch to spaces.
+- Use Python >= 3.10 and `X | Y` union syntax.
+- Command output must preserve the JSON envelope contract: stdout is agent-readable JSON only, stderr is logs and progress.
+- Commit messages use the repository Chinese format `type: 中文描述`.
+- Type checking is blocking in CI. New code must pass `uv run mypy src/boss_agent_cli`.
   - ✅ `feat: 新增配置管理命令`
   - ❌ `feat: add config command`  (English description)
   - ❌ `feat: 新增 config 命令`  (mixed English/Chinese, forbidden)
   - Do NOT add `Co-authored-by` trailers or any AI-attribution lines
+
+## Local Verification
+
+Run the full matrix before submitting code changes:
+
+```bash
+uv run pytest tests/ -q
+uv run ruff check src/ tests/
+uv run mypy src/boss_agent_cli
+uv run boss --help
+uv run boss schema --format native
+```
+
+For documentation-only changes, run at least:
+
+```bash
+uv run pytest tests/test_agent_docs.py tests/test_open_source_docs.py -q
+git diff --check
+```
 
 ## Pull Request Workflow
 

--- a/CONTRIBUTING.en.md
+++ b/CONTRIBUTING.en.md
@@ -2,6 +2,8 @@
 
 Thanks for your interest in `boss-agent-cli`! This guide is the English companion of [CONTRIBUTING.md](CONTRIBUTING.md) — both describe the same workflow, so pick whichever fits you.
 
+Before your first contribution, complete the local preflight and developer verification in [Getting Started](docs/getting-started.en.md).
+
 ## Development Environment
 
 ```bash

--- a/CONTRIBUTING.en.md
+++ b/CONTRIBUTING.en.md
@@ -45,6 +45,12 @@ Python **≥ 3.10** is required. We use [`uv`](https://github.com/astral-sh/uv) 
 
 Maintainers will `squash merge`, so the squash title must follow the commit convention above.
 
+## Maintainer Docs
+
+- [Release Checklist](docs/maintainer/release-checklist.md)
+- [Labels And Triage](docs/maintainer/labels.md)
+- [Branch Protection](docs/maintainer/branch-protection.md)
+
 ## Adding a New Command
 
 1. Create a file under `src/boss_agent_cli/commands/`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,12 @@ uv run pre-commit install
 4. 提交并推送
 5. 创建 Pull Request
 
+## 维护者文档
+
+- [Release Checklist](docs/maintainer/release-checklist.md)
+- [Labels And Triage](docs/maintainer/labels.md)
+- [Branch Protection](docs/maintainer/branch-protection.md)
+
 ## 添加新命令
 
 1. 在 `src/boss_agent_cli/commands/` 下新建文件

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,10 +18,31 @@ uv run pre-commit install
 
 ## 编码规范
 
-- 缩进使用 **tab**
-- Python >= 3.10（使用 `X | Y` 联合类型）
-- commit message：`type: 中文描述`（feat / fix / refactor / docs / test / chore）
-- 类型检查：`uv run mypy src/boss_agent_cli`（CI 阻塞式门禁，新代码必须零 mypy 错误）
+- Python 源码缩进使用 **tab**。
+- `pyproject.toml` 中的 `indent-width = 4` 表示格式工具的视觉宽度，不表示改为空格缩进。
+- Python >= 3.10，使用 `X | Y` 联合类型。
+- 命令输出必须保持 JSON 信封契约：stdout 只输出 Agent 可读 JSON，stderr 输出日志和进度。
+- commit message：`type: 中文描述`（feat / fix / refactor / docs / test / chore / ci）。
+- 类型检查：`uv run mypy src/boss_agent_cli`，CI 阻塞式门禁，新代码必须零 mypy 错误。
+
+## 本地验证
+
+代码改动提交前尽量运行完整矩阵：
+
+```bash
+uv run pytest tests/ -q
+uv run ruff check src/ tests/
+uv run mypy src/boss_agent_cli
+uv run boss --help
+uv run boss schema --format native
+```
+
+文档改动至少运行：
+
+```bash
+uv run pytest tests/test_agent_docs.py tests/test_open_source_docs.py -q
+git diff --check
+```
 
 ## 提交流程
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 感谢你对 boss-agent-cli 的关注！English version: [CONTRIBUTING.en.md](CONTRIBUTING.en.md)
 
+首次贡献前请先完成 [快速上手](docs/getting-started.md) 中的本地自检与开发者验证。
+
 ## 开发环境
 
 ```bash

--- a/README.en.md
+++ b/README.en.md
@@ -18,7 +18,7 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/can4hou6joeng4/boss-agent-cli/pulls)
 [![Open in Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/can4hou6joeng4/boss-agent-cli)
 
-[Install](#-install) · [Quickstart](#-quickstart) · [Roles & Platforms](#-roles--platforms) · [Agent Integration](#-agent-integration) · [Commands](#-commands) · [Troubleshooting](#-troubleshooting) · [Architecture](#-architecture) · [Changelog](CHANGELOG.md) · [Roadmap](ROADMAP.en.md)
+[Getting Started](docs/getting-started.en.md) · [Install](#-install) · [Quickstart](#-quickstart) · [Roles & Platforms](#-roles--platforms) · [Agent Integration](#-agent-integration) · [Commands](#-commands) · [Troubleshooting](#-troubleshooting) · [Architecture](#-architecture) · [Changelog](CHANGELOG.md) · [Roadmap](ROADMAP.en.md)
 
 [中文](README.md) | **English**
 

--- a/README.en.md
+++ b/README.en.md
@@ -236,6 +236,8 @@ boss doctor   # outputs JSON with 7 diagnostic checks
 <details>
 <summary>📖 Login issues</summary>
 
+For Cookie, CDP, patchright, real-account, request-rate, or platform-drift issues, read [Platform Risk Boundaries](docs/platform-risk.en.md) first.
+
 ### Cookie extraction fails
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ boss hr jobs list                     # 我发布的职位
 - `boss --platform zhilian` 目前已支持候选者侧 `search / detail / recommend / user_info / greet / apply`
 - `boss --platform zhilian hr ...` 仍不支持，CLI 会直接拒绝执行招聘者侧子命令
 
+涉及 Cookie、CDP、patchright、真实账号、请求频率或平台接口漂移的问题，请先阅读 [平台风险边界](docs/platform-risk.md)。
+
 <details>
 <summary>📖 CDP 启动示例</summary>
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/can4hou6joeng4/boss-agent-cli/pulls)
 [![Open in Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/can4hou6joeng4/boss-agent-cli)
 
-[安装](#-安装) · [快速开始](#-快速开始) · [角色模式](#-角色模式与多平台) · [Agent 集成](#-ai-agent-集成) · [命令参考](#-命令参考) · [排障](#-诊断与排障) · [架构](#-技术架构) · [更新日志](CHANGELOG.md) · [路线图](ROADMAP.md)
+[快速上手](docs/getting-started.md) · [安装](#-安装) · [快速开始](#-快速开始) · [角色模式](#-角色模式与多平台) · [Agent 集成](#-ai-agent-集成) · [命令参考](#-命令参考) · [排障](#-诊断与排障) · [架构](#-技术架构) · [更新日志](CHANGELOG.md) · [路线图](ROADMAP.md)
 
 **中文** | [English](README.en.md)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,3 +32,5 @@
 - **浏览器自动化**：所有浏览器操作限定在 `zhipin.com` 域名
 - **本地数据**：缓存数据存储在 `~/.boss-agent/`，不上传任何数据到第三方服务
 - **CSV/HTML 导出**：已实施公式注入防护和 XSS 防护
+
+更多平台自动化、Cookie/CDP、真实账号和 smoke test 风险边界见 [docs/platform-risk.md](docs/platform-risk.md)。

--- a/docs/getting-started.en.md
+++ b/docs/getting-started.en.md
@@ -1,0 +1,112 @@
+# Getting Started
+
+This page keeps only the shortest verifiable path. See [README.en.md](../README.en.md) for the full feature overview and [agent-quickstart.en.md](agent-quickstart.en.md) for agent integration.
+
+## 1. Install
+
+```bash
+uv tool install boss-agent-cli
+patchright install chromium
+```
+
+Source checkout:
+
+```bash
+git clone https://github.com/can4hou6joeng4/boss-agent-cli.git
+cd boss-agent-cli
+uv sync --all-extras
+uv run patchright install chromium
+```
+
+## 2. Local preflight
+
+```bash
+boss doctor
+boss status
+boss schema --format native
+```
+
+Expected behavior:
+
+- `boss doctor` returns `ok:true` or an `ok:false` envelope with a clear `recovery_action`.
+- `boss status` reports whether the current login state is usable.
+- `boss schema --format native` returns the JSON envelope that describes CLI capabilities.
+
+## 3. First read-only command
+
+After login, start with read-only commands before debugging write actions.
+
+```bash
+boss search "Golang" --city 广州 --welfare "双休"
+boss detail <security_id>
+```
+
+`security_id` comes from the `search` JSON response. Redact it in issues. Never paste real `security_id`, cookies, tokens, phone numbers, WeChat IDs, names, or company-private information.
+
+## 4. JSON envelope contract
+
+Agent-readable stdout should be one JSON envelope:
+
+```json
+{
+	"ok": true,
+	"schema_version": "1.0",
+	"command": "schema",
+	"data": {},
+	"pagination": null,
+	"error": null,
+	"hints": null
+}
+```
+
+Failure output:
+
+```json
+{
+	"ok": false,
+	"schema_version": "1.0",
+	"command": "status",
+	"data": null,
+	"pagination": null,
+	"error": {
+		"code": "AUTH_REQUIRED",
+		"message": "Not logged in",
+		"recoverable": true,
+		"recovery_action": "boss login"
+	},
+	"hints": null
+}
+```
+
+## 5. Developer verification
+
+Run the same verification matrix before and after code changes:
+
+```bash
+uv run pytest tests/ -q
+uv run ruff check src/ tests/
+uv run mypy src/boss_agent_cli
+uv run boss --help
+uv run boss schema --format native
+```
+
+For documentation-only changes, run at least:
+
+```bash
+uv run pytest tests/test_agent_docs.py tests/test_open_source_docs.py -q
+git diff --check
+```
+
+## 6. Before filing an issue
+
+Bug reports should include:
+
+- `boss --version`
+- Python version
+- Operating system
+- Platform: `zhipin` or `zhilian`
+- Role: `candidate` or `recruiter`
+- Full redacted JSON envelope
+- Redacted `boss doctor` output
+
+For upstream platform drift, login failures, risk control, Cookie/CDP, or browser automation issues, read [platform-risk.en.md](platform-risk.en.md).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,112 @@
+# 快速上手
+
+这份文档只保留最短可验证路径。完整能力说明见 [README.md](../README.md)，Agent 接入见 [agent-quickstart.md](agent-quickstart.md)。
+
+## 1. 安装
+
+```bash
+uv tool install boss-agent-cli
+patchright install chromium
+```
+
+源码开发环境：
+
+```bash
+git clone https://github.com/can4hou6joeng4/boss-agent-cli.git
+cd boss-agent-cli
+uv sync --all-extras
+uv run patchright install chromium
+```
+
+## 2. 本地自检
+
+```bash
+boss doctor
+boss status
+boss schema --format native
+```
+
+期望结果：
+
+- `boss doctor` 返回 `ok:true` 或带有明确 `recovery_action` 的 `ok:false`。
+- `boss status` 能说明当前登录态是否可用。
+- `boss schema --format native` 返回 JSON 信封，并列出当前 CLI 能力。
+
+## 3. 第一个只读命令
+
+登录后先执行只读命令，不要从写操作开始排障。
+
+```bash
+boss search "Golang" --city 广州 --welfare "双休"
+boss detail <security_id>
+```
+
+`security_id` 来自 `search` 返回的 JSON 数据。提交 Issue 时必须脱敏，不要粘贴真实 `security_id`、Cookie、Token、手机号、微信号、姓名或公司内部信息。
+
+## 4. JSON 信封契约
+
+所有 Agent 可读输出都应是单个 JSON 信封：
+
+```json
+{
+	"ok": true,
+	"schema_version": "1.0",
+	"command": "schema",
+	"data": {},
+	"pagination": null,
+	"error": null,
+	"hints": null
+}
+```
+
+失败时：
+
+```json
+{
+	"ok": false,
+	"schema_version": "1.0",
+	"command": "status",
+	"data": null,
+	"pagination": null,
+	"error": {
+		"code": "AUTH_REQUIRED",
+		"message": "未登录",
+		"recoverable": true,
+		"recovery_action": "boss login"
+	},
+	"hints": null
+}
+```
+
+## 5. 开发者验证
+
+修改代码前后使用同一组命令验证：
+
+```bash
+uv run pytest tests/ -q
+uv run ruff check src/ tests/
+uv run mypy src/boss_agent_cli
+uv run boss --help
+uv run boss schema --format native
+```
+
+如果只改文档，至少运行：
+
+```bash
+uv run pytest tests/test_agent_docs.py tests/test_open_source_docs.py -q
+git diff --check
+```
+
+## 6. 提交问题前
+
+提交 Bug 时请提供：
+
+- `boss --version`
+- Python 版本
+- 操作系统
+- 平台：`zhipin` 或 `zhilian`
+- 角色：`candidate` 或 `recruiter`
+- 完整 JSON 信封，已脱敏
+- `boss doctor` 输出，已脱敏
+
+平台接口变化、登录失效、风控、Cookie/CDP、浏览器自动化问题，先阅读 [platform-risk.md](platform-risk.md)。

--- a/docs/maintainer/branch-protection.md
+++ b/docs/maintainer/branch-protection.md
@@ -14,15 +14,18 @@ The default branch is `master`. Keep branch protection aligned with the quality 
 
 ## Required status checks
 
-Use stable GitHub Actions job names:
+Select the concrete check contexts emitted by `.github/workflows/ci.yml`:
 
-- `CI / test`
-- `CI / lint`
-- `CI / typecheck`
+- `test (3.10)`
+- `test (3.11)`
+- `test (3.12)`
+- `test (3.13)`
+- `lint`
+- `typecheck`
 
 The project may also require documentation checks when `.github/workflows/docs.yml` is enabled:
 
-- `Docs / docs`
+- `docs`
 
 ## Verification
 

--- a/docs/maintainer/branch-protection.md
+++ b/docs/maintainer/branch-protection.md
@@ -1,0 +1,51 @@
+# Branch Protection
+
+The default branch is `master`. Keep branch protection aligned with the quality bar described in `AGENTS.md`.
+
+## Required Settings
+
+- Require a pull request before merging.
+- Require at least 1 approving review.
+- Enforce rules for administrators.
+- Disable force pushes.
+- Disable branch deletions.
+- Require conversation resolution when review threads are used for blocking feedback.
+- Require status checks before merging.
+
+## Required status checks
+
+Use stable GitHub Actions job names:
+
+- `CI / test`
+- `CI / lint`
+- `CI / typecheck`
+
+The project may also require documentation checks when `.github/workflows/docs.yml` is enabled:
+
+- `Docs / docs`
+
+## Verification
+
+Run:
+
+```bash
+gh api repos/can4hou6joeng4/boss-agent-cli/branches/master/protection
+```
+
+The response should show:
+
+```json
+{
+	"required_pull_request_reviews": {
+		"required_approving_review_count": 1
+	},
+	"allow_force_pushes": {
+		"enabled": false
+	},
+	"allow_deletions": {
+		"enabled": false
+	}
+}
+```
+
+If `required_status_checks` is missing, configure required status checks in GitHub repository settings before treating branch protection as complete.

--- a/docs/maintainer/labels.md
+++ b/docs/maintainer/labels.md
@@ -1,0 +1,37 @@
+# Labels And Triage
+
+Use labels to make outside contribution easier.
+
+## Type labels
+
+- `bug`: Confirmed defect or reproducible regression.
+- `enhancement`: New capability or behavior improvement.
+- `documentation`: Documentation-only change.
+- `test`: Test coverage or test infrastructure.
+- `ci`: GitHub Actions, packaging, or release automation.
+- `security`: Security-sensitive report that is safe to discuss publicly.
+
+## Workflow labels
+
+- `triage`: Needs maintainer classification.
+- `needs-repro`: Needs a minimal command, JSON envelope, or environment detail.
+- `good first issue`: Small, well-scoped issue suitable for a first contributor.
+- `help wanted`: Maintainers agree on the direction and welcome outside implementation.
+- `blocked`: Cannot proceed until external information or platform behavior is known.
+
+## Domain labels
+
+- `contract`: JSON envelope, schema, exit code, stdout/stderr, or error-code contract.
+- `platform-drift`: Live platform behavior changed while local contracts still pass.
+- `auth`: Cookie, token, CDP, QR login, browser login, or logout.
+- `candidate`: Candidate-side workflow.
+- `recruiter`: Recruiter-side workflow.
+- `docs-parity`: Chinese and English docs need synchronization.
+
+## Triage rules
+
+- Add `triage` to every new issue.
+- Remove `triage` once the issue has type, domain, and workflow labels.
+- Use `platform-drift` only when mock tests can pass while live commands fail.
+- Use `contract` when stdout, stderr, exit code, schema, or error envelopes are involved.
+- Use `good first issue` only when the expected files, tests, and acceptance criteria are written in the issue.

--- a/docs/maintainer/release-checklist.md
+++ b/docs/maintainer/release-checklist.md
@@ -1,0 +1,65 @@
+# Release Checklist
+
+Use this checklist before publishing a release tag.
+
+## 1. Confirm scope
+
+- The release has a single coherent theme.
+- Breaking changes are called out in `CHANGELOG.md`.
+- CLI JSON envelope changes are documented.
+- `boss schema --format native` still describes the released capability surface.
+
+## 2. Local verification
+
+```bash
+uv sync --all-extras
+uv run pytest tests/ -q
+uv run ruff check src/ tests/
+uv run mypy src/boss_agent_cli
+uv run boss --help
+uv run boss schema --format native
+BOSS_SMOKE_DRY_RUN=1 uv run python scripts/smoke_p0.py
+git diff --check
+```
+
+## 3. Sensitive data check
+
+- No cookies, tokens, phone numbers, WeChat IDs, real names, company-private data, or live `security_id` values appear in commits.
+- Issue and smoke-test examples use redacted placeholders.
+- Release notes do not include raw live command output.
+- Demo files do not expose private account information.
+
+## 4. Package check
+
+```bash
+uv build
+```
+
+Inspect generated artifacts:
+
+```bash
+python -m tarfile -l dist/*.tar.gz | sed -n '1,80p'
+python -m zipfile -l dist/*.whl | sed -n '1,80p'
+```
+
+## 5. Publish
+
+Create an annotated release tag only after CI is green:
+
+```bash
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+The release workflow runs tests, builds the package, creates a GitHub Release, and publishes to PyPI with:
+
+```bash
+uv publish
+```
+
+## 6. Post-release
+
+- Confirm the GitHub Release exists.
+- Confirm PyPI shows the new version.
+- Confirm `uv tool install --upgrade boss-agent-cli` can install the release.
+- Create follow-up issues for known limitations instead of hiding them in release notes.

--- a/docs/maintainer/release-checklist.md
+++ b/docs/maintainer/release-checklist.md
@@ -47,7 +47,7 @@ python -m zipfile -l dist/*.whl | sed -n '1,80p'
 Create an annotated release tag only after CI is green:
 
 ```bash
-git tag vX.Y.Z
+git tag -a vX.Y.Z -m "vX.Y.Z"
 git push origin vX.Y.Z
 ```
 

--- a/docs/platform-risk.en.md
+++ b/docs/platform-risk.en.md
@@ -1,0 +1,51 @@
+# Platform Risk Boundaries
+
+boss-agent-cli automates access to recruitment platforms, but it does not control platform rules, account risk control, API drift, or third-party browser environments.
+
+## 1. Platform APIs can drift
+
+The project depends on web pages, APIs, cookies, login state, and response shapes from platforms such as BOSS Zhipin and Zhaopin. These platforms can change fields, risk-control behavior, endpoint paths, or page flows at any time.
+
+Treat these symptoms as possible platform drift:
+
+- Previously working read-only commands suddenly return `NETWORK_ERROR`, `AUTH_EXPIRED`, `TOKEN_REFRESH_FAILED`, or malformed structures.
+- `search` returns results but `detail` fails.
+- `boss schema --format native` works, but live commands fail.
+- Mock tests pass while real-account commands fail.
+
+## 2. Login and Cookie boundaries
+
+Login can use Cookie extraction, CDP, QR httpx, or patchright browser automation. The project reads and stores login state locally. Users should never submit cookies, tokens, phone numbers, WeChat IDs, names, company-private information, or real `security_id` values to the repository.
+
+Redact issue payloads:
+
+```json
+{
+	"security_id": "<redacted>",
+	"cookie": "<redacted>",
+	"token": "<redacted>"
+}
+```
+
+## 3. Request rate and account responsibility
+
+The default request interval is controlled by `--delay`. Do not use this tool for high-frequency scraping, spam, bypassing platform limits, or violating platform terms. For write actions such as `greet`, `apply`, `exchange`, and `hr reply`, confirm the target and context with read-only commands first.
+
+## 4. Browser automation boundaries
+
+patchright, CDP, local Chrome profiles, system keychains, browser extensions, and platform risk-control systems all affect login and access stability. A working browser session does not guarantee the httpx path works; a working httpx path does not guarantee the patchright login path works.
+
+## 5. Smoke-test boundaries
+
+Real-flow smoke tests must be explicitly configured and should not access real accounts from regular CI:
+
+```bash
+BOSS_SMOKE_DRY_RUN=1 uv run python scripts/smoke_p0.py
+BOSS_SMOKE_PLATFORM=zhipin BOSS_SMOKE_QUERY=Golang BOSS_SMOKE_SECURITY_ID=<redacted> uv run python scripts/smoke_p0.py
+```
+
+`BOSS_SMOKE_DRY_RUN=1` verifies the plan only. It does not prove live platform availability.
+
+## 6. Reporting security issues
+
+If a report involves cookies, tokens, accounts, contact details, private resumes, company-private information, or exploitable automation bypasses, do not open a public issue. Use the private disclosure channels in [SECURITY.md](../SECURITY.md).

--- a/docs/platform-risk.md
+++ b/docs/platform-risk.md
@@ -1,0 +1,51 @@
+# 平台风险边界
+
+boss-agent-cli 自动化访问招聘平台，但不控制平台规则、账号风控、接口变更或第三方浏览器环境。使用者需要理解以下边界。
+
+## 1. 平台接口可能变化
+
+项目依赖 BOSS 直聘、智联招聘等平台的网页、接口、Cookie、登录态和响应结构。平台可能随时调整字段、风控、接口路径或页面行为。
+
+当出现以下现象时，优先按平台漂移处理：
+
+- 之前正常的只读命令突然返回 `NETWORK_ERROR`、`AUTH_EXPIRED`、`TOKEN_REFRESH_FAILED` 或结构异常。
+- `search` 有结果但 `detail` 失败。
+- `boss schema --format native` 正常，但 live 命令失败。
+- 同一命令在 mock 测试中通过，在真实账号中失败。
+
+## 2. 登录和 Cookie 边界
+
+登录链路会使用 Cookie 提取、CDP、QR httpx 或 patchright 浏览器自动化。项目只在本地读取和保存登录态，不要求用户把 Cookie、Token、手机号、微信号、姓名、公司信息或 `security_id` 提交到仓库。
+
+提交 Issue 前必须脱敏：
+
+```json
+{
+	"security_id": "<redacted>",
+	"cookie": "<redacted>",
+	"token": "<redacted>"
+}
+```
+
+## 3. 请求频率和账号责任
+
+默认请求间隔由 `--delay` 控制。不要把本工具用于高频抓取、批量骚扰、绕过平台限制或违反平台条款的用途。写操作，例如 `greet`、`apply`、`exchange`、`hr reply`，应先使用只读命令确认目标和上下文。
+
+## 4. 浏览器自动化边界
+
+patchright、CDP、Chrome 本地 profile、系统钥匙串、浏览器插件和平台风控都会影响登录与访问稳定性。浏览器能打开不代表 httpx 链路一定可用；httpx 链路可用也不代表 patchright 登录链路一定可用。
+
+## 5. 烟测边界
+
+真实流烟测必须显式配置环境变量，不应在普通 CI 中自动访问真实账号：
+
+```bash
+BOSS_SMOKE_DRY_RUN=1 uv run python scripts/smoke_p0.py
+BOSS_SMOKE_PLATFORM=zhipin BOSS_SMOKE_QUERY=Golang BOSS_SMOKE_SECURITY_ID=<redacted> uv run python scripts/smoke_p0.py
+```
+
+`BOSS_SMOKE_DRY_RUN=1` 只验证计划，不验证真实平台可用性。
+
+## 6. 报告安全问题
+
+如果问题涉及 Cookie、Token、账号、联系方式、私有简历、公司内部信息或可利用的自动化绕过路径，不要公开发 Issue。请按 [SECURITY.md](../SECURITY.md) 使用私密渠道报告。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ boss-mcp = "boss_agent_cli.mcp_server:run"
 testpaths = ["tests"]
 pythonpath = ["src"]
 
+# Python files intentionally use tabs. Ruff's indent-width controls visual width.
 [tool.ruff]
 line-length = 120
 indent-width = 4

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -185,7 +185,16 @@ def test_docs_workflow_runs_open_source_doc_checks():
 		"uv python install 3.11",
 		"uv sync --all-extras",
 		"uv run pytest tests/test_agent_docs.py tests/test_open_source_docs.py -q",
-		"git diff --check",
+		(
+			"if [ \"${{ github.event_name }}\" = \"pull_request\" ]; then\n"
+			"  git fetch --no-tags --depth=1 origin \"${{ github.base_ref }}\"\n"
+			"  git diff --check \"origin/${{ github.base_ref }}...HEAD\"\n"
+			"elif git rev-parse --verify HEAD^ >/dev/null 2>&1; then\n"
+			"  git diff --check HEAD^...HEAD\n"
+			"else\n"
+			"  git diff --check\n"
+			"fi\n"
+		),
 	]
 
 	assert "name: Docs" in raw_workflow
@@ -194,9 +203,9 @@ def test_docs_workflow_runs_open_source_doc_checks():
 	triggers = workflow["on"]
 	assert {"push", "pull_request", "workflow_dispatch"} <= set(triggers)
 	assert triggers["push"]["branches"] == ["master"]
+	assert set(expected_paths) <= set(triggers["push"]["paths"])
 	assert triggers["pull_request"]["branches"] == ["master"]
-	for trigger_name in ("push", "pull_request"):
-		assert set(expected_paths) <= set(triggers[trigger_name]["paths"])
+	assert "paths" not in triggers["pull_request"]
 
 	jobs = workflow["jobs"]
 	assert "docs" in jobs

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -27,3 +27,23 @@ def test_readme_and_contributing_link_getting_started_docs():
 	assert "docs/getting-started.en.md" in read("README.en.md")
 	assert "docs/getting-started.md" in read("CONTRIBUTING.md")
 	assert "docs/getting-started.en.md" in read("CONTRIBUTING.en.md")
+
+
+def test_platform_risk_docs_exist_and_cover_sensitive_boundaries():
+	zh = read("docs/platform-risk.md")
+	en = read("docs/platform-risk.en.md")
+
+	for content in (zh, en):
+		assert "Cookie" in content
+		assert "CDP" in content
+		assert "patchright" in content
+		assert "rate" in content.lower() or "频率" in content
+		assert "security_id" in content
+		assert "BOSS_SMOKE_DRY_RUN" in content
+		assert "redact" in content.lower() or "脱敏" in content
+
+
+def test_security_and_readme_link_platform_risk_docs():
+	assert "docs/platform-risk.md" in read("README.md")
+	assert "docs/platform-risk.en.md" in read("README.en.md")
+	assert "docs/platform-risk.md" in read("SECURITY.md")

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -211,6 +211,9 @@ def test_docs_workflow_runs_open_source_doc_checks():
 	assert "docs" in jobs
 	docs_job = jobs["docs"]
 	assert docs_job["runs-on"] == "ubuntu-latest"
+	checkout_step = docs_job["steps"][0]
+	assert checkout_step["uses"] == "actions/checkout@v6"
+	assert checkout_step["with"]["fetch-depth"] == 0
 	run_commands = [
 		step["run"]
 		for step in docs_job["steps"]

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -84,3 +84,36 @@ def test_contributing_links_maintainer_governance_docs():
 	assert "docs/maintainer/labels.md" in read("CONTRIBUTING.md")
 	assert "docs/maintainer/release-checklist.md" in read("CONTRIBUTING.en.md")
 	assert "docs/maintainer/labels.md" in read("CONTRIBUTING.en.md")
+
+
+def test_pull_request_template_requires_quality_and_risk_checks():
+	template = read(".github/PULL_REQUEST_TEMPLATE.md")
+
+	assert "uv run pytest tests/ -q" in template
+	assert "uv run ruff check src/ tests/" in template
+	assert "uv run mypy src/boss_agent_cli" in template
+	assert "docs/platform-risk.md" in template
+	assert "docs/maintainer/release-checklist.md" in template
+	assert "JSON 信封" in template
+	assert "Token / 密码 / Cookie / security_id" in template
+
+
+def test_issue_templates_collect_contract_and_platform_context():
+	bug = read(".github/ISSUE_TEMPLATE/bug_report.yml")
+	feature = read(".github/ISSUE_TEMPLATE/feature_request.yml")
+	docs = read(".github/ISSUE_TEMPLATE/documentation.yml")
+
+	assert "platform" in bug
+	assert "role" in bug
+	assert "security_id" in bug
+	assert "平台漂移" in bug
+	assert "JSON 信封" in bug
+	assert "redacted" in bug or "脱敏" in bug
+
+	assert "platform" in feature
+	assert "role" in feature
+	assert "JSON 信封" in feature
+	assert "Agent" in feature
+
+	assert "docs-parity" in docs
+	assert "README.en.md" in docs

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -47,3 +47,36 @@ def test_security_and_readme_link_platform_risk_docs():
 	assert "docs/platform-risk.md" in read("README.md")
 	assert "docs/platform-risk.en.md" in read("README.en.md")
 	assert "docs/platform-risk.md" in read("SECURITY.md")
+
+
+def test_maintainer_docs_cover_open_source_governance():
+	branch = read("docs/maintainer/branch-protection.md")
+	release = read("docs/maintainer/release-checklist.md")
+	labels = read("docs/maintainer/labels.md")
+
+	assert "required status checks" in branch
+	assert "CI / test" in branch
+	assert "CI / lint" in branch
+	assert "CI / typecheck" in branch
+	assert "allow_force_pushes" in branch
+	assert "allow_deletions" in branch
+
+	assert "uv run pytest tests/ -q" in release
+	assert "uv run ruff check src/ tests/" in release
+	assert "uv run mypy src/boss_agent_cli" in release
+	assert "uv build" in release
+	assert "uv publish" in release
+	assert "schema" in release
+	assert "redact" in release.lower()
+
+	assert "good first issue" in labels
+	assert "platform-drift" in labels
+	assert "contract" in labels
+	assert "triage" in labels
+
+
+def test_contributing_links_maintainer_governance_docs():
+	assert "docs/maintainer/release-checklist.md" in read("CONTRIBUTING.md")
+	assert "docs/maintainer/labels.md" in read("CONTRIBUTING.md")
+	assert "docs/maintainer/release-checklist.md" in read("CONTRIBUTING.en.md")
+	assert "docs/maintainer/labels.md" in read("CONTRIBUTING.en.md")

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -162,3 +162,13 @@ def test_issue_templates_are_valid_structured_forms():
 				assert options
 
 		assert len(ids) == len(set(ids))
+
+
+def test_docs_workflow_runs_open_source_doc_checks():
+	workflow = read(".github/workflows/docs.yml")
+
+	assert "name: Docs" in workflow
+	assert "uv run pytest tests/test_agent_docs.py tests/test_open_source_docs.py -q" in workflow
+	assert "git diff --check" in workflow
+	assert "pull_request" in workflow
+	assert "master" in workflow

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -1,11 +1,25 @@
 from pathlib import Path
 
+import yaml
+
 
 ROOT = Path(__file__).resolve().parents[1]
+ISSUE_FORM_PATHS = [
+	".github/ISSUE_TEMPLATE/bug_report.yml",
+	".github/ISSUE_TEMPLATE/feature_request.yml",
+	".github/ISSUE_TEMPLATE/documentation.yml",
+]
+SUPPORTED_ISSUE_FORM_TYPES = {"markdown", "input", "textarea", "dropdown", "checkboxes"}
 
 
 def read(path: str) -> str:
 	return (ROOT / path).read_text(encoding="utf-8")
+
+
+def load_yaml(path: str) -> dict:
+	content = yaml.safe_load(read(path))
+	assert isinstance(content, dict)
+	return content
 
 
 def test_getting_started_docs_exist_and_cover_happy_path():
@@ -96,6 +110,8 @@ def test_pull_request_template_requires_quality_and_risk_checks():
 	assert "docs/maintainer/release-checklist.md" in template
 	assert "JSON 信封" in template
 	assert "Token / 密码 / Cookie / security_id" in template
+	assert "commit message 格式: `type: 中文描述`" in template
+	assert "（或英文等价）" not in template
 
 
 def test_issue_templates_collect_contract_and_platform_context():
@@ -117,3 +133,32 @@ def test_issue_templates_collect_contract_and_platform_context():
 
 	assert "docs-parity" in docs
 	assert "README.en.md" in docs
+
+
+def test_issue_templates_are_valid_structured_forms():
+	for path in ISSUE_FORM_PATHS:
+		form = load_yaml(path)
+
+		assert {"name", "description", "title", "labels", "body"} <= set(form)
+
+		body = form["body"]
+		assert isinstance(body, list)
+		assert body
+
+		ids = []
+		for item in body:
+			assert isinstance(item, dict)
+			assert item.get("type") in SUPPORTED_ISSUE_FORM_TYPES
+
+			if item["type"] != "markdown":
+				assert item.get("id")
+				ids.append(item["id"])
+
+			if item["type"] in {"dropdown", "checkboxes"}:
+				attributes = item.get("attributes")
+				assert isinstance(attributes, dict)
+				options = attributes.get("options")
+				assert isinstance(options, list)
+				assert options
+
+		assert len(ids) == len(set(ids))

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+	return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_getting_started_docs_exist_and_cover_happy_path():
+	zh = read("docs/getting-started.md")
+	en = read("docs/getting-started.en.md")
+
+	for content in (zh, en):
+		assert "uv tool install boss-agent-cli" in content
+		assert "patchright install chromium" in content
+		assert "boss doctor" in content
+		assert "boss status" in content
+		assert "boss schema --format native" in content
+		assert "JSON" in content
+		assert "security_id" in content
+
+
+def test_readme_and_contributing_link_getting_started_docs():
+	assert "docs/getting-started.md" in read("README.md")
+	assert "docs/getting-started.en.md" in read("README.en.md")
+	assert "docs/getting-started.md" in read("CONTRIBUTING.md")
+	assert "docs/getting-started.en.md" in read("CONTRIBUTING.en.md")

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -165,10 +165,46 @@ def test_issue_templates_are_valid_structured_forms():
 
 
 def test_docs_workflow_runs_open_source_doc_checks():
-	workflow = read(".github/workflows/docs.yml")
+	raw_workflow = read(".github/workflows/docs.yml")
+	workflow = load_yaml(".github/workflows/docs.yml")
 
-	assert "name: Docs" in workflow
-	assert "uv run pytest tests/test_agent_docs.py tests/test_open_source_docs.py -q" in workflow
-	assert "git diff --check" in workflow
-	assert "pull_request" in workflow
-	assert "master" in workflow
+	expected_paths = [
+		"README.md",
+		"README.en.md",
+		"CONTRIBUTING.md",
+		"CONTRIBUTING.en.md",
+		"SECURITY.md",
+		"docs/**",
+		".github/ISSUE_TEMPLATE/**",
+		".github/PULL_REQUEST_TEMPLATE.md",
+		"tests/test_agent_docs.py",
+		"tests/test_open_source_docs.py",
+		".github/workflows/docs.yml",
+	]
+	expected_run_commands = [
+		"uv python install 3.11",
+		"uv sync --all-extras",
+		"uv run pytest tests/test_agent_docs.py tests/test_open_source_docs.py -q",
+		"git diff --check",
+	]
+
+	assert "name: Docs" in raw_workflow
+	assert workflow["name"] == "Docs"
+
+	triggers = workflow["on"]
+	assert {"push", "pull_request", "workflow_dispatch"} <= set(triggers)
+	assert triggers["push"]["branches"] == ["master"]
+	assert triggers["pull_request"]["branches"] == ["master"]
+	for trigger_name in ("push", "pull_request"):
+		assert set(expected_paths) <= set(triggers[trigger_name]["paths"])
+
+	jobs = workflow["jobs"]
+	assert "docs" in jobs
+	docs_job = jobs["docs"]
+	assert docs_job["runs-on"] == "ubuntu-latest"
+	run_commands = [
+		step["run"]
+		for step in docs_job["steps"]
+		if "run" in step
+	]
+	assert run_commands == expected_run_commands

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -55,9 +55,13 @@ def test_maintainer_docs_cover_open_source_governance():
 	labels = read("docs/maintainer/labels.md")
 
 	assert "required status checks" in branch
-	assert "CI / test" in branch
-	assert "CI / lint" in branch
-	assert "CI / typecheck" in branch
+	assert "test (3.10)" in branch
+	assert "test (3.11)" in branch
+	assert "test (3.12)" in branch
+	assert "test (3.13)" in branch
+	assert "lint" in branch
+	assert "typecheck" in branch
+	assert "docs" in branch
 	assert "allow_force_pushes" in branch
 	assert "allow_deletions" in branch
 

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -208,3 +208,19 @@ def test_docs_workflow_runs_open_source_doc_checks():
 		if "run" in step
 	]
 	assert run_commands == expected_run_commands
+
+
+def test_contributing_clarifies_verification_and_tab_indentation():
+	zh = read("CONTRIBUTING.md")
+	en = read("CONTRIBUTING.en.md")
+	pyproject = read("pyproject.toml")
+
+	for content in (zh, en):
+		assert "tab" in content.lower()
+		assert "indent-width" in content
+		assert "uv run pytest tests/ -q" in content
+		assert "uv run ruff check src/ tests/" in content
+		assert "uv run mypy src/boss_agent_cli" in content
+		assert "uv run boss schema --format native" in content
+
+	assert "# Python files intentionally use tabs" in pyproject


### PR DESCRIPTION
## Summary

- Add concise getting-started docs for users and contributors.
- Document platform automation risks, maintainer release checks, branch protection guidance, and label triage.
- Harden issue and PR templates around JSON contracts, redaction, platform drift, and verification.
- Add documentation governance workflow and parser-backed docs/template tests.

## Test Plan

- uv run pytest tests/ -q
- uv run ruff check src/ tests/
- uv run mypy src/boss_agent_cli
- uv run boss --help
- uv run boss schema --format native
- BOSS_SMOKE_DRY_RUN=1 uv run python scripts/smoke_p0.py
- git diff --check

## Notes

- Runtime behavior is intentionally unchanged.
- Current master branch protection still lacks required_status_checks; after this PR exposes the new Docs workflow check on GitHub, configure required checks for test matrix, lint, typecheck, and docs.