### PR TITLE
fix: 修复沟通列表空消息崩溃

### DIFF
--- a/src/boss_agent_cli/commands/chat.py
+++ b/src/boss_agent_cli/commands/chat.py
@@ -105,6 +105,13 @@ def chat_cmd(ctx: click.Context, page: int, from_who: str | None, days: int | No
 				last_time_str = _format_ts(last_ts)
 			else:
 				last_time_str = item.get("lastTime", "-")
+			last_message_info = item.get("lastMessageInfo") or {}
+			message_status = last_message_info.get("status")
+			msg_status_label = (
+				_MSG_STATUS_LABELS.get(message_status, "未知")
+				if isinstance(message_status, int)
+				else "未知"
+			)
 
 			friends.append({
 				"name": item.get("name") or "-",
@@ -114,9 +121,7 @@ def chat_cmd(ctx: click.Context, page: int, from_who: str | None, days: int | No
 				"last_msg": item.get("lastMsg") or "-",
 				"last_time": last_time_str,
 				"last_ts": last_ts,
-				"msg_status": _MSG_STATUS_LABELS.get(
-					item.get("lastMessageInfo", {}).get("status"), "未知"
-				),
+				"msg_status": msg_status_label,
 				"security_id": item.get("securityId") or "",
 				"encrypt_job_id": item.get("encryptJobId") or "",
 				"unread": item.get("unreadMsgCount") or 0,

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -805,6 +805,31 @@ def test_chat_days_filter(mock_auth_cls, mock_client_cls):
 
 @patch("boss_agent_cli.commands.chat.get_platform_instance")
 @patch("boss_agent_cli.commands.chat.AuthManager")
+def test_chat_handles_null_last_message_info(mock_auth_cls, mock_client_cls):
+	"""BOSS 可能返回 lastMessageInfo=null，chat 应兜底而不是崩溃。"""
+	import time
+	now_ms = int(time.time() * 1000)
+	mock_auth_cls.return_value.check_status.return_value = {"cookies": {}}
+	_ctx_mock(mock_client_cls)
+	item = _make_friend_item("HR", "腾讯", 2, now_ms)
+	item["lastMsg"] = None
+	item["lastMessageInfo"] = None
+	mock_client_cls.return_value.friend_list.return_value = {
+		"zpData": {
+			"result": [item],
+		},
+	}
+	runner = CliRunner()
+	result = runner.invoke(cli, ["chat"])
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"][0]["last_msg"] == "-"
+	assert parsed["data"][0]["msg_status"] == "未知"
+
+
+@patch("boss_agent_cli.commands.chat.get_platform_instance")
+@patch("boss_agent_cli.commands.chat.AuthManager")
 def test_chat_combined_filter(mock_auth_cls, mock_client_cls):
 	"""--from boss --days 3 组合筛选"""
 	import time


### PR DESCRIPTION
## 关联 Issue / Related Issue

无。当前是独立修复。

## 变更说明 / Summary

修复 `chat` 在 `friend_list` 返回 `lastMessageInfo: null` 时的崩溃；对空消息记录兜底为 `last_msg: "-"`、`msg_status: "未知"`，并补充回归测试。

## 变更类型 / Type

- [x] fix: Bug 修复

## Breaking Change

- [x] 本 PR 不包含 破坏性变更

## 测试 / Test Plan

- [x] `uv run pytest tests/ -q` 全部通过
- [x] `uv run ruff check src/ tests/` 无报错
- [x] `uv run mypy src/boss_agent_cli` 无报错
- [x] `uv run boss --help` 可加载
- [x] `uv run boss schema --format native` 返回合法 JSON 信封
- [x] 新增/修改的功能已有对应测试覆盖
- [x] 本地跑过 `boss chat`，真实返回的空消息会话不再崩溃

## Docs & Contracts

- [x] 无新增命令 / MCP 工具 / 错误码 / CLI 契约变更

## Safety & Convention

- [x] commit message 格式符合要求
- [x] 无敏感信息
- [x] 已检查 `docs/platform-risk.md` 不涉及新增风险项