### PR TITLE
feat: 新增 hr jobs detail 命令 — 查看职位完整 JD（重做 #234，仅 job-detail 范围）

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -91,7 +91,7 @@ Every command outputs **structured JSON** that AI Agents parse directly. No frag
 - **Structured transport**: stdout is JSON-only, stderr is logs-only, which keeps automation stable
 - **Platform-aware login**: `zhipin` uses Cookie → CDP → QR httpx → patchright; `zhilian` uses Cookie → CDP → browser login
 - **Cross-platform adapter layer**: `Platform` / `RecruiterPlatform` registries are live; BOSS is available on both candidate and recruiter sides, and Zhaopin already has candidate-side login plus read/write flow wired in
-- **MCP server with 52 tools**: ready for Claude Desktop / Cursor / Windsurf, including recruiter-side tools without wrapping your own bridge
+- **MCP server with 53 tools**: ready for Claude Desktop / Cursor / Windsurf, including recruiter-side tools without wrapping your own bridge
 
 ## 📦 Install
 

--- a/src/boss_agent_cli/api/recruiter.yaml
+++ b/src/boss_agent_cli/api/recruiter.yaml
@@ -101,6 +101,10 @@ endpoints:
     method: POST
     path: "/wapi/zpjob/job/online"
     referer: "/web/chat/index"
+  boss_job_edit:
+    method: GET
+    path: "/wapi/zpjob/job/edit"
+    referer: "/web/frame/job/edit"
 
   # ── 交换联系方式（手机/微信/简历）──────────────────
   # type 取值（实证抓包，issue #217）：

--- a/src/boss_agent_cli/api/recruiter_client.py
+++ b/src/boss_agent_cli/api/recruiter_client.py
@@ -242,6 +242,7 @@ class BossRecruiterClient:
 
 	def _request(self, method: str, url: str, **kwargs: Any) -> dict[str, Any]:
 		"""httpx request with retry loop."""
+		extra_headers_override: dict[str, str] = kwargs.pop("extra_headers", {})
 		for attempt in range(_MAX_RETRIES + 1):
 			client = self._get_client()
 			token = self._auth.get_token()
@@ -254,8 +255,8 @@ class BossRecruiterClient:
 
 			self._throttle.wait()
 
-			extra_headers = self._headers_for(url)
-			resp = client.request(method, url, headers=extra_headers, **kwargs)
+			headers = {**self._headers_for(url), **extra_headers_override}
+			resp = client.request(method, url, headers=headers, **kwargs)
 			self._throttle.mark()
 			self._merge_cookies(resp)
 
@@ -641,6 +642,11 @@ class BossRecruiterClient:
 	def job_online(self, job_id: str) -> dict[str, Any]:
 		data = {"encryptJobId": job_id}
 		return self._browser_request("POST", ep.BOSS_JOB_ONLINE_URL, data=data)
+
+	def job_detail(self, enc_job_id: str) -> dict[str, Any]:
+		params = {"encJobId": enc_job_id, "lid": "", "encAtsJobId": ""}
+		referer = f"{ep.BASE_URL}/web/frame/job/edit?jobversion=9921&encryptId={enc_job_id}&jobCreateSource=0&enterSource=6"
+		return self._request("GET", ep.BOSS_JOB_EDIT_URL, params=params, extra_headers={"Referer": referer})
 
 	# ── 交换联系方式（手机/微信/简历）─────────────────────
 

--- a/src/boss_agent_cli/api/recruiter_client.py
+++ b/src/boss_agent_cli/api/recruiter_client.py
@@ -242,6 +242,8 @@ class BossRecruiterClient:
 
 	def _request(self, method: str, url: str, **kwargs: Any) -> dict[str, Any]:
 		"""httpx request with retry loop."""
+		# extra_headers overrides yaml-driven defaults from _headers_for(url); use only when
+		# a static yaml referer can't carry per-call query params (e.g. job/edit needs encryptId).
 		extra_headers_override: dict[str, str] = kwargs.pop("extra_headers", {})
 		for attempt in range(_MAX_RETRIES + 1):
 			client = self._get_client()

--- a/src/boss_agent_cli/api/recruiter_endpoints.py
+++ b/src/boss_agent_cli/api/recruiter_endpoints.py
@@ -45,6 +45,7 @@ BOSS_CHAT_GEEK_INFO_URL = _url("boss_chat_geek_info")
 BOSS_JOB_LIST_URL = _url("boss_job_list")
 BOSS_JOB_OFFLINE_URL = _url("boss_job_offline")
 BOSS_JOB_ONLINE_URL = _url("boss_job_online")
+BOSS_JOB_EDIT_URL = _url("boss_job_edit")
 
 # ── 交换联系方式 ────────────────────────────────────
 BOSS_EXCHANGE_TEST_URL = _url("boss_exchange_test")

--- a/src/boss_agent_cli/commands/recruiter/jobs.py
+++ b/src/boss_agent_cli/commands/recruiter/jobs.py
@@ -91,3 +91,30 @@ def jobs_online_cmd(ctx: click.Context, job_id: str) -> None:
 			return
 		data = {"job_id": job_id, "message": "职位已上线"}
 		handle_output(ctx, "recruiter-jobs-online", data)
+
+
+@jobs_group.command("detail")
+@click.argument("enc_job_id")
+@click.pass_context
+@handle_auth_errors("recruiter-jobs-detail")
+def jobs_detail_cmd(ctx: click.Context, enc_job_id: str) -> None:
+	"""查看职位详情（含完整 JD）"""
+	data_dir = ctx.obj["data_dir"]
+	logger = ctx.obj["logger"]
+
+	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
+	with get_recruiter_platform_instance(ctx, auth) as platform:
+		result = platform.job_detail(enc_job_id)
+		if not platform.is_success(result):
+			code, message = platform.parse_error(result)
+			recoverable, recovery_action = error_contract_for_code(code)
+			handle_error_output(
+				ctx, "recruiter-jobs-detail",
+				code=code,
+				message=message or "职位详情获取失败",
+				recoverable=recoverable,
+				recovery_action=recovery_action,
+			)
+			return
+		data = platform.unwrap_data(result) or {}
+		handle_output(ctx, "recruiter-jobs-detail", data)

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -779,7 +779,7 @@ SCHEMA_DATA = {
 				"chat": "查看与候选人的沟通列表（含未读数和最近消息摘要）",
 				"chatmsg": "查看与指定候选人的聊天消息历史",
 				"last-messages": "批量查看候选人最近消息摘要",
-				"jobs": "管理职位发布（list/offline/online）",
+				"jobs": "管理职位发布（list/offline/online/detail）",
 				"candidates": "搜索候选人（支持 city/job-id/experience/degree/age/school-level/activeness/source/salary/select/page 筛选）",
 				"reply": "回复候选人消息",
 				"request-resume": "请求候选人分享附件简历",

--- a/src/boss_agent_cli/mcp_server.py
+++ b/src/boss_agent_cli/mcp_server.py
@@ -672,6 +672,17 @@ TOOLS = [
 			"required": [],
 		},
 	),
+	Tool(
+		name="boss_hr_jobs_detail",
+		description="招聘者模式：查看指定职位的完整详情（包括岗位描述 postDescription）",
+		inputSchema={
+			"type": "object",
+			"properties": {
+				"enc_job_id": {"type": "string", "description": "职位的加密 ID（encryptJobId）"},
+			},
+			"required": ["enc_job_id"],
+		},
+	),
 ]
 
 _decorate_tool_descriptions()
@@ -972,6 +983,9 @@ def _build_args(tool_name: str, arguments: dict) -> list[str]:
 		if action in {"online", "offline"}:
 			args.append(str(arguments["job_id"]))
 		return args
+
+	if name == "hr_jobs_detail":
+		return ["hr", "jobs", "detail", str(arguments["enc_job_id"])]
 
 	# 无参数命令：status, doctor, cities, interviews, history, pipeline
 	return [name]

--- a/src/boss_agent_cli/platforms/zhipin_recruiter.py
+++ b/src/boss_agent_cli/platforms/zhipin_recruiter.py
@@ -144,6 +144,9 @@ class BossRecruiterPlatform(RecruiterPlatform):
 	def job_online(self, job_id: str) -> dict[str, Any]:
 		return self._client.job_online(job_id)
 
+	def job_detail(self, enc_job_id: str) -> dict[str, Any]:
+		return self._client.job_detail(enc_job_id)
+
 	# ── 交换联系方式 ──────────────────────────────────────
 
 	def exchange_request(self, exchange_type: int, uid: int, job_id: int, gid: int) -> dict[str, Any]:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -98,6 +98,7 @@ def test_required_tools_present():
 		"boss_hr_applications", "boss_hr_candidates", "boss_hr_chat",
 		"boss_hr_chatmsg", "boss_hr_last_messages", "boss_hr_resume",
 		"boss_hr_exchange", "boss_hr_reply", "boss_hr_request_resume", "boss_hr_jobs",
+		"boss_hr_jobs_detail",
 	}
 	missing = required - names
 	assert not missing, f"缺少核心工具: {missing}"
@@ -105,7 +106,7 @@ def test_required_tools_present():
 
 def test_tool_count():
 	"""工具总数应与当前注册一致。"""
-	assert len(TOOLS) == 52
+	assert len(TOOLS) == 53
 
 
 def test_search_tool_requires_query():
@@ -548,7 +549,7 @@ def test_build_args_shortlist_list():
 
 def test_tool_count_after_pr41():
 	"""协议服务工具总数应与当前 MCP 暴露能力完全一致。"""
-	assert len(TOOLS) == 52
+	assert len(TOOLS) == 53
 
 
 def test_build_args_shortlist_add():
@@ -677,3 +678,7 @@ def test_build_args_hr_jobs_list():
 
 def test_build_args_hr_jobs_online():
 	assert _build_args("boss_hr_jobs", {"action": "online", "job_id": "77"}) == ["hr", "jobs", "online", "77"]
+
+
+def test_build_args_hr_jobs_detail():
+	assert _build_args("boss_hr_jobs_detail", {"enc_job_id": "abc123"}) == ["hr", "jobs", "detail", "abc123"]


### PR DESCRIPTION
## 背景

招聘者需要在 CLI / MCP 环境中直接读取岗位的完整 JD（`postDescription`），现有 `hr jobs list` 只返回摘要字段，无法满足需求。

通过 CDP 抓包逆向分析，确认 BOSS 直聘使用以下端点返回完整职位数据：

```
GET /wapi/zpjob/job/edit?encJobId=<encryptJobId>&lid=&encAtsJobId=
Referer: https://www.zhipin.com/web/frame/job/edit?jobversion=9921&encryptId=<encryptJobId>&...
```

## 与 #234 的关系

本 PR 是 #234 的**重做版本**，按 reviewer 反馈，将范围严格限定为 `hr jobs detail` 一个特性，**剔除了**原 #234 中混入的 `skills/boss-resume-downloader/` 相关文件——那些属于 #229 的范围，会单独评审。

可在合入本 PR 后关闭 #234。

## 变更内容

| 文件 | 变更 |
|------|------|
| `api/recruiter.yaml` | 新增 `boss_job_edit` 端点 |
| `api/recruiter_endpoints.py` | 暴露 `BOSS_JOB_EDIT_URL` |
| `api/recruiter_client.py` | 新增 `job_detail(enc_job_id)`，携带动态 Referer；`_request` 支持 `extra_headers` 覆盖 |
| `platforms/zhipin_recruiter.py` | 平台类补充 `job_detail` 代理方法 |
| `commands/recruiter/jobs.py` | 新增 `hr jobs detail <enc_job_id>` 子命令 |
| `mcp_server.py` | 新增 MCP 工具 `boss_hr_jobs_detail` |
| `commands/schema.py` | 更新 jobs 说明（含 detail） |
| `tests/test_mcp_server.py` | 工具数 52→53，补充 `_build_args` 测试 |
| `README.en.md` | 工具数 52→53 |

## 使用方式

```bash
# 先取职位列表，拿 encryptJobId
boss hr jobs list

# 查看完整 JD
boss hr jobs detail <encryptJobId>
```

## 实测验证

在本地通过 CDP 登录后，成功获取完整岗位描述（包含技术要求、加分项等 `postDescription` 内容）。

本地 `pytest tests/test_mcp_server.py`：95 passed。

## 流程图

```
hr jobs detail <encryptJobId>
        │
        ▼
GET /wapi/zpjob/job/edit?encJobId=...
        │
        ▼
zpData.job.postDescription  ←── 完整 JD 文本
```
