### PR TITLE
docs(contributing): 中文版补齐英文版独有的几节

### DIFF
--- a/CONTRIBUTING.en.md
+++ b/CONTRIBUTING.en.md
@@ -82,7 +82,7 @@ Maintainers will `squash merge`, so the squash title must follow the commit conv
 6. Update `AGENTS.md` (command-count invariant)
 7. Update `README.md` and `README.en.md` (command reference table)
 8. Update the relevant module's `CLAUDE.md`
-9. If the command is useful for Agents via MCP, also register it in `mcp-server/server.py` (both the `Tool` definition and `_build_args` branch)
+9. If the command is useful for Agents via MCP, also register it in `src/boss_agent_cli/mcp_server.py` (add a Tool to the `TOOLS` list and a branch in `_build_args`; `mcp-server/server.py` is a thin wrapper that auto re-exports both)
 
 ## Output Contract (Do Not Break)
 
@@ -105,7 +105,7 @@ Every command must output a JSON envelope to **stdout**:
 - `exit 0` — success (`ok=true`)
 - `exit 1` — failure (`ok=false`)
 
-On error, the envelope must contain `error.code`, `error.recoverable`, and `error.recovery_action`. See `ERROR_CODES` in `schema.py` for the current enum.
+On error, the envelope must contain `error.code`, `error.recoverable`, and `error.recovery_action`. See `SCHEMA_DATA["error_codes"]` in `src/boss_agent_cli/commands/schema.py` (around line 855) for the current enum.
 
 ## Testing Philosophy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,8 @@ uv run pytest tests/ -v
 uv run pre-commit install
 ```
 
+Python **≥ 3.10** 是最低要求。项目使用 [`uv`](https://github.com/astral-sh/uv) 管理依赖，`uv sync --all-extras` 会在本地 `.venv` 中安装运行时和开发依赖。
+
 ## 编码规范
 
 - Python 源码缩进使用 **tab**。
@@ -24,6 +26,10 @@ uv run pre-commit install
 - 命令输出必须保持 JSON 信封契约：stdout 只输出 Agent 可读 JSON，stderr 输出日志和进度。
 - commit message：`type: 中文描述`（feat / fix / refactor / docs / test / chore / ci）。
 - 类型检查：`uv run mypy src/boss_agent_cli`，CI 阻塞式门禁，新代码必须零 mypy 错误。
+  - ✅ `feat: 新增配置管理命令`
+  - ❌ `feat: add config command`（英文描述）
+  - ❌ `feat: 新增 config 命令`（中英混杂）
+  - 不要添加 `Co-authored-by` 尾注或任何 AI 署名行
 
 ## 本地验证
 
@@ -46,11 +52,48 @@ git diff --check
 
 ## 提交流程
 
-1. Fork 本仓库
-2. 创建功能分支：`git checkout -b feat/your-feature`
-3. 编写测试 → 实现功能 → 确保测试通过
-4. 提交并推送
-5. 创建 Pull Request
+1. **Fork** 本仓库并 clone 到本地。
+2. 从 `master` 创建功能分支：`git checkout -b feat/your-feature`。
+3. **先写测试**：写失败的测试，再写实现，再跑全套。
+4. **本地 lint + 测试**：
+   ```bash
+   uv run ruff check src/ tests/ mcp-server/
+   uv run pytest tests/ -q
+   ```
+5. **原子提交**：每个 commit 只做一件事。
+6. **Push** 并向 `master` 发起 Pull Request。
+7. **CI 全绿**才能合并：4 个 Python 版本（3.10–3.13）跑测试，加 lint / typecheck / docs / 安全扫描。
+
+维护者会使用 squash merge，所以最终 squash 标题也要遵守上面的 commit 格式。
+
+## 输出契约（不可破坏）
+
+每个命令必须向 **stdout** 输出 JSON 信封：
+
+```json
+{
+  "ok": true,
+  "schema_version": "1.0",
+  "command": "search",
+  "data": [...],
+  "pagination": {...},
+  "error": null,
+  "hints": {...}
+}
+```
+
+- `stdout` 只放 JSON，不要直接 `print()` 到 stdout。
+- `stderr` 放日志和进度信息（受 `--log-level` 控制）。
+- `exit 0` 表示成功（`ok=true`）。
+- `exit 1` 表示失败（`ok=false`）。
+
+出错时信封必须包含 `error.code`、`error.recoverable` 和 `error.recovery_action`。可用错误码见 `schema.py` 中的 `ERROR_CODES`。
+
+## 测试理念
+
+- **鼓励 TDD**：先写测试再写实现。CI 覆盖率在 [Codecov](https://codecov.io/gh/can4hou6joeng4/boss-agent-cli) 追踪，基线 80%。
+- **Mock 外部 I/O**：`AuthManager`、`BossClient`、`CacheStore`、`AIService` 是 mock 边界，测试不应真正调用 BOSS 直聘 API。
+- **错误路径对等**：每条成功路径至少对应一条错误路径测试（认证过期、限流、参数非法等）。
 
 ## 维护者文档
 
@@ -62,9 +105,31 @@ git diff --check
 
 1. 在 `src/boss_agent_cli/commands/` 下新建文件
 2. 在 `main.py` 中注册命令
-3. 在 `schema.py` 中添加命令描述
-4. 在 `tests/test_commands.py` 中添加测试
+3. 在 `schema.py`（`SCHEMA_DATA["commands"]`）中添加命令描述
+4. 在 `tests/test_commands.py` 或按命令名新建测试文件
 5. 更新 `skills/boss-agent-cli/SKILL.md`（命令速查表）
 6. 更新 `AGENTS.md`（CLI 不变量契约中的命令数）
-7. 更新 `README.md`（命令参考表）
+7. 更新 `README.md` 和 `README.en.md`（命令参考表）
 8. 更新对应模块的 `CLAUDE.md`
+9. 如果命令对 Agent 通过 MCP 调用有用，还需在 `mcp-server/server.py` 中注册（`Tool` 定义和 `_build_args` 分支）
+
+## 提交 Issue
+
+请在 `.github/ISSUE_TEMPLATE/` 下选择对应模板：
+
+- **bug_report**：附上 `boss doctor` 输出和版本号
+- **feature_request**：描述使用场景和期望行为
+- **documentation**：错别字、缺失文档、过时示例
+
+## 非代码贡献
+
+不写代码也能帮忙：
+
+- 翻译改进（如 `README.en.md` 润色）
+- 带复现步骤的 bug 报告
+- 在新的 Agent 宿主中编写使用示例（见 `docs/integrations/`）
+- 不同机器 / 系统 / Chrome 版本的性能测试结果
+
+## 有问题？
+
+欢迎在 [Discussions](https://github.com/can4hou6joeng4/boss-agent-cli/discussions) 发帖，或在相关 [Issue](https://github.com/can4hou6joeng4/boss-agent-cli/issues) 下留言。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ git diff --check
 - `exit 0` 表示成功（`ok=true`）。
 - `exit 1` 表示失败（`ok=false`）。
 
-出错时信封必须包含 `error.code`、`error.recoverable` 和 `error.recovery_action`。可用错误码见 `schema.py` 中的 `ERROR_CODES`。
+出错时信封必须包含 `error.code`、`error.recoverable` 和 `error.recovery_action`。可用错误码见 `src/boss_agent_cli/commands/schema.py` 中 `SCHEMA_DATA["error_codes"]`（约 line 855）。
 
 ## 测试理念
 
@@ -111,7 +111,7 @@ git diff --check
 6. 更新 `AGENTS.md`（CLI 不变量契约中的命令数）
 7. 更新 `README.md` 和 `README.en.md`（命令参考表）
 8. 更新对应模块的 `CLAUDE.md`
-9. 如果命令对 Agent 通过 MCP 调用有用，还需在 `mcp-server/server.py` 中注册（`Tool` 定义和 `_build_args` 分支）
+9. 如果命令对 Agent 通过 MCP 调用有用，还需在 `src/boss_agent_cli/mcp_server.py` 的 `TOOLS` 列表加 Tool 定义、在 `_build_args` 函数加分支（`mcp-server/server.py` 是 thin wrapper，会自动 re-export）
 
 ## 提交 Issue
 


### PR DESCRIPTION
## 关联 Issue / Related Issue

无关联 issue。看到 \`CONTRIBUTING.en.md\` 比中文版多写了几节（commit 反例 / PR workflow 详细步骤 / 输出契约 / 测试理念 / issue 模板指引 / 非代码贡献），中文 contributor 看到的规则比英文版少不少东西，把缺的几节同步回去。

## 变更说明 / Summary

- 同步以下内容到 \`CONTRIBUTING.md\`（按英文版结构）：
  - Python ≥ 3.10 + uv 环境要求
  - commit message 反例（英文描述 / 中英混杂 / Co-authored-by 尾注三种禁忌）
  - PR workflow 详细步骤（TDD / lint / CI 矩阵 / squash merge）
  - 输出契约整节（JSON envelope + stderr 边界 + 错误信封字段）
  - 测试理念（TDD 鼓励 / mock 边界 / 错误路径对等）
  - 提交 issue 时的模板指引
  - 非代码贡献清单 + Discussions 入口
- "新增命令的步骤"补齐英文版独有的 \`README.en.md\` 同步项 + 第 9 步 MCP 工具注册
- commit 反例区保留英文范例 + 中文说明（与 owner 自己英文版的中英混排风格一致）

## 变更类型 / Type

- [x] docs: 仅文档更新

## Breaking Change

- [x] 本 PR **不包含** 破坏性变更

## 测试 / Test Plan

文本同步，无代码改动。

- [x] \`.venv/Scripts/python.exe -m pytest tests/test_agent_docs.py tests/test_open_source_docs.py -v\` → 31 passed
- [x] \`.venv/Scripts/python.exe -m pytest tests/ -q\` → 1339 passed（12 fail 是 pre-existing）

## 文档与契约 / Docs & Contracts

- [x] 已更新 \`CONTRIBUTING.md\`
- [ ] 如新增命令：N/A
- [ ] 如新增错误码：N/A

## 安全与规范 / Safety & Convention

- [x] commit message 格式: \`type: 中文描述\`
- [x] 无敏感信息
- [x] 无新增依赖