### PR TITLE
Stabilize BOSS search and add AI PM market scan

### DIFF
--- a/src/boss_agent_cli/api/browser_client.py
+++ b/src/boss_agent_cli/api/browser_client.py
@@ -12,6 +12,7 @@ import time
 from pathlib import Path
 from types import TracebackType
 from typing import Any, cast
+from urllib.parse import urlencode
 
 from patchright.sync_api import sync_playwright
 
@@ -20,6 +21,19 @@ from boss_agent_cli.api.throttle import RequestThrottle
 from boss_agent_cli.auth.browser import _DEFAULT_CDP_URL as CDP_DEFAULT_URL
 
 HOME_URL = "https://www.zhipin.com/"
+SEARCH_PAGE_URL = "https://www.zhipin.com/web/geek/jobs"
+
+
+def _pick_existing_platform_page(context: Any) -> Any | None:
+	"""优先复用已存在的 zhipin 页面，避免新建 CDP page 导航时销毁执行上下文。"""
+	for page in context.pages:
+		try:
+			url = page.url or ""
+		except Exception:
+			continue
+		if "zhipin.com" in url:
+			return page
+	return None
 
 
 class RecruiterChatTabRequired(RuntimeError):
@@ -38,8 +52,10 @@ class RecruiterChatTabRequired(RuntimeError):
 
 # 超时常量
 _CDP_PROBE_TIMEOUT = 3           # CDP 探测 HTTP 超时（秒）
+_CDP_CONNECT_TIMEOUT_MS = 5000   # CDP 建连超时（毫秒）
 _NAV_TIMEOUT_MS = 15000          # 页面导航超时（毫秒）
 _HEADLESS_NETWORKIDLE_GRACE_MS = 3000  # headless 预热的额外宽限，避免卡满 30s
+_SEARCH_RESPONSE_TIMEOUT_MS = 8000      # 搜索页真实 joblist 响应等待超时（毫秒）
 
 # macOS / Linux / Windows Chrome user data 默认路径
 _CHROME_USER_DATA_CANDIDATES = [
@@ -123,24 +139,30 @@ class BrowserSession:
 		  2. Default http://localhost:9222 (+ auto WS fallback)
 		  3. WebSocket URL from Chrome's DevToolsActivePort file
 		"""
-		urls_to_try = []
-		if self._cdp_url:
-			urls_to_try.append(self._cdp_url)
-		urls_to_try.append(CDP_DEFAULT_URL)
+		urls_to_try: list[str] = []
+		seen: set[str] = set()
+
+		def add_url(candidate: str | None) -> None:
+			if candidate and candidate not in seen:
+				urls_to_try.append(candidate)
+				seen.add(candidate)
+
+		# 先尝试 WebSocket 端点，避免 connect_over_cdp(http://...) 在部分环境长时间卡住。
+		if self._cdp_url and self._cdp_url.startswith("ws"):
+			add_url(self._cdp_url)
+		elif self._cdp_url:
+			add_url(self._fetch_ws_url(self._cdp_url))
+			add_url(self._cdp_url)
+
+		add_url(self._fetch_ws_url(CDP_DEFAULT_URL))
+		add_url(CDP_DEFAULT_URL)
 
 		# 从 DevToolsActivePort 文件读取 WebSocket URL
-		ws_url = self._read_devtools_active_port()
-		if ws_url:
-			urls_to_try.append(ws_url)
+		add_url(self._read_devtools_active_port())
 
 		for url in urls_to_try:
 			if self._try_connect(url):
 				return True
-			# HTTP URL 连接失败时，尝试从 /json/version 获取 WS URL
-			if url.startswith("http"):
-				ws = self._fetch_ws_url(url)
-				if ws and self._try_connect(ws):
-					return True
 		return False
 
 	def _try_connect(self, url: str) -> bool:
@@ -151,7 +173,7 @@ class BrowserSession:
 		a new context when none exists.
 		"""
 		try:
-			self._browser = self._pw.chromium.connect_over_cdp(url)
+			self._browser = self._pw.chromium.connect_over_cdp(url, timeout=_CDP_CONNECT_TIMEOUT_MS)
 			contexts = self._browser.contexts
 
 			if contexts:
@@ -168,15 +190,19 @@ class BrowserSession:
 					])
 				self._own_context = True
 
-			self._page = self._context.new_page()
-			# CDP 模式下用较长超时 + commit 级等待（避免 networkidle 卡住）
-			try:
-				self._page.goto(HOME_URL, wait_until="commit", timeout=_NAV_TIMEOUT_MS)
-			except Exception:
-				pass  # 即使导航超时，页面 JS 环境已可用
+			reused_page = _pick_existing_platform_page(self._context)
+			if reused_page is not None:
+				self._page = reused_page
+			else:
+				self._page = self._context.new_page()
+				# CDP 模式下用较长超时 + commit 级等待（避免 networkidle 卡住）
+				try:
+					self._page.goto(HOME_URL, wait_until="commit", timeout=_NAV_TIMEOUT_MS)
+				except Exception:
+					pass  # 即使导航超时，页面 JS 环境已可用
 			self._started = True
 			self._is_cdp = True
-			reuse_label = "复用用户 context" if not self._own_context else "新建 context"
+			reuse_label = "复用用户 context + 现有页面" if reused_page is not None else ("复用用户 context" if not self._own_context else "新建 context")
 			self._log(f"[boss] CDP 连接成功 ({url})，{reuse_label}")
 			return True
 		except Exception:
@@ -193,7 +219,7 @@ class BrowserSession:
 		"""Fetch WebSocket debugger URL from Chrome's /json/version endpoint."""
 		import httpx
 		try:
-			resp = httpx.get(f"{http_url}/json/version", timeout=_CDP_PROBE_TIMEOUT)
+			resp = httpx.get(f"{http_url}/json/version", timeout=_CDP_PROBE_TIMEOUT, trust_env=False)
 			payload = resp.json()
 			if not isinstance(payload, dict):
 				return None
@@ -243,30 +269,31 @@ class BrowserSession:
 		self._is_cdp = False
 		self._log("[boss] CDP 不可用（提示：需以 --remote-debugging-port=9222 启动 Chrome），降级到 headless patchright")
 
-	# ── Core request via browser fetch() ─────────────────────────────
+	def _navigate_for_search(self, data: dict[str, Any]) -> None:
+		"""先导航到真实搜索页，建立和前端一致的运行时上下文。"""
+		params: dict[str, Any] = {}
+		if query := data.get("query"):
+			params["query"] = str(query)
+		if city := data.get("city"):
+			params["city"] = str(city)
+		target = SEARCH_PAGE_URL
+		if params:
+			target = f"{target}?{urlencode(params)}"
+		try:
+			self._page.goto(target, wait_until="domcontentloaded", timeout=_NAV_TIMEOUT_MS)
+		except Exception as e:
+			self._log(f"[boss] 搜索页导航未完全完成（{e}），继续尝试页内搜索请求")
 
-	def request(self, method: str, url: str, *, params: dict[str, Any] | None = None, data: dict[str, Any] | None = None) -> dict[str, Any]:
-		self._ensure_started()
-		self._throttle.wait()
-
-		referer = endpoints.REFERER_MAP.get(url, f"{endpoints.BASE_URL}/")
-
-		# Bridge 模式：通过扩展 fetch
-		if self._is_bridge and self._bridge_client:
-			import urllib.parse
-			full_url = url
-			if params:
-				full_url = f"{url}?{urllib.parse.urlencode(params)}"
-			result = self._bridge_client.fetch_json(
-				full_url,
-				method=method,
-				data=data,
-				referer=referer,
-			)
-			self._throttle.mark()
-			return cast("dict[str, Any]", result)
-
-		# Playwright 模式（CDP 或 headless）
+	def _fetch_json_in_page(
+		self,
+		method: str,
+		url: str,
+		*,
+		params: dict[str, Any] | None = None,
+		data: dict[str, Any] | None = None,
+		referer: str,
+	) -> dict[str, Any]:
+		"""在当前页面上下文里直接发 fetch 请求并返回 JSON。"""
 		result = self._page.evaluate("""
 			async ({method, url, params, data, referer}) => {
 				try {
@@ -305,7 +332,134 @@ class BrowserSession:
 				}
 			}
 		""", {"method": method, "url": url, "params": params or {}, "data": data, "referer": referer})
+		return cast("dict[str, Any]", result)
 
+	def _cdp_http_url(self) -> str:
+		"""Resolve the CDP HTTP endpoint used by raw websocket helpers."""
+		if self._cdp_url and self._cdp_url.startswith("http"):
+			return self._cdp_url.rstrip("/")
+		return CDP_DEFAULT_URL
+
+	def _search_request_via_raw_cdp(self, url: str, data: dict[str, Any], referer: str) -> dict[str, Any] | None:
+		"""Use a raw CDP temp page for search to avoid patchright CDP attach instability."""
+		cdp_http_url = self._cdp_http_url()
+		if not self._fetch_ws_url(cdp_http_url):
+			return None
+		params: dict[str, str] = {}
+		if query := data.get("query"):
+			params["query"] = str(query)
+		if city := data.get("city"):
+			params["city"] = str(city)
+		search_page_url = SEARCH_PAGE_URL
+		if params:
+			search_page_url = f"{search_page_url}?{urlencode(params)}"
+		return _cdp_fetch_in_temp_page(cdp_http_url, search_page_url, "POST", url, params=None, data=data, referer=referer)
+
+	def _detail_request_via_raw_cdp(self, url: str, params: dict[str, Any], referer: str) -> dict[str, Any] | None:
+		"""Use a raw CDP temp page for detail when httpx stoken refresh fails."""
+		cdp_http_url = self._cdp_http_url()
+		if not self._fetch_ws_url(cdp_http_url):
+			return None
+		job_id = str(params.get("encryptJobId", ""))
+		page_params = {"jid": job_id} if job_id else {}
+		page_url = endpoints.WEB_GEEK_JOB_URL
+		if page_params:
+			page_url = f"{page_url}?{urlencode(page_params)}"
+		return _cdp_fetch_in_temp_page(cdp_http_url, page_url, "GET", url, params=params, data=None, referer=referer)
+
+	def _consume_search_page_response(self, url: str, data: dict[str, Any]) -> dict[str, Any]:
+		"""等待真实搜索页自己发出的 joblist 响应。"""
+		with self._page.expect_response(
+			lambda resp: (
+				resp.request.method == "POST"
+				and url in resp.url
+			),
+			timeout=_SEARCH_RESPONSE_TIMEOUT_MS,
+		) as response_info:
+			self._navigate_for_search(data)
+
+		resp = response_info.value
+		return cast("dict[str, Any]", resp.json())
+
+	def _search_request(self, url: str, data: dict[str, Any], referer: str) -> dict[str, Any]:
+		"""搜索专用请求：优先消费真实页面响应，超时后降级为页内 fetch。"""
+		last_error: Exception | None = None
+		for attempt in range(2):
+			try:
+				result = self._consume_search_page_response(url, data)
+			except Exception as e:
+				last_error = e
+				self._log(f"[boss] 未等到真实搜索页响应（{e}），降级为页内 fetch")
+				try:
+					self._navigate_for_search(data)
+					result = self._fetch_json_in_page("POST", url, data=data, referer=referer)
+				except Exception as fetch_error:
+					last_error = fetch_error
+					if attempt == 0:
+						self._log(f"[boss] 搜索页内 fetch 失败（{fetch_error}），重试一次")
+						continue
+					raise
+			if attempt == 0 and isinstance(result, dict) and result.get("code") == endpoints.CODE_STOKEN_EXPIRED:
+				self._log("[boss] 搜索返回 code 37，重建搜索页上下文后重试一次")
+				continue
+			return cast("dict[str, Any]", result)
+		if last_error is not None:
+			raise last_error
+		return {"code": -1, "message": "search request failed", "zpData": {}}
+
+	# ── Core request via browser fetch() ─────────────────────────────
+
+	def request(self, method: str, url: str, *, params: dict[str, Any] | None = None, data: dict[str, Any] | None = None) -> dict[str, Any]:
+		self._throttle.wait()
+
+		referer = endpoints.REFERER_MAP.get(url, f"{endpoints.BASE_URL}/")
+
+		if method == "POST" and url == endpoints.SEARCH_URL and data:
+			try:
+				raw_cdp_result = self._search_request_via_raw_cdp(url, data, referer)
+			except Exception as e:
+				self._log(f"[boss] 原生 CDP 搜索失败（{e}），回退到浏览器附着链路")
+			else:
+				if raw_cdp_result is not None:
+					self._throttle.mark()
+					return cast("dict[str, Any]", raw_cdp_result)
+
+		if method == "GET" and url == endpoints.DETAIL_URL and params:
+			try:
+				raw_cdp_result = self._detail_request_via_raw_cdp(url, params, referer)
+			except Exception as e:
+				self._log(f"[boss] 原生 CDP 详情失败（{e}），回退到浏览器附着链路")
+			else:
+				if raw_cdp_result is not None:
+					self._throttle.mark()
+					return cast("dict[str, Any]", raw_cdp_result)
+
+		self._ensure_started()
+
+
+		# Bridge 模式：通过扩展 fetch
+		if self._is_bridge and self._bridge_client:
+			import urllib.parse
+			full_url = url
+			if params:
+				full_url = f"{url}?{urllib.parse.urlencode(params)}"
+			result = self._bridge_client.fetch_json(
+				full_url,
+				method=method,
+				data=data,
+				referer=referer,
+			)
+			self._throttle.mark()
+			return cast("dict[str, Any]", result)
+
+		# 搜索接口对页面上下文更敏感：先进入真实搜索页，再发页内请求更稳定。
+		if method == "POST" and url == endpoints.SEARCH_URL and data:
+			result = self._search_request(url, data, referer)
+			self._throttle.mark()
+			return cast("dict[str, Any]", result)
+
+		# Playwright 模式（CDP 或 headless）
+		result = self._fetch_json_in_page(method, url, params=params, data=data, referer=referer)
 		self._throttle.mark()
 		return cast("dict[str, Any]", result)
 
@@ -371,7 +525,12 @@ class BrowserSession:
 
 		if self._is_cdp:
 			# CDP 模式：关闭我们创建的 page 和 context，不关闭用户浏览器
-			if self._page:
+			if self._page and self._own_context:
+				try:
+					self._page.close()
+				except Exception:
+					pass
+			elif self._page and self._context and self._page not in getattr(self._context, "pages", []):
 				try:
 					self._page.close()
 				except Exception:
@@ -580,3 +739,139 @@ def _cdp_evaluate_with_chat_events_in_chat_tab(
 				"bytes": len(bs),
 				"utf8_bits": _carve_utf8_bits(bs)[:10],
 			})
+
+
+def _cdp_fetch_in_temp_page(
+	cdp_http_url: str,
+	page_url: str,
+	method: str,
+	api_url: str,
+	*,
+	params: dict[str, Any] | None,
+	data: dict[str, Any] | None,
+	referer: str,
+) -> dict[str, Any]:
+	"""Open a temporary CDP page, navigate to a same-origin page, then run fetch there."""
+	import json as _json
+	import urllib.request
+
+	import websockets.sync.client as _ws_client
+
+	create_url = cdp_http_url.rstrip("/") + "/json/new?" + page_url
+	close_url_template = cdp_http_url.rstrip("/") + "/json/close/{target_id}"
+	target_id = ""
+	target_ws = ""
+
+	try:
+		req = urllib.request.Request(create_url, method="PUT")
+		with urllib.request.urlopen(req, timeout=5) as resp:
+			payload = _json.load(resp)
+			target_id = cast("str", payload["id"])
+			target_ws = cast("str", payload["webSocketDebuggerUrl"])
+	except Exception as exc:
+		raise RuntimeError(f"cannot create CDP search page: {exc}") from exc
+
+	script = """
+		async ({method, apiUrl, params, data, referer}) => {
+			let fetchUrl = apiUrl;
+			if (params && Object.keys(params).length > 0) {
+				const sp = new URLSearchParams();
+				for (const [k, v] of Object.entries(params)) {
+					if (v !== null && v !== undefined) sp.append(k, String(v));
+				}
+				fetchUrl = apiUrl + '?' + sp.toString();
+			}
+			const options = {
+				method,
+				credentials: 'include',
+				headers: {
+					'Accept': 'application/json, text/plain, */*',
+					'Referer': referer,
+					'X-Requested-With': 'XMLHttpRequest',
+				},
+			};
+			if (method === 'POST' && data) {
+				options.headers['Content-Type'] = 'application/x-www-form-urlencoded';
+				const formData = new URLSearchParams();
+				for (const [k, v] of Object.entries(data)) {
+					if (v !== null && v !== undefined) formData.append(k, String(v));
+				}
+				options.body = formData.toString();
+			}
+			const resp = await fetch(fetchUrl, options);
+			return await resp.json();
+		}
+	"""
+
+	try:
+		with _ws_client.connect(target_ws, max_size=8 * 1024 * 1024) as ws:
+			ws.send(_json.dumps({
+				"id": 1,
+				"method": "Page.enable",
+			}))
+			ws.send(_json.dumps({
+				"id": 2,
+				"method": "Runtime.enable",
+			}))
+			ws.send(_json.dumps({
+				"id": 3,
+				"method": "Page.navigate",
+				"params": {"url": page_url},
+			}))
+
+			deadline = time.time() + 15.0
+			load_fired = False
+			while time.time() < deadline:
+				raw = ws.recv(timeout=max(0.1, deadline - time.time()))
+				msg = _json.loads(raw)
+				if msg.get("method") == "Page.loadEventFired":
+					load_fired = True
+					break
+			if not load_fired:
+				raise RuntimeError("CDP Page.navigate timed out after 15s")
+
+			expression = _build_eval_expression(script, {
+				"method": method,
+				"apiUrl": api_url,
+				"params": params or {},
+				"data": data,
+				"referer": referer,
+			})
+			ws.send(_json.dumps({
+				"id": 4,
+				"method": "Runtime.evaluate",
+				"params": {
+					"expression": expression,
+					"returnByValue": True,
+					"awaitPromise": True,
+				},
+			}))
+
+			eval_deadline = time.time() + 30.0
+			while time.time() < eval_deadline:
+				raw = ws.recv(timeout=max(0.1, eval_deadline - time.time()))
+				msg = _json.loads(raw)
+				if msg.get("id") != 4:
+					continue
+				err = msg.get("error")
+				if err:
+					raise RuntimeError(f"CDP Runtime.evaluate error: {err}")
+				result = msg.get("result", {}).get("result", {})
+				if "value" in result:
+					value = result["value"]
+					return cast("dict[str, Any]", value)
+				exc_details = msg.get("result", {}).get("exceptionDetails")
+				if exc_details:
+					raise RuntimeError(
+						f"JS exception: {exc_details.get('text')} — "
+						f"{exc_details.get('exception', {}).get('description', '')[:300]}"
+					)
+			raise RuntimeError("CDP search evaluate timed out after 30s")
+	finally:
+		if target_id:
+			try:
+				req = urllib.request.Request(close_url_template.format(target_id=target_id), method="GET")
+				with urllib.request.urlopen(req, timeout=5):
+					pass
+			except Exception:
+				pass

--- a/src/boss_agent_cli/api/client.py
+++ b/src/boss_agent_cli/api/client.py
@@ -111,7 +111,7 @@ class BossClient:
 			stoken = token.get("stoken", "")
 
 			if method == "GET":
-				params = kwargs.get("params", {})
+				params = dict(kwargs.get("params", {}))
 				params["__zp_stoken__"] = stoken
 				kwargs["params"] = params
 
@@ -174,10 +174,27 @@ class BossClient:
 
 	# ── Public API ───────────────────────────────────────────────────
 	# High-risk: search, recommend, greet, job_card → browser channel
-	# Low-risk: status, me, cities, schema, detail → httpx channel
+	# Low-risk: status, me, cities, schema → httpx channel
 
 	def search_jobs(self, query: str, **filters: Any) -> dict[str, Any]:
-		params: dict[str, Any] = {"query": query, "page": filters.get("page", 1)}
+		params: dict[str, Any] = {
+			"query": query,
+			"page": filters.get("page", 1),
+			"pageSize": filters.get("page_size", 15),
+			"expectInfo": "",
+			"multiSubway": "",
+			"multiBusinessDistrict": "",
+			"position": "",
+			"jobType": "",
+			"salary": "",
+			"experience": "",
+			"degree": "",
+			"industry": "",
+			"scale": "",
+			"stage": "",
+			"scene": 1,
+			"encryptExpectId": "",
+		}
 		if city := filters.get("city"):
 			code = endpoints.CITY_CODES.get(city)
 			if code is None:
@@ -211,7 +228,7 @@ class BossClient:
 			code = endpoints.JOB_TYPE_CODES.get(job_type)
 			if code:
 				params["jobType"] = code
-		return self._browser_request("GET", endpoints.SEARCH_URL, params=params)
+		return self._browser_request("POST", endpoints.SEARCH_URL, data=params)
 
 	def recommend_jobs(self, page: int = 1) -> dict[str, Any]:
 		params = {"page": page}
@@ -253,7 +270,13 @@ class BossClient:
 
 	def job_detail(self, job_id: str) -> dict[str, Any]:
 		params = {"encryptJobId": job_id}
-		return self._request("GET", endpoints.DETAIL_URL, params=params)
+		try:
+			result = self._request("GET", endpoints.DETAIL_URL, params=params)
+		except Exception:
+			return self._browser_request("GET", endpoints.DETAIL_URL, params=params)
+		if result.get("code") == endpoints.CODE_STOKEN_EXPIRED:
+			return self._browser_request("GET", endpoints.DETAIL_URL, params=params)
+		return result
 
 	def user_info(self) -> dict[str, Any]:
 		return self._request("GET", endpoints.USER_INFO_URL)

--- a/src/boss_agent_cli/auth/browser.py
+++ b/src/boss_agent_cli/auth/browser.py
@@ -54,6 +54,38 @@ def _extract_zhilian_client_id(page: Any) -> str:
 		return ""
 
 
+def _collect_cdp_token(ctx: Any, *, platform: str, cookie_domain: str) -> dict[str, Any]:
+	"""从当前 CDP context 收集已登录 token。"""
+	all_cookies = {c["name"]: c["value"] for c in ctx.cookies() if cookie_domain in c.get("domain", "")}
+
+	extraction_page = None
+	for candidate in ctx.pages:
+		try:
+			if cookie_domain in candidate.url:
+				extraction_page = candidate
+				break
+		except Exception:
+			continue
+
+	if extraction_page is None:
+		extraction_page = ctx.new_page()
+		try:
+			extraction_page.goto(_get_platform_config(platform)["home_url"], wait_until="commit", timeout=_NAV_TIMEOUT_MS)
+		except Exception:
+			pass
+
+	ua = extraction_page.evaluate("navigator.userAgent")
+	stoken = all_cookies.get("__zp_stoken__", "") if platform == "zhipin" else ""
+	if platform == "zhipin" and not stoken:
+		stoken = _extract_stoken(extraction_page)
+	x_zp_client_id = _extract_zhilian_client_id(extraction_page) if platform == "zhilian" else ""
+
+	result: dict[str, Any] = {"cookies": all_cookies, "stoken": stoken, "user_agent": ua}
+	if x_zp_client_id:
+		result["x_zp_client_id"] = x_zp_client_id
+	return result
+
+
 def _warm_home_for_runtime(page: Any, home_url: str, *, stage: str) -> None:
 	"""预热首页运行时；networkidle 只尽力等待，不作为必须条件。"""
 	try:
@@ -71,10 +103,91 @@ def probe_cdp(cdp_url: str | None = None) -> str | None:
 	import httpx
 	base = cdp_url or _DEFAULT_CDP_URL
 	try:
-		resp = httpx.get(f"{base}/json/version", timeout=_CDP_PROBE_TIMEOUT)
+		# 本地 CDP 端口不应走环境代理；部分用户代理配置会让 localhost 探测超时。
+		resp = httpx.get(f"{base}/json/version", timeout=_CDP_PROBE_TIMEOUT, trust_env=False)
 		return cast("str | None", resp.json().get("webSocketDebuggerUrl"))
 	except (httpx.HTTPError, ValueError, KeyError):
 		return None
+
+
+def _create_cdp_page(cdp_url: str | None, target_url: str) -> tuple[str, str, str]:
+	"""Create a temporary page through Chrome's raw CDP HTTP endpoint."""
+	import json
+	import urllib.request
+
+	base = (cdp_url or _DEFAULT_CDP_URL).rstrip("/")
+	create_url = f"{base}/json/new?{target_url}"
+	try:
+		req = urllib.request.Request(create_url, method="PUT")
+		with urllib.request.urlopen(req, timeout=5) as resp:
+			payload = json.load(resp)
+			return base, cast("str", payload["id"]), cast("str", payload["webSocketDebuggerUrl"])
+	except Exception as exc:
+		raise RuntimeError(f"cannot create CDP page: {exc}") from exc
+
+
+def _close_cdp_page(cdp_http_url: str, target_id: str) -> None:
+	import urllib.request
+
+	try:
+		req = urllib.request.Request(f"{cdp_http_url}/json/close/{target_id}", method="GET")
+		with urllib.request.urlopen(req, timeout=5):
+			pass
+	except Exception:
+		pass
+
+
+def _raw_cdp_evaluate(cdp_url: str | None, page_url: str, expression: str, *, timeout: float = 20.0, settle_seconds: float = 1.0) -> Any:
+	"""Evaluate JavaScript in a temporary page using raw CDP, bypassing patchright attach."""
+	import json
+
+	import websockets.sync.client as ws_client
+
+	cdp_http_url, target_id, target_ws = _create_cdp_page(cdp_url, page_url)
+	try:
+		with ws_client.connect(target_ws, max_size=8 * 1024 * 1024) as ws:
+			ws.send(json.dumps({"id": 1, "method": "Page.enable"}))
+			ws.send(json.dumps({"id": 2, "method": "Runtime.enable"}))
+			ws.send(json.dumps({"id": 3, "method": "Page.navigate", "params": {"url": page_url}}))
+
+			deadline = time.time() + timeout
+			settle_deadline = min(deadline, time.time() + settle_seconds)
+			while time.time() < settle_deadline:
+				try:
+					raw = ws.recv(timeout=max(0.1, settle_deadline - time.time()))
+				except TimeoutError:
+					break
+				msg = json.loads(raw)
+				if msg.get("method") in ("Page.domContentEventFired", "Page.loadEventFired"):
+					break
+
+			ws.send(json.dumps({
+				"id": 4,
+				"method": "Runtime.evaluate",
+				"params": {
+					"expression": expression,
+					"returnByValue": True,
+					"awaitPromise": True,
+				},
+			}))
+			while time.time() < deadline:
+				raw = ws.recv(timeout=max(0.1, deadline - time.time()))
+				msg = json.loads(raw)
+				if msg.get("id") != 4:
+					continue
+				if err := msg.get("error"):
+					raise RuntimeError(f"CDP Runtime.evaluate error: {err}")
+				payload = msg.get("result", {})
+				if exc_details := payload.get("exceptionDetails"):
+					raise RuntimeError(
+						f"JS exception: {exc_details.get('text')} - "
+						f"{exc_details.get('exception', {}).get('description', '')[:300]}"
+					)
+				result = payload.get("result", {})
+				return result.get("value", result)
+			raise RuntimeError(f"CDP Runtime.evaluate timed out after {timeout:.0f}s")
+	finally:
+		_close_cdp_page(cdp_http_url, target_id)
 
 
 def login_via_cdp(*, cdp_url: str | None = None, timeout: int = 120, platform: str = "zhipin") -> dict[str, Any]:
@@ -93,50 +206,72 @@ def login_via_cdp(*, cdp_url: str | None = None, timeout: int = 120, platform: s
 
 	print("[boss] 正在 CDP Chrome 中打开登录页...", file=sys.stderr)
 	pw = sync_playwright().start()
-	browser = pw.chromium.connect_over_cdp(ws_url)
-	ctx = browser.contexts[0] if browser.contexts else browser.new_context()
-	page = ctx.new_page()
-
 	try:
+		browser = pw.chromium.connect_over_cdp(ws_url)
+		ctx = browser.contexts[0] if browser.contexts else browser.new_context()
+
+		# 若用户已在 CDP Chrome 中登录，直接提取当前会话，避免重复打开登录页造成卡顿。
 		try:
-			page.goto(
-				login_page_url,
-				wait_until="commit", timeout=_NAV_TIMEOUT_MS,
-			)
+			existing_cookies = ctx.cookies()
 		except Exception:
-			pass
+			existing_cookies = []
+		if any(c["name"] == success_cookie and cookie_domain in c.get("domain", "") for c in existing_cookies):
+			print("[boss] 检测到现有登录态，直接提取凭证...", file=sys.stderr)
+			return _collect_cdp_token(ctx, platform=platform, cookie_domain=cookie_domain)
 
-		print(f"[boss] 请在 Chrome 中扫码登录，等待中...（超时 {timeout}s）", file=sys.stderr)
-
-		for i in range(timeout):
-			time.sleep(1)
-			cookies = ctx.cookies()
-			success = [c for c in cookies if c["name"] == success_cookie and cookie_domain in c.get("domain", "")]
-			if success:
-				print("[boss] 检测到登录成功！", file=sys.stderr)
-				break
-			if i > 0 and i % 15 == 0:
-				print(f"[boss] 等待中... {i}s", file=sys.stderr)
-		else:
-			raise TimeoutError(f"CDP 扫码登录超时（{timeout}s）")
-
+		page = ctx.new_page()
 		try:
-			page.goto(home_url, wait_until="domcontentloaded", timeout=_NAV_TIMEOUT_MS)
-		except Exception:
-			pass
-		all_cookies = {c["name"]: c["value"] for c in ctx.cookies() if cookie_domain in c.get("domain", "")}
-		ua = page.evaluate("navigator.userAgent")
-		x_zp_client_id = _extract_zhilian_client_id(page) if platform == "zhilian" else ""
+			try:
+				page.goto(
+					login_page_url,
+					wait_until="commit", timeout=_NAV_TIMEOUT_MS,
+				)
+			except Exception:
+				pass
 
-		result: dict[str, Any] = {"cookies": all_cookies, "stoken": "", "user_agent": ua}
-		if x_zp_client_id:
-			result["x_zp_client_id"] = x_zp_client_id
-		return result
-	finally:
-		try:
-			page.close()
+			print(f"[boss] 请在 Chrome 中扫码登录，等待中...（超时 {timeout}s）", file=sys.stderr)
+
+			for i in range(timeout):
+				time.sleep(1)
+				cookies = ctx.cookies()
+				success = [c for c in cookies if c["name"] == success_cookie and cookie_domain in c.get("domain", "")]
+				if success:
+					print("[boss] 检测到登录成功！", file=sys.stderr)
+					break
+				if i > 0 and i % 15 == 0:
+					print(f"[boss] 等待中... {i}s", file=sys.stderr)
+			else:
+				raise TimeoutError(f"CDP 扫码登录超时（{timeout}s）")
+
+			return _collect_cdp_token(ctx, platform=platform, cookie_domain=cookie_domain)
 		finally:
-			pw.stop()
+			try:
+				page.close()
+			except Exception:
+				pass
+	finally:
+		pw.stop()
+
+
+def sync_token_from_cdp(*, cdp_url: str | None = None, platform: str = "zhipin") -> dict[str, Any]:
+	"""从当前已连接的 CDP Chrome 同步已登录会话，不触发登录流程。"""
+	config = _get_platform_config(platform)
+	cookie_domain = config["cookie_domain"]
+	success_cookie = config["success_cookie"]
+	ws_url = probe_cdp(cdp_url)
+	if not ws_url:
+		raise ConnectionError("CDP 不可用，请先启动带调试端口的 Chrome")
+
+	pw = sync_playwright().start()
+	try:
+		browser = pw.chromium.connect_over_cdp(ws_url)
+		ctx = browser.contexts[0] if browser.contexts else browser.new_context()
+		cookies = ctx.cookies()
+		if not any(c["name"] == success_cookie and cookie_domain in c.get("domain", "") for c in cookies):
+			raise RuntimeError("当前 CDP Chrome 中未检测到已登录会话，请先在该 Chrome 中登录")
+		return _collect_cdp_token(ctx, platform=platform, cookie_domain=cookie_domain)
+	finally:
+		pw.stop()
 
 
 def login_via_browser(*, timeout: int = 120, platform: str = "zhipin") -> dict[str, Any]:
@@ -221,20 +356,27 @@ def refresh_stoken_via_cdp(cdp_url: str | None = None) -> str:
 	if not ws_url:
 		raise ConnectionError("CDP 不可用")
 
-	pw = sync_playwright().start()
-	browser = pw.chromium.connect_over_cdp(ws_url)
-	ctx = browser.contexts[0] if browser.contexts else browser.new_context()
-	page = ctx.new_page()
-
-	try:
-		page.goto(HOME_URL, wait_until="commit", timeout=15000)
-	except Exception:
-		pass
-	time.sleep(_STOKEN_GENERATION_WAIT)
-
-	stoken = _extract_stoken(page)
-	page.close()
-	pw.stop()
+	stoken = cast("str", _raw_cdp_evaluate(
+		cdp_url,
+		HOME_URL,
+		"""
+		new Promise((resolve) => {
+			const read = () => {
+				const match = document.cookie.match(/__zp_stoken__=([^;]+)/);
+				if (match) return match[1];
+				if (window.__zp_stoken__) return window.__zp_stoken__;
+				return '';
+			};
+			const existing = read();
+			if (existing) {
+				resolve(existing);
+				return;
+			}
+			setTimeout(() => resolve(read()), 2000);
+		})
+		""",
+		timeout=20,
+	))
 
 	if not stoken:
 		raise RuntimeError("CDP 刷新 stoken 失败：页面未生成 stoken")

--- a/src/boss_agent_cli/auth/manager.py
+++ b/src/boss_agent_cli/auth/manager.py
@@ -174,7 +174,9 @@ class AuthManager:
 						current["cookies"],
 						current.get("user_agent", ""),
 					)
-				refreshed = {**current, "stoken": new_stoken}
+				cookies = dict(current.get("cookies", {}))
+				cookies["__zp_stoken__"] = new_stoken
+				refreshed = {**current, "cookies": cookies, "stoken": new_stoken}
 				self._store.save(refreshed)
 				self._token = refreshed
 			except Exception as e:

--- a/src/boss_agent_cli/commands/doctor.py
+++ b/src/boss_agent_cli/commands/doctor.py
@@ -200,7 +200,7 @@ def doctor_cmd(ctx: click.Context) -> None:
 		cdp_detail = ws_url or f"CDP 不可用（目标: {cdp_url or _DEFAULT_CDP_URL}）"
 		if ws_url:
 			try:
-				resp = httpx.get(f"{cdp_url or _DEFAULT_CDP_URL}/json/version", timeout=3)
+				resp = httpx.get(f"{cdp_url or _DEFAULT_CDP_URL}/json/version", timeout=3, trust_env=False)
 				meta = resp.json()
 				browser_name = meta.get("Browser") or "unknown-browser"
 				user_agent = meta.get("User-Agent") or "unknown-ua"

--- a/src/boss_agent_cli/commands/login.py
+++ b/src/boss_agent_cli/commands/login.py
@@ -1,5 +1,6 @@
 import click
 
+from boss_agent_cli.auth.browser import sync_token_from_cdp
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.display import boss_command_for_ctx, login_action_for_ctx
 from boss_agent_cli.output import emit_error, emit_success
@@ -9,8 +10,9 @@ from boss_agent_cli.output import emit_error, emit_success
 @click.option("--timeout", default=120, help="扫码登录超时时间（秒）")
 @click.option("--cookie-source", default=None, help="指定浏览器提取 Cookie（如 chrome/firefox/edge），不指定则自动检测")
 @click.option("--cdp", is_flag=True, default=False, help="强制 CDP 模式（跳过 Cookie 提取，CDP 不可用直接报错）")
+@click.option("--sync-cdp", is_flag=True, default=False, help="直接从当前已登录的 CDP Chrome 同步登录态，不触发扫码流程")
 @click.pass_context
-def login_cmd(ctx: click.Context, timeout: int, cookie_source: str | None, cdp: bool) -> None:
+def login_cmd(ctx: click.Context, timeout: int, cookie_source: str | None, cdp: bool, sync_cdp: bool) -> None:
 	"""登录当前招聘平台（按平台走对应的 Cookie / CDP / 浏览器降级链路）"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
@@ -19,13 +21,19 @@ def login_cmd(ctx: click.Context, timeout: int, cookie_source: str | None, cdp: 
 
 	auth = AuthManager(data_dir, logger=logger, platform=platform_name)
 	try:
-		token = auth.login(
-			timeout=timeout,
-			cookie_source=cookie_source,
-			cdp_url=cdp_url,
-			force_cdp=cdp,
-		)
-		method = token.pop("_method", "未知")
+		if sync_cdp:
+			token = sync_token_from_cdp(cdp_url=cdp_url, platform=platform_name)
+			auth._store.save(token)
+			auth._token = token
+			method = "CDP 会话同步"
+		else:
+			token = auth.login(
+				timeout=timeout,
+				cookie_source=cookie_source,
+				cdp_url=cdp_url,
+				force_cdp=cdp,
+			)
+			method = token.pop("_method", "未知")
 		status_cmd = boss_command_for_ctx(ctx, "status")
 		search_cmd = boss_command_for_ctx(ctx, "search <query>")
 		recommend_cmd = boss_command_for_ctx(ctx, "recommend")

--- a/src/boss_agent_cli/commands/market.py
+++ b/src/boss_agent_cli/commands/market.py
@@ -1,0 +1,735 @@
+from __future__ import annotations
+
+from collections import Counter
+from statistics import median
+from typing import Any
+
+import click
+from rich.panel import Panel
+from rich.table import Table
+
+from boss_agent_cli.api.endpoints import CITY_CODES
+from boss_agent_cli.api.models import JobItem
+from boss_agent_cli.auth.manager import AuthManager
+from boss_agent_cli.commands._platform import get_platform_instance
+from boss_agent_cli.display import console, handle_auth_errors, handle_error_output, handle_output
+from boss_agent_cli.search_filters import parse_salary_range
+
+DEFAULT_AI_PM_CITIES = ("杭州", "上海")
+DEFAULT_AI_PM_QUERIES = (
+	"AI 产品经理",
+	"AIGC 产品经理",
+	"大模型产品经理",
+	"智能体产品经理",
+	"Agent 产品经理",
+	"AI应用产品经理",
+	"产品经理",
+)
+
+PROFILE_POINTS = (
+	"B 端和 C 端产品经验都能覆盖",
+	"有 0-1 上线经验，能把需求拆到 PRD、流程和版本推进",
+	"理解 AI / LLM / AIGC / 智能体相关项目",
+	"做过运营，能补用户调研、数据复盘和业务闭环",
+)
+
+PRODUCT_SEQUENCE_TERMS = (
+	"产品经理",
+	"产品专家",
+	"产品负责人",
+	"产品助理",
+	"产品专员",
+	"产品管培生",
+	"产品总监",
+)
+
+NON_PM_TITLE_TERMS = (
+	"产品运营",
+	"内容运营",
+	"用户运营",
+	"活动运营",
+	"社群运营",
+	"工程师",
+	"开发工程师",
+	"算法工程师",
+	"测试",
+	"设计师",
+	"销售",
+	"客服",
+	"实施顾问",
+)
+
+AI_RELEVANCE_TERMS = (
+	"ai",
+	"aigc",
+	"llm",
+	"agent",
+	"chatgpt",
+	"大模型",
+	"智能体",
+	"人工智能",
+	"生成式",
+	"机器人",
+	"语义",
+	"语音",
+	"视觉",
+	"机器学习",
+	"算法",
+	"prompt",
+	"rag",
+	"workflow",
+	"工作流",
+	"coze",
+	"dify",
+	"n8n",
+)
+
+HIGH_VALUE_SKILLS = (
+	"B端产品",
+	"C端产品",
+	"AI产品",
+	"AI机器人",
+	"语义类AI",
+	"语音类AI",
+	"视觉类AI",
+	"机器学习类AI",
+	"智能体",
+	"SaaS",
+	"ToB",
+	"Prompt Engineering",
+	"Workflow",
+	"PRD",
+	"用户调研",
+	"数据分析",
+)
+
+SKILL_IGNORE_TERMS = {
+	"在校/应届",
+	"经验不限",
+	"1-3年",
+	"3-5年",
+	"5-10年",
+	"本科",
+	"大专",
+	"硕士",
+	"博士",
+	"学历不限",
+}
+
+THEMES = (
+	{
+		"key": "agent_workflow",
+		"name": "Agent / Workflow / Skill 编排",
+		"keywords": ("agent", "智能体", "workflow", "工作流", "skill", "技能", "coze", "dify", "n8n"),
+		"meaning": "岗位更看重把大模型能力嵌进真实业务流程，而不只是做聊天入口。",
+		"positioning": "突出你对智能体/AIGC项目的理解，并把 0-1 上线经验讲成“从场景拆解到流程编排再到上线验证”。",
+	},
+	{
+		"key": "llm_productization",
+		"name": "LLM 能力边界 / Prompt / 模型产品化",
+		"keywords": ("llm", "大模型", "prompt", "模型", "api", "badcase", "rag", "上下文"),
+		"meaning": "不少岗位要求产品经理能理解模型调用、效果评估和 badcase 归因。",
+		"positioning": "强调你不是只会写 PRD，而是能和算法/工程讨论模型能力边界、效果指标和迭代优先级。",
+	},
+	{
+		"key": "tob_delivery",
+		"name": "ToB / SaaS / 客户共创",
+		"keywords": ("tob", "b端", "saas", "客户", "交付", "解决方案", "行业场景", "企业"),
+		"meaning": "上海和杭州都有一批岗位在找能把 AI 做进企业场景的人。",
+		"positioning": "把你的 B 端经验、流程拆解能力和推进上线能力放到前面，补一句能承接客户不确定性。",
+	},
+	{
+		"key": "c_end_aigc",
+		"name": "C 端 / 内容 / AIGC 体验",
+		"keywords": ("c端", "用户增长", "社区", "社交", "内容", "视频", "图像", "创作", "aigc"),
+		"meaning": "C 端 AI 产品更关注用户体验、留存、内容生产链路和增长闭环。",
+		"positioning": "用你的 C 端和运营经历讲用户调研、数据复盘、业务闭环，而不是只讲功能设计。",
+	},
+	{
+		"key": "product_basics",
+		"name": "PRD / 需求拆解 / 0-1 上线",
+		"keywords": ("prd", "需求", "0-1", "从0到1", "上线", "流程", "项目推进", "竞品", "用户调研", "数据"),
+		"meaning": "AI 相关岗位仍然在考传统产品基本功，只是场景换成了 AI。",
+		"positioning": "把你的 PRD、流程拆解、上线推进和运营复盘串成一条完整产品闭环。",
+	},
+	{
+		"key": "cross_function",
+		"name": "算法 / 工程 / 业务跨团队协作",
+		"keywords": ("算法", "工程", "研发", "技术", "跨团队", "协同", "资源协调"),
+		"meaning": "AI 产品经理通常要在业务目标、模型效果和工程实现之间做翻译。",
+		"positioning": "准备一个你推动多方协作上线的案例，重点讲目标对齐、取舍和结果复盘。",
+	},
+)
+
+
+@click.group("market", help="岗位市场扫描与 JD 共性分析")
+def market_group() -> None:
+	"""Market analysis commands."""
+
+
+@market_group.command("ai-pm")
+@click.option("--city", "cities", multiple=True, default=DEFAULT_AI_PM_CITIES, help="目标城市，可重复传入")
+@click.option("--query", "queries", multiple=True, help="追加或替换搜索关键词，可重复传入")
+@click.option("--page", default=1, type=int, help="起始页码")
+@click.option("--pages", default=1, type=int, help="每组关键词扫描页数")
+@click.option("--limit", default=30, type=int, help="最多输出职位数")
+@click.option("--detail-limit", default=6, type=int, help="最多拉取多少个代表性 JD 详情")
+@click.option("--min-score", default=45, type=int, help="市场匹配分阈值")
+@click.option("--no-detail", is_flag=True, default=False, help="只看列表页，不拉取详情 JD")
+@click.pass_context
+@handle_auth_errors("market.ai-pm")
+def ai_pm_cmd(
+	ctx: click.Context,
+	cities: tuple[str, ...],
+	queries: tuple[str, ...],
+	page: int,
+	pages: int,
+	limit: int,
+	detail_limit: int,
+	min_score: int,
+	no_detail: bool,
+) -> None:
+	"""扫描杭州/上海 AI 产品经理市场，并提炼 JD 共性要求。"""
+	if ctx.obj.get("platform") != "zhipin":
+		handle_error_output(
+			ctx,
+			"market.ai-pm",
+			code="NOT_SUPPORTED",
+			message="AI 产品经理市场扫描当前只支持 BOSS 直聘字段结构",
+			recoverable=True,
+			recovery_action="boss --platform zhipin market ai-pm",
+		)
+		return
+	if page < 1 or pages < 1 or limit < 1 or detail_limit < 0:
+		handle_error_output(ctx, "market.ai-pm", code="INVALID_PARAM", message="page/pages/limit/detail-limit 必须为正数")
+		return
+
+	city_list = list(cities or DEFAULT_AI_PM_CITIES)
+	query_list = list(queries or DEFAULT_AI_PM_QUERIES)
+	invalid_cities = [city for city in city_list if city not in CITY_CODES]
+	if invalid_cities:
+		handle_error_output(
+			ctx,
+			"market.ai-pm",
+			code="INVALID_PARAM",
+			message=f"未知城市: {', '.join(invalid_cities)}",
+		)
+		return
+
+	data_dir = ctx.obj["data_dir"]
+	logger = ctx.obj["logger"]
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
+
+	with get_platform_instance(ctx, auth) as platform:
+		try:
+			report = _build_ai_pm_market_report(
+				platform,
+				logger,
+				cities=city_list,
+				queries=query_list,
+				start_page=page,
+				pages=pages,
+				limit=limit,
+				detail_limit=0 if no_detail else detail_limit,
+				min_score=min_score,
+			)
+		except MarketScanPlatformError as exc:
+			handle_error_output(ctx, "market.ai-pm", code=exc.code, message=exc.message)
+			return
+
+	hints = {
+		"next_actions": [
+			"用代表性 JD 的 requirement_themes 起草简历主线",
+			"对 jobs 中 match_score 高的岗位执行 boss detail <security_id> --job-id <job_id>",
+			"如果想更激进扩样，可加 --pages 2 或 --query 'AI Agent 产品经理'",
+		],
+	}
+	handle_output(ctx, "market.ai-pm", report, render=render_ai_pm_market_report, hints=hints)
+
+
+class MarketScanPlatformError(Exception):
+	def __init__(self, code: str, message: str):
+		self.code = code
+		self.message = message
+		super().__init__(message)
+
+
+def _build_ai_pm_market_report(
+	platform: Any,
+	logger: Any,
+	*,
+	cities: list[str],
+	queries: list[str],
+	start_page: int,
+	pages: int,
+	limit: int,
+	detail_limit: int,
+	min_score: int,
+) -> dict[str, Any]:
+	raw_jobs: list[dict[str, Any]] = []
+	stats = {
+		"search_requests": 0,
+		"jobs_seen": 0,
+		"jobs_filtered_out": 0,
+		"search_errors": [],
+	}
+
+	for city in cities:
+		for query in queries:
+			for offset in range(pages):
+				current_page = start_page + offset
+				logger.info(f"market ai-pm: {city} / {query} / page {current_page}")
+				raw = platform.search_jobs(query, city=city, page=current_page)
+				stats["search_requests"] += 1
+				if not platform.is_success(raw):
+					code, message = platform.parse_error(raw)
+					raise MarketScanPlatformError(code, message or f"{city} {query} 搜索失败")
+				data = platform.unwrap_data(raw) or {}
+				job_list = data.get("jobList", [])
+				stats["jobs_seen"] += len(job_list)
+				for raw_item in job_list:
+					job = _normalize_market_job(raw_item, query)
+					if not _is_ai_pm_job(job):
+						stats["jobs_filtered_out"] += 1
+						continue
+					score, reasons = _score_market_job(job)
+					if score < min_score:
+						stats["jobs_filtered_out"] += 1
+						continue
+					job["match_score"] = score
+					job["match_reasons"] = reasons
+					raw_jobs.append(job)
+
+	jobs = _dedupe_jobs(raw_jobs)
+	jobs.sort(key=lambda item: (item.get("match_score", 0), _salary_high(item.get("salary", ""))), reverse=True)
+	jobs = jobs[:limit]
+
+	detail_result = _fetch_representative_details(platform, jobs, detail_limit, logger)
+	details = detail_result["items"]
+
+	return {
+		"profile": {
+			"target": "杭州/上海 AI 相关产品经理序列",
+			"cities": cities,
+			"queries": queries,
+			"candidate_assumptions": list(PROFILE_POINTS),
+		},
+		"summary": {
+			"search_requests": stats["search_requests"],
+			"jobs_seen": stats["jobs_seen"],
+			"jobs_matched": len(jobs),
+			"jobs_filtered_out": stats["jobs_filtered_out"],
+			"companies": len({job.get("company", "") for job in jobs if job.get("company")}),
+			"detail_success": len(details),
+			"detail_failed": len(detail_result["errors"]),
+		},
+		"market_signals": _analyze_market_signals(jobs, details),
+		"jobs": jobs,
+		"representative_jds": details,
+		"detail_errors": detail_result["errors"],
+	}
+
+
+def _normalize_market_job(raw_item: dict[str, Any], query: str) -> dict[str, Any]:
+	item = JobItem.from_api(raw_item).to_dict()
+	item["query"] = query
+	item["lid"] = raw_item.get("lid", "")
+	item["raw_skills"] = raw_item.get("skills", []) or raw_item.get("jobLabels", []) or []
+	return item
+
+
+def _is_ai_pm_job(job: dict[str, Any]) -> bool:
+	title = str(job.get("title") or "")
+	if any(term in title for term in NON_PM_TITLE_TERMS):
+		return False
+	if not any(term in title for term in PRODUCT_SEQUENCE_TERMS):
+		return False
+	return _has_ai_relevance(_job_text(job, include_query=False))
+
+
+def _has_ai_relevance(text: str) -> bool:
+	text_lower = text.lower()
+	return any(term.lower() in text_lower for term in AI_RELEVANCE_TERMS)
+
+
+def _job_text(job: dict[str, Any], *, include_query: bool = True) -> str:
+	parts = [
+		job.get("title", ""),
+		job.get("company", ""),
+		job.get("industry", ""),
+		" ".join(job.get("skills", []) or []),
+		" ".join(job.get("raw_skills", []) or []),
+		" ".join(job.get("welfare", []) or []),
+	]
+	if include_query:
+		parts.append(job.get("query", ""))
+	return " ".join(str(part) for part in parts if part)
+
+
+def _score_market_job(job: dict[str, Any]) -> tuple[int, list[str]]:
+	score = 0
+	reasons: list[str] = []
+	title = str(job.get("title") or "")
+	text = _job_text(job)
+	text_lower = text.lower()
+
+	if any(term.lower() in title.lower() for term in ("ai", "aigc", "大模型", "智能体", "agent", "AI应用".lower())):
+		score += 35
+		reasons.append("标题直接命中 AI/AIGC/大模型/智能体")
+	elif _has_ai_relevance(text):
+		score += 20
+		reasons.append("职位标签或行业体现 AI 相关性")
+
+	skills = set(job.get("skills", []) or []) | set(job.get("raw_skills", []) or [])
+	valuable_skills = [skill for skill in HIGH_VALUE_SKILLS if skill.lower() in text_lower or skill in skills]
+	if valuable_skills:
+		score += min(25, 8 + len(valuable_skills) * 4)
+		reasons.append("技能标签匹配: " + "、".join(valuable_skills[:4]))
+
+	exp = str(job.get("experience") or "")
+	if exp in {"1-3年", "经验不限", "在校/应届", "应届", "1年以内"} or "应届" in exp:
+		score += 25
+		reasons.append(f"经验口径友好: {exp or '未注明'}")
+	elif exp == "3-5年":
+		score += 8
+		reasons.append("经验略高但可作为市场参照")
+	elif exp in {"5-10年", "10年以上"}:
+		score -= 20
+		reasons.append(f"经验要求偏高: {exp}")
+
+	industry = str(job.get("industry") or "")
+	if any(term in industry for term in ("人工智能", "互联网", "移动互联网", "企业服务", "电子商务", "在线教育", "计算机软件")):
+		score += 10
+		reasons.append(f"行业相关: {industry}")
+
+	stage = str(job.get("stage") or "")
+	if stage in {"已上市", "B轮", "C轮", "D轮及以上", "不需要融资"}:
+		score += 5
+		reasons.append(f"公司阶段较稳: {stage}")
+
+	scale = str(job.get("scale") or "")
+	if scale in {"100-499人", "500-999人", "1000-9999人", "10000人以上"}:
+		score += 5
+		reasons.append(f"团队规模可参考: {scale}")
+
+	if "产品助理" in title or "产品专员" in title:
+		score -= 6
+		reasons.append("职级可能偏初级")
+	if "产品总监" in title or "产品负责人" in title:
+		score -= 8
+		reasons.append("职级可能偏高，优先作为市场样本")
+
+	return max(score, 0), reasons
+
+
+def _dedupe_jobs(jobs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+	seen: dict[str, dict[str, Any]] = {}
+	for job in jobs:
+		key = job.get("job_id") or job.get("security_id") or "|".join(
+			str(job.get(part, "")) for part in ("company", "title", "city")
+		)
+		if key not in seen:
+			job["queries"] = [job.get("query", "")]
+			seen[key] = job
+			continue
+		existing = seen[key]
+		query = job.get("query", "")
+		if query and query not in existing["queries"]:
+			existing["queries"].append(query)
+		if job.get("match_score", 0) > existing.get("match_score", 0):
+			existing["match_score"] = job.get("match_score", 0)
+			existing["match_reasons"] = job.get("match_reasons", [])
+	return list(seen.values())
+
+
+def _fetch_representative_details(platform: Any, jobs: list[dict[str, Any]], limit: int, logger: Any) -> dict[str, Any]:
+	if limit <= 0:
+		return {"items": [], "errors": []}
+
+	items: list[dict[str, Any]] = []
+	errors: list[dict[str, str]] = []
+	for job in jobs[:limit]:
+		job_id = job.get("job_id", "")
+		if not job_id:
+			continue
+		try:
+			raw = platform.job_detail(job_id)
+		except Exception as exc:
+			logger.info(f"market ai-pm detail failed, fallback to job_card: {job.get('company', '')} {exc}")
+			raw = _try_job_card_fallback(platform, job)
+		if raw is None:
+			errors.append({"job_id": job_id, "company": job.get("company", ""), "message": "detail and job_card fallback failed"})
+			continue
+		if platform.is_success(raw):
+			data = platform.unwrap_data(raw) or {}
+			items.append(_normalize_any_detail(data, job))
+			continue
+
+		fallback = _try_job_card_fallback(platform, job)
+		if fallback is not None and platform.is_success(fallback):
+			data = platform.unwrap_data(fallback) or {}
+			items.append(_normalize_any_detail(data, job))
+			continue
+		else:
+			code, message = platform.parse_error(raw)
+			errors.append({"job_id": job_id, "company": job.get("company", ""), "message": f"{code}: {message}"})
+	return {"items": items, "errors": errors}
+
+
+def _try_job_card_fallback(platform: Any, job: dict[str, Any]) -> dict[str, Any] | None:
+	security_id = job.get("security_id", "")
+	if not security_id:
+		return None
+	try:
+		return platform.job_card(security_id, job.get("lid", ""))
+	except (AttributeError, NotImplementedError, TypeError, OSError, KeyError):
+		return None
+
+
+def _normalize_any_detail(data: dict[str, Any], fallback_job: dict[str, Any]) -> dict[str, Any]:
+	if "jobCard" in data:
+		return _normalize_card_detail(data.get("jobCard", {}) or {}, fallback_job)
+	return _normalize_detail(data, fallback_job)
+
+
+def _normalize_detail(data: dict[str, Any], fallback_job: dict[str, Any]) -> dict[str, Any]:
+	job_info = data.get("jobInfo", {}) or {}
+	brand_info = data.get("brandComInfo", {}) or {}
+	boss_info = data.get("bossInfo", {}) or {}
+	description = data.get("jobDetail", "") or job_info.get("postDescription", "") or ""
+	detail = {
+		"job_id": job_info.get("encryptJobId") or fallback_job.get("job_id", ""),
+		"security_id": job_info.get("securityId") or fallback_job.get("security_id", ""),
+		"title": job_info.get("jobName") or fallback_job.get("title", ""),
+		"company": brand_info.get("brandName") or fallback_job.get("company", ""),
+		"salary": job_info.get("salaryDesc") or fallback_job.get("salary", ""),
+		"city": job_info.get("cityName") or fallback_job.get("city", ""),
+		"experience": job_info.get("experienceName") or fallback_job.get("experience", ""),
+		"education": job_info.get("degreeName") or fallback_job.get("education", ""),
+		"skills": job_info.get("jobLabels") or job_info.get("skills") or fallback_job.get("skills", []),
+		"boss_name": boss_info.get("name", ""),
+		"boss_title": boss_info.get("title", ""),
+		"description_excerpt": _excerpt(description, 420),
+	}
+	detail["key_requirements"] = _extract_key_requirement_lines(description)
+	detail["requirement_themes"] = _themes_for_text(_detail_text(detail, description))
+	detail["matching_angles"] = _build_matching_angles(detail, description)
+	return detail
+
+
+def _normalize_card_detail(card: dict[str, Any], fallback_job: dict[str, Any]) -> dict[str, Any]:
+	description = card.get("postDescription", "") or ""
+	detail = {
+		"job_id": card.get("encryptJobId") or fallback_job.get("job_id", ""),
+		"security_id": card.get("securityId") or fallback_job.get("security_id", ""),
+		"title": card.get("jobName") or fallback_job.get("title", ""),
+		"company": card.get("brandName") or fallback_job.get("company", ""),
+		"salary": card.get("salaryDesc") or fallback_job.get("salary", ""),
+		"city": card.get("cityName") or fallback_job.get("city", ""),
+		"experience": card.get("experienceName") or card.get("jobExperience") or fallback_job.get("experience", ""),
+		"education": card.get("degreeName") or card.get("jobDegree") or fallback_job.get("education", ""),
+		"skills": card.get("jobLabels") or card.get("skills") or fallback_job.get("skills", []),
+		"boss_name": card.get("bossName", ""),
+		"boss_title": card.get("bossTitle", ""),
+		"description_excerpt": _excerpt(description, 420),
+	}
+	detail["key_requirements"] = _extract_key_requirement_lines(description)
+	detail["requirement_themes"] = _themes_for_text(_detail_text(detail, description))
+	detail["matching_angles"] = _build_matching_angles(detail, description)
+	return detail
+
+
+def _extract_key_requirement_lines(description: str) -> list[str]:
+	lines = []
+	for raw_line in description.replace("；", "\n").replace("。", "\n").splitlines():
+		line = raw_line.strip(" \t-•、")
+		if len(line) < 6:
+			continue
+		if len(line) > 120:
+			line = line[:117] + "..."
+		lines.append(line)
+	return lines[:8]
+
+
+def _build_matching_angles(detail: dict[str, Any], description: str) -> list[str]:
+	text = _detail_text(detail, description).lower()
+	angles: list[str] = []
+	if any(term in text for term in ("tob", "b端", "saas", "客户", "交付", "企业")):
+		angles.append("主打 B 端产品、流程拆解和跨团队推进，把经验讲成“能把 AI 落到业务流程并上线”。")
+	if any(term in text for term in ("c端", "社区", "社交", "内容", "用户", "增长")):
+		angles.append("主打 C 端体验和运营复盘，用用户调研、数据复盘、业务闭环证明你能做增长与留存。")
+	if any(term in text for term in ("agent", "智能体", "workflow", "工作流", "coze", "dify")):
+		angles.append("把 AI/LLM/智能体理解具体化到 workflow、skill、场景拆解和效果验证。")
+	if any(term in text for term in ("prompt", "大模型", "llm", "模型", "rag", "badcase")):
+		angles.append("强调你能理解模型能力边界，和算法/工程一起定位 badcase、定义迭代优先级。")
+	if any(term in text for term in ("prd", "需求", "0-1", "上线", "项目推进", "流程")):
+		angles.append("准备一个 0-1 上线案例，按“背景-拆解-PRD-协同-上线-复盘”讲。")
+	if not angles:
+		angles.append("用 B/C 端产品经验 + 0-1 上线 + 运营闭环做通用匹配主线，再补 AI 项目理解。")
+	return angles[:4]
+
+
+def _analyze_market_signals(jobs: list[dict[str, Any]], details: list[dict[str, Any]]) -> dict[str, Any]:
+	salary_ranges = [parse_salary_range(job.get("salary", "")) for job in jobs]
+	salary_ranges = [item for item in salary_ranges if item]
+	low_values = [item[0] for item in salary_ranges]
+	high_values = [item[1] for item in salary_ranges]
+	all_texts = [_job_text(job) for job in jobs] + [_detail_text(detail, "") for detail in details]
+
+	return {
+		"city_distribution": _counter_items(Counter(job.get("city", "") for job in jobs if job.get("city"))),
+		"experience_distribution": _counter_items(Counter(job.get("experience", "") for job in jobs if job.get("experience"))),
+		"salary": {
+			"sample_count": len(salary_ranges),
+			"median_low_k": int(median(low_values)) if low_values else None,
+			"median_high_k": int(median(high_values)) if high_values else None,
+			"bands": _salary_band_counts(salary_ranges),
+		},
+		"top_skills": _top_skills(jobs),
+		"requirement_themes": _theme_counts(all_texts),
+	}
+
+
+def _top_skills(jobs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+	counter: Counter[str] = Counter()
+	for job in jobs:
+		for skill in (job.get("skills", []) or []) + (job.get("raw_skills", []) or []):
+			if skill and str(skill) not in SKILL_IGNORE_TERMS:
+				counter[str(skill)] += 1
+	return _counter_items(counter, limit=12)
+
+
+def _theme_counts(texts: list[str]) -> list[dict[str, Any]]:
+	items: list[dict[str, Any]] = []
+	for theme in THEMES:
+		keywords = theme["keywords"]
+		count = sum(1 for text in texts if any(keyword.lower() in text.lower() for keyword in keywords))
+		if count <= 0:
+			continue
+		items.append({
+			"key": theme["key"],
+			"name": theme["name"],
+			"count": count,
+			"evidence_keywords": [kw for kw in keywords if any(kw.lower() in text.lower() for text in texts)][:6],
+			"what_it_means": theme["meaning"],
+			"how_you_can_position": theme["positioning"],
+		})
+	return sorted(items, key=lambda item: item["count"], reverse=True)
+
+
+def _themes_for_text(text: str) -> list[str]:
+	return [
+		theme["name"]
+		for theme in THEMES
+		if any(keyword.lower() in text.lower() for keyword in theme["keywords"])
+	]
+
+
+def _salary_band_counts(ranges: list[tuple[int, int]]) -> list[dict[str, Any]]:
+	bands = Counter()
+	for low, high in ranges:
+		mid = (low + high) / 2
+		if mid < 15:
+			bands["<15K"] += 1
+		elif mid < 25:
+			bands["15-25K"] += 1
+		elif mid < 40:
+			bands["25-40K"] += 1
+		else:
+			bands["40K+"] += 1
+	return _counter_items(bands)
+
+
+def _counter_items(counter: Counter[str], *, limit: int = 20) -> list[dict[str, Any]]:
+	return [
+		{"name": name, "count": count}
+		for name, count in counter.most_common(limit)
+		if name
+	]
+
+
+def _salary_high(value: str) -> int:
+	parsed = parse_salary_range(value)
+	return parsed[1] if parsed else 0
+
+
+def _excerpt(text: str, limit: int) -> str:
+	cleaned = " ".join(text.split())
+	if len(cleaned) <= limit:
+		return cleaned
+	return cleaned[: limit - 3] + "..."
+
+
+def _detail_text(detail: dict[str, Any], description: str) -> str:
+	return " ".join(
+		str(part)
+		for part in (
+			detail.get("title", ""),
+			detail.get("company", ""),
+			detail.get("city", ""),
+			" ".join(detail.get("skills", []) or []),
+			description,
+			detail.get("description_excerpt", ""),
+		)
+		if part
+	)
+
+
+def render_ai_pm_market_report(data: dict[str, Any]) -> None:
+	summary = data.get("summary", {})
+	profile = data.get("profile", {})
+	console.print(Panel(
+		(
+			f"[bold cyan]{profile.get('target', 'AI 产品经理市场')}[/bold cyan]\n"
+			f"matched: [green]{summary.get('jobs_matched', 0)}[/green] / seen: {summary.get('jobs_seen', 0)} "
+			f"/ companies: {summary.get('companies', 0)} / details: {summary.get('detail_success', 0)}"
+		),
+		title="market ai-pm",
+		border_style="cyan",
+	))
+
+	jobs = data.get("jobs", [])[:12]
+	if jobs:
+		table = Table(title="top AI PM jobs", show_lines=True)
+		table.add_column("#", style="dim", width=3)
+		table.add_column("title", style="bold cyan", max_width=28)
+		table.add_column("company", style="green", max_width=18)
+		table.add_column("city", style="blue", width=8)
+		table.add_column("salary", style="yellow", width=12)
+		table.add_column("exp", width=10)
+		table.add_column("score", width=6)
+		for index, job in enumerate(jobs, 1):
+			table.add_row(
+				str(index),
+				str(job.get("title", "-")),
+				str(job.get("company", "-")),
+				str(job.get("city", "-")),
+				str(job.get("salary", "-")),
+				str(job.get("experience", "-")),
+				str(job.get("match_score", "-")),
+			)
+		console.print(table)
+
+	themes = data.get("market_signals", {}).get("requirement_themes", [])[:6]
+	if themes:
+		theme_table = Table(title="JD common requirements", show_lines=True)
+		theme_table.add_column("theme", style="bold")
+		theme_table.add_column("count", width=6)
+		theme_table.add_column("how to position", max_width=70)
+		for item in themes:
+			theme_table.add_row(
+				item.get("name", "-"),
+				str(item.get("count", 0)),
+				item.get("how_you_can_position", "-"),
+			)
+		console.print(theme_table)
+
+	for detail in data.get("representative_jds", [])[:3]:
+		console.print(Panel(
+			"\n".join([
+				f"[bold]{detail.get('company', '-')} - {detail.get('title', '-')}[/bold]",
+				"匹配讲法:",
+				*detail.get("matching_angles", [])[:3],
+			]),
+			border_style="green",
+		))

--- a/src/boss_agent_cli/commands/register.py
+++ b/src/boss_agent_cli/commands/register.py
@@ -22,6 +22,7 @@ from boss_agent_cli.commands import (
 	login,
 	logout,
 	mark,
+	market,
 	me,
 	pipeline,
 	preset,
@@ -65,6 +66,7 @@ def register_candidate_commands(cli: click.Group) -> None:
 	cli.add_command(chatmsg.chatmsg_cmd, "chatmsg")
 	cli.add_command(chat_summary.chat_summary_cmd, "chat-summary")
 	cli.add_command(mark.mark_cmd, "mark")
+	cli.add_command(market.market_group, "market")
 	cli.add_command(exchange.exchange_cmd, "exchange")
 	cli.add_command(interviews.interviews_cmd, "interviews")
 	cli.add_command(show.show_cmd, "show")

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -92,6 +92,7 @@ _CANDIDATE_COMMANDS = {
 	"apply",
 	"shortlist",
 	"digest",
+	"market",
 	"stats",
 	"resume",
 	"ai",
@@ -226,7 +227,7 @@ def _format_mcp_tools(data: dict[str, Any]) -> list[dict[str, Any]]:
 
 SCHEMA_DATA = {
 	"name": "boss-agent-cli",
-	"description": "BOSS直聘求职工具。34 个顶层命令覆盖搜索、筛选、打招呼、沟通、流水线、招聘者工作流与简历优化全流程。",
+	"description": "BOSS直聘求职工具。35 个顶层命令覆盖搜索、筛选、市场扫描、打招呼、沟通、流水线、招聘者工作流与简历优化全流程。",
 	"commands": {
 		"login": {
 			"description": "按当前平台登录（zhipin: Cookie 提取 → CDP → QR httpx → patchright；zhilian: Cookie 提取 → CDP → 浏览器登录）",
@@ -362,6 +363,59 @@ SCHEMA_DATA = {
 					"type": "bool",
 					"default": False,
 					"description": "跳过缓存，强制请求接口",
+				},
+			},
+		},
+		"market": {
+			"description": "面向特定求职目标做岗位市场扫描。ai-pm 子命令默认扫描杭州/上海 AI 产品经理序列，汇总职位、代表性 JD 与共性要求",
+			"args": [],
+			"options": {},
+			"subcommands": {
+				"ai-pm": {
+					"description": "扫描杭州/上海 AI/AIGC/大模型/智能体产品经理岗位，过滤非产品经理序列，并提炼 JD 共性要求和个人匹配讲法",
+					"args": [],
+					"options": {
+						"--city": {
+							"type": "string",
+							"default": "杭州,上海",
+							"description": "目标城市，可重复传入；默认杭州、上海",
+						},
+						"--query": {
+							"type": "string",
+							"default": None,
+							"description": "自定义搜索关键词，可重复传入；不传则使用 AI/AIGC/大模型/智能体/Agent/AI应用/产品经理",
+						},
+						"--page": {
+							"type": "int",
+							"default": 1,
+							"description": "起始页码",
+						},
+						"--pages": {
+							"type": "int",
+							"default": 1,
+							"description": "每组关键词扫描页数",
+						},
+						"--limit": {
+							"type": "int",
+							"default": 30,
+							"description": "最多输出职位数",
+						},
+						"--detail-limit": {
+							"type": "int",
+							"default": 6,
+							"description": "最多拉取多少个代表性 JD 详情",
+						},
+						"--min-score": {
+							"type": "int",
+							"default": 45,
+							"description": "市场匹配分阈值",
+						},
+						"--no-detail": {
+							"type": "bool",
+							"default": False,
+							"description": "只看列表页，不拉取详情 JD",
+						},
+					},
 				},
 			},
 		},

--- a/tests/test_api_client_methods.py
+++ b/tests/test_api_client_methods.py
@@ -40,16 +40,18 @@ def test_search_jobs_minimal_params():
 	client = _make_client()
 	client.search_jobs("python")
 	call = client._browser_request.call_args
-	assert call.args == ("GET", endpoints.SEARCH_URL)
-	assert call.kwargs["params"]["query"] == "python"
-	assert call.kwargs["params"]["page"] == 1
+	assert call.args == ("POST", endpoints.SEARCH_URL)
+	assert call.kwargs["data"]["query"] == "python"
+	assert call.kwargs["data"]["page"] == 1
+	assert call.kwargs["data"]["pageSize"] == 15
+	assert call.kwargs["data"]["scene"] == 1
 
 
 def test_search_jobs_with_page():
 	client = _make_client()
 	client.search_jobs("python", page=3)
 	call = client._browser_request.call_args
-	assert call.kwargs["params"]["page"] == 3
+	assert call.kwargs["data"]["page"] == 3
 
 
 def test_search_jobs_all_filter_codes_applied():
@@ -67,7 +69,7 @@ def test_search_jobs_all_filter_codes_applied():
 		stage="A轮",
 		job_type="全职",
 	)
-	params = client._browser_request.call_args.kwargs["params"]
+	params = client._browser_request.call_args.kwargs["data"]
 	assert params["query"] == "python"
 	# 每个映射都应该生成一个 code 字段，code 非空
 	assert params.get("city") is not None
@@ -87,11 +89,11 @@ def test_search_jobs_unknown_city_raises():
 
 
 def test_search_jobs_unknown_salary_does_not_crash():
-	"""未知 salary 不生成 code，但不抛异常（静默跳过）。"""
+	"""未知 salary 保持为空，但不抛异常。"""
 	client = _make_client()
 	client.search_jobs("python", salary="unknown-range")
-	params = client._browser_request.call_args.kwargs["params"]
-	assert "salary" not in params
+	params = client._browser_request.call_args.kwargs["data"]
+	assert params["salary"] == ""
 
 
 def test_recommend_jobs_default_page():
@@ -202,6 +204,36 @@ def test_job_detail_passes_encrypted_job_id():
 	call = client._request.call_args
 	assert call.args == ("GET", endpoints.DETAIL_URL)
 	assert call.kwargs["params"] == {"encryptJobId": "encrypted_j1"}
+
+
+def test_job_detail_falls_back_to_browser_on_code_37():
+	client = _make_client()
+	client._request.return_value = {"code": endpoints.CODE_STOKEN_EXPIRED, "message": "expired", "zpData": {}}
+	client._browser_request.return_value = {"code": 0, "zpData": {"jobInfo": {"jobName": "AI产品经理"}}}
+
+	result = client.job_detail("encrypted_j1")
+
+	assert result["code"] == 0
+	client._browser_request.assert_called_once_with(
+		"GET",
+		endpoints.DETAIL_URL,
+		params={"encryptJobId": "encrypted_j1"},
+	)
+
+
+def test_job_detail_falls_back_to_browser_on_httpx_exception():
+	client = _make_client()
+	client._request.side_effect = RuntimeError("httpx failed")
+	client._browser_request.return_value = {"code": 0, "zpData": {"jobInfo": {"jobName": "AI产品经理"}}}
+
+	result = client.job_detail("encrypted_j1")
+
+	assert result["code"] == 0
+	client._browser_request.assert_called_once_with(
+		"GET",
+		endpoints.DETAIL_URL,
+		params={"encryptJobId": "encrypted_j1"},
+	)
 
 
 def test_user_info_no_params():

--- a/tests/test_api_client_retry.py
+++ b/tests/test_api_client_retry.py
@@ -119,6 +119,27 @@ def test_request_retries_after_stoken_expired_code(mock_http_client_cls, mock_sl
 	assert second.calls[0]["kwargs"]["params"]["__zp_stoken__"] == "refreshed-1"
 
 
+@patch("boss_agent_cli.api.client.random.uniform", return_value=0)
+@patch("boss_agent_cli.api.client.time.sleep")
+@patch("boss_agent_cli.api.client.httpx.Client")
+def test_request_does_not_mutate_original_get_params_across_retries(mock_http_client_cls, mock_sleep, mock_uniform):
+	auth = FakeAuthManager()
+	first = FakeHttpxClient([FakeResponse(payload={"code": endpoints.CODE_STOKEN_EXPIRED})])
+	second = FakeHttpxClient([FakeResponse(payload={"code": 0, "zpData": {"ok": True}})])
+	mock_http_client_cls.side_effect = [first, second]
+	original_params = {"encryptJobId": "job-1"}
+
+	client = BossClient(auth)
+	client._throttle.wait = lambda: None
+	client._throttle.mark = lambda: None
+
+	client._request("GET", endpoints.DETAIL_URL, params=original_params)
+
+	assert original_params == {"encryptJobId": "job-1"}
+	assert first.calls[0]["kwargs"]["params"]["__zp_stoken__"] == "initial-stoken"
+	assert second.calls[0]["kwargs"]["params"]["__zp_stoken__"] == "refreshed-1"
+
+
 @patch("boss_agent_cli.api.client.time.sleep")
 @patch("boss_agent_cli.api.client.httpx.Client")
 def test_request_retries_after_rate_limited_code(mock_http_client_cls, mock_sleep):

--- a/tests/test_auth_browser.py
+++ b/tests/test_auth_browser.py
@@ -7,9 +7,11 @@ from boss_agent_cli.auth.browser import (
 	LOGIN_PAGE_URL,
 	_NAV_TIMEOUT_MS,
 	_NETWORKIDLE_GRACE_MS,
+	probe_cdp,
 	login_via_cdp,
 	login_via_browser,
 	refresh_stoken,
+	refresh_stoken_via_cdp,
 )
 
 
@@ -58,18 +60,85 @@ def test_login_via_cdp_stops_playwright_on_timeout(mock_sleep, mock_probe_cdp):
 @patch("boss_agent_cli.auth.browser.time.sleep", return_value=None)
 def test_login_via_cdp_stops_playwright_when_user_agent_extraction_fails(mock_sleep, mock_probe_cdp):
 	mock_context = MagicMock()
+	mock_runtime_page = MagicMock()
+	mock_runtime_page.url = "https://www.zhipin.com/shanghai/"
+	mock_runtime_page.evaluate.side_effect = RuntimeError("user agent unavailable")
+	mock_context.pages = [mock_runtime_page]
 	mock_context.cookies.side_effect = [
 		[{"name": "wt2", "value": "token", "domain": ".zhipin.com"}],
 		[{"name": "wt2", "value": "token", "domain": ".zhipin.com"}],
 	]
 	mock_launcher, mock_playwright, mock_page = _mock_cdp_playwright(mock_context)
-	mock_page.evaluate.side_effect = RuntimeError("user agent unavailable")
 
 	with patch("boss_agent_cli.auth.browser.sync_playwright", return_value=mock_launcher):
 		with pytest.raises(RuntimeError, match="user agent unavailable"):
 			login_via_cdp(timeout=1)
 
-	mock_page.close.assert_called_once()
+	mock_playwright.stop.assert_called_once()
+
+
+@patch("boss_agent_cli.auth.browser.probe_cdp", return_value="ws://localhost/devtools/browser")
+@patch("boss_agent_cli.auth.browser.time.sleep", return_value=None)
+def test_login_via_cdp_extracts_stoken_from_cookie_and_existing_page(mock_sleep, mock_probe_cdp):
+	mock_login_page = MagicMock()
+	mock_login_page.url = "https://www.zhipin.com/web/user/"
+	mock_runtime_page = MagicMock()
+	mock_runtime_page.url = "https://www.zhipin.com/shanghai/"
+	mock_runtime_page.evaluate.return_value = "UA"
+
+	mock_context = MagicMock()
+	mock_context.new_page.return_value = mock_login_page
+	mock_context.pages = [mock_runtime_page, mock_login_page]
+	mock_context.cookies.side_effect = [
+		[{"name": "wt2", "value": "token", "domain": ".zhipin.com"}],
+		[
+			{"name": "wt2", "value": "token", "domain": ".zhipin.com"},
+			{"name": "__zp_stoken__", "value": "stoken-from-cookie", "domain": ".zhipin.com"},
+		],
+	]
+
+	mock_launcher, mock_playwright, _ = _mock_cdp_playwright(mock_context)
+
+	with patch("boss_agent_cli.auth.browser.sync_playwright", return_value=mock_launcher):
+		result = login_via_cdp(timeout=1)
+
+	assert result["stoken"] == "stoken-from-cookie"
+	assert result["user_agent"] == "UA"
+	mock_runtime_page.evaluate.assert_called_once_with("navigator.userAgent")
+	mock_playwright.stop.assert_called_once()
+
+
+@patch("boss_agent_cli.auth.browser.probe_cdp", return_value="ws://localhost/devtools/browser")
+def test_login_via_cdp_reuses_existing_logged_in_context(mock_probe_cdp):
+	mock_runtime_page = MagicMock()
+	mock_runtime_page.url = "https://www.zhipin.com/shanghai/"
+	mock_runtime_page.evaluate.return_value = "UA"
+
+	mock_context = MagicMock()
+	mock_context.pages = [mock_runtime_page]
+	mock_context.cookies.side_effect = [
+		[{"name": "wt2", "value": "token", "domain": ".zhipin.com"}],
+		[
+			{"name": "wt2", "value": "token", "domain": ".zhipin.com"},
+			{"name": "__zp_stoken__", "value": "stoken-from-cookie", "domain": ".zhipin.com"},
+		],
+	]
+
+	mock_browser = MagicMock()
+	mock_browser.contexts = [mock_context]
+
+	mock_playwright = MagicMock()
+	mock_playwright.chromium.connect_over_cdp.return_value = mock_browser
+
+	mock_launcher = MagicMock()
+	mock_launcher.start.return_value = mock_playwright
+
+	with patch("boss_agent_cli.auth.browser.sync_playwright", return_value=mock_launcher):
+		result = login_via_cdp(timeout=1)
+
+	assert result["stoken"] == "stoken-from-cookie"
+	assert result["user_agent"] == "UA"
+	mock_context.new_page.assert_not_called()
 	mock_playwright.stop.assert_called_once()
 
 
@@ -124,3 +193,36 @@ def test_refresh_stoken_tolerates_networkidle_timeout(mock_extract_stoken):
 	mock_page.wait_for_load_state.assert_called_once_with("networkidle", timeout=_NETWORKIDLE_GRACE_MS)
 	mock_extract_stoken.assert_called_once_with(mock_page)
 	mock_browser.close.assert_called_once()
+
+
+@patch("boss_agent_cli.auth.browser.probe_cdp", return_value="ws://localhost/devtools/browser")
+@patch("boss_agent_cli.auth.browser._raw_cdp_evaluate", return_value="fresh-cdp-token")
+def test_refresh_stoken_via_cdp_uses_raw_cdp_evaluate(mock_raw_eval, mock_probe_cdp):
+	result = refresh_stoken_via_cdp("http://localhost:9222")
+
+	assert result == "fresh-cdp-token"
+	mock_probe_cdp.assert_called_once_with("http://localhost:9222")
+	assert mock_raw_eval.call_args.args[0] == "http://localhost:9222"
+	assert mock_raw_eval.call_args.args[1] == HOME_URL
+	assert mock_raw_eval.call_args.kwargs["timeout"] == 20
+
+
+@patch("boss_agent_cli.auth.browser.probe_cdp", return_value="ws://localhost/devtools/browser")
+@patch("boss_agent_cli.auth.browser._raw_cdp_evaluate", return_value="")
+def test_refresh_stoken_via_cdp_raises_when_stoken_missing(mock_raw_eval, mock_probe_cdp):
+	with pytest.raises(RuntimeError, match="页面未生成 stoken"):
+		refresh_stoken_via_cdp("http://localhost:9222")
+
+
+@patch("httpx.get")
+def test_probe_cdp_ignores_env_proxy(mock_get):
+	mock_get.return_value.json.return_value = {"webSocketDebuggerUrl": "ws://localhost/devtools/browser"}
+
+	result = probe_cdp("http://localhost:9222")
+
+	assert result == "ws://localhost/devtools/browser"
+	mock_get.assert_called_once_with(
+		"http://localhost:9222/json/version",
+		timeout=3,
+		trust_env=False,
+	)

--- a/tests/test_auth_manager_flow.py
+++ b/tests/test_auth_manager_flow.py
@@ -219,7 +219,24 @@ def test_force_refresh_prefers_cdp_and_persists_new_stoken(
 	store.save.assert_called_once()
 	saved_token = store.save.call_args.args[0]
 	assert saved_token["stoken"] == "new-token"
-	assert manager._token["stoken"] == "new-token"
+	assert saved_token["cookies"]["__zp_stoken__"] == "new-token"
+
+
+@patch("boss_agent_cli.commands.login.sync_token_from_cdp")
+def test_login_sync_cdp_saves_session(mock_sync_cdp, tmp_path):
+	from click.testing import CliRunner
+	from boss_agent_cli.main import cli
+
+	mock_sync_cdp.return_value = {
+		"cookies": {"wt2": "cdp-cookie"},
+		"stoken": "cdp-stoken",
+		"user_agent": "ua",
+	}
+
+	result = CliRunner().invoke(cli, ["--data-dir", str(tmp_path), "login", "--sync-cdp"])
+
+	assert result.exit_code == 0
+	assert '"ok": true' in result.output
 
 
 @patch("boss_agent_cli.auth.manager.TokenStore")

--- a/tests/test_browser_client.py
+++ b/tests/test_browser_client.py
@@ -4,9 +4,11 @@ import httpx
 
 from boss_agent_cli.api.browser_client import (
 	CDP_DEFAULT_URL,
+	_CDP_CONNECT_TIMEOUT_MS,
 	HOME_URL,
 	_HEADLESS_NETWORKIDLE_GRACE_MS,
 	_NAV_TIMEOUT_MS,
+	_SEARCH_RESPONSE_TIMEOUT_MS,
 	BrowserSession,
 )
 
@@ -25,6 +27,11 @@ def test_fetch_ws_url_success():
 		mock_get.return_value = mock_resp
 		ws = BrowserSession._fetch_ws_url("http://127.0.0.1:9222")
 		assert ws == "ws://127.0.0.1:9222/devtools/browser/abc"
+		mock_get.assert_called_once_with(
+			"http://127.0.0.1:9222/json/version",
+			timeout=3,
+			trust_env=False,
+		)
 
 
 def test_fetch_ws_url_failure():
@@ -192,6 +199,26 @@ def test_try_connect_reuses_existing_context():
 	mock_user_context.new_page.assert_called_once()
 
 
+def test_try_connect_reuses_existing_platform_page():
+	session = BrowserSession(cookies={}, user_agent="")
+	session._pw = MagicMock()
+
+	mock_browser = MagicMock()
+	mock_user_context = MagicMock()
+	mock_existing_page = MagicMock()
+	mock_existing_page.url = "https://www.zhipin.com/shanghai/"
+	mock_user_context.pages = [mock_existing_page]
+	mock_browser.contexts = [mock_user_context]
+
+	session._pw.chromium.connect_over_cdp.return_value = mock_browser
+
+	result = session._try_connect("ws://localhost:9222/test")
+
+	assert result is True
+	assert session._page is mock_existing_page
+	mock_user_context.new_page.assert_not_called()
+
+
 def test_try_connect_creates_new_context_when_none_exists():
 	"""CDP 连接无已存在 context 时创建新 context 并注入 cookies"""
 	session = BrowserSession(cookies={"wt2": "abc"}, user_agent="")
@@ -286,7 +313,7 @@ def test_try_cdp_attempts_http_ws_and_devtools_urls_before_falling_back():
 
 	with (
 		patch.object(session, "_try_connect", return_value=False) as mock_try_connect,
-		patch.object(BrowserSession, "_fetch_ws_url", side_effect=[None, "ws://127.0.0.1:9222/devtools/browser/default"]) as mock_fetch_ws_url,
+		patch.object(BrowserSession, "_fetch_ws_url", side_effect=["ws://127.0.0.1:9333/devtools/browser/custom", "ws://127.0.0.1:9222/devtools/browser/default"]) as mock_fetch_ws_url,
 		patch.object(BrowserSession, "_read_devtools_active_port", return_value="ws://127.0.0.1:9222/devtools/browser/file") as mock_read_port,
 	):
 		result = session._try_cdp()
@@ -294,9 +321,10 @@ def test_try_cdp_attempts_http_ws_and_devtools_urls_before_falling_back():
 	assert result is False
 	mock_read_port.assert_called_once()
 	assert [call.args[0] for call in mock_try_connect.call_args_list] == [
+		"ws://127.0.0.1:9333/devtools/browser/custom",
 		"http://127.0.0.1:9333",
-		CDP_DEFAULT_URL,
 		"ws://127.0.0.1:9222/devtools/browser/default",
+		CDP_DEFAULT_URL,
 		"ws://127.0.0.1:9222/devtools/browser/file",
 	]
 	assert [call.args[0] for call in mock_fetch_ws_url.call_args_list] == [
@@ -305,30 +333,161 @@ def test_try_cdp_attempts_http_ws_and_devtools_urls_before_falling_back():
 	]
 
 
+def test_try_connect_uses_explicit_cdp_timeout():
+	session = BrowserSession(cookies={}, user_agent="")
+	session._pw = MagicMock()
+
+	mock_browser = MagicMock()
+	mock_user_context = MagicMock()
+	mock_user_context.pages = []
+	mock_page = MagicMock()
+	mock_user_context.new_page.return_value = mock_page
+	mock_browser.contexts = [mock_user_context]
+	session._pw.chromium.connect_over_cdp.return_value = mock_browser
+
+	result = session._try_connect("ws://127.0.0.1:9222/devtools/browser/test")
+
+	assert result is True
+	session._pw.chromium.connect_over_cdp.assert_called_once_with(
+		"ws://127.0.0.1:9222/devtools/browser/test",
+		timeout=_CDP_CONNECT_TIMEOUT_MS,
+	)
+
+
 def test_request_returns_browser_evaluation_json_and_marks_throttle():
 	session = BrowserSession(cookies={}, user_agent="")
 	session._started = True
 	session._page = MagicMock()
 	session._throttle = MagicMock()
 	expected = {"code": 0, "zpData": {"jobs": []}}
-	session._page.evaluate.return_value = expected
+	mock_response = MagicMock()
+	mock_response.json.return_value = expected
+	mock_cm = MagicMock()
+	mock_cm.__enter__.return_value = mock_cm
+	mock_cm.__exit__.return_value = False
+	mock_cm.value = mock_response
+	session._page.expect_response.return_value = mock_cm
 
-	result = session.request(
-		"POST",
-		"https://www.zhipin.com/wapi/zpgeek/search/joblist.json",
-		params={"query": "python", "page": 1},
-		data={"city": "101020100"},
-	)
+	with patch.object(session, "_search_request_via_raw_cdp", return_value=None):
+		result = session.request(
+			"POST",
+			"https://www.zhipin.com/wapi/zpgeek/search/joblist.json",
+			data={"query": "python", "page": 1, "city": "101020100", "pageSize": 15, "scene": 1},
+		)
 
 	assert result == expected
 	session._throttle.wait.assert_called_once()
 	session._throttle.mark.assert_called_once()
-	evaluate_script, evaluate_args = session._page.evaluate.call_args.args
-	assert "fetch(fetchUrl, options)" in evaluate_script
-	assert evaluate_args == {
-		"method": "POST",
-		"url": "https://www.zhipin.com/wapi/zpgeek/search/joblist.json",
-		"params": {"query": "python", "page": 1},
-		"data": {"city": "101020100"},
-		"referer": "https://www.zhipin.com/web/geek/job",
-	}
+	session._page.expect_response.assert_called_once()
+	session._page.goto.assert_called_once()
+
+
+def test_request_prefers_raw_cdp_search_before_patchright_attach():
+	session = BrowserSession(cookies={}, user_agent="")
+	session._throttle = MagicMock()
+
+	with (
+		patch.object(session, "_search_request_via_raw_cdp", return_value={"code": 0, "zpData": {"jobList": []}}) as mock_raw_cdp,
+		patch.object(session, "_ensure_started") as mock_ensure_started,
+	):
+		result = session.request(
+			"POST",
+			"https://www.zhipin.com/wapi/zpgeek/search/joblist.json",
+			data={"query": "AIGC 产品经理", "page": 1, "city": "101020100", "pageSize": 15, "scene": 1},
+		)
+
+	assert result["code"] == 0
+	mock_raw_cdp.assert_called_once()
+	mock_ensure_started.assert_not_called()
+	session._throttle.wait.assert_called_once()
+	session._throttle.mark.assert_called_once()
+
+
+def test_request_prefers_raw_cdp_detail_before_patchright_attach():
+	session = BrowserSession(cookies={}, user_agent="")
+	session._throttle = MagicMock()
+
+	with (
+		patch.object(session, "_detail_request_via_raw_cdp", return_value={"code": 0, "zpData": {"jobInfo": {}}}) as mock_raw_cdp,
+		patch.object(session, "_ensure_started") as mock_ensure_started,
+	):
+		result = session.request(
+			"GET",
+			"https://www.zhipin.com/wapi/zpgeek/job/detail.json",
+			params={"encryptJobId": "encrypted_j1"},
+		)
+
+	assert result["code"] == 0
+	mock_raw_cdp.assert_called_once()
+	mock_ensure_started.assert_not_called()
+	session._throttle.wait.assert_called_once()
+	session._throttle.mark.assert_called_once()
+
+
+def test_search_request_navigates_and_retries_once_on_code_37():
+	session = BrowserSession(cookies={}, user_agent="")
+	session._started = True
+	session._page = MagicMock()
+	mock_response_1 = MagicMock()
+	mock_response_1.json.return_value = {"code": 37, "message": "expired", "zpData": {}}
+	mock_response_2 = MagicMock()
+	mock_response_2.json.return_value = {"code": 0, "message": "Success", "zpData": {"jobList": [{"jobName": "AI产品经理"}]}}
+	mock_cm_1 = MagicMock()
+	mock_cm_1.__enter__.return_value = mock_cm_1
+	mock_cm_1.__exit__.return_value = False
+	mock_cm_1.value = mock_response_1
+	mock_cm_2 = MagicMock()
+	mock_cm_2.__enter__.return_value = mock_cm_2
+	mock_cm_2.__exit__.return_value = False
+	mock_cm_2.value = mock_response_2
+	session._page.expect_response.side_effect = [mock_cm_1, mock_cm_2]
+
+	result = session._search_request(
+		"https://www.zhipin.com/wapi/zpgeek/search/joblist.json",
+		{"query": "AI 产品经理", "city": "101210100", "page": 1, "pageSize": 15, "scene": 1},
+		"https://www.zhipin.com/web/geek/job",
+	)
+
+	assert result["code"] == 0
+	assert session._page.goto.call_count == 2
+	assert session._page.expect_response.call_count == 2
+
+
+def test_search_request_falls_back_to_in_page_fetch_when_page_response_times_out():
+	session = BrowserSession(cookies={}, user_agent="")
+	session._started = True
+	session._page = MagicMock()
+	session._page.expect_response.side_effect = Exception("Timeout 8000ms exceeded")
+	session._page.evaluate.return_value = {"code": 0, "zpData": {"jobList": [{"jobName": "AIGC产品经理"}]}}
+
+	result = session._search_request(
+		"https://www.zhipin.com/wapi/zpgeek/search/joblist.json",
+		{"query": "AIGC 产品经理", "city": "101020100", "page": 1, "pageSize": 15, "scene": 1},
+		"https://www.zhipin.com/web/geek/job",
+	)
+
+	assert result["code"] == 0
+	assert session._page.expect_response.call_count == 1
+	session._page.goto.assert_called_once()
+	session._page.evaluate.assert_called_once()
+
+
+def test_search_request_uses_shorter_page_response_timeout():
+	session = BrowserSession(cookies={}, user_agent="")
+	session._started = True
+	session._page = MagicMock()
+	mock_response = MagicMock()
+	mock_response.json.return_value = {"code": 0, "zpData": {"jobList": []}}
+	mock_cm = MagicMock()
+	mock_cm.__enter__.return_value = mock_cm
+	mock_cm.__exit__.return_value = False
+	mock_cm.value = mock_response
+	session._page.expect_response.return_value = mock_cm
+
+	session._search_request(
+		"https://www.zhipin.com/wapi/zpgeek/search/joblist.json",
+		{"query": "AI 产品经理", "city": "101210100", "page": 1, "pageSize": 15, "scene": 1},
+		"https://www.zhipin.com/web/geek/job",
+	)
+
+	assert session._page.expect_response.call_args.kwargs["timeout"] == _SEARCH_RESPONSE_TIMEOUT_MS

--- a/tests/test_market_command.py
+++ b/tests/test_market_command.py
@@ -1,0 +1,239 @@
+import json
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from boss_agent_cli.main import cli
+
+
+def _ctx_mock(mock_cls):
+	instance = mock_cls.return_value
+	instance.__enter__ = lambda self: self
+	instance.__exit__ = lambda self, *a: None
+	instance.is_success.side_effect = lambda response: response.get("code") == 0
+	instance.unwrap_data.side_effect = lambda response: response.get("zpData")
+	instance.parse_error.return_value = ("UNKNOWN", "failed")
+	return instance
+
+
+@patch("boss_agent_cli.commands.market.AuthManager")
+@patch("boss_agent_cli.commands.market.get_platform_instance")
+def test_market_ai_pm_filters_and_summarizes(mock_platform_cls, mock_auth_cls):
+	platform = _ctx_mock(mock_platform_cls)
+	platform.search_jobs.return_value = {
+		"code": 0,
+		"zpData": {
+			"jobList": [
+				{
+					"encryptJobId": "j_step",
+					"jobName": "【急招】ai产品经理",
+					"brandName": "阶跃星辰",
+					"salaryDesc": "35-65K·16薪",
+					"cityName": "上海",
+					"jobExperience": "1-3年",
+					"jobDegree": "本科",
+					"skills": ["B端产品", "ToB", "agent", "LLM", "Workflow", "Prompt Engineering"],
+					"brandIndustry": "人工智能",
+					"brandScaleName": "100-499人",
+					"brandStageName": "B轮",
+					"securityId": "sec_step",
+				},
+				{
+					"encryptJobId": "j_ops",
+					"jobName": "AI产品运营",
+					"brandName": "运营公司",
+					"salaryDesc": "15-25K",
+					"cityName": "上海",
+					"jobExperience": "1-3年",
+					"jobDegree": "本科",
+					"skills": ["AI产品"],
+					"brandIndustry": "互联网",
+					"securityId": "sec_ops",
+				},
+				{
+					"encryptJobId": "j_generic",
+					"jobName": "产品经理",
+					"brandName": "普通公司",
+					"salaryDesc": "15-25K",
+					"cityName": "上海",
+					"jobExperience": "1-3年",
+					"jobDegree": "本科",
+					"skills": ["支付产品"],
+					"brandIndustry": "金融",
+					"securityId": "sec_generic",
+				},
+				{
+					"encryptJobId": "j_fresh",
+					"jobName": "AI产品经理",
+					"brandName": "应届友好公司",
+					"salaryDesc": "20-40K",
+					"cityName": "杭州",
+					"jobExperience": "经验不限",
+					"jobDegree": "本科",
+					"skills": ["C端产品", "AIGC"],
+					"brandIndustry": "人工智能",
+					"brandScaleName": "500-999人",
+					"brandStageName": "已上市",
+					"securityId": "sec_fresh",
+				},
+			]
+		},
+	}
+	platform.job_detail.return_value = {
+		"code": 0,
+		"zpData": {
+			"jobInfo": {
+				"encryptJobId": "j_step",
+				"securityId": "sec_step",
+				"jobName": "【急招】ai产品经理",
+				"salaryDesc": "35-65K·16薪",
+				"cityName": "上海",
+				"experienceName": "1-3年",
+				"degreeName": "本科",
+				"jobLabels": ["B端产品", "ToB", "agent", "LLM", "Workflow", "Prompt Engineering"],
+			},
+			"brandComInfo": {"brandName": "阶跃星辰"},
+			"bossInfo": {"name": "王总", "title": "产品负责人"},
+			"jobDetail": (
+				"负责企业 Agent 产品设计，围绕金融顾问和零售场景寻找高价值业务流程。"
+				"输出 PRD，设计 Workflow 和 Skill，理解 LLM API 能力边界和 Prompt Engineering。"
+				"推动 Demo 到生产上线，和算法、工程、客户共创完成商业闭环。"
+			),
+		},
+	}
+
+	runner = CliRunner()
+	result = runner.invoke(
+		cli,
+		[
+			"--json",
+			"market",
+			"ai-pm",
+			"--city",
+			"上海",
+			"--query",
+			"AI 产品经理",
+			"--limit",
+			"10",
+			"--detail-limit",
+			"1",
+		],
+	)
+
+	assert result.exit_code == 0, result.output
+	payload = json.loads(result.output)
+	assert payload["command"] == "market.ai-pm"
+
+	data = payload["data"]
+	titles = {job["title"] for job in data["jobs"]}
+	assert "【急招】ai产品经理" in titles
+	assert "AI产品经理" in titles
+	assert "AI产品运营" not in titles
+	assert "产品经理" not in titles
+	assert data["summary"]["jobs_matched"] == 2
+	assert data["summary"]["detail_success"] == 1
+	assert data["market_signals"]["requirement_themes"][0]["count"] >= 1
+	assert any("Workflow" in item["name"] or "agent" in item["name"] for item in data["market_signals"]["top_skills"])
+	platform.job_detail.assert_called_once_with("j_step")
+
+
+@patch("boss_agent_cli.commands.market.AuthManager")
+@patch("boss_agent_cli.commands.market.get_platform_instance")
+def test_market_ai_pm_supports_no_detail(mock_platform_cls, mock_auth_cls):
+	platform = _ctx_mock(mock_platform_cls)
+	platform.search_jobs.return_value = {
+		"code": 0,
+		"zpData": {
+			"jobList": [
+				{
+					"encryptJobId": "j1",
+					"jobName": "AIGC产品经理",
+					"brandName": "同花顺",
+					"salaryDesc": "25-40K",
+					"cityName": "杭州",
+					"jobExperience": "1-3年",
+					"jobDegree": "本科",
+					"skills": ["C端产品", "AIGC"],
+					"brandIndustry": "互联网",
+					"securityId": "sec1",
+				},
+			]
+		},
+	}
+
+	result = CliRunner().invoke(
+		cli,
+		["--json", "market", "ai-pm", "--city", "杭州", "--query", "AIGC 产品经理", "--no-detail"],
+	)
+
+	assert result.exit_code == 0, result.output
+	payload = json.loads(result.output)
+	assert payload["data"]["summary"]["detail_success"] == 0
+	assert payload["data"]["representative_jds"] == []
+	platform.job_detail.assert_not_called()
+
+
+@patch("boss_agent_cli.commands.market.AuthManager")
+@patch("boss_agent_cli.commands.market.get_platform_instance")
+def test_market_ai_pm_falls_back_to_job_card_detail(mock_platform_cls, mock_auth_cls):
+	platform = _ctx_mock(mock_platform_cls)
+	platform.search_jobs.return_value = {
+		"code": 0,
+		"zpData": {
+			"jobList": [
+				{
+					"encryptJobId": "j1",
+					"jobName": "AI产品经理",
+					"brandName": "网易",
+					"salaryDesc": "21-35K·16薪",
+					"cityName": "杭州",
+					"jobExperience": "在校/应届",
+					"jobDegree": "本科",
+					"skills": ["AI产品"],
+					"brandIndustry": "互联网",
+					"brandScaleName": "10000人以上",
+					"brandStageName": "已上市",
+					"securityId": "sec1",
+					"lid": "lid1",
+				},
+			]
+		},
+	}
+	platform.job_detail.return_value = {"code": 1, "message": "缺少必要参数"}
+	platform.job_card.return_value = {
+		"code": 0,
+		"zpData": {
+			"jobCard": {
+				"encryptJobId": "j1",
+				"securityId": "sec1",
+				"jobName": "AI产品经理",
+				"brandName": "网易",
+				"salaryDesc": "21-35K·16薪",
+				"cityName": "杭州",
+				"experienceName": "在校/应届",
+				"degreeName": "本科",
+				"jobLabels": ["AI产品", "C端产品"],
+				"postDescription": "负责 AI 产品 0-1 上线，输出 PRD，推进算法和工程协作，基于用户反馈做数据复盘。",
+			}
+		},
+	}
+
+	result = CliRunner().invoke(
+		cli,
+		["--json", "market", "ai-pm", "--city", "杭州", "--query", "AI 产品经理", "--detail-limit", "1"],
+	)
+
+	assert result.exit_code == 0, result.output
+	data = json.loads(result.output)["data"]
+	assert data["summary"]["detail_success"] == 1
+	assert data["representative_jds"][0]["company"] == "网易"
+	assert "PRD" in " ".join(data["representative_jds"][0]["key_requirements"])
+	platform.job_card.assert_called_once_with("sec1", "lid1")
+
+
+def test_schema_includes_market_command():
+	result = CliRunner().invoke(cli, ["schema"])
+	assert result.exit_code == 0
+	commands = json.loads(result.output)["data"]["commands"]
+	assert "market" in commands
+	assert "ai-pm" in commands["market"]["subcommands"]


### PR DESCRIPTION
## Summary

- 修复 BOSS 搜索/详情/CDP 刷新链路不稳定的问题
- 新增 `boss market ai-pm`，用于扫描杭州/上海 AI 产品经理岗位并总结 JD 共性要求
- 补充相关测试

## Type

- [x] feat: 新功能
- [x] fix: Bug 修复
- [x] test: 测试

## Breaking Change

- [x] 本 PR 不包含破坏性变更

## Test Plan

- [x] `.venv/bin/pytest -q`
- [x] 本地跑过 `boss market ai-pm --city 杭州/上海 ...`

测试结果：`1316 passed`