### PR TITLE
fix: 修复服务端子进程阻塞

### DIFF
--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -37,6 +37,26 @@ In Cursor Settings → MCP, add a stdio server that points to this repo's `mcp-s
 
 Once enabled, Composer will automatically discover `boss_search`, `boss_detail`, `boss_greet`, and the rest of the 49 MCP tools. No extra shell prompt glue is required.
 
+For Windows / VS Code-style `mcp.json`, use escaped backslashes in the project path:
+
+```json
+{
+  "servers": {
+    "boss-agent-cli": {
+      "type": "stdio",
+      "command": "uv",
+      "args": [
+        "--directory",
+        "E:\\tools\\boss-agent-cli",
+        "run",
+        "python",
+        "mcp-server/server.py"
+      ]
+    }
+  }
+}
+```
+
 ### Option 2: shell-command integration
 
 Add a rule like this to `.cursor/rules/boss-agent-cli.mdc`:

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -47,6 +47,40 @@ uv tool install "boss-agent-cli[mcp]"
 }
 ```
 
+## 配置 VS Code（Windows）
+
+在 VS Code 的 `mcp.json` 中添加 stdio server。将 `E:\tools\boss-agent-cli` 替换为你的本地项目路径：
+
+```json
+{
+  "servers": {
+    "boss-agent-cli": {
+      "type": "stdio",
+      "command": "uv",
+      "args": [
+        "--directory",
+        "E:\\tools\\boss-agent-cli",
+        "run",
+        "python",
+        "mcp-server/server.py"
+      ]
+    }
+  }
+}
+```
+
+如果你的 VS Code MCP 配置使用顶层 server 对象，也可以只保留内部条目：
+
+```json
+"boss-agent-cli": {
+  "type": "stdio",
+  "command": "uv",
+  "args": ["--directory", "E:\\tools\\boss-agent-cli", "run", "python", "mcp-server/server.py"]
+}
+```
+
+MCP Server 内部调用 `boss` CLI 时会关闭子进程 stdin，避免子进程误读 VS Code 的 MCP stdio 协议流导致阻塞超时。
+
 ## 可用工具
 
 当前 MCP Server 暴露 **49 个工具**，覆盖求职者链路、AI 辅助能力，以及招聘者侧 `hr` 工作流。

--- a/src/boss_agent_cli/mcp_server.py
+++ b/src/boss_agent_cli/mcp_server.py
@@ -641,7 +641,13 @@ _decorate_tool_descriptions()
 def _run_boss(*args: str) -> dict[str, Any]:
 	"""调用 boss CLI 并返回解析后的 JSON。"""
 	cmd = ["boss", "--json", *args]
-	result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+	result = subprocess.run(
+		cmd,
+		capture_output=True,
+		text=True,
+		timeout=120,
+		stdin=subprocess.DEVNULL,
+	)
 	try:
 		return json.loads(result.stdout)
 	except json.JSONDecodeError:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -24,6 +24,7 @@ sys.modules.setdefault("mcp.server.stdio", _mcp_stdio)
 sys.modules.setdefault("mcp.types", _mcp_types)
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "mcp-server"))
+import server  # noqa: E402
 from server import (  # noqa: E402
 	TOOLS,
 	_build_args,
@@ -359,6 +360,16 @@ def test_run_boss_timeout(mock_run):
 	mock_run.return_value = MagicMock(stdout='{"ok": true}', stderr="")
 	_run_boss("doctor")
 	assert mock_run.call_args[1]["timeout"] == 120
+
+
+@patch("server.subprocess.run")
+def test_run_boss_detaches_child_stdin_from_mcp_stdio(mock_run):
+	"""boss 子进程不应继承 MCP stdio 协议输入流。"""
+	mock_run.return_value = MagicMock(stdout='{"ok": true}', stderr="")
+
+	_run_boss("status")
+
+	assert mock_run.call_args[1]["stdin"] is server.subprocess.DEVNULL
 
 
 def test_parse_cli_args_defaults():


### PR DESCRIPTION
## 变更说明

Closes #222

- 在 MCP Server 调用 `boss` CLI 时显式设置 `stdin=subprocess.DEVNULL`，避免 VS Code MCP stdio 协议流被子进程继承后阻塞。
- 补充 Windows / VS Code `mcp.json` 配置示例，说明如何通过 `uv run` 启动 `mcp-server/server.py`。
- 增加 `_run_boss()` 回归测试，锁定子进程 stdin 隔离契约。

## 根因

VS Code MCP 使用 stdio 作为协议通道。原实现启动 `boss` 子进程时没有隔离 stdin，子进程可能继承 MCP Server 的协议输入流，导致命令等待输入直到超时。

## 验证

- `uv run pytest tests/test_mcp_server.py tests/test_agent_docs.py tests/test_agent_host_examples.py -q`
- `uv run ruff check src/boss_agent_cli/mcp_server.py tests/test_mcp_server.py`
- `git diff --check -- src/boss_agent_cli/mcp_server.py tests/test_mcp_server.py mcp-server/README.md docs/integrations/cursor.md`