### PR TITLE
test: 强化招聘端点契约

### DIFF
--- a/tests/test_recruiter_endpoints.py
+++ b/tests/test_recruiter_endpoints.py
@@ -1,4 +1,5 @@
 """Verify recruiter.yaml loads and produces expected endpoint constants."""
+from boss_agent_cli.api.endpoints_loader import get_recruiter_spec
 from boss_agent_cli.api.recruiter_endpoints import (
 	BASE_URL,
 	BOSS_FRIEND_LIST_URL,
@@ -8,7 +9,12 @@ from boss_agent_cli.api.recruiter_endpoints import (
 	BOSS_JOB_LIST_URL,
 	BOSS_JOB_OFFLINE_URL,
 	BOSS_SEND_MESSAGE_URL,
+	CODE_ACCOUNT_RISK,
+	CODE_RATE_LIMITED,
+	CODE_STOKEN_EXPIRED,
 	CODE_SUCCESS,
+	DEFAULT_HEADERS,
+	REFERER_MAP,
 )
 
 
@@ -31,3 +37,47 @@ def test_recruiter_urls_are_absolute():
 
 def test_recruiter_response_codes():
 	assert CODE_SUCCESS == 0
+
+
+
+def test_recruiter_response_code_contracts_include_retryable_failures():
+	assert {
+		"success": CODE_SUCCESS,
+		"stoken_expired": CODE_STOKEN_EXPIRED,
+		"rate_limited": CODE_RATE_LIMITED,
+		"account_risk": CODE_ACCOUNT_RISK,
+	} == {
+		"success": 0,
+		"stoken_expired": 37,
+		"rate_limited": 9,
+		"account_risk": 36,
+	}
+
+
+def test_recruiter_spec_keeps_named_endpoint_methods_and_urls():
+	spec = get_recruiter_spec()
+
+	assert spec.endpoints["boss_friend_list"].method == "POST"
+	assert spec.endpoints["boss_friend_list"].url == BOSS_FRIEND_LIST_URL
+	assert spec.endpoints["boss_search_geek"].method == "GET"
+	assert spec.endpoints["boss_search_geek"].url == BOSS_SEARCH_GEEK_URL
+	assert spec.endpoints["boss_send_message"].method == "POST"
+	assert spec.endpoints["boss_send_message"].url == BOSS_SEND_MESSAGE_URL
+
+
+def test_recruiter_endpoint_urls_are_unique_and_referers_are_mapped():
+	spec = get_recruiter_spec()
+	urls = [endpoint.url for endpoint in spec.endpoints.values()]
+
+	assert len(urls) == len(set(urls))
+	assert set(REFERER_MAP) == set(urls)
+	assert REFERER_MAP[BOSS_SEARCH_GEEK_URL] == "https://www.zhipin.com/web/frame/search/"
+	assert REFERER_MAP[BOSS_SEND_MESSAGE_URL] == "https://www.zhipin.com/web/chat/index"
+
+
+def test_recruiter_default_headers_include_browser_origin_contract():
+	assert DEFAULT_HEADERS["Origin"] == BASE_URL
+	assert DEFAULT_HEADERS["Referer"] == f"{BASE_URL}/"
+	assert DEFAULT_HEADERS["Accept"] == "application/json, text/plain, */*"
+	assert DEFAULT_HEADERS["Sec-Fetch-Site"] == "same-origin"
+	assert DEFAULT_HEADERS["sec-ch-ua-platform"] == '"macOS"'


### PR DESCRIPTION
## Summary
- strengthen recruiter endpoint tests for response codes, method/url bindings, referer map, uniqueness, and browser header defaults
- keep this PR limited to tests/test_recruiter_endpoints.py

## Validation
- PYTHONPATH=src:mcp-server .venv/bin/pytest -q tests/test_recruiter_endpoints.py
- PYTHONPATH=src:mcp-server .venv/bin/pytest -q tests/test_recruiter_endpoints.py tests/test_endpoints_loader.py tests/test_api_client_methods.py tests/test_api_client_retry.py tests/test_api.py tests/test_public_api.py tests/test_api_httpx_helpers.py tests/test_new_commands.py tests/test_display.py tests/test_cli_invariants.py tests/test_smoke_p0.py
- .venv/bin/ruff check tests/test_recruiter_endpoints.py
- .venv/bin/python -m compileall -q src tests
- git diff --check