### PR TITLE
fix: 修复敏感信息输出脱敏

### DIFF
--- a/src/boss_agent_cli/commands/export.py
+++ b/src/boss_agent_cli/commands/export.py
@@ -26,7 +26,7 @@ from boss_agent_cli.search_filters import SearchUrlParseError, parse_boss_search
 @click.option("--count", default=50, type=int, help="导出数量")
 @click.option("--format", "fmt", default="csv", type=click.Choice(["html", "csv", "json"]), help="输出格式")
 @click.option("--output", "-o", default=None, help="输出文件路径（不指定则输出到 stdout JSON 信封）")
-@click.option("--include-private", is_flag=True, help="导出明文平台标识和招聘者姓名等私有字段")
+@click.option("--include-private", is_flag=True, help="CSV/JSON/stdout 保留明文平台标识和招聘者姓名；HTML 始终省略")
 @click.pass_context
 @handle_auth_errors("export")
 def export_cmd(ctx: click.Context, query: str | None, search_url: str | None, city: str | None, salary: str | None, experience: str | None, education: str | None, industry: str | None, scale: str | None, stage: str | None, job_type: str | None, count: int, fmt: str, output: str | None, include_private: bool) -> None:
@@ -112,14 +112,14 @@ def export_cmd(ctx: click.Context, query: str | None, search_url: str | None, ci
 			page += 1
 
 		if output:
-			write_items = all_items if include_private else [_redact_export_item(item) for item in all_items]
+			write_items = _prepare_export_items(all_items, fmt=fmt, include_private=include_private)
 			_write_to_file(write_items, fmt, output)
 			data = {
 				"message": f"已导出 {len(all_items)} 条到 {output}",
 				"count": len(all_items),
 				"format": fmt,
 				"path": output,
-				"private_fields": "included" if include_private else "redacted",
+				"private_fields": _private_fields_state(fmt=fmt, include_private=include_private),
 			}
 			handle_output(
 				ctx, "export", data,
@@ -149,12 +149,33 @@ def export_cmd(ctx: click.Context, query: str | None, search_url: str | None, ci
 			)
 
 
+def _prepare_export_items(items: list[dict[str, Any]], *, fmt: str, include_private: bool) -> list[dict[str, Any]]:
+	if fmt == "html":
+		return [_public_html_export_item(item) for item in items]
+	if include_private:
+		return items
+	return [_redact_export_item(item) for item in items]
+
+
+def _private_fields_state(*, fmt: str, include_private: bool) -> str:
+	if fmt == "html":
+		return "omitted"
+	return "included" if include_private else "redacted"
+
+
 def _redact_export_item(item: dict[str, Any]) -> dict[str, Any]:
 	redacted = dict(item)
 	for key in ("job_id", "security_id", "boss_name"):
 		if key in redacted:
 			redacted[key] = "[REDACTED]"
 	return redacted
+
+
+def _public_html_export_item(item: dict[str, Any]) -> dict[str, Any]:
+	public_item = dict(item)
+	for key in ("job_id", "security_id", "boss_name"):
+		public_item.pop(key, None)
+	return public_item
 
 
 def _write_to_file(items: list[dict[str, Any]], fmt: str, path: str) -> None:
@@ -223,7 +244,6 @@ def _write_html(items: list[dict[str, Any]], path: str) -> None:
 			f"<td>{esc(item.get('education', ''))}</td>"
 			f"<td>{skills_html}</td>"
 			f"<td>{welfare_html}</td>"
-			f"<td class='dim'>{esc(item.get('boss_name', ''))}</td>"
 			f"</tr>"
 		)
 
@@ -255,7 +275,7 @@ def _write_html(items: list[dict[str, Any]], path: str) -> None:
 <table>
   <thead><tr>
     <th>#</th><th>岗位</th><th>公司</th><th>薪资</th><th>城市</th>
-    <th>经验</th><th>学历</th><th>技能</th><th>福利</th><th>招聘者</th>
+    <th>经验</th><th>学历</th><th>技能</th><th>福利</th>
   </tr></thead>
   <tbody>{''.join(rows)}</tbody>
 </table>

--- a/src/boss_agent_cli/mcp_server.py
+++ b/src/boss_agent_cli/mcp_server.py
@@ -299,7 +299,7 @@ TOOLS = [
 	),
 	Tool(
 		name="boss_export",
-		description="导出搜索结果为 CSV / JSON / HTML 文件，支持 BOSS 直聘搜索页 URL 复用筛选条件。默认脱敏 job_id/security_id/boss_name。",
+		description="导出搜索结果为 CSV / JSON / HTML 文件，支持 BOSS 直聘搜索页 URL 复用筛选条件。默认脱敏 job_id/security_id/boss_name，HTML 始终省略这些私有字段。",
 		inputSchema={
 			"type": "object",
 			"properties": {
@@ -316,7 +316,7 @@ TOOLS = [
 				"count": {"type": "integer", "description": "导出数量", "default": 50},
 				"format": {"type": "string", "enum": ["csv", "json", "html"], "description": "输出格式", "default": "csv"},
 				"output_file": {"type": "string", "description": "输出文件路径；不传则在 stdout 信封内 inline 返回 jobs 列表"},
-				"include_private": {"type": "boolean", "description": "保留 job_id/security_id/boss_name 明文（默认脱敏）", "default": False},
+				"include_private": {"type": "boolean", "description": "CSV/JSON/stdout 保留 job_id/security_id/boss_name 明文；HTML 始终省略", "default": False},
 			},
 			"required": [],
 		},

--- a/src/boss_agent_cli/output.py
+++ b/src/boss_agent_cli/output.py
@@ -1,6 +1,9 @@
 import json
+import re
 import sys
 from typing import Any
+
+import click
 
 _LEVEL_ORDER = {"debug": 0, "info": 1, "warning": 2, "error": 3}
 _REDACTED = "[REDACTED]"
@@ -16,6 +19,17 @@ _SENSITIVE_KEY_PARTS = (
 	"session",
 	"stoken",
 	"token",
+)
+_PUBLIC_METADATA_KEYS = {
+	"private_fields",
+}
+_SENSITIVE_TEXT_PATTERNS = tuple(
+	re.compile(pattern, re.IGNORECASE)
+	for pattern in (
+		r"\b(authorization)\b(\s*[:=]\s*)(bearer\s+)?([^\s,;]+)",
+		r"\b(api[_-]?key|authorization|cookie|credential|password|secret|session(?:[_-]?id)?|stoken|token)\b(\s*[:=]\s*)([^\s,;]+)",
+		r"\b(bearer)\s+([^\s,;]+)",
+	)
 )
 
 
@@ -39,6 +53,8 @@ def redact_sensitive(value: Any) -> Any:
 			key_text = str(key).lower()
 			if _is_error_code_metadata(item):
 				redacted[key] = redact_sensitive(item)
+			elif key_text in _PUBLIC_METADATA_KEYS:
+				redacted[key] = redact_sensitive(item)
 			elif any(part in key_text for part in _SENSITIVE_KEY_PARTS) and not isinstance(item, bool):
 				redacted[key] = _REDACTED
 			else:
@@ -48,7 +64,22 @@ def redact_sensitive(value: Any) -> Any:
 		return [redact_sensitive(item) for item in value]
 	if isinstance(value, tuple):
 		return [redact_sensitive(item) for item in value]
+	if isinstance(value, str):
+		return redact_sensitive_text(value)
 	return value
+
+
+def redact_sensitive_text(message: str) -> str:
+	"""Redact credential-like values embedded in free-form text."""
+	redacted = message
+	for pattern in _SENSITIVE_TEXT_PATTERNS:
+		if pattern.pattern.startswith("\\b(bearer)"):
+			redacted = pattern.sub(r"\1 [REDACTED]", redacted)
+		elif pattern.pattern.startswith("\\b(authorization)"):
+			redacted = pattern.sub(r"\1\2[REDACTED]", redacted)
+		else:
+			redacted = pattern.sub(r"\1\2[REDACTED]", redacted)
+	return redacted
 
 
 def envelope_success(
@@ -90,7 +121,7 @@ def envelope_error(
 			"pagination": None,
 			"error": {
 				"code": code,
-				"message": message,
+				"message": redact_sensitive_text(message),
 				"recoverable": recoverable,
 				"recovery_action": recovery_action,
 			},
@@ -101,11 +132,11 @@ def envelope_error(
 
 
 def emit_success(command: str, data: Any, **kwargs: Any) -> None:
-	print(envelope_success(command, data, **kwargs))
+	click.echo(envelope_success(command, data, **kwargs))
 
 
 def emit_error(command: str, **kwargs: Any) -> None:
-	print(envelope_error(command, **kwargs))
+	click.echo(envelope_error(command, **kwargs))
 	sys.exit(1)
 
 
@@ -117,7 +148,7 @@ class Logger:
 		if _LEVEL_ORDER.get(level, 0) >= self._threshold:
 			import datetime
 			ts = datetime.datetime.now().strftime("%H:%M:%S")
-			print(f"[{level.upper()} {ts}] {message}", file=sys.stderr)
+			print(f"[{level.upper()} {ts}] {redact_sensitive_text(message)}", file=sys.stderr)
 
 	def debug(self, message: str) -> None:
 		self._log("debug", message)

--- a/tests/test_export_extended.py
+++ b/tests/test_export_extended.py
@@ -176,7 +176,7 @@ def test_export_html_to_file(mock_auth_cls, mock_client_cls, tmp_path: Path):
 	assert "Full-Stack" in content
 	assert "TestCo" in content
 	assert "李" not in content
-	assert "[REDACTED]" in content
+	assert "招聘者" not in content
 	# 技能和福利应各自带标签样式
 	assert 'class="tag sk"' in content
 	assert 'class="tag wf"' in content
@@ -184,6 +184,34 @@ def test_export_html_to_file(mock_auth_cls, mock_client_cls, tmp_path: Path):
 	assert "双休" in content
 	# 共 1 条应显示
 	assert "共 1 条" in content
+
+
+@patch("boss_agent_cli.commands.export.get_platform_instance")
+@patch("boss_agent_cli.commands.export.AuthManager")
+def test_export_html_include_private_still_omits_private_fields(mock_auth_cls, mock_client_cls, tmp_path: Path):
+	"""HTML 文件是可分享报表，即使显式 include_private 也不写路由/招聘者私有字段。"""
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.search_jobs.return_value = _api_response([
+		_make_raw_job("Full-Stack", skills=["Python", "React"], welfare=["双休", "五险"], security_id="sec_private"),
+	])
+
+	out_path = tmp_path / "jobs-private.html"
+	runner = CliRunner()
+	result = runner.invoke(
+		cli,
+		["export", "fullstack", "--count", "1", "--format", "html", "--include-private", "-o", str(out_path)],
+	)
+
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["data"]["private_fields"] == "omitted"
+	content = out_path.read_text(encoding="utf-8")
+	assert "Full-Stack" in content
+	assert "TestCo" in content
+	assert "李" not in content
+	assert "sec_private" not in content
+	assert "j_sec_private" not in content
+	assert "招聘者" not in content
 
 
 @patch("boss_agent_cli.commands.export.get_platform_instance")

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,6 +1,7 @@
 import json
+import pytest
 
-from boss_agent_cli.output import envelope_success, envelope_error, Logger
+from boss_agent_cli.output import envelope_success, envelope_error, emit_error, emit_success, Logger
 
 
 def test_envelope_success_minimal():
@@ -61,6 +62,19 @@ def test_redaction_preserves_public_error_code_metadata():
 	assert parsed["data"]["real_token"] == "[REDACTED]"
 
 
+def test_redaction_preserves_public_private_fields_metadata():
+	result = envelope_success(
+		"export",
+		{
+			"private_fields": "omitted",
+			"private_token": "secret-token",
+		},
+	)
+	parsed = json.loads(result)
+	assert parsed["data"]["private_fields"] == "omitted"
+	assert parsed["data"]["private_token"] == "[REDACTED]"
+
+
 def test_envelope_error():
 	result = envelope_error(
 		"search",
@@ -74,10 +88,28 @@ def test_envelope_error():
 	assert parsed["ok"] is False
 	assert parsed["data"] is None
 	assert parsed["error"]["code"] == "AUTH_EXPIRED"
-	assert parsed["error"]["message"] == "登录态已过期 token=secret-token"
+	assert parsed["error"]["message"] == "登录态已过期 token=[REDACTED]"
 	assert parsed["error"]["recoverable"] is True
 	assert parsed["error"]["recovery_action"] == "boss login"
 	assert parsed["hints"]["cookie"] == "[REDACTED]"
+
+
+def test_envelope_error_redacts_sensitive_values_inside_message():
+	result = envelope_error(
+		"search",
+		code="NETWORK_ERROR",
+		message="请求失败 token=secret-token cookie: wt2=secret-cookie session_id=abc123 password=hunter2 authorization: Bearer auth-secret",
+		recoverable=True,
+		recovery_action="重试",
+	)
+	parsed = json.loads(result)
+	message = parsed["error"]["message"]
+	assert "secret-token" not in message
+	assert "secret-cookie" not in message
+	assert "abc123" not in message
+	assert "hunter2" not in message
+	assert "auth-secret" not in message
+	assert message.count("[REDACTED]") == 5
 
 
 def test_logger_filters_by_level(capsys):
@@ -91,6 +123,37 @@ def test_logger_filters_by_level(capsys):
 	assert "info msg" not in captured.err
 	assert "warn msg" in captured.err
 	assert "error msg" in captured.err
+
+
+def test_logger_redacts_sensitive_values_inside_message(capsys):
+	logger = Logger("debug")
+	logger.error("refresh failed token=secret-token cookie: wt2=secret-cookie session=abc123")
+	captured = capsys.readouterr()
+	assert "secret-token" not in captured.err
+	assert "secret-cookie" not in captured.err
+	assert "abc123" not in captured.err
+	assert "token=[REDACTED]" in captured.err
+	assert "cookie: [REDACTED]" in captured.err
+	assert "session=[REDACTED]" in captured.err
+
+
+def test_emit_success_redacts_sensitive_text_at_stdout_boundary(capsys):
+	emit_success("status", {"message": "token=secret-token", "cookie": "secret-cookie"})
+	captured = capsys.readouterr()
+	assert "secret-token" not in captured.out
+	assert "secret-cookie" not in captured.out
+	parsed = json.loads(captured.out)
+	assert parsed["data"]["message"] == "token=[REDACTED]"
+	assert parsed["data"]["cookie"] == "[REDACTED]"
+
+
+def test_emit_error_redacts_sensitive_text_at_stdout_boundary(capsys):
+	with pytest.raises(SystemExit):
+		emit_error("status", code="NETWORK_ERROR", message="cookie: wt2=secret-cookie")
+	captured = capsys.readouterr()
+	assert "secret-cookie" not in captured.out
+	parsed = json.loads(captured.out)
+	assert parsed["error"]["message"] == "cookie: [REDACTED]"
 
 
 def test_config_defaults():


### PR DESCRIPTION
## Summary

- redact credential-like values embedded in JSON envelope strings and stderr log messages
- make HTML job exports omit private routing/recruiter fields even when `--include-private` is passed
- update MCP `boss_export` descriptions and add regression coverage for redaction and HTML private-field omission

## Why

This addresses the existing CodeQL sensitive-data alerts on the export file sink and stdout/stderr envelope/logging sinks. The fix keeps stdout as a single JSON envelope while adding text-level redaction at the output boundary.

## Validation

- PASS: `python3 -m compileall -q src/boss_agent_cli/output.py src/boss_agent_cli/commands/export.py src/boss_agent_cli/mcp_server.py tests/test_output.py tests/test_export_extended.py`
- PASS: `git diff --check`
- BLOCKED locally: `uv run ruff check src/boss_agent_cli/output.py src/boss_agent_cli/commands/export.py src/boss_agent_cli/mcp_server.py tests/test_output.py tests/test_export_extended.py` exited 137 with no output in this machine environment
- BLOCKED locally: `uv run pytest tests/test_output.py tests/test_export_extended.py -q` exited 137 with no output in this machine environment

GitHub CI should be treated as the merge gate for ruff and pytest on this PR.
