### PR TITLE
  fix(recruiter): correct search_geeks endpoint path and params

### DIFF
--- a/docs/capability-matrix.en.md
+++ b/docs/capability-matrix.en.md
@@ -92,7 +92,7 @@ Use this matrix to keep CLI, skills, and MCP integrations aligned across differe
 | Capability | CLI command | Login required | Transport |
 |---|---|---|---|
 | Application inbox | `boss hr applications` | Yes | httpx |
-| Candidate search | `boss hr candidates` | Yes | httpx |
+| Candidate search | `boss hr candidates` | Yes | httpx, supports `--city` / `--job-id` / `--experience` / `--degree` / `--age` / `--school-level` / `--activeness` / `--source` / `--salary` / `--select` / `--page` |
 | Recruiter chat list | `boss hr chat` | Yes | httpx |
 | Online resume view | `boss hr resume` | Yes | httpx |
 | Reply to candidate | `boss hr reply` | Yes | httpx |

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -92,7 +92,7 @@
 | 能力 | CLI 命令 | 需要登录 | 通道 |
 |---|---|---|---|
 | 投递申请列表 | `boss hr applications` | 是 | httpx |
-| 候选人搜索 | `boss hr candidates` | 是 | httpx |
+| 候选人搜索 | `boss hr candidates` | 是 | httpx，支持 `--city` / `--job-id` / `--experience` / `--degree` / `--age` / `--school-level` / `--activeness` / `--source` / `--salary` / `--select` / `--page` |
 | 沟通列表 | `boss hr chat` | 是 | httpx |
 | 在线简历查看 | `boss hr resume` | 是 | httpx |
 | 消息回复 | `boss hr reply` | 是 | httpx |

--- a/src/boss_agent_cli/api/recruiter.yaml
+++ b/src/boss_agent_cli/api/recruiter.yaml
@@ -77,8 +77,8 @@ endpoints:
   # ── 候选人搜索与简历查看 ────────────────────────────
   boss_search_geek:
     method: GET
-    path: "/wapi/zpitem/web/boss/search/geek/info"
-    referer: "/web/chat/search"
+    path: "/wapi/zpitem/web/boss/search/geeks.json"
+    referer: "/web/frame/search/"
   boss_view_geek:
     method: GET
     path: "/wapi/zpjob/view/geek/info"

--- a/src/boss_agent_cli/api/recruiter_client.py
+++ b/src/boss_agent_cli/api/recruiter_client.py
@@ -4,6 +4,7 @@ Dual-channel like BossClient: httpx for low-risk reads, browser for high-risk wr
 Endpoints sourced from newboss/boss-cli project (confirmed via reverse engineering).
 """
 import atexit
+import json
 import random
 import time
 import weakref
@@ -179,11 +180,12 @@ class BossRecruiterClient:
 	# ── 候选人搜索与简历 ──────────────────────────────────
 
 	def search_geeks(self, query: str, *, city: str | None = None, page: int = 1, job_id: str | None = None, experience: str | None = None, degree: str | None = None, age: str | None = None, school_level: str | None = None, activeness: str | None = None, source: str | None = None, select: bool = False, salary: str | None = None) -> dict[str, Any]:
+		city_code = city or "-2"
 		params: dict[str, Any] = {
 			"page": page,
 			"keywords": query or "",
 			"tag": "",
-			"city": city or "-2",
+			"city": city_code,
 			"gender": "-1",
 			"experience": experience or "-1,-1",
 			"salary": salary or "-1,-1",
@@ -201,7 +203,14 @@ class BossRecruiterClient:
 			"activeness": activeness or 0,
 			"defaultCondition": 2,
 			"hasRcd": 0,
-			"filterParams": '{"sortType":1,"region":{"cityCode":"-2","cityName":"","areas":[]},"overSeaWorkExperience":0,"overSeaWorkLanguage":0,"overSeaWorkWill":0,"manageExperience":0}',
+			"filterParams": json.dumps({
+				"sortType": 1,
+				"region": {"cityCode": city_code, "cityName": "", "areas": []},
+				"overSeaWorkExperience": 0,
+				"overSeaWorkLanguage": 0,
+				"overSeaWorkWill": 0,
+				"manageExperience": 0,
+			}, separators=(",", ":")),
 		}
 		if school_level:
 			params["schoolLevel"] = school_level

--- a/src/boss_agent_cli/api/recruiter_client.py
+++ b/src/boss_agent_cli/api/recruiter_client.py
@@ -178,16 +178,37 @@ class BossRecruiterClient:
 
 	# ── 候选人搜索与简历 ──────────────────────────────────
 
-	def search_geeks(self, query: str, *, city: str | None = None, page: int = 1, job_id: str | None = None, experience: str | None = None, degree: str | None = None) -> dict[str, Any]:
-		params: dict[str, Any] = {"query": query, "page": page}
-		if city:
-			params["city"] = city
+	def search_geeks(self, query: str, *, city: str | None = None, page: int = 1, job_id: str | None = None, experience: str | None = None, degree: str | None = None, age: str | None = None, school_level: str | None = None, activeness: str | None = None, source: str | None = None, select: bool = False, salary: str | None = None) -> dict[str, Any]:
+		params: dict[str, Any] = {
+			"page": page,
+			"keywords": query or "",
+			"tag": "",
+			"city": city or "-2",
+			"gender": "-1",
+			"experience": experience or "-1,-1",
+			"salary": salary or "-1,-1",
+			"age": age or "-1,-1",
+			"applyStatus": "-1",
+			"degree": degree or "-1,-1",
+			"switchFreq": 0,
+			"manageExperience": 0,
+			"geekJobRequirements": 0,
+			"exchangeResume": 0,
+			"viewResume": 0,
+			"firstDegree": 0,
+			"queryAnd": 0,
+			"source": source or 4,
+			"activeness": activeness or 0,
+			"defaultCondition": 2,
+			"hasRcd": 0,
+			"filterParams": '{"sortType":1,"region":{"cityCode":"-2","cityName":"","areas":[]},"overSeaWorkExperience":0,"overSeaWorkLanguage":0,"overSeaWorkWill":0,"manageExperience":0}',
+		}
+		if school_level:
+			params["schoolLevel"] = school_level
+		if select:
+			params["select"] = "true"
 		if job_id:
-			params["encryptJobId"] = job_id
-		if experience:
-			params["experience"] = experience
-		if degree:
-			params["degree"] = degree
+			params["jobId"] = job_id
 		return self._request("GET", ep.BOSS_SEARCH_GEEK_URL, params=params)
 
 	def view_geek(self, geek_id: str, job_id: str, security_id: str | None = None) -> dict[str, Any]:

--- a/src/boss_agent_cli/commands/recruiter/candidates.py
+++ b/src/boss_agent_cli/commands/recruiter/candidates.py
@@ -8,14 +8,20 @@ from boss_agent_cli.display import error_contract_for_code, handle_auth_errors, 
 
 @click.command("candidates")
 @click.argument("query", required=False, default="")
-@click.option("--city", default=None, help="城市筛选")
+@click.option("--city", default=None, help="城市筛选（cityCode，如 101020100；-2=全国）")
 @click.option("--job-id", default=None, help="按职位筛选")
-@click.option("--experience", default=None, help="经验要求")
-@click.option("--degree", default=None, help="学历要求")
+@click.option("--experience", default=None, help="经验要求，如 -3,-3（应届）/ -1,-1（不限）")
+@click.option("--degree", default=None, help="学历要求，如 201,201 / -1,-1")
+@click.option("--age", default=None, help="年龄范围，如 20,25")
+@click.option("--school-level", default=None, help="学校层次（如 1101）")
+@click.option("--activeness", default=None, help="活跃度，如 2")
+@click.option("--source", default=None, help="来源编码（默认 4）")
+@click.option("--salary", default=None, help="薪资范围，如 -1,3")
+@click.option("--select", is_flag=True, default=False, help="是否带 select=true")
 @click.option("--page", default=1, type=int, help="页码")
 @click.pass_context
 @handle_auth_errors("recruiter-candidates")
-def candidates_cmd(ctx: click.Context, query: str, city: str | None, job_id: str | None, experience: str | None, degree: str | None, page: int) -> None:
+def candidates_cmd(ctx: click.Context, query: str, city: str | None, job_id: str | None, experience: str | None, degree: str | None, age: str | None, school_level: str | None, activeness: str | None, source: str | None, salary: str | None, select: bool, page: int) -> None:
 	"""搜索候选人"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
@@ -25,6 +31,9 @@ def candidates_cmd(ctx: click.Context, query: str, city: str | None, job_id: str
 		result = platform.search_geeks(
 			query, city=city, page=page, job_id=job_id,
 			experience=experience, degree=degree,
+			age=age, school_level=school_level,
+			activeness=activeness, source=source,
+			select=select, salary=salary,
 		)
 		if not platform.is_success(result):
 			code, message = platform.parse_error(result)

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -659,7 +659,7 @@ SCHEMA_DATA = {
 				"resume": "查看或请求候选人简历",
 				"chat": "查看与候选人的沟通列表",
 				"jobs": "管理职位发布（list/offline/online）",
-				"candidates": "搜索候选人",
+				"candidates": "搜索候选人（支持 city/job-id/experience/degree/age/school-level/activeness/source/salary/select/page 筛选）",
 				"reply": "回复候选人消息",
 				"request-resume": "请求候选人分享附件简历",
 			},

--- a/src/boss_agent_cli/mcp_server.py
+++ b/src/boss_agent_cli/mcp_server.py
@@ -552,10 +552,16 @@ TOOLS = [
 			"type": "object",
 			"properties": {
 				"query": {"type": "string", "description": "搜索关键词（可选，不传时返回默认候选集）"},
-				"city": {"type": "string", "description": "城市筛选"},
+				"city": {"type": "string", "description": "城市筛选（cityCode，如 101020100；-2=全国）"},
 				"job_id": {"type": "string", "description": "按职位筛选"},
-				"experience": {"type": "string", "description": "经验要求"},
-				"degree": {"type": "string", "description": "学历要求"},
+				"experience": {"type": "string", "description": "经验要求，如 -3,-3（应届）/ -1,-1（不限）"},
+				"degree": {"type": "string", "description": "学历要求，如 201,201 / -1,-1"},
+				"age": {"type": "string", "description": "年龄范围，如 20,25"},
+				"school_level": {"type": "string", "description": "学校层次（如 1101）"},
+				"activeness": {"type": "string", "description": "活跃度，如 2"},
+				"source": {"type": "string", "description": "来源编码（默认 4）"},
+				"salary": {"type": "string", "description": "薪资范围，如 -1,3"},
+				"select": {"type": "boolean", "description": "是否带 select=true", "default": False},
 				"page": {"type": "integer", "description": "页码", "default": 1},
 			},
 			"required": [],
@@ -855,9 +861,11 @@ def _build_args(tool_name: str, arguments: dict) -> list[str]:
 		args = ["hr", "candidates"]
 		if arguments.get("query"):
 			args.append(arguments["query"])
-		for opt in ("city", "job_id", "experience", "degree"):
+		for opt in ("city", "job_id", "experience", "degree", "age", "school_level", "activeness", "source", "salary"):
 			if arguments.get(opt):
 				args.extend([f"--{opt.replace('_', '-')}", str(arguments[opt])])
+		if arguments.get("select"):
+			args.append("--select")
 		if "page" in arguments:
 			args.extend(["--page", str(arguments["page"])])
 		return args

--- a/src/boss_agent_cli/platforms/recruiter_base.py
+++ b/src/boss_agent_cli/platforms/recruiter_base.py
@@ -85,7 +85,7 @@ class RecruiterPlatform(ABC):
 	# ── 候选人搜索与简历 ────────────────────────────────
 
 	@abstractmethod
-	def search_geeks(self, query: str, *, city: str | None = None, page: int = 1, job_id: str | None = None, experience: str | None = None, degree: str | None = None) -> dict[str, Any]:
+	def search_geeks(self, query: str, *, city: str | None = None, page: int = 1, job_id: str | None = None, experience: str | None = None, degree: str | None = None, age: str | None = None, school_level: str | None = None, activeness: str | None = None, source: str | None = None, select: bool = False, salary: str | None = None) -> dict[str, Any]:
 		"""搜索候选人。"""
 
 	@abstractmethod

--- a/src/boss_agent_cli/platforms/zhipin_recruiter.py
+++ b/src/boss_agent_cli/platforms/zhipin_recruiter.py
@@ -68,8 +68,8 @@ class BossRecruiterPlatform(RecruiterPlatform):
 
 	# ── 候选人搜索与简历 ────────────────────────────────
 
-	def search_geeks(self, query: str, *, city: str | None = None, page: int = 1, job_id: str | None = None, experience: str | None = None, degree: str | None = None) -> dict[str, Any]:
-		return self._client.search_geeks(query, city=city, page=page, job_id=job_id, experience=experience, degree=degree)
+	def search_geeks(self, query: str, *, city: str | None = None, page: int = 1, job_id: str | None = None, experience: str | None = None, degree: str | None = None, age: str | None = None, school_level: str | None = None, activeness: str | None = None, source: str | None = None, select: bool = False, salary: str | None = None) -> dict[str, Any]:
+		return self._client.search_geeks(query, city=city, page=page, job_id=job_id, experience=experience, degree=degree, age=age, school_level=school_level, activeness=activeness, source=source, select=select, salary=salary)
 
 	def view_geek(self, geek_id: str, job_id: str, security_id: str | None = None) -> dict[str, Any]:
 		return self._client.view_geek(geek_id, job_id=job_id, security_id=security_id)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -590,6 +590,12 @@ def test_build_args_hr_candidates():
 		"job_id": "42",
 		"experience": "3-5年",
 		"degree": "本科",
+		"age": "20,25",
+		"school_level": "1101",
+		"activeness": "2",
+		"source": "4",
+		"salary": "-1,3",
+		"select": True,
 		"page": 2,
 	})
 	assert args == [
@@ -598,8 +604,24 @@ def test_build_args_hr_candidates():
 		"--job-id", "42",
 		"--experience", "3-5年",
 		"--degree", "本科",
+		"--age", "20,25",
+		"--school-level", "1101",
+		"--activeness", "2",
+		"--source", "4",
+		"--salary", "-1,3",
+		"--select",
 		"--page", "2",
 	]
+
+
+def test_build_args_hr_candidates_minimal():
+	args = _build_args("boss_hr_candidates", {"query": "golang"})
+	assert args == ["hr", "candidates", "golang"]
+
+
+def test_build_args_hr_candidates_select_false_omitted():
+	args = _build_args("boss_hr_candidates", {"query": "golang", "select": False})
+	assert "--select" not in args
 
 
 def test_build_args_hr_chat():

--- a/tests/test_recruiter_client.py
+++ b/tests/test_recruiter_client.py
@@ -48,8 +48,64 @@ def test_search_geeks_calls_get():
 		result = client.search_geeks("Python", city="101010100", page=2)
 		mock_req.assert_called_once_with(
 			"GET", ep.BOSS_SEARCH_GEEK_URL,
-			params={"query": "Python", "page": 2, "city": "101010100"},
+			params={
+				"page": 2,
+				"keywords": "Python",
+				"tag": "",
+				"city": "101010100",
+				"gender": "-1",
+				"experience": "-1,-1",
+				"salary": "-1,-1",
+				"age": "-1,-1",
+				"applyStatus": "-1",
+				"degree": "-1,-1",
+				"switchFreq": 0,
+				"manageExperience": 0,
+				"geekJobRequirements": 0,
+				"exchangeResume": 0,
+				"viewResume": 0,
+				"firstDegree": 0,
+				"queryAnd": 0,
+				"source": 4,
+				"activeness": 0,
+				"defaultCondition": 2,
+				"hasRcd": 0,
+				"filterParams": '{"sortType":1,"region":{"cityCode":"-2","cityName":"","areas":[]},"overSeaWorkExperience":0,"overSeaWorkLanguage":0,"overSeaWorkWill":0,"manageExperience":0}',
+			},
 		)
+		assert result == mock_result
+	client.close()
+
+
+def test_search_geeks_forwards_new_filters():
+	auth = _make_auth()
+	client = BossRecruiterClient(auth)
+	mock_result = {"code": 0, "zpData": {"list": []}}
+	with patch.object(client, "_request", return_value=mock_result) as mock_req:
+		result = client.search_geeks(
+			"Python",
+			page=3,
+			job_id="job123",
+			experience="3,5",
+			degree="201,201",
+			age="20,30",
+			school_level="1101",
+			activeness="2",
+			source="5",
+			salary="-1,3",
+			select=True,
+		)
+		params = mock_req.call_args.kwargs["params"]
+		assert params["jobId"] == "job123"
+		assert params["experience"] == "3,5"
+		assert params["degree"] == "201,201"
+		assert params["age"] == "20,30"
+		assert params["schoolLevel"] == "1101"
+		assert params["activeness"] == "2"
+		assert params["source"] == "5"
+		assert params["salary"] == "-1,3"
+		assert params["select"] == "true"
+		assert params["page"] == 3
 		assert result == mock_result
 	client.close()
 

--- a/tests/test_recruiter_client.py
+++ b/tests/test_recruiter_client.py
@@ -1,4 +1,5 @@
 """BossRecruiterClient unit tests — mock httpx + browser channels."""
+import json
 from unittest.mock import MagicMock, patch
 
 from boss_agent_cli.api.recruiter_client import BossRecruiterClient
@@ -70,7 +71,7 @@ def test_search_geeks_calls_get():
 				"activeness": 0,
 				"defaultCondition": 2,
 				"hasRcd": 0,
-				"filterParams": '{"sortType":1,"region":{"cityCode":"-2","cityName":"","areas":[]},"overSeaWorkExperience":0,"overSeaWorkLanguage":0,"overSeaWorkWill":0,"manageExperience":0}',
+				"filterParams": '{"sortType":1,"region":{"cityCode":"101010100","cityName":"","areas":[]},"overSeaWorkExperience":0,"overSeaWorkLanguage":0,"overSeaWorkWill":0,"manageExperience":0}',
 			},
 		)
 		assert result == mock_result
@@ -107,6 +108,19 @@ def test_search_geeks_forwards_new_filters():
 		assert params["select"] == "true"
 		assert params["page"] == 3
 		assert result == mock_result
+	client.close()
+
+
+def test_search_geeks_filter_params_city_defaults_to_nationwide():
+	auth = _make_auth()
+	client = BossRecruiterClient(auth)
+	mock_result = {"code": 0, "zpData": {"list": []}}
+	with patch.object(client, "_request", return_value=mock_result) as mock_req:
+		client.search_geeks("Python")
+		params = mock_req.call_args.kwargs["params"]
+		filter_params = json.loads(params["filterParams"])
+		assert params["city"] == "-2"
+		assert filter_params["region"]["cityCode"] == "-2"
 	client.close()
 
 

--- a/tests/test_recruiter_commands.py
+++ b/tests/test_recruiter_commands.py
@@ -47,6 +47,45 @@ def test_recruiter_candidates_supports_data_envelope(mock_auth_cls, mock_platfor
 
 @patch("boss_agent_cli.commands.recruiter.candidates.get_recruiter_platform_instance")
 @patch("boss_agent_cli.commands.recruiter.candidates.AuthManager")
+def test_recruiter_candidates_forwards_filters(mock_auth_cls, mock_platform_cls):
+	mock_platform = _ctx_mock(mock_platform_cls)
+	mock_platform.search_geeks.return_value = {
+		"code": 200,
+		"data": {"geekList": [], "hasMore": False},
+	}
+	result = _invoke(
+		"hr", "candidates", "python",
+		"--city", "101010100",
+		"--job-id", "job123",
+		"--experience", "3,5",
+		"--degree", "201,201",
+		"--age", "20,30",
+		"--school-level", "1101",
+		"--activeness", "2",
+		"--source", "5",
+		"--salary", "-1,3",
+		"--select",
+		"--page", "3",
+	)
+	assert result.exit_code == 0
+	mock_platform.search_geeks.assert_called_once_with(
+		"python",
+		city="101010100",
+		page=3,
+		job_id="job123",
+		experience="3,5",
+		degree="201,201",
+		age="20,30",
+		school_level="1101",
+		activeness="2",
+		source="5",
+		select=True,
+		salary="-1,3",
+	)
+
+
+@patch("boss_agent_cli.commands.recruiter.candidates.get_recruiter_platform_instance")
+@patch("boss_agent_cli.commands.recruiter.candidates.AuthManager")
 def test_recruiter_candidates_reports_error_when_platform_rejects(mock_auth_cls, mock_platform_cls):
 	mock_platform = _ctx_mock(mock_platform_cls)
 	mock_platform.search_geeks.return_value = {"code": 9, "message": "too fast"}

--- a/tests/test_recruiter_platform.py
+++ b/tests/test_recruiter_platform.py
@@ -66,6 +66,7 @@ def test_search_geeks_delegates():
 	result = platform.search_geeks("Python", city="101010100", page=2)
 	client.search_geeks.assert_called_once_with(
 		"Python", city="101010100", page=2, job_id=None, experience=None, degree=None,
+		age=None, school_level=None, activeness=None, source=None, select=False, salary=None,
 	)
 	assert result == {"code": 0, "zpData": {"list": []}}
 


### PR DESCRIPTION
 ## 问题
  `boss hr candidates` 始终返回空 `zpData: {}`。

  ## 根因
  - endpoint 路径过期：`/wapi/zpitem/web/boss/search/geek/info` → 现为
  `/wapi/zpitem/web/boss/search/geeks.json`
  - 请求参数键名与服务端契约不一致：`query` → `keywords`，`encryptJobId` → `jobId`
  - 缺失服务端要求的默认字段（tag/gender/salary/age/filterParams 等），缺一返回空

  ## 修复
  - 修正 path 与 referer
  - 按抓取的真实 curl 请求重写参数构建
  - 暴露新 CLI 过滤项：`--age` `--school-level` `--activeness` `--source` `--salary` `--select`
  - 兼容上游已有的错误契约/`unwrap_data` 流程

  ## 验证
  `boss --role recruiter hr candidates "Python 爬虫" --job-id <id>` 现返回 15
  条有效候选人，`hasMore=true` 分页正常。