### PR TITLE
fix: 明确招聘端非法请求错误

### DIFF
--- a/src/boss_agent_cli/platforms/zhipin_recruiter.py
+++ b/src/boss_agent_cli/platforms/zhipin_recruiter.py
@@ -21,6 +21,7 @@ _ERROR_CODE_MAP: dict[int, str] = {
 	9: "RATE_LIMITED",
 	36: "ACCOUNT_RISK",
 	37: "TOKEN_REFRESH_FAILED",
+	121: "INVALID_PARAM",
 }
 
 

--- a/tests/test_recruiter_commands.py
+++ b/tests/test_recruiter_commands.py
@@ -102,6 +102,25 @@ def test_recruiter_candidates_reports_error_when_platform_rejects(mock_auth_cls,
 	)
 
 
+@patch("boss_agent_cli.commands.recruiter.reply.get_recruiter_platform_instance")
+@patch("boss_agent_cli.commands.recruiter.reply.AuthManager")
+def test_recruiter_reply_maps_invalid_request_contract(mock_auth_cls, mock_platform_cls):
+	mock_platform = _ctx_mock(mock_platform_cls)
+	mock_platform.send_message.return_value = {"code": 121, "message": "请求不合法(121)"}
+	mock_platform.is_success.return_value = False
+	mock_platform.parse_error.return_value = ("INVALID_PARAM", "请求不合法(121)")
+	result = _invoke("hr", "reply", "36226510", "你好")
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	_assert_error_contract(
+		parsed,
+		code="INVALID_PARAM",
+		message="请求不合法(121)",
+		recoverable=False,
+		recovery_action="修正参数",
+	)
+
+
 @patch("boss_agent_cli.commands.recruiter.chat.get_recruiter_platform_instance")
 @patch("boss_agent_cli.commands.recruiter.chat.AuthManager")
 def test_recruiter_chat_supports_data_envelope(mock_auth_cls, mock_platform_cls):

--- a/tests/test_recruiter_platform.py
+++ b/tests/test_recruiter_platform.py
@@ -41,6 +41,14 @@ def test_boss_recruiter_parse_error():
 	assert "too fast" in message
 
 
+def test_boss_recruiter_parse_error_maps_invalid_request():
+	client = _mock_client()
+	platform = BossRecruiterPlatform(client)
+	unified, message = platform.parse_error({"code": 121, "message": "请求不合法(121)"})
+	assert unified == "INVALID_PARAM"
+	assert message == "请求不合法(121)"
+
+
 def test_friend_list_delegates():
 	client = _mock_client()
 	client.friend_list.return_value = {"code": 0, "zpData": {"result": []}}


### PR DESCRIPTION
## Summary

Map recruiter-side error code 121 to `INVALID_PARAM` so illegal request responses use the same structured error contract as other recruiter command failures.

## Details

- Add error code 121 to the recruiter platform error-code map.
- Cover the platform parser behavior for `请求不合法(121)`.
- Cover the `boss hr reply` command error envelope for invalid request responses.

## Validation

- `uv run pytest tests/test_recruiter_commands.py tests/test_recruiter_platform.py tests/test_recruiter_client.py tests/test_mcp_server.py`
- `uv run ruff check src/boss_agent_cli/platforms/zhipin_recruiter.py tests/test_recruiter_commands.py tests/test_recruiter_platform.py`
