### PR TITLE
fix: 拆分报表文件写入路径

### DIFF
--- a/src/boss_agent_cli/commands/export.py
+++ b/src/boss_agent_cli/commands/export.py
@@ -121,10 +121,10 @@ def export_cmd(ctx: click.Context, query: str | None, search_url: str | None, ci
 
 		if output:
 			if html_file_output:
-				_write_to_file(html_items, fmt, output)
+				_write_html(html_items, output)
 				item_count = len(html_items)
 			else:
-				write_items = _prepare_export_items(all_items, fmt=fmt, include_private=include_private)
+				write_items = _prepare_export_items(all_items, include_private=include_private)
 				_write_to_file(write_items, fmt, output)
 				item_count = len(all_items)
 			data = {
@@ -168,9 +168,7 @@ def _export_item_count(all_items: list[dict[str, Any]], html_items: list[dict[st
 	return len(all_items)
 
 
-def _prepare_export_items(items: list[dict[str, Any]], *, fmt: str, include_private: bool) -> list[dict[str, Any]]:
-	if fmt == "html":
-		return [_public_html_export_item(item) for item in items]
+def _prepare_export_items(items: list[dict[str, Any]], *, include_private: bool) -> list[dict[str, Any]]:
 	if include_private:
 		return items
 	return [_redact_export_item(item) for item in items]
@@ -188,10 +186,6 @@ def _redact_export_item(item: dict[str, Any]) -> dict[str, Any]:
 		if key in redacted:
 			redacted[key] = "[REDACTED]"
 	return redacted
-
-
-def _public_html_export_item(item: dict[str, Any]) -> dict[str, Any]:
-	return {key: item[key] for key in _HTML_PUBLIC_EXPORT_FIELDS if key in item}
 
 
 def _public_html_export_item_from_api(raw: dict[str, Any]) -> dict[str, Any]:
@@ -230,8 +224,6 @@ def _write_to_file(items: list[dict[str, Any]], fmt: str, path: str) -> None:
 				# CSV 公式注入防护
 				row = {k: _sanitize_csv_cell(str(v)) for k, v in row.items()}
 				writer.writerow(row)
-	elif fmt == "html":
-		_write_html(items, path)
 
 
 def _sanitize_csv_cell(value: str) -> str:


### PR DESCRIPTION
## 背景

PR #256 已修复 CodeQL #11/#12；PR #257 和 PR #258 继续收紧 HTML 导出，但默认分支 CodeQL #10 仍保持 open。

最新 #10 数据流仍把 `JobItem.to_dict()["salary"]` 连接到 `src/boss_agent_cli/commands/export.py` 的 HTML `f.write(html_content)` sink。上一轮已经让 HTML 文件使用公开 API projection，但通用 `_write_to_file()` 里仍保留 HTML 分发，扫描器仍能把 CSV/JSON/HTML 文件写入路径混在一起。

## 变更

- 从通用 `_write_to_file()` 中移除 HTML 分发路径。
- HTML 文件导出只通过 `_write_html(html_items, output)` 写入专用公开数据源。
- CSV/JSON 文件导出仍通过 `_write_to_file()`，行为不变。

## 验证

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/test_export_extended.py::test_export_html_to_file tests/test_export_extended.py::test_export_html_include_private_still_omits_private_fields tests/test_export_extended.py::test_export_html_to_file_uses_public_api_projection tests/test_export_extended.py::test_export_paginates_until_count_reached -q`：4 passed
- `uv run pytest tests/test_export_extended.py tests/test_output.py tests/test_mcp_server.py -q`：134 passed
- `uv run ruff check src/ tests/`：passed
- `uv run mypy src/boss_agent_cli`：passed
- `uv run boss --help`：passed
- `uv run boss schema --format native`：valid JSON envelope
- `uv run pytest tests/ -q`：1360 passed
- `git diff --check`：passed
- `python3 -m py_compile src/boss_agent_cli/commands/export.py tests/test_export_extended.py`：passed