### PR TITLE
[codex] fix code scanning alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,9 @@ concurrency:
   group: docs-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/demo/index.html
+++ b/demo/index.html
@@ -326,8 +326,8 @@
   </div>
 </footer>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" integrity="sha384-g4NTh/Iv5PPU4xPyhEWqPcwtNXOvdaDI8LLnyYfyNZOjKJeYQyjzQ9X5275eBjpt" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" integrity="sha384-Z3REaz79l2IaAZqJsSABtTbhjgOUYyV3p90XNnAPCSHg3EMTz1fouunq9WZRtj3d" crossorigin="anonymous"></script>
 <script src="main.js"></script>
 </body>
 </html>

--- a/src/boss_agent_cli/commands/export.py
+++ b/src/boss_agent_cli/commands/export.py
@@ -18,9 +18,10 @@ from boss_agent_cli.display import handle_auth_errors, handle_error_output, hand
 @click.option("--count", default=50, type=int, help="导出数量")
 @click.option("--format", "fmt", default="csv", type=click.Choice(["html", "csv", "json"]), help="输出格式")
 @click.option("--output", "-o", default=None, help="输出文件路径（不指定则输出到 stdout JSON 信封）")
+@click.option("--include-private", is_flag=True, help="导出明文平台标识和招聘者姓名等私有字段")
 @click.pass_context
 @handle_auth_errors("export")
-def export_cmd(ctx: click.Context, query: str, city: str | None, salary: str | None, count: int, fmt: str, output: str | None) -> None:
+def export_cmd(ctx: click.Context, query: str, city: str | None, salary: str | None, count: int, fmt: str, output: str | None, include_private: bool) -> None:
 	"""导出搜索结果为 CSV 或 JSON 文件"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
@@ -59,12 +60,14 @@ def export_cmd(ctx: click.Context, query: str, city: str | None, salary: str | N
 			page += 1
 
 		if output:
-			_write_to_file(all_items, fmt, output)
+			write_items = all_items if include_private else [_redact_export_item(item) for item in all_items]
+			_write_to_file(write_items, fmt, output)
 			data = {
 				"message": f"已导出 {len(all_items)} 条到 {output}",
 				"count": len(all_items),
 				"format": fmt,
 				"path": output,
+				"private_fields": "included" if include_private else "redacted",
 			}
 			handle_output(
 				ctx, "export", data,
@@ -91,6 +94,14 @@ def export_cmd(ctx: click.Context, query: str, city: str | None, salary: str | N
 					],
 				},
 			)
+
+
+def _redact_export_item(item: dict[str, Any]) -> dict[str, Any]:
+	redacted = dict(item)
+	for key in ("job_id", "security_id", "boss_name"):
+		if key in redacted:
+			redacted[key] = "[REDACTED]"
+	return redacted
 
 
 def _write_to_file(items: list[dict[str, Any]], fmt: str, path: str) -> None:

--- a/src/boss_agent_cli/output.py
+++ b/src/boss_agent_cli/output.py
@@ -3,6 +3,38 @@ import sys
 from typing import Any
 
 _LEVEL_ORDER = {"debug": 0, "info": 1, "warning": 2, "error": 3}
+_REDACTED = "[REDACTED]"
+_SENSITIVE_KEY_PARTS = (
+	"api_key",
+	"apikey",
+	"authorization",
+	"cookie",
+	"credential",
+	"password",
+	"private",
+	"secret",
+	"session",
+	"stoken",
+	"token",
+)
+
+
+def redact_sensitive(value: Any) -> Any:
+	"""Return a JSON-safe copy with credential-like fields redacted."""
+	if isinstance(value, dict):
+		redacted: dict[Any, Any] = {}
+		for key, item in value.items():
+			key_text = str(key).lower()
+			if any(part in key_text for part in _SENSITIVE_KEY_PARTS) and not isinstance(item, bool):
+				redacted[key] = _REDACTED
+			else:
+				redacted[key] = redact_sensitive(item)
+		return redacted
+	if isinstance(value, list):
+		return [redact_sensitive(item) for item in value]
+	if isinstance(value, tuple):
+		return [redact_sensitive(item) for item in value]
+	return value
 
 
 def envelope_success(
@@ -17,10 +49,10 @@ def envelope_success(
 			"ok": True,
 			"schema_version": "1.0",
 			"command": command,
-			"data": data,
-			"pagination": pagination,
+			"data": redact_sensitive(data),
+			"pagination": redact_sensitive(pagination),
 			"error": None,
-			"hints": hints,
+			"hints": redact_sensitive(hints),
 		},
 		ensure_ascii=False,
 	)
@@ -48,7 +80,7 @@ def envelope_error(
 				"recoverable": recoverable,
 				"recovery_action": recovery_action,
 			},
-			"hints": hints,
+			"hints": redact_sensitive(hints),
 		},
 		ensure_ascii=False,
 	)

--- a/tests/test_doctor_extended.py
+++ b/tests/test_doctor_extended.py
@@ -418,4 +418,4 @@ def test_zhilian_doctor_uses_platform_specific_cookie_and_network_messages(tmp_p
 	assert "boss --platform zhilian login" in ce["hint"]
 	network = _find_check(parsed["data"]["checks"], "network")
 	assert network is not None
-	assert "zhaopin.com" in network["detail"]
+	assert network["detail"] == "访问 zhaopin.com 返回 HTTP 200"

--- a/tests/test_doctor_zhilian.py
+++ b/tests/test_doctor_zhilian.py
@@ -14,7 +14,10 @@ def test_doctor_includes_zhilian_network_check(tmp_path: Path) -> None:
 	def fake_get(url: str, **kwargs: object) -> httpx.Response:
 		return httpx.Response(200, request=httpx.Request("GET", url))
 
-	with patch("httpx.get", side_effect=fake_get):
+	with (
+		patch("httpx.get", side_effect=fake_get),
+		patch("boss_agent_cli.commands.doctor.extract_cookies", return_value=None),
+	):
 		runner = CliRunner()
 		result = runner.invoke(cli, ["--data-dir", str(tmp_path), "doctor"])
 	assert result.exit_code in (0, 1), result.output
@@ -29,7 +32,10 @@ def test_doctor_zhilian_check_handles_network_error(tmp_path: Path) -> None:
 	def fake_get(url: str, **kwargs: object) -> httpx.Response:
 		raise httpx.ConnectError("network down")
 
-	with patch("httpx.get", side_effect=fake_get):
+	with (
+		patch("httpx.get", side_effect=fake_get),
+		patch("boss_agent_cli.commands.doctor.extract_cookies", return_value=None),
+	):
 		runner = CliRunner()
 		result = runner.invoke(cli, ["--data-dir", str(tmp_path), "doctor"])
 	assert result.exit_code in (0, 1), result.output

--- a/tests/test_export_extended.py
+++ b/tests/test_export_extended.py
@@ -131,7 +131,27 @@ def test_export_json_to_file(mock_auth_cls, mock_client_cls, tmp_path: Path):
 	data = json.loads(out_path.read_text(encoding="utf-8"))
 	assert len(data) == 2
 	assert data[0]["title"] == "Go 1"
-	assert data[1]["security_id"] == "s2"
+	assert data[1]["security_id"] == "[REDACTED]"
+	assert data[1]["boss_name"] == "[REDACTED]"
+
+
+@patch("boss_agent_cli.commands.export.get_platform_instance")
+@patch("boss_agent_cli.commands.export.AuthManager")
+def test_export_json_include_private_keeps_routing_fields(mock_auth_cls, mock_client_cls, tmp_path: Path):
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.search_jobs.return_value = _api_response([_make_raw_job("Go", security_id="s1")])
+
+	out_path = tmp_path / "jobs-private.json"
+	runner = CliRunner()
+	result = runner.invoke(
+		cli,
+		["export", "golang", "--count", "1", "--format", "json", "--include-private", "-o", str(out_path)],
+	)
+
+	assert result.exit_code == 0
+	data = json.loads(out_path.read_text(encoding="utf-8"))
+	assert data[0]["security_id"] == "s1"
+	assert data[0]["boss_name"] == "李"
 
 
 # ── 文件输出 · HTML ──────────────────────────────────────────────────
@@ -155,6 +175,8 @@ def test_export_html_to_file(mock_auth_cls, mock_client_cls, tmp_path: Path):
 	assert "<!DOCTYPE html>" in content
 	assert "Full-Stack" in content
 	assert "TestCo" in content
+	assert "李" not in content
+	assert "[REDACTED]" in content
 	# 技能和福利应各自带标签样式
 	assert 'class="tag sk"' in content
 	assert 'class="tag wf"' in content

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -18,7 +18,15 @@ def test_envelope_success_minimal():
 def test_envelope_success_with_pagination():
 	result = envelope_success(
 		"search",
-		{"jobs": []},
+		{
+			"jobs": [],
+			"auth": {
+				"token": "secret-token",
+				"api_key_set": False,
+				"cookies": {"wt2": "secret-cookie"},
+				"security_id": "sec_001",
+			},
+		},
 		pagination={"page": 1, "total_pages": 5, "total_count": 50, "has_next": True},
 		hints={"next_actions": ["boss search q --page 2"]},
 	)
@@ -26,22 +34,30 @@ def test_envelope_success_with_pagination():
 	assert parsed["ok"] is True
 	assert parsed["pagination"]["has_next"] is True
 	assert parsed["hints"]["next_actions"][0] == "boss search q --page 2"
+	assert parsed["data"]["auth"]["token"] == "[REDACTED]"
+	assert parsed["data"]["auth"]["api_key_set"] is False
+	assert parsed["data"]["auth"]["cookies"] == "[REDACTED]"
+	# security_id is a CLI routing identifier and must remain available in stdout envelopes.
+	assert parsed["data"]["auth"]["security_id"] == "sec_001"
 
 
 def test_envelope_error():
 	result = envelope_error(
 		"search",
 		code="AUTH_EXPIRED",
-		message="登录态已过期",
+		message="登录态已过期 token=secret-token",
 		recoverable=True,
 		recovery_action="boss login",
+		hints={"cookie": "secret-cookie"},
 	)
 	parsed = json.loads(result)
 	assert parsed["ok"] is False
 	assert parsed["data"] is None
 	assert parsed["error"]["code"] == "AUTH_EXPIRED"
+	assert parsed["error"]["message"] == "登录态已过期 token=secret-token"
 	assert parsed["error"]["recoverable"] is True
 	assert parsed["error"]["recovery_action"] == "boss login"
+	assert parsed["hints"]["cookie"] == "[REDACTED]"
 
 
 def test_logger_filters_by_level(capsys):

--- a/tests/test_platform_base.py
+++ b/tests/test_platform_base.py
@@ -9,6 +9,7 @@
 
 from __future__ import annotations
 
+from urllib.parse import urlparse
 from unittest.mock import MagicMock
 
 import pytest
@@ -31,7 +32,7 @@ class TestPlatformABC:
 		plat = BossPlatform(MagicMock())
 		assert plat.name == "zhipin"
 		assert plat.display_name == "BOSS 直聘"
-		assert "zhipin.com" in plat.base_url
+		assert urlparse(plat.base_url).hostname == "www.zhipin.com"
 
 
 class TestBossEnvelopeAdapter:

--- a/tests/test_zhilian_stub.py
+++ b/tests/test_zhilian_stub.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from urllib.parse import urlparse
 from unittest.mock import MagicMock
 from click.testing import CliRunner
 
@@ -42,7 +43,7 @@ class TestZhilianMetadata:
 		assert self.plat.display_name == "智联招聘"
 
 	def test_base_url_points_to_zhaopin(self) -> None:
-		assert "zhaopin.com" in self.plat.base_url
+		assert urlparse(self.plat.base_url).hostname == "m.zhaopin.com"
 
 
 class TestZhilianEnvelopeAdapter:


### PR DESCRIPTION
## Summary

- restrict GitHub Actions token permissions for CI and docs workflows
- add SRI metadata for the demo page CDN scripts
- redact credential-like fields in CLI JSON envelopes
- redact private export identifiers by default, with `--include-private` for explicit full exports
- replace URL substring assertions in tests with host or exact-output checks

## Why

GitHub Code Scanning reported open alerts for workflow permissions, CDN script integrity, clear-text sensitive output/storage, and URL substring checks in tests. The changes address those alert sources while preserving CLI routing fields in stdout responses where commands depend on them.

## Validation

- `uv run pytest tests/test_output.py tests/test_export_extended.py tests/test_platform_base.py tests/test_zhilian_stub.py tests/test_doctor_extended.py -q`
- `uv run pytest tests/test_ai_commands.py::test_config_show_default tests/test_doctor_zhilian.py tests/test_output.py tests/test_export_extended.py -q`
- `uv run ruff check src/ tests/`
- `uv run mypy src/boss_agent_cli`
- `uv run pytest -q`
- `git diff --check`
