### PR TITLE
fix: 招聘者端点漂移场景错误码契约修正

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,9 @@ pythonpath = ["src"]
 line-length = 120
 indent-width = 4
 
+[tool.ruff.format]
+indent-style = "tab"
+
 [tool.mypy]
 python_version = "3.10"
 # 渐进接入：仅跑基础类型检查，允许现有未注解函数存在

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,27 @@
+# scripts/
+
+仓库辅助脚本目录。
+
+## smoke_p0.py
+P0 模块可导入性冒烟脚本，CI 与本地排障复用。
+
+```bash
+uv run python scripts/smoke_p0.py
+```
+
+## probe_recruiter_chat_frontend.py
+issue #217 — 探测 BOSS 招聘者 chat 页前端 sendMessage JS 入口。脚本注入 WebSocket
+spy + Vuex 探测，需在 CDP Chrome 中手动配合操作。
+
+```bash
+# 1. 启动 CDP Chrome 并登录招聘者账号
+boss-chrome
+
+# 2. 跑脚本（friend_id 来自已沟通候选人，可在 boss hr chat 输出中拿到）
+uv run python scripts/probe_recruiter_chat_frontend.py --friend-id 12345 --output report.json
+
+# 3. 按脚本提示在 Chrome 中手动发一条「探测消息」
+# 4. 把 report.json 内容粘贴到 issue #217 评论
+```
+
+`--dry-run` 仅打印将执行的 JS payload 用于审阅，不连 CDP。

--- a/scripts/probe_recruiter_chat_frontend.py
+++ b/scripts/probe_recruiter_chat_frontend.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Probe BOSS recruiter chat frontend for sendMessage JS entry points.
+
+Issue can4hou6joeng4/boss-agent-cli#217 — BOSS 招聘者发消息端点已从
+``fastReply/sendReplyMsg`` 迁移到 WebSocket + Protobuf 双通道。本脚本通过
+CDP Chrome 在招聘者 chat 页注入 WebSocket 监听 + Vuex 探测，定位前端实际
+负责发送消息的 JS 入口（chat store action / function），为后续修复方案
+（无论 A / A' / B）提供精确的现场信息。
+
+使用前置：
+  1. 用 ``boss-chrome`` 启动 CDP Chrome（带远程调试端口）
+  2. 在该 Chrome 中扫码登录招聘者账号
+  3. 先在 chat 页与任一候选人建立沟通（保证 friend_id 有效）
+
+跑脚本：
+  uv run python scripts/probe_recruiter_chat_frontend.py --friend-id 12345
+  uv run python scripts/probe_recruiter_chat_frontend.py --dry-run       # 只打印 JS payload
+
+脚本会引导你在浏览器里**手动**输入一条测试消息并点发送——这一步触发的
+WebSocket 帧 + JS 调用栈是侦察的核心信号源。完成后 5 秒内自动汇总输出。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from typing import Any
+
+_DEFAULT_CDP_URL = "http://localhost:9222"
+_CHAT_URL_TPL = "https://www.zhipin.com/web/boss/chat/index?friendId={friend_id}"
+
+# ─── JS payloads ─────────────────────────────────────────────────────────
+
+# 在导航前注入：劫持 window.WebSocket，记录 url + 每条 send 的 stack trace
+JS_WEBSOCKET_SPY = r"""
+(() => {
+  if (window.__hf_ws_probe__) return;
+  window.__hf_ws_probe__ = { calls: [], sends: [] };
+  const OriginalWS = window.WebSocket;
+  function PatchedWS(url, protocols) {
+    const ws = protocols ? new OriginalWS(url, protocols) : new OriginalWS(url);
+    window.__hf_ws_probe__.calls.push({
+      url: String(url),
+      created_at: Date.now(),
+    });
+    const origSend = ws.send.bind(ws);
+    ws.send = function(data) {
+      try {
+        const stack = (new Error()).stack || '';
+        window.__hf_ws_probe__.sends.push({
+          url: String(url),
+          ts: Date.now(),
+          byte_len: data && data.byteLength != null ? data.byteLength : (data ? String(data).length : 0),
+          stack: stack.split('\n').slice(0, 8).join('\n'),
+        });
+      } catch (e) {}
+      return origSend(data);
+    };
+    return ws;
+  }
+  PatchedWS.prototype = OriginalWS.prototype;
+  PatchedWS.CONNECTING = OriginalWS.CONNECTING;
+  PatchedWS.OPEN = OriginalWS.OPEN;
+  PatchedWS.CLOSING = OriginalWS.CLOSING;
+  PatchedWS.CLOSED = OriginalWS.CLOSED;
+  window.WebSocket = PatchedWS;
+})();
+"""
+
+# 全局变量扫描：列出 window 上 chat/message/store 相关的键
+JS_GLOBAL_SCAN = r"""
+() => {
+  const keys = [];
+  try {
+    for (const k of Object.keys(window)) {
+      if (/chat|message|msg|store|app|vue|nuxt|pinia/i.test(k)) keys.push(k);
+    }
+  } catch (e) {}
+  return keys.sort();
+}
+"""
+
+# Vue / Vuex / Pinia 探测：在 #wrap / #app DOM 节点上找 __vue_app__ / __vue__
+JS_VUE_PROBE = r"""
+() => {
+  const out = [];
+  const tryNode = (sel) => {
+    const el = document.querySelector(sel);
+    if (!el) return;
+    if (el.__vue_app__) {
+      const app = el.__vue_app__;
+      out.push({source: 'vue3-app@' + sel, version: app.version});
+      try {
+        const props = app._context && app._context.config && app._context.config.globalProperties;
+        if (props) {
+          out.push({source: 'vue3-globalProperties@' + sel, keys: Object.keys(props)});
+          if (props.$store) {
+            out.push({
+              source: 'vuex-store@' + sel,
+              state_keys: Object.keys(props.$store.state || {}),
+              action_keys: Object.keys(props.$store._actions || {}),
+              module_keys: Object.keys(props.$store._modules?.root?._children || {}),
+            });
+          }
+          if (props.$pinia) {
+            out.push({source: 'pinia@' + sel, store_keys: Object.keys(props.$pinia.state.value || {})});
+          }
+        }
+      } catch (e) { out.push({source: 'vue3-error@' + sel, error: String(e)}); }
+    }
+    if (el.__vue__) {
+      const root = el.__vue__;
+      out.push({source: 'vue2-root@' + sel, has_store: !!root.$store});
+      try {
+        if (root.$store) {
+          out.push({
+            source: 'vuex2-store@' + sel,
+            state_keys: Object.keys(root.$store.state || {}),
+            action_keys: Object.keys(root.$store._actions || {}),
+            module_keys: Object.keys(root.$store._modules?.root?._children || {}),
+          });
+        }
+      } catch (e) { out.push({source: 'vue2-error@' + sel, error: String(e)}); }
+    }
+  };
+  ['#wrap', '#app', 'body', 'main', '[data-v-app]'].forEach(tryNode);
+  return out;
+}
+"""
+
+# WebSocket 监控结果回收
+JS_DUMP_WS = r"""
+() => window.__hf_ws_probe__ || {calls: [], sends: []}
+"""
+
+# ─── Runner ───────────────────────────────────────────────────────────────
+
+
+def _build_report(*, friend_id: int | None, cdp_url: str) -> dict[str, Any]:
+	return {
+		"ts": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+		"issue": "https://github.com/can4hou6joeng4/boss-agent-cli/issues/217",
+		"cdp_url": cdp_url,
+		"friend_id": friend_id,
+		"global_chat_keys": [],
+		"vue_candidates": [],
+		"websocket": {"calls": [], "sends": []},
+	}
+
+
+def _emit_dry_run(report: dict[str, Any]) -> None:
+	"""--dry-run 模式：打印 JS payloads + 空 report 骨架，用于审阅。"""
+	print("=== dry-run: JS payloads that will be evaluated ===", file=sys.stderr)
+	print("\n--- WebSocket spy (add_init_script) ---", file=sys.stderr)
+	print(JS_WEBSOCKET_SPY, file=sys.stderr)
+	print("\n--- Global var scan ---", file=sys.stderr)
+	print(JS_GLOBAL_SCAN, file=sys.stderr)
+	print("\n--- Vue/Vuex/Pinia probe ---", file=sys.stderr)
+	print(JS_VUE_PROBE, file=sys.stderr)
+	print("\n--- WebSocket dump ---", file=sys.stderr)
+	print(JS_DUMP_WS, file=sys.stderr)
+	print("\n=== report skeleton ===", file=sys.stderr)
+	print(json.dumps(report, ensure_ascii=False, indent=2))
+
+
+def _run_live_probe(report: dict[str, Any], *, friend_id: int, cdp_url: str, wait_seconds: int) -> dict[str, Any]:
+	from patchright.sync_api import sync_playwright
+
+	with sync_playwright() as pw:
+		try:
+			browser = pw.chromium.connect_over_cdp(cdp_url)
+		except Exception as exc:
+			raise SystemExit(f"无法连接 CDP Chrome ({cdp_url}): {exc}") from exc
+
+		contexts = browser.contexts
+		if not contexts:
+			raise SystemExit("CDP Chrome 没有可用 context，先在 Chrome 中扫码登录招聘者账号")
+		context = contexts[0]
+
+		# 在导航前注入 WebSocket spy
+		context.add_init_script(JS_WEBSOCKET_SPY)
+		page = context.new_page()
+		try:
+			chat_url = _CHAT_URL_TPL.format(friend_id=friend_id)
+			page.goto(chat_url, wait_until="domcontentloaded", timeout=20000)
+			page.wait_for_timeout(3000)  # 让 Vue 挂载完
+
+			report["global_chat_keys"] = page.evaluate(JS_GLOBAL_SCAN)
+			report["vue_candidates"] = page.evaluate(JS_VUE_PROBE)
+
+			print(
+				"\n>>> 现在请在 Chrome 招聘者后台手动输入一条「探测消息」并点发送按钮，"
+				f"脚本将在 {wait_seconds} 秒后采集 WebSocket 调用栈\n",
+				file=sys.stderr,
+			)
+			page.wait_for_timeout(wait_seconds * 1000)
+			report["websocket"] = page.evaluate(JS_DUMP_WS)
+		finally:
+			page.close()
+
+	return report
+
+
+def main(argv: list[str] | None = None) -> int:
+	parser = argparse.ArgumentParser(
+		description="Probe BOSS recruiter chat frontend for sendMessage JS entry points",
+	)
+	parser.add_argument("--cdp-url", default=_DEFAULT_CDP_URL, help=f"CDP debug URL (default: {_DEFAULT_CDP_URL})")
+	parser.add_argument("--friend-id", type=int, help="已沟通过的候选人 friendId（非 dry-run 必填）")
+	parser.add_argument("--output", help="JSON 输出文件路径（默认 stdout）")
+	parser.add_argument("--wait", type=int, default=15, help="等待用户手动发送消息的秒数（默认 15）")
+	parser.add_argument("--dry-run", action="store_true", help="只打印 JS payload，不连 CDP")
+	args = parser.parse_args(argv)
+
+	report = _build_report(friend_id=args.friend_id, cdp_url=args.cdp_url)
+
+	if args.dry_run:
+		_emit_dry_run(report)
+		return 0
+
+	if not args.friend_id:
+		parser.error("--friend-id 在非 dry-run 模式下必填")
+
+	report = _run_live_probe(
+		report,
+		friend_id=args.friend_id,
+		cdp_url=args.cdp_url,
+		wait_seconds=args.wait,
+	)
+
+	output_text = json.dumps(report, ensure_ascii=False, indent=2)
+	if args.output:
+		with open(args.output, "w", encoding="utf-8") as fp:
+			fp.write(output_text)
+		print(f"报告已写入 {args.output}", file=sys.stderr)
+	else:
+		print(output_text)
+	return 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/src/boss_agent_cli/api/recruiter_client.py
+++ b/src/boss_agent_cli/api/recruiter_client.py
@@ -3,6 +3,7 @@
 Dual-channel like BossClient: httpx for low-risk reads, browser for high-risk writes.
 Endpoints sourced from newboss/boss-cli project (confirmed via reverse engineering).
 """
+
 import atexit
 import json
 import random
@@ -43,7 +44,9 @@ class RecruiterAuthError(Exception):
 class BossRecruiterClient:
 	"""Recruiter-side hybrid API client."""
 
-	def __init__(self, auth_manager: "AuthManager", *, delay: tuple[float, float] = (1.5, 3.0), cdp_url: str | None = None) -> None:
+	def __init__(
+		self, auth_manager: "AuthManager", *, delay: tuple[float, float] = (1.5, 3.0), cdp_url: str | None = None
+	) -> None:
 		self._auth = auth_manager
 		self._delay = delay
 		self._client: httpx.Client | None = None
@@ -60,6 +63,7 @@ class BossRecruiterClient:
 			if ua := token.get("user_agent"):
 				headers["User-Agent"] = ua
 			import sys
+
 			if sys.platform == "win32":
 				headers["sec-ch-ua-platform"] = '"Windows"'
 			elif sys.platform == "linux":
@@ -76,13 +80,14 @@ class BossRecruiterClient:
 	def _get_browser(self) -> "BrowserSession":
 		if self._browser_session is None:
 			from boss_agent_cli.api.browser_client import BrowserSession
+
 			token = self._auth.get_token()
 			self._browser_session = BrowserSession(
 				cookies=token.get("cookies", {}),
 				user_agent=token.get("user_agent", ""),
 				delay=self._delay,
 				cdp_url=self._cdp_url,
-				logger=getattr(self._auth, '_logger', None),
+				logger=getattr(self._auth, "_logger", None),
 			)
 		return self._browser_session
 
@@ -117,7 +122,7 @@ class BossRecruiterClient:
 			if resp.status_code == 403 or "安全验证" in resp.text:
 				if attempt >= _MAX_RETRIES:
 					raise RecruiterAuthError("Token 刷新后仍被拒绝，请重新登录")
-				backoff = (2 ** attempt) + random.uniform(0.5, 1.5)
+				backoff = (2**attempt) + random.uniform(0.5, 1.5)
 				time.sleep(backoff)
 				self._auth.force_refresh(cdp_url=self._cdp_url)
 				self._client = None
@@ -128,23 +133,30 @@ class BossRecruiterClient:
 			code = data.get("code")
 
 			if code == ep.CODE_STOKEN_EXPIRED and attempt < _MAX_RETRIES:
-				backoff = (2 ** attempt) + random.uniform(0.5, 1.5)
+				backoff = (2**attempt) + random.uniform(0.5, 1.5)
 				time.sleep(backoff)
 				self._auth.force_refresh(cdp_url=self._cdp_url)
 				self._client = None
 				continue
 
 			if code == ep.CODE_RATE_LIMITED and attempt < _MAX_RETRIES:
-				cooldown = min(60, 10 * (2 ** attempt))
+				cooldown = min(60, 10 * (2**attempt))
 				time.sleep(cooldown)
 				continue
 
+			if isinstance(data, dict):
+				data.setdefault("__cli_endpoint_hint__", url)
 			return cast("dict[str, Any]", data)
 
 		raise RecruiterAuthError("请求失败，已达最大重试次数")
 
-	def _browser_request(self, method: str, url: str, *, params: dict[str, Any] | None = None, data: dict[str, Any] | None = None) -> dict[str, Any]:
-		return self._get_browser().request(method, url, params=params, data=data)
+	def _browser_request(
+		self, method: str, url: str, *, params: dict[str, Any] | None = None, data: dict[str, Any] | None = None
+	) -> dict[str, Any]:
+		result = self._get_browser().request(method, url, params=params, data=data)
+		if isinstance(result, dict):
+			result.setdefault("__cli_endpoint_hint__", url)
+		return result
 
 	# ── Public API ───────────────────────────────────────────────────
 
@@ -179,7 +191,22 @@ class BossRecruiterClient:
 
 	# ── 候选人搜索与简历 ──────────────────────────────────
 
-	def search_geeks(self, query: str, *, city: str | None = None, page: int = 1, job_id: str | None = None, experience: str | None = None, degree: str | None = None, age: str | None = None, school_level: str | None = None, activeness: str | None = None, source: str | None = None, select: bool = False, salary: str | None = None) -> dict[str, Any]:
+	def search_geeks(
+		self,
+		query: str,
+		*,
+		city: str | None = None,
+		page: int = 1,
+		job_id: str | None = None,
+		experience: str | None = None,
+		degree: str | None = None,
+		age: str | None = None,
+		school_level: str | None = None,
+		activeness: str | None = None,
+		source: str | None = None,
+		select: bool = False,
+		salary: str | None = None,
+	) -> dict[str, Any]:
 		city_code = city or "-2"
 		params: dict[str, Any] = {
 			"page": page,
@@ -203,14 +230,17 @@ class BossRecruiterClient:
 			"activeness": activeness or 0,
 			"defaultCondition": 2,
 			"hasRcd": 0,
-			"filterParams": json.dumps({
-				"sortType": 1,
-				"region": {"cityCode": city_code, "cityName": "", "areas": []},
-				"overSeaWorkExperience": 0,
-				"overSeaWorkLanguage": 0,
-				"overSeaWorkWill": 0,
-				"manageExperience": 0,
-			}, separators=(",", ":")),
+			"filterParams": json.dumps(
+				{
+					"sortType": 1,
+					"region": {"cityCode": city_code, "cityName": "", "areas": []},
+					"overSeaWorkExperience": 0,
+					"overSeaWorkLanguage": 0,
+					"overSeaWorkWill": 0,
+					"manageExperience": 0,
+				},
+				separators=(",", ":"),
+			),
 		}
 		if school_level:
 			params["schoolLevel"] = school_level

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -59,14 +59,42 @@ def _command_to_json_schema(cmd_name: str, cmd_spec: dict[str, Any]) -> dict[str
 
 
 _ROLE_BOTH_COMMANDS = {
-	"login", "status", "doctor", "logout", "schema", "config", "clean", "cities",
+	"login",
+	"status",
+	"doctor",
+	"logout",
+	"schema",
+	"config",
+	"clean",
+	"cities",
 }
 
 _CANDIDATE_COMMANDS = {
-	"search", "detail", "greet", "batch-greet", "recommend", "export", "me", "show",
-	"history", "chat", "chatmsg", "chat-summary", "mark", "exchange", "interviews",
-	"watch", "preset", "pipeline", "follow-up", "apply", "shortlist", "digest",
-	"stats", "resume", "ai",
+	"search",
+	"detail",
+	"greet",
+	"batch-greet",
+	"recommend",
+	"export",
+	"me",
+	"show",
+	"history",
+	"chat",
+	"chatmsg",
+	"chat-summary",
+	"mark",
+	"exchange",
+	"interviews",
+	"watch",
+	"preset",
+	"pipeline",
+	"follow-up",
+	"apply",
+	"shortlist",
+	"digest",
+	"stats",
+	"resume",
+	"ai",
 }
 
 
@@ -75,9 +103,7 @@ def _availability_note(availability: dict[str, Any]) -> str:
 	candidate_platforms = ", ".join(availability.get("candidate_platforms", [])) or "-"
 	recruiter_platforms = ", ".join(availability.get("recruiter_platforms", [])) or "-"
 	return (
-		f"可用性: roles={roles}; "
-		f"candidate_platforms={candidate_platforms}; "
-		f"recruiter_platforms={recruiter_platforms}"
+		f"可用性: roles={roles}; candidate_platforms={candidate_platforms}; recruiter_platforms={recruiter_platforms}"
 	)
 
 
@@ -151,14 +177,16 @@ def _format_openai_tools(data: dict[str, Any]) -> list[dict[str, Any]]:
 		description = cmd_spec.get("description", "")
 		if availability := cmd_spec.get("availability"):
 			description = f"{description} [{_availability_note(availability)}]"
-		tools.append({
-			"type": "function",
-			"function": {
-				"name": f"boss_{cmd_name.replace('-', '_')}",
-				"description": description,
-				"parameters": _command_to_json_schema(cmd_name, cmd_spec),
-			},
-		})
+		tools.append(
+			{
+				"type": "function",
+				"function": {
+					"name": f"boss_{cmd_name.replace('-', '_')}",
+					"description": description,
+					"parameters": _command_to_json_schema(cmd_name, cmd_spec),
+				},
+			}
+		)
 	return tools
 
 
@@ -169,11 +197,13 @@ def _format_anthropic_tools(data: dict[str, Any]) -> list[dict[str, Any]]:
 		description = cmd_spec.get("description", "")
 		if availability := cmd_spec.get("availability"):
 			description = f"{description} [{_availability_note(availability)}]"
-		tools.append({
-			"name": f"boss_{cmd_name.replace('-', '_')}",
-			"description": description,
-			"input_schema": _command_to_json_schema(cmd_name, cmd_spec),
-		})
+		tools.append(
+			{
+				"name": f"boss_{cmd_name.replace('-', '_')}",
+				"description": description,
+				"input_schema": _command_to_json_schema(cmd_name, cmd_spec),
+			}
+		)
 	return tools
 
 
@@ -184,11 +214,13 @@ def _format_mcp_tools(data: dict[str, Any]) -> list[dict[str, Any]]:
 		description = cmd_spec.get("description", "")
 		if availability := cmd_spec.get("availability"):
 			description = f"{description} [{_availability_note(availability)}]"
-		tools.append({
-			"name": f"boss_{cmd_name.replace('-', '_')}",
-			"description": description,
-			"inputSchema": _command_to_json_schema(cmd_name, cmd_spec),
-		})
+		tools.append(
+			{
+				"name": f"boss_{cmd_name.replace('-', '_')}",
+				"description": description,
+				"inputSchema": _command_to_json_schema(cmd_name, cmd_spec),
+			}
+		)
 	return tools
 
 
@@ -264,7 +296,33 @@ SCHEMA_DATA = {
 					"type": "string",
 					"default": None,
 					"description": "行业类型",
-					"choices": ["不限", "互联网", "电子商务", "游戏", "软件/信息服务", "人工智能", "大数据", "云计算", "区块链", "物联网", "金融", "银行", "保险", "证券/基金", "教育培训", "医疗健康", "房地产", "汽车", "物流/运输", "广告/传媒", "消费品", "制造业", "能源/环保", "政府/非营利", "农业"],
+					"choices": [
+						"不限",
+						"互联网",
+						"电子商务",
+						"游戏",
+						"软件/信息服务",
+						"人工智能",
+						"大数据",
+						"云计算",
+						"区块链",
+						"物联网",
+						"金融",
+						"银行",
+						"保险",
+						"证券/基金",
+						"教育培训",
+						"医疗健康",
+						"房地产",
+						"汽车",
+						"物流/运输",
+						"广告/传媒",
+						"消费品",
+						"制造业",
+						"能源/环保",
+						"政府/非营利",
+						"农业",
+					],
 				},
 				"--scale": {
 					"type": "string",
@@ -310,7 +368,11 @@ SCHEMA_DATA = {
 		"detail": {
 			"description": "查看职位完整信息（职位描述、地址、招聘者信息）。传入 --job-id 走 httpx 快速通道（毫秒级），否则先查缓存、最后降级浏览器通道（秒级）",
 			"args": [
-				{"name": "security_id", "required": True, "description": "安全 ID，从 search/chat/recommend 结果中获取"},
+				{
+					"name": "security_id",
+					"required": True,
+					"description": "安全 ID，从 search/chat/recommend 结果中获取",
+				},
 			],
 			"options": {
 				"--job-id": {
@@ -369,7 +431,33 @@ SCHEMA_DATA = {
 					"type": "string",
 					"default": None,
 					"description": "行业类型",
-					"choices": ["不限", "互联网", "电子商务", "游戏", "软件/信息服务", "人工智能", "大数据", "云计算", "区块链", "物联网", "金融", "银行", "保险", "证券/基金", "教育培训", "医疗健康", "房地产", "汽车", "物流/运输", "广告/传媒", "消费品", "制造业", "能源/环保", "政府/非营利", "农业"],
+					"choices": [
+						"不限",
+						"互联网",
+						"电子商务",
+						"游戏",
+						"软件/信息服务",
+						"人工智能",
+						"大数据",
+						"云计算",
+						"区块链",
+						"物联网",
+						"金融",
+						"银行",
+						"保险",
+						"证券/基金",
+						"教育培训",
+						"医疗健康",
+						"房地产",
+						"汽车",
+						"物流/运输",
+						"广告/传媒",
+						"消费品",
+						"制造业",
+						"能源/环保",
+						"政府/非营利",
+						"农业",
+					],
 				},
 				"--scale": {
 					"type": "string",
@@ -418,7 +506,12 @@ SCHEMA_DATA = {
 				"--city": {"type": "string", "default": None, "description": "城市名称"},
 				"--salary": {"type": "string", "default": None, "description": "薪资范围"},
 				"--count": {"type": "int", "default": 50, "description": "导出数量"},
-				"--format": {"type": "string", "default": "csv", "description": "输出格式", "enum": ["html", "csv", "json"]},
+				"--format": {
+					"type": "string",
+					"default": "csv",
+					"description": "输出格式",
+					"enum": ["html", "csv", "json"],
+				},
 				"--output": {"type": "string", "default": None, "description": "输出文件路径（不指定则输出到 stdout）"},
 			},
 		},
@@ -517,7 +610,12 @@ SCHEMA_DATA = {
 				{"name": "security_id", "required": True, "description": "联系人的 security_id（从 chat 命令获取）"},
 			],
 			"options": {
-				"--label": {"type": "string", "required": True, "description": "标签名称或 ID", "enum": ["新招呼", "沟通中", "已约面", "已获取简历", "已交换电话", "已交换微信", "不合适", "收藏"]},
+				"--label": {
+					"type": "string",
+					"required": True,
+					"description": "标签名称或 ID",
+					"enum": ["新招呼", "沟通中", "已约面", "已获取简历", "已交换电话", "已交换微信", "不合适", "收藏"],
+				},
 				"--remove": {"type": "boolean", "default": False, "description": "移除标签（默认为添加）"},
 			},
 		},
@@ -527,7 +625,12 @@ SCHEMA_DATA = {
 				{"name": "security_id", "required": True, "description": "联系人的 security_id（从 chat 命令获取）"},
 			],
 			"options": {
-				"--type": {"type": "string", "default": "phone", "description": "交换类型", "enum": ["phone", "wechat"]},
+				"--type": {
+					"type": "string",
+					"default": "phone",
+					"description": "交换类型",
+					"enum": ["phone", "wechat"],
+				},
 			},
 		},
 		"interviews": {
@@ -584,8 +687,16 @@ SCHEMA_DATA = {
 			"args": [],
 			"options": {
 				"--days-stale": {"type": "int", "default": 3, "description": "超过 N 天未推进则视为 follow_up"},
-				"--format": {"type": "string", "default": "json", "description": "输出格式（json 信封 / md 可直发邮件飞书）"},
-				"-o, --output": {"type": "string", "default": None, "description": "Markdown 输出路径（仅 --format md 时有效）"},
+				"--format": {
+					"type": "string",
+					"default": "json",
+					"description": "输出格式（json 信封 / md 可直发邮件飞书）",
+				},
+				"-o, --output": {
+					"type": "string",
+					"default": None,
+					"description": "Markdown 输出路径（仅 --format md 时有效）",
+				},
 			},
 		},
 		"config": {
@@ -613,8 +724,16 @@ SCHEMA_DATA = {
 			"args": [],
 			"options": {
 				"--days": {"type": "int", "default": 30, "description": "统计窗口天数"},
-				"--format": {"type": "string", "default": "json", "description": "输出格式：json（JSON 信封）或 html（自包含报表）"},
-				"-o, --output": {"type": "string", "default": None, "description": "HTML 输出路径（仅 --format html 时有效）"},
+				"--format": {
+					"type": "string",
+					"default": "json",
+					"description": "输出格式：json（JSON 信封）或 html（自包含报表）",
+				},
+				"-o, --output": {
+					"type": "string",
+					"default": None,
+					"description": "HTML 输出路径（仅 --format html 时有效）",
+				},
 			},
 		},
 		"resume": {
@@ -761,6 +880,11 @@ SCHEMA_DATA = {
 			"recoverable": False,
 			"recovery_action": "修正参数",
 		},
+		"ENDPOINT_DEPRECATED": {
+			"message": "服务端端点已迁移，CLI 当前实现无法直接发送",
+			"recoverable": False,
+			"recovery_action": "跟进 https://github.com/can4hou6joeng4/boss-agent-cli/issues/217",
+		},
 		"NOT_SUPPORTED": {
 			"message": "当前平台暂不支持该能力",
 			"recoverable": True,
@@ -835,7 +959,8 @@ SCHEMA_DATA = {
 
 @click.command("schema")
 @click.option(
-	"--format", "output_format",
+	"--format",
+	"output_format",
 	type=click.Choice(["native", "openai-tools", "anthropic-tools", "mcp-tools"]),
 	default="native",
 	help="输出格式：native（本项目信封）/ openai-tools（OpenAI Functions & Tools API）/ anthropic-tools（Claude Tool Use API）/ mcp-tools（Model Context Protocol Tools）",

--- a/src/boss_agent_cli/platforms/zhipin_recruiter.py
+++ b/src/boss_agent_cli/platforms/zhipin_recruiter.py
@@ -24,6 +24,10 @@ _ERROR_CODE_MAP: dict[int, str] = {
 	121: "INVALID_PARAM",
 }
 
+# 端点路径片段 → 已知端点漂移场景（命中后将该路径下的 121 重映射为 ENDPOINT_DEPRECATED）
+# 真源：issue #217 — qianjunye 抓包确认 fastReply/sendReplyMsg 已被 BOSS 替换为 WS+Protobuf 双通道。
+_DEPRECATED_ENDPOINT_FRAGMENTS: tuple[str, ...] = ("fastReply/sendReplyMsg",)
+
 
 class BossRecruiterPlatform(RecruiterPlatform):
 	"""BOSS 直聘招聘者平台实现。"""
@@ -48,6 +52,12 @@ class BossRecruiterPlatform(RecruiterPlatform):
 		code = response.get("code")
 		message = str(response.get("message") or response.get("zpData") or "")
 		unified = _ERROR_CODE_MAP.get(code, "UNKNOWN") if isinstance(code, int) else "UNKNOWN"
+		# 端点漂移场景下重映射 121：调用方（_browser_request / _request）在 response dict 注入
+		# __cli_endpoint_hint__ 字段（CLI 内部命名空间，避免与服务端字段冲突）。
+		if code == 121:
+			hint = response.get("__cli_endpoint_hint__")
+			if isinstance(hint, str) and any(frag in hint for frag in _DEPRECATED_ENDPOINT_FRAGMENTS):
+				unified = "ENDPOINT_DEPRECATED"
 		return unified, message
 
 	# ── 候选人列表与筛选 ────────────────────────────────
@@ -69,8 +79,36 @@ class BossRecruiterPlatform(RecruiterPlatform):
 
 	# ── 候选人搜索与简历 ────────────────────────────────
 
-	def search_geeks(self, query: str, *, city: str | None = None, page: int = 1, job_id: str | None = None, experience: str | None = None, degree: str | None = None, age: str | None = None, school_level: str | None = None, activeness: str | None = None, source: str | None = None, select: bool = False, salary: str | None = None) -> dict[str, Any]:
-		return self._client.search_geeks(query, city=city, page=page, job_id=job_id, experience=experience, degree=degree, age=age, school_level=school_level, activeness=activeness, source=source, select=select, salary=salary)
+	def search_geeks(
+		self,
+		query: str,
+		*,
+		city: str | None = None,
+		page: int = 1,
+		job_id: str | None = None,
+		experience: str | None = None,
+		degree: str | None = None,
+		age: str | None = None,
+		school_level: str | None = None,
+		activeness: str | None = None,
+		source: str | None = None,
+		select: bool = False,
+		salary: str | None = None,
+	) -> dict[str, Any]:
+		return self._client.search_geeks(
+			query,
+			city=city,
+			page=page,
+			job_id=job_id,
+			experience=experience,
+			degree=degree,
+			age=age,
+			school_level=school_level,
+			activeness=activeness,
+			source=source,
+			select=select,
+			salary=salary,
+		)
 
 	def view_geek(self, geek_id: str, job_id: str, security_id: str | None = None) -> dict[str, Any]:
 		return self._client.view_geek(geek_id, job_id=job_id, security_id=security_id)

--- a/tests/test_probe_script.py
+++ b/tests/test_probe_script.py
@@ -1,0 +1,45 @@
+"""issue #217 侦察脚本 dry-run 路径回归。"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "probe_recruiter_chat_frontend.py"
+
+
+def _load_script_module():
+	spec = importlib.util.spec_from_file_location("probe_recruiter_chat_frontend", _SCRIPT)
+	assert spec and spec.loader, "spec 加载失败"
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+def test_dry_run_emits_report_skeleton_and_js_payloads(capsys):
+	"""--dry-run 路径：stdout 输出 report skeleton，stderr 输出 JS payloads。"""
+	module = _load_script_module()
+	exit_code = module.main(["--dry-run"])
+	assert exit_code == 0
+	captured = capsys.readouterr()
+
+	parsed = json.loads(captured.out)
+	assert parsed["issue"].endswith("issues/217")
+	assert "websocket" in parsed
+	assert parsed["friend_id"] is None
+	assert parsed["global_chat_keys"] == []
+
+	assert "WebSocket spy" in captured.err
+	assert "__hf_ws_probe__" in captured.err
+	assert "Vue/Vuex/Pinia probe" in captured.err
+
+
+def test_dry_run_friend_id_passthrough(capsys):
+	"""--dry-run 时也保留 friend_id 信息，方便用户审阅命令是否填对。"""
+	module = _load_script_module()
+	exit_code = module.main(["--dry-run", "--friend-id", "99999"])
+	assert exit_code == 0
+	captured = capsys.readouterr()
+	parsed = json.loads(captured.out)
+	assert parsed["friend_id"] == 99999

--- a/tests/test_recruiter_platform.py
+++ b/tests/test_recruiter_platform.py
@@ -49,6 +49,35 @@ def test_boss_recruiter_parse_error_maps_invalid_request():
 	assert message == "请求不合法(121)"
 
 
+def test_parse_error_send_message_121_maps_to_endpoint_deprecated():
+	"""issue #217 — sendReplyMsg 端点 121 重映射为 ENDPOINT_DEPRECATED，引导用户跟 issue。"""
+	client = _mock_client()
+	platform = BossRecruiterPlatform(client)
+	unified, message = platform.parse_error(
+		{
+			"code": 121,
+			"message": "请求不合法(121)",
+			"__cli_endpoint_hint__": "https://www.zhipin.com/wapi/zpchat/fastReply/sendReplyMsg",
+		}
+	)
+	assert unified == "ENDPOINT_DEPRECATED"
+	assert "请求不合法" in message
+
+
+def test_parse_error_exchange_121_keeps_invalid_param():
+	"""保护边界：exchange_request 端点的 121 根因待查，保持 INVALID_PARAM 不动。"""
+	client = _mock_client()
+	platform = BossRecruiterPlatform(client)
+	unified, _ = platform.parse_error(
+		{
+			"code": 121,
+			"message": "请求不合法(121)",
+			"__cli_endpoint_hint__": "https://www.zhipin.com/wapi/zpchat/exchange/request",
+		}
+	)
+	assert unified == "INVALID_PARAM"
+
+
 def test_friend_list_delegates():
 	client = _mock_client()
 	client.friend_list.return_value = {"code": 0, "zpData": {"result": []}}
@@ -73,8 +102,18 @@ def test_search_geeks_delegates():
 	platform = BossRecruiterPlatform(client)
 	result = platform.search_geeks("Python", city="101010100", page=2)
 	client.search_geeks.assert_called_once_with(
-		"Python", city="101010100", page=2, job_id=None, experience=None, degree=None,
-		age=None, school_level=None, activeness=None, source=None, select=False, salary=None,
+		"Python",
+		city="101010100",
+		page=2,
+		job_id=None,
+		experience=None,
+		degree=None,
+		age=None,
+		school_level=None,
+		activeness=None,
+		source=None,
+		select=False,
+		salary=None,
 	)
 	assert result == {"code": 0, "zpData": {"list": []}}
 


### PR DESCRIPTION
## Summary

issue #217 报告 v1.11.0 招聘者侧 `hr reply` 等命令返 BOSS code 121「请求不合法」。@qianjunye 通过 CDP Chrome 抓包定位真根因——`fastReply/sendReplyMsg` 端点已被 BOSS 替换为 WS+Protobuf 双通道，CLI 当前实现无法直接发送，且 121 在 CLI 信封里映射为误导性的 `INVALID_PARAM`。

本 PR 是**与方案选择无关**的底层准备，不抢 @qianjunye 在 issue 中认领的真实通道实现工作：

- 新增错误码 `ENDPOINT_DEPRECATED`，`fastReply/sendReplyMsg` 路径命中 121 时重映射为该码，`recovery_action` 直接指向 issue #217
- 错误码映射通过端点 URL 提示位（`__cli_endpoint_hint__`，CLI 内部命名空间）注入 + 读取，对其它端点（`exchange/request` 等）的 121 行为不变
- `_request` / `_browser_request` 均注入提示位，覆盖招聘者侧全部端点路径
- 新增 CDP 侦察脚本 `scripts/probe_recruiter_chat_frontend.py` — 注入 WebSocket spy + Vue/Vuex/Pinia 探测，帮助为后续真实通道实现（A / A' / B 任一方案）提供前端 sendMessage JS 入口的现场信息
- 顺手修 `pyproject.toml` 缺 `[tool.ruff.format] indent-style = "tab"` 的配置漂移——CLAUDE.md 注释明确「intentionally use tabs」但 ruff 不知道，导致 `uv run ruff format` 会把现有 tab 缩进改成空格

## Test plan

- [x] `uv run pytest tests/ -q` 1277 passed
- [x] `uv run mypy src/boss_agent_cli/platforms/zhipin_recruiter.py src/boss_agent_cli/api/recruiter_client.py src/boss_agent_cli/commands/schema.py` 0 issues
- [x] `uv run ruff check src/ tests/ scripts/` All checks passed
- [x] `uv run ruff format --check` 涉及文件全部通过
- [x] `uv run python scripts/probe_recruiter_chat_frontend.py --dry-run` 输出 report skeleton + JS payloads 完整
- [ ] @qianjunye 或 @applexph 在自己的 CDP Chrome 招聘者后台跑一次 `uv run python scripts/probe_recruiter_chat_frontend.py --friend-id <fid> --output report.json` 并把报告粘到 issue #217 评论（用于真实通道方案 A / A' / B 的精确实现）

## Relates

- Closes #nothing — 不闭合 issue #217（真实通道实现由 @qianjunye 主导，待他 PR）
- Refs #217