### PR TITLE
test: 补强招聘端低风险阻断回归

### DIFF
--- a/docs/agent-quickstart.en.md
+++ b/docs/agent-quickstart.en.md
@@ -66,7 +66,9 @@ Recommended usage:
 - `boss hr <subcommand>` switches to recruiter mode automatically, so you do not need to infer `--role` yourself
 - Candidate-side and recruiter-side commands share the same `stdout JSON / stderr logs` contract
 - `hr` currently supports `zhipin-recruiter` only; if the active platform is `zhilian`, recruiter commands are rejected intentionally
+- Default low-risk mode blocks recruiter candidate screening commands such as `hr candidates`, `hr resume`, and `hr request-resume`; complete those candidate-data workflows manually on the official website
 - When a sensitive subcommand returns `COMPLIANCE_BLOCKED`, do not switch automation channels to continue
+- When platform responses map to `ACCOUNT_RISK` or `RATE_LIMITED`, stop automated access instead of retrying a batch
 
 ## 3) Recovery flow and troubleshooting
 

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -41,6 +41,22 @@ def test_default_low_risk_mode_blocks_platform_data_aggregation():
 	_assert_compliance_block_hints(parsed)
 
 
+def test_default_low_risk_mode_blocks_recruiter_candidate_screening():
+	for args, command in [
+		(("hr", "candidates", "python"), "recruiter-candidates"),
+		(("hr", "resume", "geek_001", "--job-id", "job_001", "--security-id", "sec_001"), "recruiter-resume"),
+		(("hr", "request-resume", "12345"), "recruiter-request-resume"),
+	]:
+		code, parsed = _invoke(*args)
+		assert code == 1
+		assert parsed["ok"] is False
+		assert parsed["command"] == command
+		assert parsed["error"]["code"] == "COMPLIANCE_BLOCKED"
+		assert "候选" in parsed["error"]["message"] or "简历" in parsed["error"]["message"]
+		assert parsed["error"]["recoverable"] is False
+		_assert_compliance_block_hints(parsed)
+
+
 def test_raw_chatmsg_does_not_bypass_low_risk_compliance():
 	code, parsed = _invoke("chatmsg", "sec_001", "--raw")
 	assert code == 1


### PR DESCRIPTION
## Summary
- add low-risk compliance regression coverage for recruiter candidate screening commands
- document recruiter candidate-data workflows as manual-only in default low-risk mode

## Tests
- uv run pytest tests/test_compliance.py -q
- uv run pytest tests/test_recruiter_commands.py -q -k "candidates or resume or request_resume"
- uv run pytest -q

Closes #232