### PR TITLE
doc: Add Windows Powershell instructions for CDP

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -269,14 +269,45 @@ boss logout && boss login
 
 BOSS Zhipin's risk system flags headless browsers. Fix by attaching to your real Chrome:
 
+macOS:
+
 ```bash
-# 1. Quit Chrome completely, then:
 /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
   --remote-debugging-port=9222 \
   --user-data-dir="$HOME/.boss-agent/chrome-cdp-profile" \
   --no-first-run
+```
 
-# 2. In another terminal:
+Linux:
+
+```bash
+google-chrome \
+  --remote-debugging-port=9222 \
+  --user-data-dir="$HOME/.boss-agent/chrome-cdp-profile" \
+  --no-first-run
+```
+
+Windows PowerShell:
+
+```powershell
+$chromeCandidates = @(
+  "$env:ProgramFiles\Google\Chrome\Application\chrome.exe",
+  "${env:ProgramFiles(x86)}\Google\Chrome\Application\chrome.exe",
+  "$env:LOCALAPPDATA\Google\Chrome\Application\chrome.exe"
+)
+
+$chrome = $chromeCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+if (-not $chrome) { throw "Google Chrome executable was not found" }
+
+& $chrome `
+  --remote-debugging-port=9222 `
+  --remote-allow-origins=* `
+  --user-data-dir="$env:LOCALAPPDATA\boss-agent-cdp-profile"
+```
+
+Then sign in from another terminal:
+
+```bash
 boss login --cdp
 boss search "python" --city 北京
 ```

--- a/README.md
+++ b/README.md
@@ -207,15 +207,25 @@ boss hr jobs list                     # 我发布的职位
 <details>
 <summary>📖 CDP 启动示例</summary>
 
+macOS：
+
 ```bash
-# macOS
 /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
-  --remote-debugging-port=9222 --user-data-dir=/tmp/boss-chrome
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/boss-chrome
+```
 
-# Linux
-google-chrome --remote-debugging-port=9222 --user-data-dir=/tmp/boss-chrome
+Linux：
 
-# Windows Powershell
+```bash
+google-chrome \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/boss-chrome
+```
+
+Windows PowerShell：
+
+```powershell
 $chromeCandidates = @(
   "$env:ProgramFiles\Google\Chrome\Application\chrome.exe",
   "${env:ProgramFiles(x86)}\Google\Chrome\Application\chrome.exe",
@@ -223,13 +233,17 @@ $chromeCandidates = @(
 )
 
 $chrome = $chromeCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+if (-not $chrome) { throw "Google Chrome executable was not found" }
 
 & $chrome `
   --remote-debugging-port=9222 `
   --remote-allow-origins=* `
   --user-data-dir="$env:LOCALAPPDATA\boss-agent-cdp-profile"
+```
 
-# 使用 CDP 登录
+启动后在另一个终端使用 CDP 登录：
+
+```bash
 boss --cdp-url http://localhost:9222 login --cdp
 ```
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,20 @@ boss hr jobs list                     # 我发布的职位
 # Linux
 google-chrome --remote-debugging-port=9222 --user-data-dir=/tmp/boss-chrome
 
+# Windows Powershell
+$chromeCandidates = @(
+  "$env:ProgramFiles\Google\Chrome\Application\chrome.exe",
+  "${env:ProgramFiles(x86)}\Google\Chrome\Application\chrome.exe",
+  "$env:LOCALAPPDATA\Google\Chrome\Application\chrome.exe"
+)
+
+$chrome = $chromeCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+
+& $chrome `
+  --remote-debugging-port=9222 `
+  --remote-allow-origins=* `
+  --user-data-dir="$env:LOCALAPPDATA\boss-agent-cdp-profile"
+
 # 使用 CDP 登录
 boss --cdp-url http://localhost:9222 login --cdp
 ```


### PR DESCRIPTION
## Summary

- Adds structured CDP Chrome startup examples for macOS, Linux, and Windows PowerShell.
- Keeps Chinese and English README guidance in sync.
- Adds an explicit Windows error when Chrome cannot be found.

## Test Plan

- uv run pytest tests/test_agent_docs.py tests/test_open_source_docs.py -q
- uv run ruff check src/ tests/ scripts/
- GitHub CI and Docs are green.

## Notes

Documentation-only change. No CLI behavior change.