### PR TITLE
fix: 改善登录错误诊断

### DIFF
--- a/src/boss_agent_cli/commands/login.py
+++ b/src/boss_agent_cli/commands/login.py
@@ -5,6 +5,91 @@ from boss_agent_cli.display import boss_command_for_ctx, login_action_for_ctx
 from boss_agent_cli.output import emit_error, emit_success
 
 
+def _classify_login_error(exc: Exception, ctx: click.Context) -> dict[str, object]:
+	"""Return a user-facing, redacted login error envelope payload.
+
+	The login flow intentionally remains unchanged; this helper only turns broad
+	Cookie/CDP/QR/browser failures into actionable CLI diagnostics.
+	"""
+	raw_message = str(exc) or exc.__class__.__name__
+	message = raw_message.lower()
+	recovery_action = login_action_for_ctx(ctx)
+
+	def payload(code: str, user_message: str, next_actions: list[str]) -> dict[str, object]:
+		return {
+			"code": code,
+			"message": user_message,
+			"recoverable": True,
+			"recovery_action": recovery_action,
+			"hints": {"next_actions": next_actions},
+		}
+
+	if isinstance(exc, TimeoutError) or "timeout" in message or "超时" in raw_message:
+		return payload(
+			"LOGIN_TIMEOUT",
+			f"登录等待超时: {raw_message}",
+			[
+				"确认二维码已完成扫码并在网页端授权登录",
+				"网络较慢时可追加 --timeout 180 或更长时间",
+				"如已打开本机 Chrome，可先运行 boss-chrome 后再重试登录",
+			],
+		)
+
+	if "cdp" in message or "chrome" in message or isinstance(exc, ConnectionError):
+		return payload(
+			"CDP_UNAVAILABLE",
+			f"Chrome 调试连接不可用: {raw_message}",
+			[
+				"运行 boss-chrome 启动带调试端口的 Chrome",
+				"或去掉 --cdp，让命令自动尝试 Cookie / QR 登录降级链路",
+				"确认 --cdp-url 指向可访问的 Chrome DevTools 地址",
+			],
+		)
+
+	if any(term in message for term in ("403", "forbidden", "风控", "risk", "rate limit", "too many")):
+		return payload(
+			"LOGIN_RISK_CONTROL",
+			f"登录请求可能触发平台风控: {raw_message}",
+			[
+				"暂停自动化重试，改用浏览器手动确认账号状态",
+				"降低请求频率，避免短时间重复登录或刷新",
+				"必要时联系平台客服确认账号是否受限",
+			],
+		)
+
+	if any(term in message for term in ("401", "unauthorized", "expired", "过期", "未登录")):
+		return payload(
+			"LOGIN_EXPIRED",
+			f"登录态已失效或授权不足: {raw_message}",
+			[
+				"重新执行登录并完成网页端授权",
+				"如使用 Cookie 提取，确认浏览器内目标平台仍处于登录状态",
+				"登录后运行 status 验证本地登录态",
+			],
+		)
+
+	if any(term in message for term in ("cookie", "stoken", "token", "凭证")):
+		return payload(
+			"LOGIN_CREDENTIAL_EXTRACTION_FAILED",
+			f"登录成功后提取凭证失败: {raw_message}",
+			[
+				"确认浏览器已完成登录并进入平台首页",
+				"若 Cookie 提取失败，可指定 --cookie-source chrome/firefox/edge",
+				"若仍失败，可运行 boss-chrome 后使用 --cdp 重试",
+			],
+		)
+
+	return payload(
+		"NETWORK_ERROR",
+		f"登录失败: {raw_message}",
+		[
+			"检查网络连通性后重试",
+			"如浏览器内已登录，可尝试指定 --cookie-source chrome/firefox/edge",
+			"若问题持续，请运行 boss doctor 并附带诊断输出反馈",
+		],
+	)
+
+
 @click.command("login")
 @click.option("--timeout", default=120, help="扫码登录超时时间（秒）")
 @click.option("--cookie-source", default=None, help="指定浏览器提取 Cookie（如 chrome/firefox/edge），不指定则自动检测")
@@ -36,27 +121,5 @@ def login_cmd(ctx: click.Context, timeout: int, cookie_source: str | None, cdp: 
 				f"{recommend_cmd} — 获取个性化推荐",
 			],
 		})
-	except ConnectionError as e:
-		emit_error(
-			"login",
-			code="NETWORK_ERROR",
-			message=str(e),
-			recoverable=True,
-			recovery_action=login_action_for_ctx(ctx),
-		)
-	except TimeoutError as e:
-		emit_error(
-			"login",
-			code="NETWORK_ERROR",
-			message=str(e),
-			recoverable=True,
-			recovery_action=login_action_for_ctx(ctx),
-		)
 	except Exception as e:
-		emit_error(
-			"login",
-			code="NETWORK_ERROR",
-			message=f"登录失败: {e}",
-			recoverable=True,
-			recovery_action=login_action_for_ctx(ctx),
-		)
+		emit_error("login", **_classify_login_error(e, ctx))

--- a/tests/test_auth_and_login_extended.py
+++ b/tests/test_auth_and_login_extended.py
@@ -240,7 +240,7 @@ def test_login_supports_zhilian_platform(mock_auth_cls):
 
 @patch("boss_agent_cli.commands.login.AuthManager")
 def test_login_connection_error_recovery_is_boss_chrome(mock_auth_cls):
-	"""ConnectionError 应返回 NETWORK_ERROR + 重新登录恢复建议。"""
+	"""ConnectionError 应返回 CDP_UNAVAILABLE + 重新登录恢复建议。"""
 	mock_auth = MagicMock()
 	mock_auth.login.side_effect = ConnectionError("can't reach chrome")
 	mock_auth_cls.return_value = mock_auth
@@ -249,13 +249,13 @@ def test_login_connection_error_recovery_is_boss_chrome(mock_auth_cls):
 	result = runner.invoke(cli, ["login"])
 	assert result.exit_code == 1
 	parsed = json.loads(result.output)
-	assert parsed["error"]["code"] == "NETWORK_ERROR"
+	assert parsed["error"]["code"] == "CDP_UNAVAILABLE"
 	assert parsed["error"]["recovery_action"] == "boss login"
 
 
 @patch("boss_agent_cli.commands.login.AuthManager")
 def test_login_timeout_error_recovery_is_retry(mock_auth_cls):
-	"""TimeoutError 应返回 NETWORK_ERROR + 重试建议。"""
+	"""TimeoutError 应返回 LOGIN_TIMEOUT + 重试建议。"""
 	mock_auth = MagicMock()
 	mock_auth.login.side_effect = TimeoutError("扫码超时")
 	mock_auth_cls.return_value = mock_auth
@@ -264,7 +264,7 @@ def test_login_timeout_error_recovery_is_retry(mock_auth_cls):
 	result = runner.invoke(cli, ["login"])
 	assert result.exit_code == 1
 	parsed = json.loads(result.output)
-	assert parsed["error"]["code"] == "NETWORK_ERROR"
+	assert parsed["error"]["code"] == "LOGIN_TIMEOUT"
 	assert parsed["error"]["recovery_action"] == "boss login"
 
 
@@ -335,3 +335,80 @@ def test_login_cookie_source_propagates(mock_auth_cls):
 	assert result.exit_code == 0
 	kwargs = mock_auth.login.call_args.kwargs
 	assert kwargs["cookie_source"] == "chrome"
+
+
+@patch("boss_agent_cli.commands.login.AuthManager")
+def test_login_timeout_error_has_actionable_diagnostics(mock_auth_cls):
+	"""Issue #235: Playwright/扫码等待超时不应再被笼统显示为 NETWORK_ERROR。"""
+	mock_auth = MagicMock()
+	mock_auth.login.side_effect = TimeoutError("Timeout 30000ms exceeded while waiting for page")
+	mock_auth_cls.return_value = mock_auth
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["login"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "LOGIN_TIMEOUT"
+	assert "登录等待超时" in parsed["error"]["message"]
+	assert parsed["error"]["recovery_action"] == "boss login"
+	assert any("--timeout 180" in action for action in parsed["hints"]["next_actions"])
+
+
+@patch("boss_agent_cli.commands.login.AuthManager")
+def test_login_connection_error_has_cdp_diagnostics(mock_auth_cls):
+	mock_auth = MagicMock()
+	mock_auth.login.side_effect = ConnectionError("CDP 不可用，请先运行 boss-chrome")
+	mock_auth_cls.return_value = mock_auth
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["login", "--cdp"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "CDP_UNAVAILABLE"
+	assert "Chrome 调试连接不可用" in parsed["error"]["message"]
+	assert any("boss-chrome" in action for action in parsed["hints"]["next_actions"])
+
+
+@patch("boss_agent_cli.commands.login.AuthManager")
+def test_login_risk_control_error_is_not_suggested_as_plain_network_retry(mock_auth_cls):
+	mock_auth = MagicMock()
+	mock_auth.login.side_effect = RuntimeError("HTTP 403 forbidden risk control")
+	mock_auth_cls.return_value = mock_auth
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["login"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "LOGIN_RISK_CONTROL"
+	assert "风控" in parsed["error"]["message"]
+	assert any("暂停自动化重试" in action for action in parsed["hints"]["next_actions"])
+
+
+@patch("boss_agent_cli.commands.login.AuthManager")
+def test_login_credential_extraction_error_has_cookie_hints(mock_auth_cls):
+	mock_auth = MagicMock()
+	mock_auth.login.side_effect = RuntimeError("cookie exists but stoken extraction failed")
+	mock_auth_cls.return_value = mock_auth
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["login"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "LOGIN_CREDENTIAL_EXTRACTION_FAILED"
+	assert "提取凭证失败" in parsed["error"]["message"]
+	assert any("--cookie-source" in action for action in parsed["hints"]["next_actions"])
+
+
+@patch("boss_agent_cli.commands.login.AuthManager")
+def test_login_generic_error_keeps_network_fallback_with_doctor_hint(mock_auth_cls):
+	mock_auth = MagicMock()
+	mock_auth.login.side_effect = RuntimeError("unexpected upstream response")
+	mock_auth_cls.return_value = mock_auth
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["login"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == "NETWORK_ERROR"
+	assert "登录失败" in parsed["error"]["message"]
+	assert any("boss doctor" in action for action in parsed["hints"]["next_actions"])

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -41,7 +41,8 @@ def test_login_cdp_connection_error_returns_json_envelope(mock_auth_cls):
 	parsed = json.loads(result.output)
 	assert parsed["ok"] is False
 	assert parsed["command"] == "login"
-	assert parsed["error"]["code"] == "NETWORK_ERROR"
+	assert parsed["error"]["code"] == "CDP_UNAVAILABLE"
+	assert "Chrome 调试连接不可用" in parsed["error"]["message"]
 	assert parsed["error"]["recoverable"] is True
 	assert parsed["error"]["recovery_action"] == "boss login"
 
@@ -56,7 +57,8 @@ def test_login_timeout_returns_platform_aware_recovery_action(mock_auth_cls):
 	parsed = json.loads(result.output)
 	assert parsed["ok"] is False
 	assert parsed["command"] == "login"
-	assert parsed["error"]["code"] == "NETWORK_ERROR"
+	assert parsed["error"]["code"] == "LOGIN_TIMEOUT"
+	assert "登录等待超时" in parsed["error"]["message"]
 	assert parsed["error"]["recoverable"] is True
 	assert parsed["error"]["recovery_action"] == "boss --platform zhilian login"
 


### PR DESCRIPTION
## Summary
- add login error classification for timeout, CDP unavailable, auth/cookie/stoken, and risk-control failures
- surface actionable JSON hints without changing the underlying login flow
- update CLI contract tests and add non-network regression coverage for issue #235

## Tests
- PYTHONPATH=src:mcp-server .venv/bin/pytest -q

Closes #235
