### PR TITLE
fix: 分离公开报表导出数据源

### DIFF
--- a/src/boss_agent_cli/commands/export.py
+++ b/src/boss_agent_cli/commands/export.py
@@ -69,10 +69,12 @@ def export_cmd(ctx: click.Context, query: str | None, search_url: str | None, ci
 	auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 	with get_platform_instance(ctx, auth) as platform:
 		all_items: list[dict[str, Any]] = []
+		html_items: list[dict[str, Any]] = []
+		html_file_output = bool(output and fmt == "html")
 		page = 1
 		max_pages = (count + 14) // 15  # 每页约 15 条
 
-		while len(all_items) < count and page <= max_pages:
+		while _export_item_count(all_items, html_items, html_file_output=html_file_output) < count and page <= max_pages:
 			logger.info(f"正在获取第 {page} 页...")
 			search_filters: dict[str, Any] = {"page": page}
 			for key, value in {
@@ -105,21 +107,29 @@ def export_cmd(ctx: click.Context, query: str | None, search_url: str | None, ci
 				break
 
 			for raw_item in job_list:
-				if len(all_items) >= count:
+				if _export_item_count(all_items, html_items, html_file_output=html_file_output) >= count:
 					break
-				item = JobItem.from_api(raw_item)
-				all_items.append(item.to_dict())
+				if html_file_output:
+					html_items.append(_public_html_export_item_from_api(raw_item))
+				else:
+					item = JobItem.from_api(raw_item)
+					all_items.append(item.to_dict())
 
 			if not platform_data.get("hasMore", False):
 				break
 			page += 1
 
 		if output:
-			write_items = _prepare_export_items(all_items, fmt=fmt, include_private=include_private)
-			_write_to_file(write_items, fmt, output)
+			if html_file_output:
+				_write_to_file(html_items, fmt, output)
+				item_count = len(html_items)
+			else:
+				write_items = _prepare_export_items(all_items, fmt=fmt, include_private=include_private)
+				_write_to_file(write_items, fmt, output)
+				item_count = len(all_items)
 			data = {
-				"message": f"已导出 {len(all_items)} 条到 {output}",
-				"count": len(all_items),
+				"message": f"已导出 {item_count} 条到 {output}",
+				"count": item_count,
 				"format": fmt,
 				"path": output,
 				"private_fields": _private_fields_state(fmt=fmt, include_private=include_private),
@@ -152,6 +162,12 @@ def export_cmd(ctx: click.Context, query: str | None, search_url: str | None, ci
 			)
 
 
+def _export_item_count(all_items: list[dict[str, Any]], html_items: list[dict[str, Any]], *, html_file_output: bool) -> int:
+	if html_file_output:
+		return len(html_items)
+	return len(all_items)
+
+
 def _prepare_export_items(items: list[dict[str, Any]], *, fmt: str, include_private: bool) -> list[dict[str, Any]]:
 	if fmt == "html":
 		return [_public_html_export_item(item) for item in items]
@@ -176,6 +192,18 @@ def _redact_export_item(item: dict[str, Any]) -> dict[str, Any]:
 
 def _public_html_export_item(item: dict[str, Any]) -> dict[str, Any]:
 	return {key: item[key] for key in _HTML_PUBLIC_EXPORT_FIELDS if key in item}
+
+
+def _public_html_export_item_from_api(raw: dict[str, Any]) -> dict[str, Any]:
+	return {
+		"title": raw.get("jobName", ""),
+		"company": raw.get("brandName", ""),
+		"city": raw.get("cityName", ""),
+		"experience": raw.get("jobExperience", ""),
+		"education": raw.get("jobDegree", ""),
+		"skills": raw.get("skills", []),
+		"welfare": raw.get("welfareList", []),
+	}
 
 
 def _write_to_file(items: list[dict[str, Any]], fmt: str, path: str) -> None:

--- a/tests/test_export_extended.py
+++ b/tests/test_export_extended.py
@@ -218,6 +218,31 @@ def test_export_html_include_private_still_omits_private_fields(mock_auth_cls, m
 	assert "招聘者" not in content
 
 
+@patch("boss_agent_cli.commands.export.JobItem.from_api")
+@patch("boss_agent_cli.commands.export.get_platform_instance")
+@patch("boss_agent_cli.commands.export.AuthManager")
+def test_export_html_to_file_uses_public_api_projection(mock_auth_cls, mock_client_cls, mock_from_api, tmp_path: Path):
+	"""HTML 文件导出不经过包含薪资和路由字段的 JobItem.to_dict 路径。"""
+	mock_client = _ctx_mock(mock_client_cls)
+	mock_client.search_jobs.return_value = _api_response([
+		_make_raw_job("Full-Stack", skills=["Python"], welfare=["双休"], security_id="sec_private"),
+	])
+	mock_from_api.side_effect = AssertionError("HTML export should not build full JobItem")
+
+	out_path = tmp_path / "jobs-public.html"
+	runner = CliRunner()
+	result = runner.invoke(cli, ["export", "fullstack", "--count", "1", "--format", "html", "-o", str(out_path)])
+
+	assert result.exit_code == 0
+	content = out_path.read_text(encoding="utf-8")
+	assert "Full-Stack" in content
+	assert "TestCo" in content
+	assert "20K" not in content
+	assert "sec_private" not in content
+	assert "j_sec_private" not in content
+	assert mock_from_api.call_count == 0
+
+
 @patch("boss_agent_cli.commands.export.get_platform_instance")
 @patch("boss_agent_cli.commands.export.AuthManager")
 def test_export_html_empty_result(mock_auth_cls, mock_client_cls, tmp_path: Path):


### PR DESCRIPTION
## 关联 Issue / Related Issue

CodeQL alert #10

## 变更说明 / Summary

PR #257 合并后，master 上的 CodeQL #10 仍保持 open。最新实例已经收窄到 `JobItem.to_dict()["salary"]` 被追踪到 HTML 文件写入 sink。

本 PR 继续收紧 HTML 文件导出的数据流：

- `boss export --format html -o <path>` 使用独立的 `html_items` 集合
- HTML 文件路径直接从 API 原始 item 投影公开字段，不再调用 `JobItem.from_api(...).to_dict()`
- 普通 CSV / JSON / stdout 路径仍保留 `JobItem` 模型转换和原有显式导出能力
- 新增回归测试，patch `JobItem.from_api` 后 HTML 文件导出仍必须成功，证明 HTML 文件路径不经过完整 job dict

## 变更类型 / Type

- [x] fix: Bug 修复
- [x] test: 测试

## Breaking Change

- [x] 本 PR **不包含** 破坏性变更
- [ ] 本 PR **包含** 破坏性变更（请在下方说明迁移路径）

说明：HTML 省略薪资列的行为变化已在 PR #257 引入；本 PR 只进一步分离内部数据源以消除 CodeQL 数据流。

## 截图 / Screenshot

无新增 UI 变化。HTML 文件内容契约延续 PR #257：公开报表不包含薪资、平台路由字段或招聘者姓名。

## 测试 / Test Plan

- [x] `uv run pytest tests/ -q` 全部通过：1360 passed
- [x] `uv run ruff check src/ tests/` 无报错
- [x] `uv run mypy src/boss_agent_cli` 无报错
- [x] `uv run boss --help` 可加载
- [x] `uv run boss schema --format native` 返回合法 JSON 信封
- [x] 新增/修改的功能已有对应测试覆盖
- [ ] 本地跑过涉及命令（如有可粘贴已脱敏输出）

额外 focused checks：

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/test_export_extended.py::test_export_html_to_file tests/test_export_extended.py::test_export_html_include_private_still_omits_private_fields tests/test_export_extended.py::test_export_html_to_file_uses_public_api_projection tests/test_export_extended.py::test_export_paginates_until_count_reached -q`：4 passed
- `uv run pytest tests/test_export_extended.py tests/test_output.py tests/test_mcp_server.py -q`：134 passed
- `python3 -m py_compile src/boss_agent_cli/commands/export.py tests/test_export_extended.py`：通过
- `git diff --check`：通过

## 文档与契约 / Docs & Contracts

- [ ] 如新增命令：已更新 `src/boss_agent_cli/commands/schema.py`
- [ ] 如变更 CLI 行为：已更新 `README.md` 和 `docs/capability-matrix.md`
- [ ] 如新增 MCP 工具：已更新 `mcp-server/server.py` 和 `mcp-server/README.md`
- [ ] 如新增错误码：已添加到 `schema.py` 的 `error_codes`
- [ ] 已更新 `CHANGELOG.md` 的 `[Unreleased]` 段落
- [ ] 如变更 Agent 主卖点或安装路径：已同步检查 `SKILL.md` / PyPI 版本 / GitHub Release 说明

说明：本次不改变 CLI 命令、schema、MCP 工具表面或错误码，只改变 HTML 文件导出的内部数据流。

## 安全与规范 / Safety & Convention

- [x] commit message 格式: `type: 中文描述`
- [x] 无敏感信息（Token / 密码 / Cookie / security_id / 手机号 / 微信 / 真实账号）
- [x] 如涉及 Cookie、CDP、patchright、请求频率或真实账号，已阅读 `docs/platform-risk.md`
- [x] 如涉及发布流程，已阅读 `docs/maintainer/release-checklist.md`
- [x] 无新增外部 CDN / script 依赖（HTML 报表类特别注意）
