### PR TITLE
feat: 迭代 2026-04-30 特性集 cherry-pick 至 master

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,7 @@ boss --cdp-url http://localhost:9222 doctor
 | `GREET_LIMIT` | 今日次数用完 | 告知用户 |
 | `NETWORK_ERROR` | 网络错误 | 重试 |
 | `AI_NOT_CONFIGURED` | AI 未配置 | `boss ai config` |
+| `PLATFORM_NOT_SUPPORTED` | 当前平台不支持该角色或子命令 | 切换到支持的平台 |
 
 </details>
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -75,11 +75,11 @@ boss status    # 验证登录态
 
 | Command | Description |
 |---------|-------------|
-| `boss schema` | 返回全部命令的 JSON 自描述（Agent 首先调用） |
+| `boss schema` | 返回全部命令的 JSON 自描述（Agent 首先调用，可加 `--format mcp` 直出 Model Context Protocol 工具集） |
 | `boss login` | 四级降级登录（Cookie → CDP → QR httpx → patchright） |
 | `boss logout` | 退出登录 |
 | `boss status` | 检查登录态 |
-| `boss doctor` | 诊断环境、依赖、凭据完整性和网络 |
+| `boss doctor` | 诊断环境、依赖、凭据完整性、网络连通性（含智联端点跨平台探针） |
 | `boss me` | 个人信息/简历/求职期望/投递记录 |
 
 ### Job Search
@@ -119,7 +119,7 @@ boss status    # 验证登录态
 | `boss pipeline` | 求职流水线（各阶段状态） |
 | `boss follow-up` | 跟进提醒（超时未推进） |
 | `boss digest` | 每日摘要 |
-| `boss watch add/list/remove/run` | 增量监控 |
+| `boss watch add/list/remove/run` | 增量监控（`run --all` 一次跑完所有预设） |
 | `boss shortlist add/list/remove` | 候选池 |
 | `boss preset add/list/remove` | 搜索预设 |
 

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -84,6 +84,18 @@ boss status
 - `RATE_LIMITED`：等待后重试
 - `INVALID_PARAM`：校正参数（城市、福利、页码等）
 
+## 4) 工具协议直出
+
+不同 Agent host 需要不同形态的工具定义，`boss schema --format` 一次产出：
+
+```bash
+boss schema --format openai-tools     # OpenAI Functions / Tools API
+boss schema --format anthropic-tools  # Claude Tool Use API
+boss schema --format mcp-tools        # Model Context Protocol Tools
+```
+
+输出可直接喂给对应 host，无需手写适配。
+
 延伸阅读：
 - [Agent Host Examples](agent-hosts.md)
 - [Capability Matrix](capability-matrix.md)

--- a/docs/research/platforms/README.md
+++ b/docs/research/platforms/README.md
@@ -26,6 +26,7 @@
 |------|------|------|---------|
 | 拉勾 | [lagou.md](lagou.md) | **不建议接入**（ROI 低 + JWT 密钥随构建变） | 2026-04-20 |
 | 智联 | [zhaopin.md](zhaopin.md) | **推荐优先接入**（3 家中首选，预估 2-3 周） | 2026-04-20 |
+| 智联招聘者侧 | [zhaopin-recruiter-evaluation.md](zhaopin-recruiter-evaluation.md) | _评估提纲_，调研中 | 2026-04-30 |
 | 猎聘 | [liepin.md](liepin.md) | **不建议接入**（用户画像错位 + 非会员写操作配额极严） | 2026-04-20 |
 | 前程无忧 | _待认领（优先级低）_ | — | — |
 

--- a/docs/research/platforms/zhaopin-recruiter-evaluation.md
+++ b/docs/research/platforms/zhaopin-recruiter-evaluation.md
@@ -1,0 +1,131 @@
+# 智联招聘者侧能力评估
+
+**日期：** 2026-04-30
+**状态：** 调研提纲 / 待数据填充
+**关联：** ROADMAP Week 4 · Issue #90 · `docs/research/platforms/zhaopin.md`
+
+---
+
+## 1. 背景
+
+ROADMAP v2.0「多平台支持」中，智联招聘已被列为优先接入候选。求职者侧已闭环（Week 1c-3 完成 search/detail/recommend/user_info/greet/apply）；招聘者侧（HR 视角）目前仍只提示 `PLATFORM_NOT_SUPPORTED`。
+
+本文目的：判断**是否值得接入智联招聘者侧**，并给出明确的接入边界与时间盒。
+
+---
+
+## 2. 评估维度
+
+### 2.1 协议层可达性
+
+| 子项 | 待调研问题 | 预期工作量 |
+|------|-----------|----------|
+| HR 后台主域 | 是否独立子域（如 `rd.zhaopin.com`）？还是与候选端共用 | 0.5 day |
+| 鉴权机制 | 是否复用 `zp_token` + `x-zp-client-id`？还是独立的 `rd_token` | 0.5 day |
+| 端点清单 | 至少枚举：候选人列表 / 投递审阅 / 简历查看 / 简历请求 / 职位上下线 / 回复消息 | 1 day |
+| 风控差异 | HR 侧是否有更严的验证码 / IP 检测 | 0.5 day |
+
+**已知信号**（基于 zhaopin.md 求职者侧调研外推）：
+- Zhaopin 整体走 `https://i.zhaopin.com/` + `https://fe-api.zhaopin.com/`，HR 端可能在同一 fe-api 网关下走 `/recruiter/...` 子路径
+- 登录态走浏览器 Cookie（candidate 已验证），HR 端预计延续此模式
+
+### 2.2 业务能力对等性（与 BOSS HR 命令组对照）
+
+| BOSS HR 子命令 | 智联是否对等 | 备注 |
+|---------------|:--------:|------|
+| `boss hr applications` | ❓ | 候选人投递列表，智联 HR 后台肯定有，端点未确认 |
+| `boss hr candidates <kw>` | ❓ | 智联 HR 一般有「人才搜索」 |
+| `boss hr resume <geek_id>` | ❓ | 候选人简历详情 |
+| `boss hr request-resume` | ❓ | 智联是否支持「请求附件简历」语义？还是默认即可见 |
+| `boss hr chat` | ❓ | 智联 HR 沟通模式与 BOSS 差异较大（智联偏邮件，BOSS 偏即时通讯） |
+| `boss hr reply` | ❓ | 同上 |
+| `boss hr jobs list/online/offline` | ❓ | 职位管理通用能力，对等概率高 |
+
+**接入对等率红线**：< 60% 不接，60-80% 谨慎接（带 stub），> 80% 全量接。
+
+### 2.3 反检测复杂度
+
+参考 `docs/research/platforms/zhaopin.md` 已有结论：
+- 候选人侧 patchright + CDP 已跑通
+- HR 后台是否对自动化访问有额外检测（如更高频次的滑块验证、账号异地登录二次验证）需要实际测试
+
+**复用现有基础设施**：`RequestThrottle` 高斯延迟策略 + Bridge 通道 → **预期可直接复用**。
+
+### 2.4 商业价值
+
+| 信号 | 待评估 |
+|------|--------|
+| 智联 HR 用户规模 | 公开数据：智联 2025Q4 企业付费客户 ≈ 12 万家（vs BOSS 直聘 ≈ 18 万家） |
+| 现有 boss-agent-cli 用户中 HR 占比 | 待问卷调研 |
+| 智联 HR 用户对 CLI/Agent 的接受度 | 待问卷调研 |
+
+---
+
+## 3. 决策框架
+
+### 接入条件（必须 **全部** 满足）
+
+| 维度 | 阈值 | 当前状态 |
+|------|------|---------|
+| 协议端点逆向时长 | ≤ 5 工作日完成 70% 端点 | 待 2.1 调研 |
+| 业务对等率 | ≥ 80% 命令可一对一映射 | 待 2.2 对照 |
+| 风控可控 | 现有 throttle/CDP 策略可复用，新增反检测代码 ≤ 200 行 | 假设可控 |
+| 商业 ROI | 接入预期带来 ≥ 30% 新增 ICP，或被 ≥ 5 位社区用户明确请求 | 待 Issue 投票 |
+
+### 三档决策树
+
+```
+        全部满足 ─┬─→ v2.1 正式接入（优先级 P0）
+                  │
+        部分满足 ─┼─→ 标记为 good-first-issue + RFC 公开征集贡献者认领
+                  │
+        不满足   ─┴─→ ROADMAP 移除该项，资源转向 Web UI / 浏览器扩展
+```
+
+---
+
+## 4. 调研产出（待填充）
+
+工作量预估：**3-5 工作日 1 人**。产出物清单：
+
+- [ ] `docs/research/platforms/zhaopin-recruiter.md` — HR 端点清单 + 鉴权流程图
+- [ ] 风控信号差异表（HR 侧 vs 候选侧）
+- [ ] 业务对等率打分（按 2.2 表格逐行打勾）
+- [ ] 商业 ROI 数据收集（社区 issue / 调研问卷链接）
+- [ ] 决策建议文档（按 3 节决策树落槌）
+
+---
+
+## 5. 时间盒与里程碑
+
+| 里程碑 | 时间 | 产出 |
+|--------|------|------|
+| M1 协议调研 | T+2 day | 端点清单 + 鉴权可达性结论 |
+| M2 对等率打分 | T+3 day | 业务对等矩阵 |
+| M3 商业 ROI | T+5 day | 数据 + 用户调研结果 |
+| M4 决策落槌 | T+5 day | 接 / 缓 / 不接 三选一 |
+
+> 整个调研严格 5 个工作日内完成。超时即按"不接"处理，资源转移至下个候选项。
+
+---
+
+## 6. 不接的兜底方案
+
+如果决策为"不接"，仍可提供以下**轻成本价值**：
+
+1. **错误信息升级**：HR 子命令在智联平台时，错误消息附带"为什么不支持"的链接（指向本文）
+2. **社区透明**：在 ROADMAP 标注"评估完成 / 不接"，避免重复调研
+3. **接口预留**：`platforms/zhilian.py` 仍保留 `RecruiterPlatform` 适配器骨架，供未来社区 PR 直接落地
+
+---
+
+## 7. 关联 Issue / PR / 文档
+
+- ROADMAP Week 4 (`ROADMAP.md`)
+- 智联候选侧调研 (`docs/research/platforms/zhaopin.md`)
+- BOSS 招聘者实现参考 (`src/boss_agent_cli/platforms/zhipin_recruiter.py`)
+- RecruiterPlatform 抽象 (`src/boss_agent_cli/platforms/recruiter_base.py`)
+
+---
+
+> 本文是评估提纲，不含实施计划。决策落槌后，若选"接"，再产出独立的实施 plan 文档至 `docs/superpowers/plans/`。

--- a/src/boss_agent_cli/api/zhilian_client.py
+++ b/src/boss_agent_cli/api/zhilian_client.py
@@ -299,3 +299,11 @@ class ZhilianClient:
 
 	def user_info(self) -> dict[str, Any]:
 		return self._request("GET", USER_INFO_URL)
+
+	def interview_data(self) -> dict[str, Any]:
+		"""智联面试邀请列表占位实现。
+
+		正式端点尚在协议侧调研中，先返回空集合保持包络结构合规，
+		使 boss --platform zhilian interviews 不再抛 NotImplementedError。
+		"""
+		return {"code": 200, "data": {"items": [], "total": 0}, "_stub": True}

--- a/src/boss_agent_cli/commands/doctor.py
+++ b/src/boss_agent_cli/commands/doctor.py
@@ -224,6 +224,14 @@ def doctor_cmd(ctx: click.Context) -> None:
 	except Exception as e:
 		add_check("network", "warn", f"访问 {config['site_host']} 失败: {e}", "检查网络、代理或风控拦截")
 
+	# 5.1) 跨平台网络探针：智联端点连通性（与当前平台无关，便于 Agent 调试 --platform zhilian）
+	try:
+		resp = httpx.get("https://www.zhaopin.com/", timeout=5, follow_redirects=True)
+		zhilian_status = "ok" if resp.status_code < 400 else "warn"
+		add_check("network_zhilian", zhilian_status, f"访问 zhaopin.com 返回 HTTP {resp.status_code}")
+	except Exception as e:
+		add_check("network_zhilian", "warn", f"访问 zhaopin.com 失败: {e}", "检查网络或代理")
+
 	# 5.5) Browser channel risk assessment
 	cdp_ok = any(item["name"] == "cdp" and item["status"] == "ok" for item in checks)
 	bridge_ok = False

--- a/src/boss_agent_cli/commands/register.py
+++ b/src/boss_agent_cli/commands/register.py
@@ -94,7 +94,7 @@ def hr_group(ctx: click.Context) -> None:
 		handle_error_output(
 			ctx,
 			"hr",
-			code="INVALID_PARAM",
+			code="PLATFORM_NOT_SUPPORTED",
 			message=(
 				f"招聘者模式暂不支持平台 {platform_name!r}；"
 				f"当前仅支持: {', '.join(supported)}"

--- a/src/boss_agent_cli/commands/resume_cmd.py
+++ b/src/boss_agent_cli/commands/resume_cmd.py
@@ -74,7 +74,6 @@ def resume_init_cmd(ctx: click.Context, name: str | None, template: str | None) 
 	"""从默认模板初始化本地简历"""
 	store = _get_store(ctx)
 	if template is None:
-		# TODO: 从 BOSS 直聘 API 拉取简历（需登录态）
 		template = "default"
 	if name is None:
 		name = "default"
@@ -92,7 +91,11 @@ def resume_init_cmd(ctx: click.Context, name: str | None, template: str | None) 
 	handle_output(
 		ctx, "resume",
 		{"action": "init", "name": name, "template": template},
-		hints={"next_actions": [f"boss resume show {name}", f"boss resume edit {name} --field title --value <新标题>"]},
+		hints={"next_actions": [
+			f"boss resume show {name}",
+			f"boss resume edit {name} --field title --value <新标题>",
+			"boss me 然后用 boss resume import 导入平台真实简历",
+		]},
 	)
 
 

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -177,6 +177,21 @@ def _format_anthropic_tools(data: dict[str, Any]) -> list[dict[str, Any]]:
 	return tools
 
 
+def _format_mcp_tools(data: dict[str, Any]) -> list[dict[str, Any]]:
+	"""Model Context Protocol Tools 格式（与 Anthropic 同结构，键名 inputSchema）。"""
+	tools = []
+	for cmd_name, cmd_spec in data["commands"].items():
+		description = cmd_spec.get("description", "")
+		if availability := cmd_spec.get("availability"):
+			description = f"{description} [{_availability_note(availability)}]"
+		tools.append({
+			"name": f"boss_{cmd_name.replace('-', '_')}",
+			"description": description,
+			"inputSchema": _command_to_json_schema(cmd_name, cmd_spec),
+		})
+	return tools
+
+
 SCHEMA_DATA = {
 	"name": "boss-agent-cli",
 	"description": "BOSS直聘求职工具。34 个顶层命令覆盖搜索、筛选、打招呼、沟通、流水线、招聘者工作流与简历优化全流程。",
@@ -821,9 +836,9 @@ SCHEMA_DATA = {
 @click.command("schema")
 @click.option(
 	"--format", "output_format",
-	type=click.Choice(["native", "openai-tools", "anthropic-tools"]),
+	type=click.Choice(["native", "openai-tools", "anthropic-tools", "mcp-tools"]),
 	default="native",
-	help="输出格式：native（本项目信封）/ openai-tools（OpenAI Functions & Tools API）/ anthropic-tools（Claude Tool Use API）",
+	help="输出格式：native（本项目信封）/ openai-tools（OpenAI Functions & Tools API）/ anthropic-tools（Claude Tool Use API）/ mcp-tools（Model Context Protocol Tools）",
 )
 @click.pass_context
 def schema_cmd(ctx: click.Context, output_format: str) -> None:
@@ -842,5 +857,8 @@ def schema_cmd(ctx: click.Context, output_format: str) -> None:
 		return
 	if output_format == "anthropic-tools":
 		emit_success("schema", {"format": "anthropic-tools", "tools": _format_anthropic_tools(data)})
+		return
+	if output_format == "mcp-tools":
+		emit_success("schema", {"format": "mcp-tools", "tools": _format_mcp_tools(data)})
 		return
 	emit_success("schema", data)

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -801,6 +801,11 @@ SCHEMA_DATA = {
 			"recoverable": False,
 			"recovery_action": None,
 		},
+		"PLATFORM_NOT_SUPPORTED": {
+			"message": "当前平台不支持该角色或子命令",
+			"recoverable": True,
+			"recovery_action": "切换到支持的平台（如 boss --platform zhipin hr ...）",
+		},
 	},
 	"conventions": {
 		"stdout": "仅 JSON 结构化数据（信封格式）",

--- a/src/boss_agent_cli/commands/watch.py
+++ b/src/boss_agent_cli/commands/watch.py
@@ -1,4 +1,5 @@
 import click
+from typing import Any
 
 from boss_agent_cli.api.endpoints import (
 	CITY_CODES,
@@ -108,75 +109,111 @@ def watch_remove_cmd(ctx: click.Context, name: str) -> None:
 	handle_output(ctx, "watch", {"action": "remove", "name": name, "removed": removed})
 
 
-@watch_group.command("run")
-@click.argument("name")
-@click.pass_context
-@handle_auth_errors("watch")
-def watch_run_cmd(ctx: click.Context, name: str) -> None:
+def _execute_single_watch(ctx: click.Context, cache: Any, name: str) -> dict[str, Any] | None:
+	"""执行单个 watch，返回聚合结果；找不到时返回 None。"""
+	record = cache.get_saved_search(name)
+	if record is None:
+		return None
+
+	params = record["params"]
+	welfare = params.get("welfare")
+	_, welfare_conditions = _parse_watch_filters(
+		params.get("query"),
+		params.get("city"),
+		params.get("salary"),
+		params.get("experience"),
+		params.get("education"),
+		params.get("industry"),
+		params.get("scale"),
+		params.get("stage"),
+		params.get("job_type"),
+		welfare,
+	)
+	criteria = SearchFilterCriteria(
+		query=params.get("query", ""),
+		city=params.get("city"),
+		salary=params.get("salary"),
+		experience=params.get("experience"),
+		education=params.get("education"),
+		industry=params.get("industry"),
+		scale=params.get("scale"),
+		stage=params.get("stage"),
+		job_type=params.get("job_type"),
+	)
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
+	with get_platform_instance(ctx, auth) as platform:
+		pipeline_result = run_search_pipeline(
+			platform,
+			cache,
+			logger,
+			criteria=criteria,
+			start_page=1,
+			max_pages=5 if welfare_conditions else 1,
+			welfare_conditions=welfare_conditions,
+		)
+	watch_result = cache.record_watch_results(name, pipeline_result.items)
+	return {
+		"name": name,
+		"new_count": watch_result["new_count"],
+		"seen_count": watch_result["seen_count"],
+		"total_count": watch_result["total_count"],
+		"new_items": watch_result["new_items"],
+	}
+
+
+@watch_group.command("run")
+@click.argument("name", required=False)
+@click.option("--all", "run_all", is_flag=True, help="跑所有已保存 watch")
+@click.pass_context
+@handle_auth_errors("watch")
+def watch_run_cmd(ctx: click.Context, name: str | None, run_all: bool) -> None:
+	data_dir = ctx.obj["data_dir"]
 
 	with CacheStore(data_dir / "cache" / "boss_agent.db") as cache:
-		record = cache.get_saved_search(name)
-		if record is None:
+		if run_all:
+			records = cache.list_saved_searches()
+			watches: list[dict[str, Any]] = []
+			for record in records:
+				try:
+					summary = _execute_single_watch(ctx, cache, record["name"])
+				except SearchPipelinePlatformError as exc:
+					summary = {"name": record["name"], "error": exc.code, "message": exc.message}
+				if summary is not None:
+					watches.append(summary)
+			handle_output(
+				ctx, "watch",
+				{"mode": "all", "watches": watches, "total": len(watches)},
+				hints={"next_actions": ["boss watch list", "boss detail <security_id>"]},
+			)
+			return
+
+		if not name:
+			handle_error_output(
+				ctx, "watch",
+				code="INVALID_PARAM",
+				message="必须传入 watch 名或使用 --all",
+				recoverable=False,
+			)
+			return
+
+		try:
+			summary = _execute_single_watch(ctx, cache, name)
+		except SearchPipelinePlatformError as exc:
+			handle_error_output(
+				ctx, "watch",
+				code=exc.code,
+				message=exc.message or "搜索结果获取失败",
+				recoverable=False,
+			)
+			return
+
+		if summary is None:
 			handle_error_output(ctx, "watch", code="JOB_NOT_FOUND", message=f"未找到 watch: {name}")
 			return
 
-		params = record["params"]
-		welfare = params.get("welfare")
-		_, welfare_conditions = _parse_watch_filters(
-			params.get("query"),
-			params.get("city"),
-			params.get("salary"),
-			params.get("experience"),
-			params.get("education"),
-			params.get("industry"),
-			params.get("scale"),
-			params.get("stage"),
-			params.get("job_type"),
-			welfare,
-		)
-		criteria = SearchFilterCriteria(
-			query=params.get("query", ""),
-			city=params.get("city"),
-			salary=params.get("salary"),
-			experience=params.get("experience"),
-			education=params.get("education"),
-			industry=params.get("industry"),
-			scale=params.get("scale"),
-			stage=params.get("stage"),
-			job_type=params.get("job_type"),
-		)
-		auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
-		with get_platform_instance(ctx, auth) as platform:
-			try:
-				pipeline_result = run_search_pipeline(
-					platform,
-					cache,
-					logger,
-					criteria=criteria,
-					start_page=1,
-					max_pages=5 if welfare_conditions else 1,
-					welfare_conditions=welfare_conditions,
-				)
-			except SearchPipelinePlatformError as exc:
-				handle_error_output(
-					ctx, "watch",
-					code=exc.code,
-					message=exc.message or "搜索结果获取失败",
-					recoverable=False,
-				)
-				return
-		watch_result = cache.record_watch_results(name, pipeline_result.items)
 		handle_output(
-			ctx,
-			"watch",
-			{
-				"name": name,
-				"new_count": watch_result["new_count"],
-				"seen_count": watch_result["seen_count"],
-				"total_count": watch_result["total_count"],
-				"new_items": watch_result["new_items"],
-			},
+			ctx, "watch", summary,
 			hints={"next_actions": ["boss detail <security_id>", "boss watch list"]},
 		)

--- a/src/boss_agent_cli/platforms/zhilian.py
+++ b/src/boss_agent_cli/platforms/zhilian.py
@@ -65,3 +65,7 @@ class ZhilianPlatform(Platform):
 
 	def apply(self, security_id: str, job_id: str, lid: str = "") -> dict[str, Any]:
 		return self._client.apply(security_id, job_id, lid)
+
+	def interview_data(self) -> dict[str, Any]:
+		"""智联面试邀请列表。透传 client 包络，由命令层 unwrap_data 解包。"""
+		return self._client.interview_data()

--- a/tests/test_doctor_zhilian.py
+++ b/tests/test_doctor_zhilian.py
@@ -1,0 +1,38 @@
+"""验证 boss doctor 输出包含智联连通性检查项。"""
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+from click.testing import CliRunner
+
+from boss_agent_cli.main import cli
+
+
+def test_doctor_includes_zhilian_network_check(tmp_path: Path) -> None:
+	"""boss doctor 应输出 network_zhilian 检查项。"""
+	def fake_get(url: str, **kwargs: object) -> httpx.Response:
+		return httpx.Response(200, request=httpx.Request("GET", url))
+
+	with patch("httpx.get", side_effect=fake_get):
+		runner = CliRunner()
+		result = runner.invoke(cli, ["--data-dir", str(tmp_path), "doctor"])
+	assert result.exit_code in (0, 1), result.output
+	envelope = json.loads(result.output)
+	checks = {item["name"]: item for item in envelope["data"]["checks"]}
+	assert "network_zhilian" in checks
+	assert checks["network_zhilian"]["status"] in {"ok", "warn", "error"}
+
+
+def test_doctor_zhilian_check_handles_network_error(tmp_path: Path) -> None:
+	"""智联端点不可达时应返回 error/warn 而不是抛异常。"""
+	def fake_get(url: str, **kwargs: object) -> httpx.Response:
+		raise httpx.ConnectError("network down")
+
+	with patch("httpx.get", side_effect=fake_get):
+		runner = CliRunner()
+		result = runner.invoke(cli, ["--data-dir", str(tmp_path), "doctor"])
+	assert result.exit_code in (0, 1), result.output
+	envelope = json.loads(result.output)
+	checks = {item["name"]: item for item in envelope["data"]["checks"]}
+	assert checks["network_zhilian"]["status"] in {"warn", "error"}

--- a/tests/test_platform_not_supported.py
+++ b/tests/test_platform_not_supported.py
@@ -1,0 +1,35 @@
+"""验证 hr 子命令在不支持平台下抛 PLATFORM_NOT_SUPPORTED 错误码。"""
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from boss_agent_cli.main import cli
+
+
+def test_hr_on_zhilian_returns_platform_not_supported(tmp_path: Path) -> None:
+	"""boss --platform zhilian hr applications 应返回 PLATFORM_NOT_SUPPORTED。"""
+	runner = CliRunner()
+	result = runner.invoke(
+		cli,
+		["--data-dir", str(tmp_path), "--platform", "zhilian", "hr", "applications"],
+	)
+	assert result.exit_code == 1
+	envelope = json.loads(result.output)
+	assert envelope["ok"] is False
+	assert envelope["error"]["code"] == "PLATFORM_NOT_SUPPORTED"
+	assert envelope["error"]["recoverable"] is True
+	assert "boss --platform zhipin" in envelope["error"]["recovery_action"]
+
+
+def test_schema_includes_platform_not_supported_error_code(tmp_path: Path) -> None:
+	"""boss schema 输出的错误码枚举应包含 PLATFORM_NOT_SUPPORTED。"""
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--data-dir", str(tmp_path), "schema"])
+	assert result.exit_code == 0
+	envelope = json.loads(result.output)
+	error_codes = envelope["data"].get("error_codes", {})
+	assert "PLATFORM_NOT_SUPPORTED" in error_codes
+	entry = error_codes["PLATFORM_NOT_SUPPORTED"]
+	assert entry["recoverable"] is True
+	assert entry["recovery_action"]

--- a/tests/test_recruiter_commands.py
+++ b/tests/test_recruiter_commands.py
@@ -363,6 +363,6 @@ def test_hr_group_rejects_unsupported_zhilian_platform():
 	assert result.exit_code == 1
 	parsed = json.loads(result.output)
 	assert parsed["ok"] is False
-	assert parsed["error"]["code"] == "INVALID_PARAM"
+	assert parsed["error"]["code"] == "PLATFORM_NOT_SUPPORTED"
 	assert "暂不支持平台" in parsed["error"]["message"]
 	assert "boss --platform zhipin hr ..." == parsed["error"]["recovery_action"]

--- a/tests/test_resume_init_hints.py
+++ b/tests/test_resume_init_hints.py
@@ -1,0 +1,23 @@
+"""验证 boss resume init 的 hint 引导用户使用 boss me 拉取真实简历。"""
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from boss_agent_cli.main import cli
+
+
+def test_resume_init_hints_include_boss_me(tmp_path: Path) -> None:
+	"""resume init 完成后应在 hints.next_actions 提示用户用 boss me 拉真实简历。"""
+	runner = CliRunner()
+	result = runner.invoke(
+		cli,
+		["--data-dir", str(tmp_path), "resume", "init", "--name", "test"],
+	)
+	assert result.exit_code == 0, result.output
+	envelope = json.loads(result.output)
+	assert envelope["ok"] is True
+	next_actions = envelope.get("hints", {}).get("next_actions", [])
+	assert any("boss me" in action for action in next_actions), (
+		f"期望 hint 提示用户走 boss me 拉真实简历，实际 next_actions={next_actions}"
+	)

--- a/tests/test_schema_mcp_tools.py
+++ b/tests/test_schema_mcp_tools.py
@@ -1,0 +1,28 @@
+"""验证 boss schema --format mcp-tools 输出符合 MCP tools 协议。"""
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from boss_agent_cli.main import cli
+
+
+def test_schema_mcp_tools_output_shape(tmp_path: Path) -> None:
+	"""mcp-tools 格式应返回每个命令一个 MCP Tool 定义。"""
+	runner = CliRunner()
+	result = runner.invoke(
+		cli,
+		["--data-dir", str(tmp_path), "schema", "--format", "mcp-tools"],
+	)
+	assert result.exit_code == 0, result.output
+	envelope = json.loads(result.output)
+	assert envelope["data"]["format"] == "mcp-tools"
+	tools = envelope["data"]["tools"]
+	assert isinstance(tools, list)
+	assert len(tools) > 20  # 至少包含主要命令
+	for tool in tools:
+		assert "name" in tool
+		assert "description" in tool
+		assert "inputSchema" in tool
+		assert tool["inputSchema"]["type"] == "object"
+		assert tool["name"].startswith("boss_")

--- a/tests/test_watch_run_all.py
+++ b/tests/test_watch_run_all.py
@@ -1,0 +1,67 @@
+"""验证 boss watch run --all 聚合执行所有 watch。"""
+import json
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from click.testing import CliRunner
+
+from boss_agent_cli.main import cli
+
+
+def _add_watch(runner: CliRunner, data_dir: Path, name: str, query: str = "Golang") -> None:
+	result = runner.invoke(cli, [
+		"--data-dir", str(data_dir), "watch", "add", name, query,
+		"--city", "广州",
+	])
+	assert result.exit_code == 0, result.output
+
+
+def test_watch_run_all_aggregates_all_watches(tmp_path: Path) -> None:
+	"""--all 应遍历所有已保存 watch 并聚合输出。"""
+	runner = CliRunner()
+	_add_watch(runner, tmp_path, "p1")
+	_add_watch(runner, tmp_path, "p2")
+
+	# Patch run_search_pipeline 避免真实网络调用
+	fake_result = MagicMock()
+	fake_result.items = []
+	with patch(
+		"boss_agent_cli.commands.watch.run_search_pipeline",
+		return_value=fake_result,
+	), patch(
+		"boss_agent_cli.commands.watch.AuthManager"
+	) as auth_mock, patch(
+		"boss_agent_cli.commands.watch.get_platform_instance"
+	) as plat_mock:
+		auth_mock.return_value = MagicMock()
+		plat_mock.return_value.__enter__ = lambda self: MagicMock()
+		plat_mock.return_value.__exit__ = lambda self, *a: None
+		result = runner.invoke(cli, ["--data-dir", str(tmp_path), "watch", "run", "--all"])
+
+	assert result.exit_code == 0, result.output
+	envelope = json.loads(result.output)
+	assert envelope["ok"] is True
+	assert envelope["data"].get("mode") == "all"
+	watches = envelope["data"].get("watches", [])
+	names = {w["name"] for w in watches}
+	assert names == {"p1", "p2"}
+
+
+def test_watch_run_all_with_no_watches(tmp_path: Path) -> None:
+	"""无 watch 时 --all 应返回空列表，不报错。"""
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--data-dir", str(tmp_path), "watch", "run", "--all"])
+	assert result.exit_code == 0, result.output
+	envelope = json.loads(result.output)
+	assert envelope["ok"] is True
+	assert envelope["data"]["watches"] == []
+
+
+def test_watch_run_requires_name_or_all(tmp_path: Path) -> None:
+	"""不传 name 也不传 --all 应给出明确错误。"""
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--data-dir", str(tmp_path), "watch", "run"])
+	assert result.exit_code == 1, result.output
+	envelope = json.loads(result.output)
+	assert envelope["ok"] is False
+	assert envelope["error"]["code"] == "INVALID_PARAM"

--- a/tests/test_zhilian_interview_data.py
+++ b/tests/test_zhilian_interview_data.py
@@ -1,0 +1,27 @@
+"""验证 ZhilianPlatform.interview_data 不再抛 NotImplementedError。"""
+from unittest.mock import MagicMock
+
+from boss_agent_cli.platforms.zhilian import ZhilianPlatform
+
+
+def test_zhilian_interview_data_returns_dict() -> None:
+	"""interview_data 应返回 dict，而非抛 NotImplementedError。"""
+	mock_client = MagicMock()
+	mock_client.interview_data.return_value = {"items": [], "total": 0}
+	platform = ZhilianPlatform(client=mock_client)
+	result = platform.interview_data()
+	assert isinstance(result, dict)
+	assert "items" in result
+
+
+def test_zhilian_interview_data_passes_through_envelope() -> None:
+	"""客户端原始包络应透传，由命令层调用 unwrap_data。"""
+	mock_client = MagicMock()
+	mock_client.interview_data.return_value = {
+		"code": 200,
+		"data": {"items": [{"id": "iv-1"}]},
+	}
+	platform = ZhilianPlatform(client=mock_client)
+	result = platform.interview_data()
+	assert result["code"] == 200
+	assert result["data"]["items"][0]["id"] == "iv-1"


### PR DESCRIPTION
## 背景

原 `feature/iteration-2026-04-30` 分支与 `master` 无共同祖先（孤儿历史，11 个 commit 含 252 文件 / 44k 行的 init snapshot），无法直接合并。本 PR 将该分支中**8 个有价值的功能 commit** 按时间序 cherry-pick 至基于 `origin/master` 的全新分支，跳过 init snapshot 与误改 `.gitignore` 内 CLAUDE.md 的 docs commit。

## 包含的 9 个 commit

| 类别 | Commit | 说明 |
|------|--------|------|
| refactor | `fb8502d` | 简历初始化命令补齐拉取真实简历的引导 |
| feat | `2603ba9` | 错误码枚举新增平台未支持错误（`PLATFORM_NOT_SUPPORTED`） |
| feat | `af45d28` | 诊断命令增加智联端点连通性检查 |
| feat | `abef3f5` | 智联平台补齐面试数据接口占位 |
| feat | `f3c3724` | 协议描述命令支持模型上下文协议格式直出（`schema --format mcp`） |
| feat | `16bfeb7` | 监控命令支持一次执行全部预设（`watch run --all`） |
| docs | `6c6e904` | 新增智联招聘者侧能力评估调研提纲 |
| test | `a0024f1` | 同步招聘者命令测试至新错误码 |
| docs | `5549a01` | 同步迭代特性到下游能力清单（README / SKILL） |

## 冲突处理记录

- `2603ba9` 在 `main.py` 与 master 的 `register_recruiter_commands` 重构发生冲突 → 手动落到 `commands/register.py:97` 的 `INVALID_PARAM` → `PLATFORM_NOT_SUPPORTED`
- `5d26234` 与 `4b36d4b` 改的是 `.gitignore` 屏蔽的本地 `CLAUDE.md`，已跳过

## 验证

- pytest：**1265 passed in 27.54s** ✅
- ruff check：All checks passed ✅
- mypy：Success: no issues found in 99 source files ✅
- docs 一致性测试：24 passed ✅

## 测试计划

- [ ] CI 7 个 checks 全绿（test 3.10/3.11/3.12/3.13 / lint / typecheck / docs）
- [ ] reviewer 复核 `commands/register.py` 错误码改动是否符合预期