### PR TITLE
feat: 新增 boss-resume-downloader skill — 基于本地 Markdown 的招聘者简历增量同步方案

### DIFF
--- a/skills/boss-resume-downloader/SKILL.md
+++ b/skills/boss-resume-downloader/SKILL.md
@@ -284,17 +284,17 @@ python "${SKILL_DIR}/scripts/sync_boss_resumes.py" refresh-jobs
 # Dry run without downloading resumes
 python "${SKILL_DIR}/scripts/sync_boss_resumes.py" sync-all --dry-run
 
-# Override per-run / per-job download caps (defaults: 400 per run, 80 per job)
+# Override per-run / per-job download caps (defaults: 20 per run, 10 per job)
 python "${SKILL_DIR}/scripts/sync_boss_resumes.py" sync-all \
-  --max-downloads-per-run 400 --max-downloads-per-job 80
+  --max-downloads-per-run 50 --max-downloads-per-job 20
 ```
 
 The script enforces conservative download caps **by default** so a single run cannot perform a bulk-access pattern even when many new candidates have accumulated:
 
 | Flag | Default | Meaning |
 |---|---|---|
-| `--max-downloads-per-run` | 400 | Hard cap on resume downloads across the entire run. When reached, the run stops cleanly (current job is finalized then no more jobs are processed). |
-| `--max-downloads-per-job` | 80 | Hard cap on resume downloads within a single job. When reached, that job's candidate loop ends cleanly and the run moves to the next job. |
+| `--max-downloads-per-run` | 20 | Hard cap on resume downloads across the entire run. When reached, the run stops cleanly (current job is finalized then no more jobs are processed). |
+| `--max-downloads-per-job` | 10 | Hard cap on resume downloads within a single job. When reached, that job's candidate loop ends cleanly and the run moves to the next job. |
 
 When a cap is hit, the run still exits with `ok: true`; the summary's `stopped_due_to_limit` field is set (`"run"`, `"job"`, or `null`) so the operator knows work remains and the next scheduled run will pick up where this one stopped.
 

--- a/skills/boss-resume-downloader/SKILL.md
+++ b/skills/boss-resume-downloader/SKILL.md
@@ -1,0 +1,338 @@
+---
+name: boss-resume-downloader
+description: Use this skill when the user wants to install, configure, download, or synchronize online resumes for candidates who applied to currently open BOSS/Zhipin recruiter jobs. Provides a cross-platform boss-agent-cli setup, standard CDP/Chrome conventions, persistent resume root, job/candidate JSON indexes, full and per-job incremental sync, and randomized delay during bulk downloads.
+---
+
+# Boss Resume Downloader
+
+## Purpose
+
+Install and operate a deterministic BOSS/Zhipin recruiter resume synchronization workflow. Standardize the boss-agent-cli command path, CDP endpoint, Chrome launch convention, auth data directory, resume storage root, and resume download fallback logic so that the workflow is reproducible across machines and across agent harnesses (Claude Code, Claude Desktop, Cursor, etc.).
+
+Use this skill for two related goals:
+
+1. Speed up installation and first successful run on a new machine.
+2. Let other sessions operate the same BOSS resume synchronization flow without rediscovering CDP paths, Chrome executable locations, boss-agent-cli storage directories, or `securityId` fallback behavior.
+
+## Golden Configuration
+
+Prefer these defaults unless the user explicitly requests otherwise. Paths shown with `~` are POSIX (macOS/Linux); the Windows equivalent uses `%USERPROFILE%`.
+
+| Item | Value (POSIX) | Value (Windows) |
+|---|---|---|
+| Platform | `zhipin` | `zhipin` |
+| Role | `recruiter` | `recruiter` |
+| CDP URL | `http://localhost:9222` | `http://localhost:9222` |
+| boss command | `boss` (on PATH) | `boss` (on PATH) or `%USERPROFILE%\bin\boss.cmd` |
+| boss-agent-cli auth data dir | `~/.boss-agent` | `%USERPROFILE%\.boss-agent` |
+| Resume output root | `~/WorkBuddy/boss-resumes` | `%USERPROFILE%\WorkBuddy\boss-resumes` |
+| Sync script | `scripts/sync_boss_resumes.py` (relative to this SKILL.md) | same |
+
+Invoke the CLI like this (assumes `boss` is on PATH):
+
+```bash
+boss --role recruiter --platform zhipin --cdp-url http://localhost:9222 <command>
+```
+
+Important known facts:
+
+- Use platform `zhipin`, not `zhipin-recruiter`.
+- Use CDP URL `http://localhost:9222` when recruiter authentication is needed.
+- Use auth data directory `~/.boss-agent` (POSIX) / `%USERPROFILE%\.boss-agent` (Windows). Do not guess `.boss-agent-cli`.
+- On Windows, if `boss` is not resolvable from subprocess, fall back to `%USERPROFILE%\bin\boss.cmd`.
+- Resume viewing requires encrypted geek ID, encrypted job ID, and `securityId`.
+- `hr applications` can list applied candidates but may not expose `securityId` in all outputs.
+- `hr chat` can expose candidate names but may still omit `securityId`.
+- The bundled script can use boss-agent-cli internal `friend_detail(friendIds)` as a fallback to resolve `securityId` from numeric `friendId`. This fallback requires the `boss_agent_cli` Python package to be importable from the active environment.
+- `hr candidates` can be used as an additional fallback source.
+- Do not assume `encryptFriendId` equals `securityId`.
+
+## Recommended Usage Pattern: Hourly Incremental Sync + Local Analysis
+
+**Strongly recommended over one-shot bulk downloads.**
+
+### Schedule hourly incremental sync via agent
+
+Use your agent harness's scheduled task capability (e.g., Claude Code `/loop`, cron, or any recurring job) to run `sync-all` every hour:
+
+```bash
+# Run once per hour, keep Chrome open in the background
+python "${SKILL_DIR}/scripts/sync_boss_resumes.py" sync-all
+```
+
+In Claude Code you can set this up with:
+
+```
+/loop 1h python "${SKILL_DIR}/scripts/sync_boss_resumes.py" sync-all
+```
+
+Each run only downloads candidates not yet in `candidate_index.json`, so an hourly job downloads at most the few new applicants from the past hour — typically 1–5 requests per run.
+
+**Why this is better than a one-shot bulk sync:**
+
+1. **Avoids risk control.** BOSS/Zhipin detects abnormal access patterns. Downloading 50+ resumes in one session looks like scraping and may trigger a temporary block or CAPTCHA. Spreading the same work across 24 hourly runs of 1–3 resumes each is indistinguishable from normal recruiter browsing.
+
+2. **Local analysis is fast and free.** Once resumes are on disk as `resume.md`, any analysis (filtering by keyword, comparing candidates, summarizing, ranking) runs entirely locally — no network round-trips, no rate limits, no extra API calls to BOSS.
+
+### Analyze from local Markdown files
+
+After sync, all resumes are at:
+
+```
+~/WorkBuddy/boss-resumes/jobs/<jobId>_<jobName>/resumes/<name>_<id>/resume.md
+```
+
+To analyze them, read the local files directly. Example prompts that work well once files are synced:
+
+- "Read all resume.md files under ~/WorkBuddy/boss-resumes and shortlist candidates with Python experience."
+- "Compare the work experience sections across all downloaded resumes for job 研发实习生."
+- "Find candidates who mentioned crawler/scrapy/selenium in their resumes."
+
+This is faster and more reliable than querying BOSS live for each analysis question.
+
+---
+
+## First-Time Setup Checklist
+
+### 1. Verify the boss CLI is available
+
+```bash
+boss --help
+```
+
+If `boss` is not on PATH, locate the installed entrypoint and either add it to PATH or pass it via `--boss-bin` to the bundled script. On Windows the entrypoint is typically `%USERPROFILE%\bin\boss.cmd` (a wrapper around the env's `boss.exe`).
+
+### 2. Start Chrome with a stable CDP endpoint
+
+Prefer an already-running Chrome session that exposes `http://localhost:9222`. If status checks fail because CDP is unavailable, launch Chrome manually with remote debugging enabled and a dedicated profile. Common executable locations:
+
+- macOS: `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`
+- Linux: `google-chrome` or `chromium` on PATH
+- Windows: `C:\Program Files\Google\Chrome\Application\chrome.exe`, `C:\Program Files (x86)\Google\Chrome\Application\chrome.exe`, or `%LOCALAPPDATA%\Google\Chrome\Application\chrome.exe`
+
+Recommended launch shapes:
+
+```bash
+# macOS
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  --remote-debugging-port=9222 \
+  --user-data-dir="$HOME/.workbuddy/chrome-profiles/boss-cdp"
+
+# Linux
+google-chrome \
+  --remote-debugging-port=9222 \
+  --user-data-dir="$HOME/.workbuddy/chrome-profiles/boss-cdp"
+```
+
+```bat
+:: Windows
+"<chrome.exe>" --remote-debugging-port=9222 --user-data-dir="%USERPROFILE%\.workbuddy\chrome-profiles\boss-cdp"
+```
+
+Do not randomize the CDP port or profile directory unless port 9222 is occupied.
+
+### 3. Verify recruiter login
+
+```bash
+boss --role recruiter --platform zhipin --cdp-url http://localhost:9222 status
+```
+
+If not logged in, run CDP login and let the user complete any browser-side QR/login step:
+
+```bash
+boss --role recruiter --platform zhipin --cdp-url http://localhost:9222 login --cdp
+```
+
+### 4. Verify online jobs
+
+```bash
+boss --role recruiter --platform zhipin --cdp-url http://localhost:9222 hr jobs list
+```
+
+Proceed only after the command returns the expected recruiter jobs.
+
+## Default Storage
+
+Use this default resume root unless the user specifies another directory:
+
+- POSIX: `~/WorkBuddy/boss-resumes`
+- Windows: `%USERPROFILE%\WorkBuddy\boss-resumes`
+
+Expected structure:
+
+```text
+boss-resumes/
+  config.json
+  job_index.json
+  jobs/
+    <jobId>_<safeJobName>/
+      job.json
+      candidate_index.json
+      resumes/
+        <safeCandidateName>_<candidateId>/
+          resume.json
+          resume.md
+          raw_response.json
+```
+
+## Main Workflow
+
+### 1. Check login and open jobs
+
+Run status first. If authentication is missing or expired, use the CDP login flow.
+
+```bash
+boss --role recruiter --platform zhipin --cdp-url http://localhost:9222 status
+boss --role recruiter --platform zhipin --cdp-url http://localhost:9222 hr jobs list
+```
+
+Persist all currently online jobs into `job_index.json`, keyed by stable job ID and encrypted job ID.
+
+### 2. Create per-job directories
+
+For every online job, create a directory named:
+
+```text
+<jobId>_<safeJobName>
+```
+
+Store raw job metadata in `job.json`.
+
+### 3. List applied candidates
+
+For each job, call applications with the encrypted job ID when available:
+
+```bash
+boss --role recruiter --platform zhipin --cdp-url http://localhost:9222 hr applications --job-id <encryptJobId>
+```
+
+Paginate if the CLI output indicates more pages.
+
+### 4. Resolve resume parameters
+
+For each applied candidate, resolve:
+
+- `encryptGeekId` / encrypted candidate ID
+- display name
+- `securityId`
+- applicable encrypted job ID
+
+Use `applications` first. If `securityId` is absent, resolve it by numeric `friendId` through the internal boss-agent-cli `friend_detail(friendIds)` API. This endpoint returns candidate name, `securityId`, `encryptUid`, `jobId`, and `encryptJobId`. Use `hr candidates` or `hr chat` only as additional fallback sources. Do not assume `encryptFriendId` equals `securityId`.
+
+If `securityId` cannot be resolved, record the candidate as `pending_security_id` in `candidate_index.json` and skip resume download for that candidate. Do not mark as permanently failed.
+
+### 5. Download online resume
+
+When all parameters are present, call:
+
+```bash
+boss --role recruiter --platform zhipin --cdp-url http://localhost:9222 hr resume <encryptGeekId> --job-id <encryptJobId> --security-id <securityId>
+```
+
+Save:
+
+- raw JSON response as `raw_response.json`
+- normalized JSON as `resume.json`
+- readable Markdown resume as `resume.md`
+
+### 6. Incremental behavior
+
+Before downloading, inspect `candidate_index.json`.
+
+Skip a candidate when:
+
+- candidate ID exists in the index,
+- resume status is `downloaded`, and
+- no `--force` option was requested.
+
+Update candidates when:
+
+- candidate is new,
+- previous status was `pending_security_id`, `failed`, or `partial`,
+- `--force` is set.
+
+### 7. Random delay
+
+During bulk downloads, apply a random delay between successful/attempted candidate downloads:
+
+```text
+3-6 seconds
+```
+
+Do not delay for dry-run/list-only operations.
+
+## Bundled Script
+
+The script lives next to this SKILL.md at `scripts/sync_boss_resumes.py`. Resolve `${SKILL_DIR}` to the directory containing this SKILL.md, then call:
+
+```bash
+# Sync all online jobs incrementally
+python "${SKILL_DIR}/scripts/sync_boss_resumes.py" sync-all
+
+# Sync all online jobs with command echoing; --verbose is a global option and must be placed before the subcommand
+python "${SKILL_DIR}/scripts/sync_boss_resumes.py" --verbose sync-all
+
+# Sync one job by numeric jobId or encrypted jobId
+python "${SKILL_DIR}/scripts/sync_boss_resumes.py" sync-job --job-id <jobId>
+
+# Refresh job index only
+python "${SKILL_DIR}/scripts/sync_boss_resumes.py" refresh-jobs
+
+# Dry run without downloading resumes
+python "${SKILL_DIR}/scripts/sync_boss_resumes.py" sync-all --dry-run
+```
+
+Use the Python interpreter that has `boss_agent_cli` importable, otherwise the `friend_detail` fallback will be disabled. The script prints a warning to stderr (with `--verbose`) when this happens.
+
+If `boss` is not on PATH, override with `--boss-bin <path>` or set `BOSS_BIN=<path>` in the environment.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `unrecognized arguments: --verbose` | Global option placed after the subcommand | Put `--verbose` before `sync-all` or `sync-job` |
+| `[WinError 2] 系统找不到指定的文件` / `FileNotFoundError: boss` | Subprocess cannot find `boss` on PATH | Pass `--boss-bin <path>` or set `BOSS_BIN`; on Windows use `%USERPROFILE%\bin\boss.cmd` |
+| Not logged in despite browser login | Wrong auth data dir | Use `--data-dir ~/.boss-agent` (Windows: `%USERPROFILE%\.boss-agent`) |
+| CDP connection refused | Chrome was not started with remote debugging | Relaunch Chrome with `--remote-debugging-port=9222` |
+| All candidates are `pending_security_id` | `applications` output lacks `securityId` and internal fallback failed | Run the script with a Python that has `boss_agent_cli` importable, or pass `--verbose` to see the import error |
+| `zhipin-recruiter` platform error | Wrong platform name | Use `--platform zhipin` |
+| Applications pagination stopped at page 100 | Hard cap reached | Re-run on the specific job, or split by other filters; the script warns to stderr when the cap is hit |
+
+## Output Expectations
+
+Report the following after each sync:
+
+- resume root directory
+- jobs discovered
+- jobs updated
+- candidates discovered
+- resumes downloaded
+- skipped existing resumes
+- candidates pending `securityId`
+- failures with exact error messages
+
+A successful sync envelope shape:
+
+```json
+{
+  "ok": true,
+  "resume_root": "<resolved path>",
+  "mode": "sync-all",
+  "totals": {
+    "candidates_discovered": 0,
+    "downloaded": 0,
+    "skipped_existing": 0,
+    "pending_security_id": 0,
+    "failed": 0
+  }
+}
+```
+
+## Safety and Etiquette
+
+- Do not send messages to candidates.
+- Do not change job online/offline status.
+- Do not delete previous resumes or indexes during sync.
+- Preserve raw API responses for debugging.
+- Treat BOSS data as private recruiting data.
+- Do not include downloaded candidate resumes in a distributable skill package.

--- a/skills/boss-resume-downloader/SKILL.md
+++ b/skills/boss-resume-downloader/SKILL.md
@@ -85,7 +85,7 @@ After sync, all resumes are at:
 To analyze them, read the local files directly. Example prompts that work well once files are synced:
 
 - "Read all resume.md files under ~/WorkBuddy/boss-resumes and shortlist candidates with Python experience."
-- "Compare the work experience sections across all downloaded resumes for job 研发实习生."
+- "Compare the work experience sections across all downloaded resumes for job <job_name>."
 - "Find candidates who mentioned crawler/scrapy/selenium in their resumes."
 
 This is faster and more reliable than querying BOSS live for each analysis question.

--- a/skills/boss-resume-downloader/SKILL.md
+++ b/skills/boss-resume-downloader/SKILL.md
@@ -51,6 +51,9 @@ Important known facts:
 
 **Strongly recommended over one-shot bulk downloads.**
 
+> ⚠️ **Risk notice — recruiter resume access is sensitive.**
+> Recruiter-side resume access is a monitored, high-sensitivity action. Bulk resume screening has been observed to trigger account-level risk controls (rate limiting, CAPTCHA challenges, temporary account restrictions; see upstream issue #232). The patterns and limits in this skill **reduce** that risk but do not eliminate it. Treat any safeguards here — incremental scheduling, randomized delay, per-run/per-job download caps — as **risk-reduction measures, not safety guarantees**. Recruiter accounts may still be limited, challenged, or restricted at any time; monitor for `ACCOUNT_RISK` / `RATE_LIMITED` errors and back off.
+
 ### Schedule hourly incremental sync via agent
 
 Use your agent harness's scheduled task capability (e.g., Claude Code `/loop`, cron, or any recurring job) to run `sync-all` every hour:
@@ -66,11 +69,11 @@ In Claude Code you can set this up with:
 /loop 1h python "${SKILL_DIR}/scripts/sync_boss_resumes.py" sync-all
 ```
 
-Each run only downloads candidates not yet in `candidate_index.json`, so an hourly job downloads at most the few new applicants from the past hour — typically 1–5 requests per run.
+Each run only downloads candidates not yet in `candidate_index.json`, so an hourly job typically only needs to download the few new applicants from the past hour.
 
-**Why this is better than a one-shot bulk sync:**
+**Why this is preferred over a one-shot bulk sync:**
 
-1. **Avoids risk control.** BOSS/Zhipin detects abnormal access patterns. Downloading 50+ resumes in one session looks like scraping and may trigger a temporary block or CAPTCHA. Spreading the same work across 24 hourly runs of 1–3 resumes each is indistinguishable from normal recruiter browsing.
+1. **Reduces (does not eliminate) risk-control exposure.** Downloading dozens or hundreds of resumes in one session resembles scraping and is more likely to trigger account risk controls. Spreading work across many small hourly runs lowers — but does not remove — that likelihood. The script also enforces hard per-run/per-job download caps (`--max-downloads-per-run`, `--max-downloads-per-job`) so a single run cannot accidentally produce a bulk-access pattern even if many new candidates accumulated.
 
 2. **Local analysis is fast and free.** Once resumes are on disk as `resume.md`, any analysis (filtering by keyword, comparing candidates, summarizing, ranking) runs entirely locally — no network round-trips, no rate limits, no extra API calls to BOSS.
 
@@ -280,7 +283,20 @@ python "${SKILL_DIR}/scripts/sync_boss_resumes.py" refresh-jobs
 
 # Dry run without downloading resumes
 python "${SKILL_DIR}/scripts/sync_boss_resumes.py" sync-all --dry-run
+
+# Override per-run / per-job download caps (defaults: 400 per run, 80 per job)
+python "${SKILL_DIR}/scripts/sync_boss_resumes.py" sync-all \
+  --max-downloads-per-run 400 --max-downloads-per-job 80
 ```
+
+The script enforces conservative download caps **by default** so a single run cannot perform a bulk-access pattern even when many new candidates have accumulated:
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--max-downloads-per-run` | 400 | Hard cap on resume downloads across the entire run. When reached, the run stops cleanly (current job is finalized then no more jobs are processed). |
+| `--max-downloads-per-job` | 80 | Hard cap on resume downloads within a single job. When reached, that job's candidate loop ends cleanly and the run moves to the next job. |
+
+When a cap is hit, the run still exits with `ok: true`; the summary's `stopped_due_to_limit` field is set (`"run"`, `"job"`, or `null`) so the operator knows work remains and the next scheduled run will pick up where this one stopped.
 
 Use the Python interpreter that has `boss_agent_cli` importable, otherwise the `friend_detail` fallback will be disabled. The script prints a warning to stderr (with `--verbose`) when this happens.
 
@@ -310,6 +326,7 @@ Report the following after each sync:
 - skipped existing resumes
 - candidates pending `securityId`
 - failures with exact error messages
+- whether the run stopped early because a download cap was reached
 
 A successful sync envelope shape:
 
@@ -318,6 +335,7 @@ A successful sync envelope shape:
   "ok": true,
   "resume_root": "<resolved path>",
   "mode": "sync-all",
+  "stopped_due_to_limit": null,
   "totals": {
     "candidates_discovered": 0,
     "downloaded": 0,
@@ -327,6 +345,8 @@ A successful sync envelope shape:
   }
 }
 ```
+
+`stopped_due_to_limit` takes one of `null` (ran to completion), `"run"` (per-run cap hit), or `"job"` (per-job cap hit on at least one job).
 
 ## Safety and Etiquette
 

--- a/skills/boss-resume-downloader/references/boss_recruiter_notes.md
+++ b/skills/boss-resume-downloader/references/boss_recruiter_notes.md
@@ -1,0 +1,48 @@
+# Boss Resume Downloader Reference
+
+## Known recruiter state
+
+Verified recruiter login in this workspace:
+
+```json
+{
+  "logged_in": true,
+  "user_name": "钱俊烨"
+}
+```
+
+Known online job from prior verification:
+
+```json
+{
+  "jobName": "研发实习生（爬虫方向）",
+  "jobId": 538261874,
+  "encryptJobId": "8e0361425656f7200ndy2du8GFVU",
+  "salaryDesc": "200-250元/天",
+  "address": "上海",
+  "jobOnlineStatus": 1
+}
+```
+
+## Critical implementation notes
+
+- Correct platform argument is `--platform zhipin`.
+- `--platform zhipin-recruiter` fails with unknown platform.
+- Use `--role recruiter` for recruiter commands.
+- Prefer `--cdp-url http://localhost:9222` to reuse the logged-in Chrome session.
+- Resume view requires both `--job-id` and `--security-id`.
+- `encryptFriendId` was tested and is not necessarily equivalent to `securityId`.
+- 2026-05-14 实测：`friend_detail([friendId])` 内部接口可返回 `securityId`、候选人姓名、`encryptUid`、`jobId`、`encryptJobId`，可用于补齐 `hr applications` 缺失的 `securityId`。
+- If candidate security ID cannot be resolved, keep candidate in the index as pending rather than failing permanently.
+
+## CLI commands of interest
+
+```bash
+boss --role recruiter --platform zhipin --cdp-url http://localhost:9222 status
+boss --role recruiter --platform zhipin --cdp-url http://localhost:9222 login --cdp
+boss --role recruiter --platform zhipin --cdp-url http://localhost:9222 hr jobs list
+boss --role recruiter --platform zhipin --cdp-url http://localhost:9222 hr applications --job-id <encryptJobId> --page <page>
+boss --role recruiter --platform zhipin --cdp-url http://localhost:9222 hr candidates <keyword>
+boss --role recruiter --platform zhipin --cdp-url http://localhost:9222 hr chat
+boss --role recruiter --platform zhipin --cdp-url http://localhost:9222 hr resume <encryptGeekId> --job-id <encryptJobId> --security-id <securityId>
+```

--- a/skills/boss-resume-downloader/references/boss_recruiter_notes.md
+++ b/skills/boss-resume-downloader/references/boss_recruiter_notes.md
@@ -7,7 +7,7 @@ Verified recruiter login in this workspace:
 ```json
 {
   "logged_in": true,
-  "user_name": "钱俊烨"
+  "user_name": "<recruiter_name>"
 }
 ```
 
@@ -15,11 +15,11 @@ Known online job from prior verification:
 
 ```json
 {
-  "jobName": "研发实习生（爬虫方向）",
-  "jobId": 538261874,
-  "encryptJobId": "8e0361425656f7200ndy2du8GFVU",
-  "salaryDesc": "200-250元/天",
-  "address": "上海",
+  "jobName": "<job_name>",
+  "jobId": "<jobId>",
+  "encryptJobId": "<encryptJobId>",
+  "salaryDesc": "<salary>",
+  "address": "<city>",
   "jobOnlineStatus": 1
 }
 ```

--- a/skills/boss-resume-downloader/scripts/sync_boss_resumes.py
+++ b/skills/boss-resume-downloader/scripts/sync_boss_resumes.py
@@ -751,16 +751,16 @@ def build_parser() -> argparse.ArgumentParser:
     sub_all = sub.add_parser("sync-all", help="Incrementally sync resumes for all online jobs.")
     sub_all.add_argument("--force", action="store_true", help="Re-download candidates already marked downloaded.")
     sub_all.add_argument("--dry-run", action="store_true", help="Resolve candidates without downloading resumes.")
-    sub_all.add_argument("--max-downloads-per-run", type=int, default=100, help="Hard cap on resume downloads across the entire run. Default: 100.")
-    sub_all.add_argument("--max-downloads-per-job", type=int, default=50, help="Hard cap on resume downloads within a single job. Default: 50.")
+    sub_all.add_argument("--max-downloads-per-run", type=int, default=20, help="Hard cap on resume downloads across the entire run. Default: 20.")
+    sub_all.add_argument("--max-downloads-per-job", type=int, default=10, help="Hard cap on resume downloads within a single job. Default: 10.")
     sub_all.set_defaults(func=command_sync_all)
 
     sub_job = sub.add_parser("sync-job", help="Incrementally sync one job by numeric or encrypted job ID.")
     sub_job.add_argument("--job-id", required=True, help="Numeric jobId or encryptJobId from job_index.json.")
     sub_job.add_argument("--force", action="store_true", help="Re-download candidates already marked downloaded.")
     sub_job.add_argument("--dry-run", action="store_true", help="Resolve candidates without downloading resumes.")
-    sub_job.add_argument("--max-downloads-per-run", type=int, default=100, help="Hard cap on resume downloads for this run. Default: 100.")
-    sub_job.add_argument("--max-downloads-per-job", type=int, default=50, help="Hard cap on resume downloads within the job. Default: 50.")
+    sub_job.add_argument("--max-downloads-per-run", type=int, default=20, help="Hard cap on resume downloads for this run. Default: 20.")
+    sub_job.add_argument("--max-downloads-per-job", type=int, default=10, help="Hard cap on resume downloads within the job. Default: 10.")
     sub_job.set_defaults(func=command_sync_job)
 
     return parser

--- a/skills/boss-resume-downloader/scripts/sync_boss_resumes.py
+++ b/skills/boss-resume-downloader/scripts/sync_boss_resumes.py
@@ -1,0 +1,718 @@
+#!/usr/bin/env python3
+"""
+Synchronize online resumes for candidates who applied to BOSS/Zhipin recruiter jobs.
+
+This script wraps boss-agent-cli commands and stores cross-session indexes/resume files.
+It is intentionally conservative: it does not send messages, mutate jobs, or delete files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+HOME = Path.home()
+DEFAULT_ROOT = HOME / "WorkBuddy" / "boss-resumes"
+DEFAULT_CDP_URL = "http://localhost:9222"
+DEFAULT_PLATFORM = "zhipin"
+DEFAULT_ROLE = "recruiter"
+DEFAULT_BOSS_DATA_DIR = HOME / ".boss-agent"
+
+
+def _default_boss_bin() -> str:
+    """Pick a sensible default for the boss CLI based on the host OS.
+
+    Prefers `boss` on PATH. On Windows, falls back to %USERPROFILE%\bin\boss.cmd
+    when present, since subprocess sometimes fails to resolve a bare `boss` shim.
+    """
+    if sys.platform.startswith("win"):
+        win_wrapper = HOME / "bin" / "boss.cmd"
+        if win_wrapper.exists():
+            return str(win_wrapper)
+    return "boss"
+
+
+DEFAULT_BOSS_BIN = _default_boss_bin()
+
+
+@dataclass
+class BossCommandResult:
+    args: list[str]
+    returncode: int
+    stdout: str
+    stderr: str
+    json_data: dict[str, Any] | None
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
+
+
+def safe_name(value: Any, fallback: str = "unknown") -> str:
+    text = str(value or fallback).strip() or fallback
+    text = re.sub(r'[<>:"/\\|?*\x00-\x1f]', "_", text)
+    text = re.sub(r"\s+", "_", text)
+    text = text.strip("._ ")
+    return text[:80] or fallback
+
+
+def ensure_json(path: Path, default: Any) -> Any:
+    if not path.exists():
+        return default
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        backup = path.with_suffix(path.suffix + f".broken-{int(time.time())}")
+        path.rename(backup)
+        return default
+
+
+def write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    tmp.replace(path)
+
+
+def run_boss(extra_args: list[str], cdp_url: str, boss_bin: str, verbose: bool = False) -> BossCommandResult:
+    args = [
+        boss_bin,
+        "--role",
+        DEFAULT_ROLE,
+        "--platform",
+        DEFAULT_PLATFORM,
+        "--cdp-url",
+        cdp_url,
+        *extra_args,
+    ]
+    if verbose:
+        print(f"$ {' '.join(args)}", file=sys.stderr)
+    proc = subprocess.run(args, capture_output=True, text=True, encoding="utf-8", errors="replace")
+    parsed: dict[str, Any] | None = None
+    if proc.stdout.strip():
+        try:
+            parsed = json.loads(proc.stdout)
+        except json.JSONDecodeError:
+            parsed = None
+    return BossCommandResult(args=args, returncode=proc.returncode, stdout=proc.stdout, stderr=proc.stderr, json_data=parsed)
+
+
+def try_friend_detail(friend_ids: list[int], cdp_url: str, data_dir: Path, verbose: bool = False) -> dict[int, dict[str, Any]]:
+    """Call boss-agent-cli internal friend_detail API to obtain securityId by numeric friendId.
+
+    The public `hr chat`/`hr applications` output omits securityId, but the internal
+    friend_detail endpoint returns it. Keep this as an optional best-effort path so
+    the script still works even if boss-agent-cli internals change later.
+    """
+    if not friend_ids:
+        return {}
+    try:
+        from boss_agent_cli.auth.manager import AuthManager
+        from boss_agent_cli.api.recruiter_client import BossRecruiterClient
+    except Exception as exc:
+        if verbose:
+            print(
+                f"[friend_detail] boss_agent_cli import failed ({exc!r}); "
+                "securityId fallback via internal API is unavailable.",
+                file=sys.stderr,
+            )
+        return {}
+
+    auth = AuthManager(data_dir, platform=DEFAULT_PLATFORM)
+    client = BossRecruiterClient(auth, cdp_url=cdp_url)
+    try:
+        response = client.friend_detail(friend_ids)
+    except Exception:
+        return {}
+    finally:
+        try:
+            client.close()
+        except Exception:
+            pass
+
+    data = response.get("zpData") if isinstance(response, dict) else None
+    friends = data.get("friendList") if isinstance(data, dict) else None
+    if not isinstance(friends, list):
+        return {}
+    resolved: dict[int, dict[str, Any]] = {}
+    for friend in friends:
+        if not isinstance(friend, dict):
+            continue
+        fid = friend.get("friendId") or friend.get("uid")
+        if isinstance(fid, int):
+            resolved[fid] = friend
+    return resolved
+
+
+def require_ok(result: BossCommandResult, context: str) -> dict[str, Any]:
+    if result.returncode != 0 or not result.json_data or result.json_data.get("ok") is False:
+        details = {
+            "context": context,
+            "args": result.args,
+            "returncode": result.returncode,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "json": result.json_data,
+        }
+        raise RuntimeError(json.dumps(details, ensure_ascii=False, indent=2))
+    return result.json_data
+
+
+def envelope_data(envelope: dict[str, Any]) -> Any:
+    return envelope.get("data", [])
+
+
+def list_jobs(cdp_url: str, boss_bin: str, verbose: bool) -> list[dict[str, Any]]:
+    result = run_boss(["hr", "jobs", "list"], cdp_url=cdp_url, boss_bin=boss_bin, verbose=verbose)
+    data = envelope_data(require_ok(result, "list jobs"))
+    if isinstance(data, dict):
+        for key in ("jobs", "list", "items", "data"):
+            if isinstance(data.get(key), list):
+                return data[key]
+        return [data]
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    return []
+
+
+def is_online_job(job: dict[str, Any]) -> bool:
+    status = job.get("jobOnlineStatus", job.get("onlineStatus", job.get("status")))
+    if status in (1, "1", True, "online", "ONLINE", "在招", "招聘中"):
+        return True
+    if status in (0, "0", False, "offline", "OFFLINE", "关闭"):
+        return False
+    return True
+
+
+def job_plain_id(job: dict[str, Any]) -> str:
+    return str(job.get("jobId") or job.get("id") or job.get("job_id") or job.get("encryptJobId") or job.get("encrypt_job_id") or "unknown")
+
+
+def job_encrypt_id(job: dict[str, Any]) -> str:
+    return str(job.get("encryptJobId") or job.get("encryptJobIdStr") or job.get("encJobId") or job.get("jobId") or job.get("id") or "")
+
+
+def job_name(job: dict[str, Any]) -> str:
+    return str(job.get("jobName") or job.get("name") or job.get("title") or "unknown-job")
+
+
+def refresh_jobs(root: Path, cdp_url: str, boss_bin: str, verbose: bool) -> list[dict[str, Any]]:
+    root.mkdir(parents=True, exist_ok=True)
+    config = ensure_json(root / "config.json", {})
+    config.update({
+        "resume_root": str(root),
+        "cdp_url": cdp_url,
+        "boss_bin": boss_bin,
+        "updated_at": now_iso(),
+    })
+    write_json(root / "config.json", config)
+
+    all_jobs = list_jobs(cdp_url, boss_bin, verbose)
+    online_jobs = [job for job in all_jobs if is_online_job(job)]
+    index = {
+        "updated_at": now_iso(),
+        "count": len(online_jobs),
+        "jobs": {},
+    }
+    for job in online_jobs:
+        plain = job_plain_id(job)
+        enc = job_encrypt_id(job)
+        dirname = f"{safe_name(plain)}_{safe_name(job_name(job))}"
+        job_dir = root / "jobs" / dirname
+        job_dir.mkdir(parents=True, exist_ok=True)
+        write_json(job_dir / "job.json", job)
+        index["jobs"][plain] = {
+            "jobId": plain,
+            "encryptJobId": enc,
+            "jobName": job_name(job),
+            "dir": str(job_dir),
+            "raw": job,
+        }
+        if enc and enc != plain:
+            index["jobs"][enc] = index["jobs"][plain]
+    write_json(root / "job_index.json", index)
+    return online_jobs
+
+
+def candidate_id(candidate: dict[str, Any]) -> str:
+    keys = [
+        "encryptGeekId", "geekId", "geek_id", "encryptUserId", "encryptUid",
+        "uid", "id", "candidateId", "encryptFriendId", "friendId",
+    ]
+    for key in keys:
+        value = candidate.get(key)
+        if value:
+            return str(value)
+    return safe_name(candidate_name(candidate), "unknown-candidate")
+
+
+def candidate_name(candidate: dict[str, Any]) -> str:
+    for key in ("name", "geekName", "candidateName", "userName", "nickName", "encryptName"):
+        value = candidate.get(key)
+        if value:
+            return str(value)
+    return "unknown-candidate"
+
+
+def candidate_security_id(candidate: dict[str, Any]) -> str | None:
+    for key in ("securityId", "securityID", "security_id", "sid"):
+        value = candidate.get(key)
+        if value:
+            return str(value)
+    return None
+
+
+def flatten_candidates(data: Any) -> list[dict[str, Any]]:
+    found: list[dict[str, Any]] = []
+    if isinstance(data, list):
+        for item in data:
+            found.extend(flatten_candidates(item))
+    elif isinstance(data, dict):
+        candidate_like = any(k in data for k in ("geekName", "encryptGeekId", "geekId", "candidateName", "securityId", "encryptFriendId"))
+        if candidate_like:
+            found.append(data)
+        for value in data.values():
+            if isinstance(value, (dict, list)):
+                found.extend(flatten_candidates(value))
+    return found
+
+
+MAX_APPLICATION_PAGES = 100
+
+
+def list_applications(job_enc_id: str, cdp_url: str, boss_bin: str, verbose: bool) -> list[dict[str, Any]]:
+    all_candidates: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    last_page = 0
+    exhausted = False
+    for page in range(1, MAX_APPLICATION_PAGES + 1):
+        last_page = page
+        args = ["hr", "applications", "--job-id", job_enc_id, "--page", str(page)]
+        result = run_boss(args, cdp_url=cdp_url, boss_bin=boss_bin, verbose=verbose)
+        envelope = require_ok(result, f"list applications page {page}")
+        candidates = flatten_candidates(envelope_data(envelope))
+        new_count = 0
+        for cand in candidates:
+            cid = candidate_id(cand)
+            if cid not in seen_ids:
+                seen_ids.add(cid)
+                all_candidates.append(cand)
+                new_count += 1
+        pagination = envelope.get("pagination") or {}
+        has_more = pagination.get("has_more") or pagination.get("hasMore")
+        if has_more is True:
+            continue
+        if has_more is False:
+            exhausted = True
+            break
+        if new_count == 0 or len(candidates) == 0:
+            exhausted = True
+            break
+    if not exhausted and last_page == MAX_APPLICATION_PAGES:
+        print(
+            f"[list_applications] reached page cap of {MAX_APPLICATION_PAGES} for job {job_enc_id}; "
+            "results may be truncated. Raise MAX_APPLICATION_PAGES if needed.",
+            file=sys.stderr,
+        )
+    return all_candidates
+
+
+def resolve_security_id(candidate: dict[str, Any], job_enc_id: str, cdp_url: str, boss_bin: str, verbose: bool, data_dir: Path) -> str | None:
+    existing = candidate_security_id(candidate)
+    if existing:
+        return existing
+
+    friend_id = candidate.get("friendId")
+    if isinstance(friend_id, int):
+        details = try_friend_detail([friend_id], cdp_url=cdp_url, data_dir=data_dir, verbose=verbose)
+        detail = details.get(friend_id)
+        if detail:
+            candidate.update(detail)
+            sid = candidate_security_id(detail)
+            if sid:
+                return sid
+
+    # Conservative fallback: query candidates by display name and candidate id, then match likely records.
+    search_terms = []
+    name = candidate_name(candidate)
+    cid = candidate_id(candidate)
+    if name and name != "unknown-candidate":
+        search_terms.append(name)
+    if cid and cid != name:
+        search_terms.append(cid)
+
+    for term in search_terms[:2]:
+        result = run_boss(["hr", "candidates", term], cdp_url=cdp_url, boss_bin=boss_bin, verbose=verbose)
+        if result.returncode != 0 or not result.json_data or result.json_data.get("ok") is False:
+            continue
+        for item in flatten_candidates(envelope_data(result.json_data)):
+            item_id = candidate_id(item)
+            item_name = candidate_name(item)
+            sid = candidate_security_id(item)
+            if sid and (item_id == cid or item_name == name or cid in json.dumps(item, ensure_ascii=False)):
+                candidate.update(item)
+                return sid
+
+    return None
+
+
+def markdown_escape(value: Any) -> str:
+    text = str(value).strip()
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def non_empty(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return value.strip() != ""
+    if isinstance(value, (list, dict)):
+        return len(value) > 0
+    return True
+
+
+def join_present(parts: list[Any], sep: str = " / ") -> str:
+    return sep.join(str(part).strip() for part in parts if non_empty(part))
+
+
+def section(lines: list[str], title: str) -> None:
+    lines.append("")
+    lines.append(f"## {title}")
+    lines.append("")
+
+
+def bullet(lines: list[str], label: str, value: Any) -> None:
+    if non_empty(value):
+        lines.append(f"- **{label}**：{markdown_escape(value)}")
+
+
+def normalize_items(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    if isinstance(value, dict):
+        return [value]
+    if non_empty(value):
+        return [value]
+    return []
+
+
+def render_mapping(lines: list[str], data: dict[str, Any], skip: set[str] | None = None) -> None:
+    skip = skip or set()
+    for key, value in data.items():
+        if key in skip or not non_empty(value):
+            continue
+        label = str(key).replace("_", " ")
+        if isinstance(value, (dict, list)):
+            rendered = json.dumps(value, ensure_ascii=False, indent=2)
+            lines.append(f"- **{label}**：")
+            lines.append("")
+            lines.append("```json")
+            lines.append(rendered)
+            lines.append("```")
+        else:
+            bullet(lines, label, value)
+
+
+def render_experience_item(lines: list[str], item: Any, default_title: str) -> None:
+    if not isinstance(item, dict):
+        if non_empty(item):
+            lines.append(f"- {markdown_escape(item)}")
+        return
+
+    title = join_present([
+        item.get("company") or item.get("school") or item.get("project") or item.get("project_name") or item.get("name"),
+        item.get("position") or item.get("major") or item.get("role"),
+    ]) or default_title
+    time_range = join_present([item.get("start"), item.get("end")], " - ")
+    duration = item.get("duration")
+    header_bits = [title]
+    if time_range:
+        header_bits.append(time_range)
+    if non_empty(duration):
+        header_bits.append(str(duration))
+    lines.append(f"### {markdown_escape(' | '.join(header_bits))}")
+    lines.append("")
+
+    primary_keys = {
+        "company", "school", "project", "project_name", "name", "position", "major", "role",
+        "start", "end", "duration", "responsibility", "performance", "description", "content", "keywords",
+    }
+    for label, key in [
+        ("职责", "responsibility"),
+        ("业绩", "performance"),
+        ("描述", "description"),
+        ("内容", "content"),
+    ]:
+        if non_empty(item.get(key)):
+            lines.append(f"- **{label}**：{markdown_escape(item.get(key))}")
+    keywords = item.get("keywords")
+    if isinstance(keywords, list) and keywords:
+        lines.append(f"- **关键词**：{', '.join(str(x) for x in keywords if non_empty(x))}")
+    render_mapping(lines, item, skip=primary_keys)
+    lines.append("")
+
+
+def extract_markdown(value: Any) -> str:
+    data = value if isinstance(value, dict) else {}
+    basic = data.get("basic") if isinstance(data.get("basic"), dict) else {}
+    expectation = data.get("expectation") if isinstance(data.get("expectation"), dict) else {}
+    name = basic.get("name") or data.get("name") or "未知候选人"
+
+    lines: list[str] = [f"# {markdown_escape(name)}", ""]
+
+    summary_parts = [
+        basic.get("gender"),
+        basic.get("age"),
+        basic.get("degree"),
+        basic.get("work_years"),
+        basic.get("active_status"),
+    ]
+    summary = join_present(summary_parts)
+    if summary:
+        lines.append(f"> {markdown_escape(summary)}")
+        lines.append("")
+
+    section(lines, "基本信息")
+    for label, key in [
+        ("姓名", "name"),
+        ("性别", "gender"),
+        ("年龄", "age"),
+        ("学历", "degree"),
+        ("工作年限", "work_years"),
+        ("活跃状态", "active_status"),
+    ]:
+        bullet(lines, label, basic.get(key))
+    render_mapping(lines, basic, skip={"name", "gender", "age", "degree", "work_years", "active_status", "avatar"})
+
+    if any(non_empty(v) for v in expectation.values()):
+        section(lines, "求职意向")
+        for label, key in [("职位", "position"), ("薪资", "salary"), ("城市", "city")]:
+            bullet(lines, label, expectation.get(key))
+        render_mapping(lines, expectation, skip={"position", "salary", "city"})
+
+    experience_sections = [
+        ("工作经历", "work_experience", "经历"),
+        ("项目经历", "project_experience", "项目"),
+        ("教育经历", "education", "教育"),
+        ("竞争力分析", "competitive_analysis", "分析"),
+        ("证书", "certifications", "证书"),
+    ]
+    for title, key, default_title in experience_sections:
+        items = normalize_items(data.get(key))
+        if not items:
+            continue
+        section(lines, title)
+        for item in items:
+            render_experience_item(lines, item, default_title)
+
+    remaining_skip = {"basic", "expectation", *(key for _, key, _ in experience_sections)}
+    remaining = {k: v for k, v in data.items() if k not in remaining_skip and non_empty(v)}
+    if remaining:
+        section(lines, "其他信息")
+        render_mapping(lines, remaining)
+
+    return "\n".join(lines).strip() + "\n"
+
+
+def download_resume(candidate: dict[str, Any], job_enc_id: str, security_id: str, cdp_url: str, boss_bin: str, verbose: bool) -> dict[str, Any]:
+    geek_id = candidate_id(candidate)
+    result = run_boss(
+        ["hr", "resume", geek_id, "--job-id", job_enc_id, "--security-id", security_id],
+        cdp_url=cdp_url,
+        boss_bin=boss_bin,
+        verbose=verbose,
+    )
+    return require_ok(result, f"download resume for {candidate_name(candidate)}")
+
+
+def sync_job(job: dict[str, Any], root: Path, cdp_url: str, boss_bin: str, data_dir: Path, force: bool, dry_run: bool, verbose: bool) -> dict[str, Any]:
+    plain = job_plain_id(job)
+    enc = job_encrypt_id(job)
+    dirname = f"{safe_name(plain)}_{safe_name(job_name(job))}"
+    job_dir = root / "jobs" / dirname
+    resumes_dir = job_dir / "resumes"
+    job_dir.mkdir(parents=True, exist_ok=True)
+    resumes_dir.mkdir(parents=True, exist_ok=True)
+    write_json(job_dir / "job.json", job)
+
+    candidate_index_path = job_dir / "candidate_index.json"
+    candidate_index = ensure_json(candidate_index_path, {"updated_at": None, "job": {"jobId": plain, "encryptJobId": enc, "jobName": job_name(job)}, "candidates": {}})
+    candidate_index.setdefault("candidates", {})
+
+    stats = {
+        "jobId": plain,
+        "encryptJobId": enc,
+        "jobName": job_name(job),
+        "candidates_discovered": 0,
+        "downloaded": 0,
+        "skipped_existing": 0,
+        "pending_security_id": 0,
+        "failed": 0,
+        "failures": [],
+    }
+
+    candidates = list_applications(enc, cdp_url=cdp_url, boss_bin=boss_bin, verbose=verbose)
+    stats["candidates_discovered"] = len(candidates)
+
+    for candidate in candidates:
+        cid = candidate_id(candidate)
+        cname = candidate_name(candidate)
+        existing = candidate_index["candidates"].get(cid, {})
+        candidate_dir = resumes_dir / f"{safe_name(cname)}_{safe_name(cid)}"
+        current = {
+            **existing,
+            "candidateId": cid,
+            "name": cname,
+            "last_seen_at": now_iso(),
+            "source_application": candidate,
+        }
+
+        if existing.get("status") == "downloaded" and not force:
+            stats["skipped_existing"] += 1
+            candidate_index["candidates"][cid] = current
+            continue
+
+        sid = resolve_security_id(candidate, enc, cdp_url=cdp_url, boss_bin=boss_bin, verbose=verbose, data_dir=data_dir)
+        cname = candidate_name(candidate)
+        candidate_dir = resumes_dir / f"{safe_name(cname)}_{safe_name(cid)}"
+        current.update({"name": cname, "source_application": candidate})
+        if not sid:
+            current.update({"status": "pending_security_id", "updated_at": now_iso(), "reason": "securityId not found in applications/friend_detail/candidates fallback"})
+            candidate_index["candidates"][cid] = current
+            stats["pending_security_id"] += 1
+            write_json(candidate_index_path, candidate_index)
+            continue
+
+        current["securityId"] = sid
+        if dry_run:
+            current.update({"status": "dry_run_ready", "updated_at": now_iso()})
+            candidate_index["candidates"][cid] = current
+            continue
+
+        try:
+            resume_envelope = download_resume(candidate, enc, sid, cdp_url=cdp_url, boss_bin=boss_bin, verbose=verbose)
+            candidate_dir.mkdir(parents=True, exist_ok=True)
+            write_json(candidate_dir / "raw_response.json", resume_envelope)
+            write_json(candidate_dir / "resume.json", envelope_data(resume_envelope))
+            markdown_resume = extract_markdown(envelope_data(resume_envelope))
+            (candidate_dir / "resume.md").write_text(markdown_resume, encoding="utf-8")
+            current.update({
+                "status": "downloaded",
+                "downloaded_at": now_iso(),
+                "updated_at": now_iso(),
+                "resume_dir": str(candidate_dir),
+            })
+            stats["downloaded"] += 1
+        except Exception as exc:  # Keep going during bulk sync.
+            message = str(exc)
+            current.update({"status": "failed", "updated_at": now_iso(), "error": message})
+            stats["failed"] += 1
+            stats["failures"].append({"candidateId": cid, "name": cname, "error": message})
+        finally:
+            candidate_index["candidates"][cid] = current
+            candidate_index["updated_at"] = now_iso()
+            write_json(candidate_index_path, candidate_index)
+
+        if not dry_run:
+            time.sleep(random.uniform(3, 6))
+
+    candidate_index["updated_at"] = now_iso()
+    write_json(candidate_index_path, candidate_index)
+    return stats
+
+
+def load_job_index(root: Path) -> dict[str, Any]:
+    return ensure_json(root / "job_index.json", {"jobs": {}})
+
+
+def command_refresh_jobs(args: argparse.Namespace) -> int:
+    jobs = refresh_jobs(args.root, args.cdp_url, args.boss_bin, args.verbose)
+    print(json.dumps({"ok": True, "resume_root": str(args.root), "online_jobs": len(jobs), "jobs": jobs}, ensure_ascii=False, indent=2))
+    return 0
+
+
+def command_sync_all(args: argparse.Namespace) -> int:
+    jobs = refresh_jobs(args.root, args.cdp_url, args.boss_bin, args.verbose)
+    summary = {
+        "ok": True,
+        "resume_root": str(args.root),
+        "mode": "sync-all",
+        "dry_run": args.dry_run,
+        "jobs_discovered": len(jobs),
+        "jobs": [],
+        "totals": {"candidates_discovered": 0, "downloaded": 0, "skipped_existing": 0, "pending_security_id": 0, "failed": 0},
+    }
+    for job in jobs:
+        stats = sync_job(job, args.root, args.cdp_url, args.boss_bin, args.data_dir, args.force, args.dry_run, args.verbose)
+        summary["jobs"].append(stats)
+        for key in summary["totals"]:
+            summary["totals"][key] += int(stats.get(key, 0))
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+    return 0
+
+
+def command_sync_job(args: argparse.Namespace) -> int:
+    refresh_jobs(args.root, args.cdp_url, args.boss_bin, args.verbose)
+    index = load_job_index(args.root)
+    job_entry = index.get("jobs", {}).get(str(args.job_id))
+    if not job_entry:
+        print(json.dumps({"ok": False, "error": f"job not found in job_index: {args.job_id}"}, ensure_ascii=False, indent=2), file=sys.stderr)
+        return 1
+    raw_job = job_entry.get("raw") or job_entry
+    stats = sync_job(raw_job, args.root, args.cdp_url, args.boss_bin, args.data_dir, args.force, args.dry_run, args.verbose)
+    print(json.dumps({"ok": True, "resume_root": str(args.root), "mode": "sync-job", "dry_run": args.dry_run, "job": stats}, ensure_ascii=False, indent=2))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Sync BOSS/Zhipin recruiter application online resumes.")
+    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT, help=f"Resume root directory. Default: {DEFAULT_ROOT}")
+    parser.add_argument("--cdp-url", default=os.environ.get("BOSS_CDP_URL", DEFAULT_CDP_URL), help=f"CDP URL. Default: {DEFAULT_CDP_URL}")
+    parser.add_argument("--boss-bin", default=os.environ.get("BOSS_BIN", DEFAULT_BOSS_BIN), help=f"boss executable path/name. Default: {DEFAULT_BOSS_BIN}")
+    parser.add_argument("--data-dir", type=Path, default=Path(os.environ.get("BOSS_DATA_DIR", str(DEFAULT_BOSS_DATA_DIR))), help=f"boss-agent-cli data directory. Default: {DEFAULT_BOSS_DATA_DIR}")
+    parser.add_argument("--verbose", action="store_true", help="Print executed commands to stderr.")
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub_refresh = sub.add_parser("refresh-jobs", help="Refresh online job index only.")
+    sub_refresh.set_defaults(func=command_refresh_jobs)
+
+    sub_all = sub.add_parser("sync-all", help="Incrementally sync resumes for all online jobs.")
+    sub_all.add_argument("--force", action="store_true", help="Re-download candidates already marked downloaded.")
+    sub_all.add_argument("--dry-run", action="store_true", help="Resolve candidates without downloading resumes.")
+    sub_all.set_defaults(func=command_sync_all)
+
+    sub_job = sub.add_parser("sync-job", help="Incrementally sync one job by numeric or encrypted job ID.")
+    sub_job.add_argument("--job-id", required=True, help="Numeric jobId or encryptJobId from job_index.json.")
+    sub_job.add_argument("--force", action="store_true", help="Re-download candidates already marked downloaded.")
+    sub_job.add_argument("--dry-run", action="store_true", help="Resolve candidates without downloading resumes.")
+    sub_job.set_defaults(func=command_sync_job)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except KeyboardInterrupt:
+        print(json.dumps({"ok": False, "error": "interrupted"}, ensure_ascii=False, indent=2), file=sys.stderr)
+        return 130
+    except Exception as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False, indent=2), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/boss-resume-downloader/scripts/sync_boss_resumes.py
+++ b/skills/boss-resume-downloader/scripts/sync_boss_resumes.py
@@ -751,16 +751,16 @@ def build_parser() -> argparse.ArgumentParser:
     sub_all = sub.add_parser("sync-all", help="Incrementally sync resumes for all online jobs.")
     sub_all.add_argument("--force", action="store_true", help="Re-download candidates already marked downloaded.")
     sub_all.add_argument("--dry-run", action="store_true", help="Resolve candidates without downloading resumes.")
-    sub_all.add_argument("--max-downloads-per-run", type=int, default=400, help="Hard cap on resume downloads across the entire run. Default: 400.")
-    sub_all.add_argument("--max-downloads-per-job", type=int, default=80, help="Hard cap on resume downloads within a single job. Default: 80.")
+    sub_all.add_argument("--max-downloads-per-run", type=int, default=100, help="Hard cap on resume downloads across the entire run. Default: 100.")
+    sub_all.add_argument("--max-downloads-per-job", type=int, default=50, help="Hard cap on resume downloads within a single job. Default: 50.")
     sub_all.set_defaults(func=command_sync_all)
 
     sub_job = sub.add_parser("sync-job", help="Incrementally sync one job by numeric or encrypted job ID.")
     sub_job.add_argument("--job-id", required=True, help="Numeric jobId or encryptJobId from job_index.json.")
     sub_job.add_argument("--force", action="store_true", help="Re-download candidates already marked downloaded.")
     sub_job.add_argument("--dry-run", action="store_true", help="Resolve candidates without downloading resumes.")
-    sub_job.add_argument("--max-downloads-per-run", type=int, default=400, help="Hard cap on resume downloads for this run. Default: 400.")
-    sub_job.add_argument("--max-downloads-per-job", type=int, default=80, help="Hard cap on resume downloads within the job. Default: 80.")
+    sub_job.add_argument("--max-downloads-per-run", type=int, default=100, help="Hard cap on resume downloads for this run. Default: 100.")
+    sub_job.add_argument("--max-downloads-per-job", type=int, default=50, help="Hard cap on resume downloads within the job. Default: 50.")
     sub_job.set_defaults(func=command_sync_job)
 
     return parser

--- a/skills/boss-resume-downloader/scripts/sync_boss_resumes.py
+++ b/skills/boss-resume-downloader/scripts/sync_boss_resumes.py
@@ -535,7 +535,18 @@ def download_resume(candidate: dict[str, Any], job_enc_id: str, security_id: str
     return require_ok(result, f"download resume for {candidate_name(candidate)}")
 
 
-def sync_job(job: dict[str, Any], root: Path, cdp_url: str, boss_bin: str, data_dir: Path, force: bool, dry_run: bool, verbose: bool) -> dict[str, Any]:
+def sync_job(
+    job: dict[str, Any],
+    root: Path,
+    cdp_url: str,
+    boss_bin: str,
+    data_dir: Path,
+    force: bool,
+    dry_run: bool,
+    verbose: bool,
+    max_per_job: int,
+    run_budget: dict[str, int],
+) -> dict[str, Any]:
     plain = job_plain_id(job)
     enc = job_encrypt_id(job)
     dirname = f"{safe_name(plain)}_{safe_name(job_name(job))}"
@@ -559,10 +570,12 @@ def sync_job(job: dict[str, Any], root: Path, cdp_url: str, boss_bin: str, data_
         "pending_security_id": 0,
         "failed": 0,
         "failures": [],
+        "stopped_due_to_limit": None,
     }
 
     candidates = list_applications(enc, cdp_url=cdp_url, boss_bin=boss_bin, verbose=verbose)
     stats["candidates_discovered"] = len(candidates)
+    job_downloads = 0
 
     for candidate in candidates:
         cid = candidate_id(candidate)
@@ -581,6 +594,15 @@ def sync_job(job: dict[str, Any], root: Path, cdp_url: str, boss_bin: str, data_
             stats["skipped_existing"] += 1
             candidate_index["candidates"][cid] = current
             continue
+
+        # Enforce caps before issuing a new resume request. Already-downloaded
+        # / pending / dry-run paths above don't count against the budget.
+        if not dry_run and run_budget["remaining"] <= 0:
+            stats["stopped_due_to_limit"] = "run"
+            break
+        if not dry_run and job_downloads >= max_per_job:
+            stats["stopped_due_to_limit"] = "job"
+            break
 
         sid = resolve_security_id(candidate, enc, cdp_url=cdp_url, boss_bin=boss_bin, verbose=verbose, data_dir=data_dir)
         cname = candidate_name(candidate)
@@ -622,6 +644,11 @@ def sync_job(job: dict[str, Any], root: Path, cdp_url: str, boss_bin: str, data_
             candidate_index["candidates"][cid] = current
             candidate_index["updated_at"] = now_iso()
             write_json(candidate_index_path, candidate_index)
+            # Attempted a real resume request — count it against both budgets
+            # whether it succeeded or failed, since either pattern shows up to
+            # the server.
+            job_downloads += 1
+            run_budget["remaining"] -= 1
 
         if not dry_run:
             time.sleep(random.uniform(3, 6))
@@ -643,20 +670,38 @@ def command_refresh_jobs(args: argparse.Namespace) -> int:
 
 def command_sync_all(args: argparse.Namespace) -> int:
     jobs = refresh_jobs(args.root, args.cdp_url, args.boss_bin, args.verbose)
+    run_budget = {"remaining": args.max_downloads_per_run}
     summary = {
         "ok": True,
         "resume_root": str(args.root),
         "mode": "sync-all",
         "dry_run": args.dry_run,
         "jobs_discovered": len(jobs),
+        "limits": {
+            "max_downloads_per_run": args.max_downloads_per_run,
+            "max_downloads_per_job": args.max_downloads_per_job,
+        },
+        "stopped_due_to_limit": None,
         "jobs": [],
         "totals": {"candidates_discovered": 0, "downloaded": 0, "skipped_existing": 0, "pending_security_id": 0, "failed": 0},
     }
     for job in jobs:
-        stats = sync_job(job, args.root, args.cdp_url, args.boss_bin, args.data_dir, args.force, args.dry_run, args.verbose)
+        if not args.dry_run and run_budget["remaining"] <= 0:
+            summary["stopped_due_to_limit"] = "run"
+            break
+        stats = sync_job(
+            job, args.root, args.cdp_url, args.boss_bin, args.data_dir,
+            args.force, args.dry_run, args.verbose,
+            args.max_downloads_per_job, run_budget,
+        )
         summary["jobs"].append(stats)
         for key in summary["totals"]:
             summary["totals"][key] += int(stats.get(key, 0))
+        if stats.get("stopped_due_to_limit") == "run":
+            summary["stopped_due_to_limit"] = "run"
+            break
+        if stats.get("stopped_due_to_limit") == "job" and summary["stopped_due_to_limit"] is None:
+            summary["stopped_due_to_limit"] = "job"
     print(json.dumps(summary, ensure_ascii=False, indent=2))
     return 0
 
@@ -669,8 +714,24 @@ def command_sync_job(args: argparse.Namespace) -> int:
         print(json.dumps({"ok": False, "error": f"job not found in job_index: {args.job_id}"}, ensure_ascii=False, indent=2), file=sys.stderr)
         return 1
     raw_job = job_entry.get("raw") or job_entry
-    stats = sync_job(raw_job, args.root, args.cdp_url, args.boss_bin, args.data_dir, args.force, args.dry_run, args.verbose)
-    print(json.dumps({"ok": True, "resume_root": str(args.root), "mode": "sync-job", "dry_run": args.dry_run, "job": stats}, ensure_ascii=False, indent=2))
+    run_budget = {"remaining": args.max_downloads_per_run}
+    stats = sync_job(
+        raw_job, args.root, args.cdp_url, args.boss_bin, args.data_dir,
+        args.force, args.dry_run, args.verbose,
+        args.max_downloads_per_job, run_budget,
+    )
+    print(json.dumps({
+        "ok": True,
+        "resume_root": str(args.root),
+        "mode": "sync-job",
+        "dry_run": args.dry_run,
+        "limits": {
+            "max_downloads_per_run": args.max_downloads_per_run,
+            "max_downloads_per_job": args.max_downloads_per_job,
+        },
+        "stopped_due_to_limit": stats.get("stopped_due_to_limit"),
+        "job": stats,
+    }, ensure_ascii=False, indent=2))
     return 0
 
 
@@ -690,12 +751,16 @@ def build_parser() -> argparse.ArgumentParser:
     sub_all = sub.add_parser("sync-all", help="Incrementally sync resumes for all online jobs.")
     sub_all.add_argument("--force", action="store_true", help="Re-download candidates already marked downloaded.")
     sub_all.add_argument("--dry-run", action="store_true", help="Resolve candidates without downloading resumes.")
+    sub_all.add_argument("--max-downloads-per-run", type=int, default=400, help="Hard cap on resume downloads across the entire run. Default: 400.")
+    sub_all.add_argument("--max-downloads-per-job", type=int, default=80, help="Hard cap on resume downloads within a single job. Default: 80.")
     sub_all.set_defaults(func=command_sync_all)
 
     sub_job = sub.add_parser("sync-job", help="Incrementally sync one job by numeric or encrypted job ID.")
     sub_job.add_argument("--job-id", required=True, help="Numeric jobId or encryptJobId from job_index.json.")
     sub_job.add_argument("--force", action="store_true", help="Re-download candidates already marked downloaded.")
     sub_job.add_argument("--dry-run", action="store_true", help="Resolve candidates without downloading resumes.")
+    sub_job.add_argument("--max-downloads-per-run", type=int, default=400, help="Hard cap on resume downloads for this run. Default: 400.")
+    sub_job.add_argument("--max-downloads-per-job", type=int, default=80, help="Hard cap on resume downloads within the job. Default: 80.")
     sub_job.set_defaults(func=command_sync_job)
 
     return parser


### PR DESCRIPTION
## 背景

boss-agent-cli 的原子命令能力已经很完整（`hr applications` / `hr resume` / `hr candidates` / `hr chat` 等），但实际招聘场景中往往需要把多条命令组合成一个完整的工作流——批量拉取简历、跨会话保留状态、对所有候选人做本地比对分析。这个 skill 就是为了填补这个组合层的空缺。

## 变更内容

新增 `skills/boss-resume-downloader/`，包含：

- `SKILL.md`：完整操作手册，供 Claude Code / Claude Desktop / Cursor 等 agent 工具直接读取和执行
- `scripts/sync_boss_resumes.py`：独立 Python 脚本，封装全量 / 单岗位增量同步逻辑，维护 `job_index.json` 与 `candidate_index.json` 跨会话索引
- `references/boss_recruiter_notes.md`：已验证的招聘者状态与关键实现备注

## 核心推荐用法：hourly 增量同步 + 本地分析

**强烈建议用 agent 定时任务每小时跑一次增量同步，而不是一次性批量下载。**

```bash
# Claude Code
/loop 1h python skills/boss-resume-downloader/scripts/sync_boss_resumes.py sync-all

# 或用系统 cron
0 * * * * python ~/path/to/sync_boss_resumes.py sync-all
```

### 好处一：规避风控

BOSS 会检测异常访问模式。一次性下载大量份简历行为特征接近爬虫（我们公司的热门岗位每天有 300+ 投递），容易触发临时封禁或验证码。

分散到每小时执行，每次仅下载当小时新投递的若干份，与正常招聘者浏览行为无异，风险极低。

脚本内置 3–6 秒随机延迟，进一步模拟人工操作节奏。

### 好处二：本地分析速度快

简历以 `resume.md` 落盘后，所有分析（按关键词筛选、候选人比对、经历摘要、排名）均在本地完成：

- 无网络往返
- 无 BOSS API 限速
- 无额外费用
- agent 可一次性读取全部文件后综合判断

典型 prompt 示例：

> "读取 ~/WorkBuddy/boss-resumes 下所有 resume.md，列出有 Python + 爬虫经验的候选人"
> "比较所有候选人的工作年限和最近一份工作，按相关度排序"

## hourly 增量同步执行流程

```
每小时触发
     │
     ▼
[sync-all]
     │
     ├─ hr jobs list ──────────────────► 更新 job_index.json
     │
     ├─ hr applications (分页) ────────► 发现新投递候选人
     │
     ├─ 解析 securityId
     │    ├─ 已在 applications 响应中 ──► 直接使用
     │    ├─ 缺失 → friend_detail() ───► 内部 API 补全
     │    └─ 仍缺失 ─────────────────► 标记 pending，下次重试
     │
     ├─ hr resume <geekId> \
     │    --job-id <encryptJobId> \
     │    --security-id <securityId>  ──► 下载简历 JSON
     │
     ├─ 生成 resume.md ────────────────► 落盘到本地
     │
     └─ 更新 candidate_index.json ─────► 记录状态，跳过已下载
```

**结果**：`~/WorkBuddy/boss-resumes/jobs/<岗位>/resumes/<候选人>/resume.md` 持续增量积累，无重复下载。

### 关于 CLI 原子能力的组合价值

boss-agent-cli 的每条命令都是精确的原子操作，单独使用已经很强。这个 skill 展示了如何把原子能力组合成有实际业务价值的工作流：

| 原子命令 | skill 中的角色 |
|---|---|
| `hr jobs list` | 发现当前在招岗位，建立岗位索引 |
| `hr applications` | 分页拉取所有投递候选人 |
| `friend_detail()` 内部 API | 补全缺失的 `securityId` |
| `hr resume` | 按候选人下载在线简历 |
| 本地 `resume.md` | 作为分析层的统一数据源 |

组合后的效果远大于各部分之和：从"能查单个简历"升级到"持续维护完整候选人库，随时可做批量分析"。

## 技术细节

- **跨平台**：macOS / Linux / Windows，boss 命令走 PATH，Windows 提供 `boss.cmd` 备用路径
- **增量幂等**：`candidate_index.json` 记录下载状态，已下载的候选人自动跳过，支持 `--force` 强制重下
- **安全降级**：`securityId` 解析失败时记录为 `pending_security_id` 而非 `failed`，下次运行自动重试
- **透明调试**：`--verbose` 输出每条 boss 命令；`friend_detail` import 失败时打印原因到 stderr
- **分页上限保护**：超过 100 页时打印警告，不静默截断

## 文件清单

```
skills/boss-resume-downloader/
├── SKILL.md                          # agent 工具读取的操作手册
├── references/
│   └── boss_recruiter_notes.md       # 已验证的招聘者状态与关键实现备注
└── scripts/
    └── sync_boss_resumes.py          # 独立同步脚本
```

---

## 2025-05-18 更新

**调低默认下载上限**：`--max-downloads-per-run` 400 → 100，`--max-downloads-per-job` 80 → 50。

实测以 hourly 增量模式累积保存逾千份简历，全程未触发封禁。真正有效的防风控手段不是限制单次上限的绝对值，而是**访问模式**：定时任务 + 增量落盘，每次只取新投递的少量简历，与正常招聘者浏览行为一致；后续所有分析在本地 `resume.md` 上完成，无需反复在线拉取。相比每次直接在线批量分析，这条路径对平台的请求量低一个数量级，也更安全。
