### PR TITLE
fix: 收紧导出报表敏感字段写入

### DIFF
--- a/src/boss_agent_cli/commands/export.py
+++ b/src/boss_agent_cli/commands/export.py
@@ -12,6 +12,9 @@ from boss_agent_cli.display import handle_auth_errors, handle_error_output, hand
 from boss_agent_cli.search_filters import SearchUrlParseError, parse_boss_search_url, resolve_search_code_params
 
 
+_HTML_PUBLIC_EXPORT_FIELDS = ("title", "company", "city", "experience", "education", "skills", "welfare")
+
+
 @click.command("export")
 @click.argument("query", required=False)
 @click.option("--url", "search_url", default=None, help="BOSS 直聘搜索页 URL（可从网页复制完整筛选条件）")
@@ -26,7 +29,7 @@ from boss_agent_cli.search_filters import SearchUrlParseError, parse_boss_search
 @click.option("--count", default=50, type=int, help="导出数量")
 @click.option("--format", "fmt", default="csv", type=click.Choice(["html", "csv", "json"]), help="输出格式")
 @click.option("--output", "-o", default=None, help="输出文件路径（不指定则输出到 stdout JSON 信封）")
-@click.option("--include-private", is_flag=True, help="CSV/JSON/stdout 保留明文平台标识和招聘者姓名；HTML 始终省略")
+@click.option("--include-private", is_flag=True, help="CSV/JSON/stdout 保留明文平台标识和招聘者姓名；HTML 省略平台标识、招聘者和薪资")
 @click.pass_context
 @handle_auth_errors("export")
 def export_cmd(ctx: click.Context, query: str | None, search_url: str | None, city: str | None, salary: str | None, experience: str | None, education: str | None, industry: str | None, scale: str | None, stage: str | None, job_type: str | None, count: int, fmt: str, output: str | None, include_private: bool) -> None:
@@ -172,10 +175,7 @@ def _redact_export_item(item: dict[str, Any]) -> dict[str, Any]:
 
 
 def _public_html_export_item(item: dict[str, Any]) -> dict[str, Any]:
-	public_item = dict(item)
-	for key in ("job_id", "security_id", "boss_name"):
-		public_item.pop(key, None)
-	return public_item
+	return {key: item[key] for key in _HTML_PUBLIC_EXPORT_FIELDS if key in item}
 
 
 def _write_to_file(items: list[dict[str, Any]], fmt: str, path: str) -> None:
@@ -238,7 +238,6 @@ def _write_html(items: list[dict[str, Any]], path: str) -> None:
 			f"<td>{i}</td>"
 			f"<td class='title'>{esc(item.get('title', ''))}</td>"
 			f"<td class='company'>{esc(item.get('company', ''))}</td>"
-			f"<td class='salary'>{esc(item.get('salary', ''))}</td>"
 			f"<td>{esc(item.get('city', ''))}</td>"
 			f"<td>{esc(item.get('experience', ''))}</td>"
 			f"<td>{esc(item.get('education', ''))}</td>"
@@ -264,7 +263,6 @@ def _write_html(items: list[dict[str, Any]], path: str) -> None:
   tr:hover {{ background: #f5faf8; }}
   .title {{ font-weight: 600; }}
   .company {{ color: var(--green); font-weight: 600; }}
-  .salary {{ color: #ff6633; font-weight: 700; white-space: nowrap; }}
   .dim {{ color: #888; }}
   .tag {{ display: inline-block; padding: 1px 6px; border-radius: 4px; font-size: 11px; margin: 1px; }}
   .sk {{ background: #e8f5e9; color: #2e7d32; }}
@@ -274,7 +272,7 @@ def _write_html(items: list[dict[str, Any]], path: str) -> None:
 <div class="sub">共 {len(items)} 条</div>
 <table>
   <thead><tr>
-    <th>#</th><th>岗位</th><th>公司</th><th>薪资</th><th>城市</th>
+    <th>#</th><th>岗位</th><th>公司</th><th>城市</th>
     <th>经验</th><th>学历</th><th>技能</th><th>福利</th>
   </tr></thead>
   <tbody>{''.join(rows)}</tbody>

--- a/src/boss_agent_cli/mcp_server.py
+++ b/src/boss_agent_cli/mcp_server.py
@@ -299,7 +299,7 @@ TOOLS = [
 	),
 	Tool(
 		name="boss_export",
-		description="导出搜索结果为 CSV / JSON / HTML 文件，支持 BOSS 直聘搜索页 URL 复用筛选条件。默认脱敏 job_id/security_id/boss_name，HTML 始终省略这些私有字段。",
+		description="导出搜索结果为 CSV / JSON / HTML 文件，支持 BOSS 直聘搜索页 URL 复用筛选条件。默认脱敏 job_id/security_id/boss_name，HTML 始终省略平台标识、招聘者姓名和薪资。",
 		inputSchema={
 			"type": "object",
 			"properties": {
@@ -316,7 +316,7 @@ TOOLS = [
 				"count": {"type": "integer", "description": "导出数量", "default": 50},
 				"format": {"type": "string", "enum": ["csv", "json", "html"], "description": "输出格式", "default": "csv"},
 				"output_file": {"type": "string", "description": "输出文件路径；不传则在 stdout 信封内 inline 返回 jobs 列表"},
-				"include_private": {"type": "boolean", "description": "CSV/JSON/stdout 保留 job_id/security_id/boss_name 明文；HTML 始终省略", "default": False},
+				"include_private": {"type": "boolean", "description": "CSV/JSON/stdout 保留 job_id/security_id/boss_name 明文；HTML 始终省略平台标识、招聘者姓名和薪资", "default": False},
 			},
 			"required": [],
 		},

--- a/tests/test_export_extended.py
+++ b/tests/test_export_extended.py
@@ -175,6 +175,8 @@ def test_export_html_to_file(mock_auth_cls, mock_client_cls, tmp_path: Path):
 	assert "<!DOCTYPE html>" in content
 	assert "Full-Stack" in content
 	assert "TestCo" in content
+	assert "20K" not in content
+	assert "薪资" not in content
 	assert "李" not in content
 	assert "招聘者" not in content
 	# 技能和福利应各自带标签样式
@@ -208,6 +210,8 @@ def test_export_html_include_private_still_omits_private_fields(mock_auth_cls, m
 	content = out_path.read_text(encoding="utf-8")
 	assert "Full-Stack" in content
 	assert "TestCo" in content
+	assert "20K" not in content
+	assert "薪资" not in content
 	assert "李" not in content
 	assert "sec_private" not in content
 	assert "j_sec_private" not in content


### PR DESCRIPTION
## 关联 Issue / Related Issue

CodeQL alert #10

## 变更说明 / Summary

默认分支在合并 PR #256 后仍保留 CodeQL 高危告警 #10。新的实例显示 `salary` 字段仍被 CodeQL 视为敏感数据并流向 HTML 文件写入 sink。

本 PR 将 `boss export --format html` 明确定义为公开可分享报表：

- HTML 导出数据改为公开字段白名单构造，不再从完整 job dict 复制后删除字段
- HTML 文件不再写入平台路由标识、招聘者姓名和薪资值
- CLI help 与 MCP `boss_export` 描述同步该边界
- 回归测试覆盖普通 HTML 导出和 `--include-private` HTML 导出均不含薪资与私有字段

CSV / JSON / stdout 明细导出行为保持不变，`--include-private` 仍只适用于非 HTML 输出。

## 变更类型 / Type

- [x] fix: Bug 修复
- [x] test: 测试

## Breaking Change

- [ ] 本 PR **不包含** 破坏性变更
- [x] 本 PR **包含** 破坏性变更（请在下方说明迁移路径）

`boss export --format html` 不再展示薪资列。需要薪资明细的用户应改用 CSV / JSON / stdout 导出；HTML 文件保留为公开可分享报表。

## 截图 / Screenshot

HTML 报表表头从 `# / 岗位 / 公司 / 薪资 / 城市 / ...` 变为 `# / 岗位 / 公司 / 城市 / ...`。测试断言 HTML 文件不包含 `20K` 和 `薪资`。

## 测试 / Test Plan

- [x] `uv run pytest tests/ -q` 全部通过：1359 passed
- [x] `uv run ruff check src/ tests/` 无报错
- [x] `uv run mypy src/boss_agent_cli` 无报错
- [x] `uv run boss --help` 可加载
- [x] `uv run boss schema --format native` 返回合法 JSON 信封
- [x] 新增/修改的功能已有对应测试覆盖
- [ ] 本地跑过涉及命令（如有可粘贴已脱敏输出）

额外 focused checks：

- `uv run pytest tests/test_export_extended.py tests/test_output.py tests/test_mcp_server.py -q`：133 passed
- `python3 -m py_compile src/boss_agent_cli/commands/export.py src/boss_agent_cli/mcp_server.py tests/test_export_extended.py`：通过
- `git diff --check`：通过

## 文档与契约 / Docs & Contracts

- [ ] 如新增命令：已更新 `src/boss_agent_cli/commands/schema.py`
- [ ] 如变更 CLI 行为：已更新 `README.md` 和 `docs/capability-matrix.md`
- [ ] 如新增 MCP 工具：已更新 `mcp-server/server.py` 和 `mcp-server/README.md`
- [ ] 如新增错误码：已添加到 `schema.py` 的 `error_codes`
- [ ] 已更新 `CHANGELOG.md` 的 `[Unreleased]` 段落
- [ ] 如变更 Agent 主卖点或安装路径：已同步检查 `SKILL.md` / PyPI 版本 / GitHub Release 说明

说明：本次只收紧既有 `export` HTML 文件输出边界和 MCP tool 描述，不新增命令、MCP 工具或错误码。

## 安全与规范 / Safety & Convention

- [x] commit message 格式: `type: 中文描述`
- [x] 无敏感信息（Token / 密码 / Cookie / security_id / 手机号 / 微信 / 真实账号）
- [x] 如涉及 Cookie、CDP、patchright、请求频率或真实账号，已阅读 `docs/platform-risk.md`
- [x] 如涉及发布流程，已阅读 `docs/maintainer/release-checklist.md`
- [x] 无新增外部 CDN / script 依赖（HTML 报表类特别注意）
