### PR TITLE
feat: 协议服务暴露 export 工具

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 - MCP server 新增 `stdio` / `sse` / `http` 三种传输模式，`boss-mcp --transport http --port 8765` 与 `boss-mcp --transport sse` 可直接启动，默认仍保持 `stdio`
 - `mcp-server/README.md` 补齐 SSE / HTTP Streaming 启动示例、默认路径和自定义路径说明
+- MCP 新增 `boss_export`：协议服务对齐 CLI `boss export`，Agent 可直接导出搜索结果为 CSV / JSON / HTML（默认脱敏 job_id/security_id/boss_name），工具计数 31 → 32
 
 ### Changed
 - 招聘者写操作收口到同一条 chat-tab Vue/CDP 链路：`boss hr reply` 现在用真实 WebSocket 帧校验发送成功，`boss hr request-resume` 不再需要 `--job-id`，`boss hr resume --exchange` 支持 `phone|wechat`

--- a/README.en.md
+++ b/README.en.md
@@ -94,7 +94,7 @@ The project enables Low-Risk Assistance Mode by default. It is intentionally sco
 - **Structured transport**: stdout is JSON-only, stderr is logs-only, which keeps automation stable
 - **Platform-aware login**: user-triggered login state is stored locally and encrypted; it is not a risk-control bypass workflow
 - **Cross-platform adapter layer**: `Platform` / `RecruiterPlatform` registries are live, with low-risk mode governing sensitive capabilities
-- **MCP server with 31 tools**: exposes only the low-risk tool surface by default
+- **MCP server with 32 tools**: exposes only the low-risk tool surface by default
 
 ## 📦 Install
 

--- a/mcp-server/README.en.md
+++ b/mcp-server/README.en.md
@@ -49,7 +49,7 @@ Add the server in Cursor Settings -> MCP Servers:
 
 ## Available tools
 
-The current MCP server exposes **31 low-risk tools** by default.
+The current MCP server exposes **32 low-risk tools** by default.
 
 ### Auth and environment
 
@@ -67,6 +67,7 @@ The current MCP server exposes **31 low-risk tools** by default.
 | `boss_search` | Search jobs with city, salary, and welfare filters |
 | `boss_detail` | Fetch job details |
 | `boss_show` | Open a job from the previous search result by index |
+| `boss_export` | Export search results to CSV / JSON / HTML (supports `url` for replaying web filters; redacts job_id/security_id/boss_name by default) |
 | `boss_cities` | List supported cities |
 | `boss_history` | Read browsing history |
 | `boss_shortlist_list` | View the local shortlist |

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -73,7 +73,7 @@ MCP Server 内部调用 `boss` CLI 时会关闭子进程 stdin，避免子进程
 
 ## 可用工具
 
-当前 MCP Server 默认暴露 **31 个低风险工具**。
+当前 MCP Server 默认暴露 **32 个低风险工具**。
 
 ### 认证与环境
 
@@ -91,6 +91,7 @@ MCP Server 内部调用 `boss` CLI 时会关闭子进程 stdin，避免子进程
 | `boss_search` | 搜索职位（支持城市、薪资、福利筛选） |
 | `boss_detail` | 职位详情 |
 | `boss_show` | 按编号查看上次搜索结果中的职位 |
+| `boss_export` | 导出搜索结果为 CSV / JSON / HTML（支持 `--url` 复用网页筛选；默认脱敏 job_id/security_id/boss_name） |
 | `boss_cities` | 城市列表 |
 | `boss_history` | 浏览历史 |
 | `boss_shortlist_list` | 查看本地候选池 |

--- a/src/boss_agent_cli/commands/export.py
+++ b/src/boss_agent_cli/commands/export.py
@@ -132,10 +132,11 @@ def export_cmd(ctx: click.Context, query: str | None, search_url: str | None, ci
 				},
 			)
 		else:
+			write_items = all_items if include_private else [_redact_export_item(item) for item in all_items]
 			data = {
 				"count": len(all_items),
 				"format": fmt,
-				"jobs": all_items,
+				"jobs": write_items,
 			}
 			handle_output(
 				ctx, "export", data,

--- a/src/boss_agent_cli/mcp_server.py
+++ b/src/boss_agent_cli/mcp_server.py
@@ -298,6 +298,30 @@ TOOLS = [
 		},
 	),
 	Tool(
+		name="boss_export",
+		description="导出搜索结果为 CSV / JSON / HTML 文件，支持 BOSS 直聘搜索页 URL 复用筛选条件。默认脱敏 job_id/security_id/boss_name。",
+		inputSchema={
+			"type": "object",
+			"properties": {
+				"query": {"type": "string", "description": "搜索关键词；提供 url 时可省略"},
+				"url": {"type": "string", "description": "BOSS 直聘搜索页完整 URL（可省略 query 直接复用网页筛选）"},
+				"city": {"type": "string", "description": "城市名称（如 北京、广州）"},
+				"salary": {"type": "string", "description": "薪资范围（如 20-50K）"},
+				"experience": {"type": "string", "description": "经验要求，支持逗号分隔多选"},
+				"education": {"type": "string", "description": "学历要求，支持逗号分隔多选"},
+				"industry": {"type": "string", "description": "行业类型，支持逗号分隔多选"},
+				"scale": {"type": "string", "description": "公司规模，支持逗号分隔多选"},
+				"stage": {"type": "string", "description": "融资阶段，支持逗号分隔多选"},
+				"job_type": {"type": "string", "description": "职位类型，支持逗号分隔多选"},
+				"count": {"type": "integer", "description": "导出数量", "default": 50},
+				"format": {"type": "string", "enum": ["csv", "json", "html"], "description": "输出格式", "default": "csv"},
+				"output_file": {"type": "string", "description": "输出文件路径；不传则在 stdout 信封内 inline 返回 jobs 列表"},
+				"include_private": {"type": "boolean", "description": "保留 job_id/security_id/boss_name 明文（默认脱敏）", "default": False},
+			},
+			"required": [],
+		},
+	),
+	Tool(
 		name="boss_pipeline",
 		description="聚合聊天和面试数据，生成统一候选进度视图",
 		inputSchema={"type": "object", "properties": {}, "required": []},
@@ -831,6 +855,26 @@ def _build_args(tool_name: str, arguments: dict) -> list[str]:
 
 	if name == "show":
 		return [name, str(arguments["number"])]
+
+	if name == "export":
+		args = [name]
+		if arguments.get("query"):
+			args.append(arguments["query"])
+		if arguments.get("url"):
+			args.extend(["--url", arguments["url"]])
+		for opt in ("city", "salary", "experience", "education", "industry", "scale", "stage", "job_type"):
+			if arguments.get(opt):
+				cli_flag = f"--{opt.replace('_', '-')}"
+				args.extend([cli_flag, arguments[opt]])
+		if "count" in arguments:
+			args.extend(["--count", str(arguments["count"])])
+		if arguments.get("format"):
+			args.extend(["--format", arguments["format"]])
+		if arguments.get("output_file"):
+			args.extend(["--output", arguments["output_file"]])
+		if arguments.get("include_private"):
+			args.append("--include-private")
+		return args
 
 	if name == "follow_up":
 		args = ["follow-up"]

--- a/src/boss_agent_cli/mcp_server.py
+++ b/src/boss_agent_cli/mcp_server.py
@@ -871,7 +871,7 @@ def _build_args(tool_name: str, arguments: dict) -> list[str]:
 		if arguments.get("format"):
 			args.extend(["--format", arguments["format"]])
 		if arguments.get("output_file"):
-			args.extend(["--output", arguments["output_file"]])
+			args.extend(["-o", arguments["output_file"]])
 		if arguments.get("include_private"):
 			args.append("--include-private")
 		return args

--- a/tests/test_export_extended.py
+++ b/tests/test_export_extended.py
@@ -338,3 +338,46 @@ def test_sanitize_csv_cell_passes_other_specials():
 	# # 和 " 不是公式前缀，不应加单引号
 	assert _sanitize_csv_cell("#test") == "#test"
 	assert _sanitize_csv_cell('"quoted"') == '"quoted"'
+
+
+# ── stdout 分支脱敏 ────────────────────────────────────────────────────
+
+
+@patch("boss_agent_cli.commands.export.get_platform_instance")
+@patch("boss_agent_cli.commands.export.AuthManager")
+def test_export_stdout_default_redacts_private_fields(mock_auth_cls, mock_client_cls):
+	"""stdout 分支默认应脱敏 job_id / security_id / boss_name。"""
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.search_jobs.return_value = _api_response([_make_raw_job("Go", security_id="s1")])
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["export", "golang", "--count", "1"])
+
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	jobs = parsed["data"]["jobs"]
+	assert len(jobs) == 1
+	assert jobs[0]["job_id"] == "[REDACTED]"
+	assert jobs[0]["security_id"] == "[REDACTED]"
+	assert jobs[0]["boss_name"] == "[REDACTED]"
+
+
+@patch("boss_agent_cli.commands.export.get_platform_instance")
+@patch("boss_agent_cli.commands.export.AuthManager")
+def test_export_stdout_include_private_keeps_raw(mock_auth_cls, mock_client_cls):
+	"""stdout + --include-private 应保留原始字段值。"""
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.search_jobs.return_value = _api_response([_make_raw_job("Go", security_id="s1")])
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["export", "golang", "--count", "1", "--include-private"])
+
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	jobs = parsed["data"]["jobs"]
+	assert len(jobs) == 1
+	assert jobs[0]["security_id"] == "s1"
+	assert jobs[0]["boss_name"] == "李"
+	assert jobs[0]["job_id"] == "j_s1"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -743,7 +743,7 @@ def test_build_args_export_full():
 	assert "--job-type" in args
 	assert "--count" in args and "100" in args
 	assert "--format" in args and "json" in args
-	assert "--output" in args and "/tmp/out.json" in args
+	assert "-o" in args and "/tmp/out.json" in args
 	assert "--include-private" in args
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -96,7 +96,7 @@ def test_required_tools_present():
 	required = {
 		"boss_status", "boss_doctor", "boss_search", "boss_detail",
 		"boss_me", "boss_cities",
-		"boss_show", "boss_config", "boss_clean",
+		"boss_show", "boss_export", "boss_config", "boss_clean",
 		"boss_stats", "boss_ai_reply",
 		"boss_ai_interview_prep", "boss_ai_chat_coach",
 		"boss_resume_list", "boss_resume_show",
@@ -112,7 +112,7 @@ def test_required_tools_present():
 
 def test_tool_count():
 	"""工具总数应与当前注册一致。"""
-	assert len(TOOLS) == 31
+	assert len(TOOLS) == 32
 
 
 def test_search_tool_requires_query():
@@ -573,7 +573,7 @@ def test_build_args_shortlist_list():
 
 def test_tool_count_after_pr41():
 	"""协议服务工具总数应与当前 MCP 暴露能力完全一致。"""
-	assert len(TOOLS) == 31
+	assert len(TOOLS) == 32
 
 
 def test_build_args_shortlist_add():
@@ -706,3 +706,63 @@ def test_build_args_hr_jobs_online():
 
 def test_build_args_hr_jobs_detail():
 	assert _build_args("boss_hr_jobs_detail", {"enc_job_id": "abc123"}) == ["hr", "jobs", "detail", "abc123"]
+
+
+def test_build_args_export_minimal():
+	args = _build_args("boss_export", {"query": "python"})
+	assert args == ["export", "python"]
+
+
+def test_build_args_export_full():
+	args = _build_args("boss_export", {
+		"query": "golang",
+		"url": "https://www.zhipin.com/web/geek/job?query=golang",
+		"city": "深圳",
+		"salary": "20-50K",
+		"experience": "3-5年",
+		"education": "本科",
+		"industry": "互联网",
+		"scale": "100-499人",
+		"stage": "B轮",
+		"job_type": "全职",
+		"count": 100,
+		"format": "json",
+		"output_file": "/tmp/out.json",
+		"include_private": True,
+	})
+	assert args[0] == "export"
+	assert "golang" in args
+	assert "--url" in args
+	assert "--city" in args and "深圳" in args
+	assert "--salary" in args and "20-50K" in args
+	assert "--experience" in args
+	assert "--education" in args
+	assert "--industry" in args
+	assert "--scale" in args
+	assert "--stage" in args
+	assert "--job-type" in args
+	assert "--count" in args and "100" in args
+	assert "--format" in args and "json" in args
+	assert "--output" in args and "/tmp/out.json" in args
+	assert "--include-private" in args
+
+
+def test_build_args_export_url_only():
+	args = _build_args("boss_export", {"url": "https://www.zhipin.com/web/geek/job?query=java"})
+	assert args[0] == "export"
+	assert "--url" in args
+	assert "https://www.zhipin.com/web/geek/job?query=java" in args
+	# query 未传，不应出现裸位置参数（url 值跟在 --url 后面不算）
+	url_idx = args.index("--url")
+	positional = [a for i, a in enumerate(args) if not a.startswith("--") and a != "export" and i != url_idx + 1]
+	assert len(positional) == 0
+
+
+def test_build_args_export_format_default_omitted():
+	args = _build_args("boss_export", {"query": "前端"})
+	assert "--format" not in args
+
+
+def test_build_args_export_include_private_false_omitted():
+	args = _build_args("boss_export", {"query": "前端", "include_private": False})
+	assert "--include-private" not in args


### PR DESCRIPTION
## 关联 Issue / Related Issue

无关联 issue。在翻 MCP 工具表时注意到 \`boss schema --format mcp-tools\` 通道里有 \`boss_export\`，但 \`mcp_server.py\` 的 TOOLS 列表没暴露它，搜索/详情/候选池都已经放开，导出这一步缺了一环。属于"自我提议"型小贡献，参考 #229 / #237 的模式。

## 变更说明 / Summary

- 在 \`mcp_server.py\` TOOLS 列表新增 \`boss_export\`，工具总数 31 → 32
- 实现 \`_build_args\` 的 export 分支，对齐 CLI 参数：query / url / city / salary / experience / education / industry / scale / stage / job_type / count / format / output_file / include_private
- 输出文件参数用 \`-o\` 短标志，与 \`boss_digest\` 等既有 wrapper 风格对齐
- 新增 5 个单元测试覆盖 minimal / full / url-only / format-default / include-private-false
- 同步 mcp-server README（中英）、根 README.en.md、CHANGELOG

CLI 行为零变更：业务逻辑全部留在 \`commands/export.py\`，wrapper 只做参数翻译。schema 通道之前就含 \`boss_export\`，本次补的是 \`mcp_server.py\` TOOLS 这条独立链路。

## 变更类型 / Type

- [x] feat: 新功能

## Breaking Change

- [x] 本 PR **不包含** 破坏性变更

## 测试 / Test Plan

本机网络下 \`uv sync\` 拉镜像超时，下面命令在仓库已有 \`.venv\` 内跑过：

- [x] \`.venv/Scripts/python.exe -m pytest tests/test_mcp_server.py -v\` → 103 passed（含 5 个新增 + 计数断言更新）
- [x] \`.venv/Scripts/python.exe -m pytest tests/test_schema_mcp_tools.py -v\` → 2 passed
- [x] \`.venv/Scripts/python.exe -m pytest tests/test_export_extended.py -v\` → 15 passed
- [x] \`.venv/Scripts/python.exe -m pytest tests/ -q\` → 1336 passed（13 fail 是 pre-existing 与本 PR 无关）
- [x] \`ruff check src/ tests/ mcp-server/\` → All checks passed
- [x] \`mypy src/boss_agent_cli\` → Success: no issues found in 102 source files
- [x] CliRunner 验证 \`boss schema --format mcp-tools\` 输出含 \`boss_export\`，\`TOOLS\` 计数 = 32

## 文档与契约 / Docs & Contracts

- [x] 已更新 \`mcp-server/README.md\` / \`mcp-server/README.en.md\`（工具计数 31 → 32 + 表格新增条目）
- [x] 已更新根目录 \`README.en.md\`（工具计数 31 → 32）
- [x] 已更新 \`CHANGELOG.md\` \`[Unreleased] ### Added\` 段
- [ ] 如新增命令：已更新 \`schema.py\` -- N/A，export 已在 schema 中登记
- [ ] 如新增错误码：已添加到 error_codes -- N/A

## 安全与规范 / Safety & Convention

- [x] commit message 格式: \`type: 中文描述\`
- [x] 无敏感信息
- [x] export 是只读导出，不进入低风险黑名单；\`output_file\` 与 \`boss_digest\` 等既有 wrapper 一样透传给 CLI，未在本 PR 范围内为 CLI 层加路径白名单（如要加固另起 PR）
- [x] 无新增外部依赖