### PR TITLE
整理项目演示入口

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -26,7 +26,7 @@
   <img src="demo/showcase/boss-agent-cli-showcase.gif" alt="boss-agent-cli project showcase animation" width="100%">
 </a>
 
-**[Watch the full 16-second showcase video](demo/showcase/boss-agent-cli-showcase.mp4)** · [terminal demo](demo.gif) · schema-driven · welfare filtering · JSON envelope · open-source engineering quality
+**[Watch the full showcase video](demo/showcase/boss-agent-cli-showcase.mp4)** · [view the terminal demo](demo.gif) · schema-driven · welfare filtering · JSON envelope · open-source engineering quality
 
 </div>
 
@@ -43,6 +43,7 @@ Every command outputs **structured JSON** that AI Agents parse directly. No frag
 ## 🧭 Table of Contents
 
 - [Why boss-agent-cli?](#-why-boss-agent-cli)
+- [Demo Assets](#-demo-assets)
 - [Core Capabilities](#-core-capabilities)
 - [Install](#-install)
 - [Quickstart](#-quickstart)
@@ -53,6 +54,15 @@ Every command outputs **structured JSON** that AI Agents parse directly. No frag
 - [Architecture](#-architecture)
 - [Local Storage](#-local-storage)
 - [Contributing](#-contributing)
+
+## 🎬 Demo Assets
+
+| Type | Entry | Best for |
+|------|-------|----------|
+| Project showcase animation | [Homepage autoplay GIF](demo/showcase/boss-agent-cli-showcase.gif) | Quickly understanding the project positioning, schema-driven workflow, JSON envelope, and open-source engineering quality |
+| Full showcase video | [16-second MP4](demo/showcase/boss-agent-cli-showcase.mp4) | Viewing the clearer, complete project narrative |
+| Terminal interaction demo | [Terminal GIF](demo.gif) | Seeing the CLI commands and output shape directly |
+| Reproducible source | [HyperFrames source](demo/hyperframes-showcase/) | Maintaining or iterating the README homepage animation |
 
 ## 🌟 Core Capabilities
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   <img src="demo/showcase/boss-agent-cli-showcase.gif" alt="boss-agent-cli 项目展示动图" width="100%">
 </a>
 
-**[观看 16 秒完整展示视频](demo/showcase/boss-agent-cli-showcase.mp4)** · [终端交互演示](demo.gif) · schema 驱动 · 福利筛选 · JSON 信封 · 开源工程质量
+**[观看完整展示视频](demo/showcase/boss-agent-cli-showcase.mp4)** · [查看终端交互演示](demo.gif) · schema 驱动 · 福利筛选 · JSON 信封 · 开源工程质量
 
 </div>
 
@@ -55,6 +55,7 @@ boss digest                                                  # 每日汇报
 ## 🧭 导航目录
 
 - [为什么用 boss-agent-cli](#-为什么用-boss-agent-cli)
+- [演示素材](#-演示素材)
 - [核心能力](#-核心能力)
 - [安装](#-安装)
 - [快速开始](#-快速开始)
@@ -66,6 +67,17 @@ boss digest                                                  # 每日汇报
 - [配置](#-配置)
 - [技术架构](#-技术架构)
 - [贡献](#-贡献)
+
+---
+
+## 🎬 演示素材
+
+| 类型 | 入口 | 适合场景 |
+|------|------|----------|
+| 项目展示动图 | [首页自动播放 GIF](demo/showcase/boss-agent-cli-showcase.gif) | 快速理解项目定位、schema 驱动、JSON 信封与开源工程质量 |
+| 完整展示视频 | [16 秒 MP4](demo/showcase/boss-agent-cli-showcase.mp4) | 查看更清晰、更完整的项目叙事 |
+| 终端交互演示 | [终端 GIF](demo.gif) | 直接观察 CLI 命令和输出形态 |
+| 可复现源工程 | [HyperFrames 源文件](demo/hyperframes-showcase/) | 维护或迭代 README 首页展示动画 |
 
 ---
 


### PR DESCRIPTION
## 变更内容
- 调整 README 首屏演示链接文案，保留一个自动播放 GIF 作为主视觉。
- 新增中英文 Demo/演示素材小节，集中列出首页 GIF、完整 MP4、终端 GIF 和 HyperFrames 源工程。
- 将终端交互演示保留为链接入口，而不是恢复为首屏下方第二个内嵌 GIF。

## 设计原因
- README 首屏应保持轻量，避免连续加载多个动图稀释注意力。
- 完整视频、终端演示和可复现源文件仍然有价值，但更适合集中放在素材索引中。
- 这个布局让首次访问者先看一个强主视觉，随后按需要进入完整视频或终端演示。

## 验证
- `uv run pytest tests/test_open_source_docs.py -q`
- `npx hyperframes lint demo/hyperframes-showcase`
- 检查中英文 README 的 Demo 锚点与素材链接路径。
