### PR TITLE
feat: 增加前程无忧平台占位适配器

### DIFF
--- a/src/boss_agent_cli/__init__.py
+++ b/src/boss_agent_cli/__init__.py
@@ -40,6 +40,7 @@ _LAZY_EXPORT_MODULES = {
 	"ResumeFile": "boss_agent_cli.resume.models",
 	"Platform": "boss_agent_cli.platforms",
 	"BossPlatform": "boss_agent_cli.platforms",
+	"QianchengPlatform": "boss_agent_cli.platforms",
 	"ZhilianPlatform": "boss_agent_cli.platforms",
 	"get_platform": "boss_agent_cli.platforms",
 	"list_platforms": "boss_agent_cli.platforms",
@@ -70,6 +71,7 @@ __all__ = [
 	# 平台抽象（Week 1 ABC，详见 Issue #129）
 	"Platform",
 	"BossPlatform",
+	"QianchengPlatform",
 	"ZhilianPlatform",
 	"get_platform",
 	"list_platforms",

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -156,7 +156,10 @@ def _command_availability(
 
 
 def _inject_availability(data: dict[str, Any]) -> dict[str, Any]:
-	candidate_platforms = data.get("supported_platforms", [])
+	# supported_platforms 表示“已注册 / 可选择”的平台；availability 表示命令真实可用的
+	# 平台。qiancheng/51job 当前是 NOT_SUPPORTED 占位 adapter，不能注入到
+	# search/detail/stats 等命令的可用性列表，避免误导上层 agent 调度。
+	candidate_platforms = ["zhilian", "zhipin"]
 	recruiter_platforms = data.get("supported_recruiter_platforms", [])
 	commands: dict[str, Any] = {}
 	for cmd_name, cmd_spec in data["commands"].items():
@@ -837,8 +840,8 @@ SCHEMA_DATA = {
 		"--platform": {
 			"type": "string",
 			"default": "zhipin",
-			"description": "招聘平台适配器（zhipin=BOSS 直聘求职者/招聘者均可用；zhilian=智联招聘已接通求职者侧包络与命令兼容，招聘者侧暂未接入）",
-			"choices": ["zhipin", "zhilian"],
+			"description": "招聘平台适配器（zhipin=BOSS 直聘求职者/招聘者均可用；zhilian=智联招聘已接通求职者侧包络与命令兼容；qiancheng/51job=前程无忧占位适配器，当前稳定返回 NOT_SUPPORTED）",
+			"choices": ["51job", "qiancheng", "zhipin", "zhilian"],
 		},
 		"--json": {
 			"type": "bool",

--- a/src/boss_agent_cli/platforms/__init__.py
+++ b/src/boss_agent_cli/platforms/__init__.py
@@ -19,11 +19,14 @@ from __future__ import annotations
 
 from boss_agent_cli.platforms.base import Platform
 from boss_agent_cli.platforms.recruiter_base import RecruiterPlatform
+from boss_agent_cli.platforms.qiancheng import QianchengPlatform
 from boss_agent_cli.platforms.zhilian import ZhilianPlatform
 from boss_agent_cli.platforms.zhipin import BossPlatform
 from boss_agent_cli.platforms.zhipin_recruiter import BossRecruiterPlatform
 
 _REGISTRY: dict[str, type[Platform]] = {
+	"qiancheng": QianchengPlatform,
+	"51job": QianchengPlatform,
 	"zhipin": BossPlatform,
 	"zhilian": ZhilianPlatform,
 }
@@ -77,6 +80,7 @@ def list_recruiter_platforms() -> list[str]:
 __all__ = [
 	"Platform",
 	"BossPlatform",
+	"QianchengPlatform",
 	"ZhilianPlatform",
 	"get_platform",
 	"list_platforms",

--- a/src/boss_agent_cli/platforms/qiancheng.py
+++ b/src/boss_agent_cli/platforms/qiancheng.py
@@ -1,0 +1,59 @@
+"""前程无忧（51job）平台占位实现。
+
+当前仅注册候选者侧平台身份与稳定错误包络，不接真实 51job 接口。
+真实只读 search/detail MVP 需另行确认稳定入口、脱敏 fixture 与错误映射后再启用。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from boss_agent_cli.platforms.base import Platform
+
+
+_NOT_SUPPORTED_MESSAGE = "51job/前程无忧适配器仍处于 research backlog，当前版本暂不支持真实平台能力"
+
+
+class QianchengPlatform(Platform):
+	"""51job 候选者侧占位 adapter。
+
+	该实现有意不委托底层 client，也不访问任何 51job 真实接口；所有必需能力
+	均返回稳定 ``NOT_SUPPORTED`` 包络，供 CLI / schema / 上层自动化明确识别。
+	"""
+
+	name = "qiancheng"
+	display_name = "前程无忧（51job）"
+	base_url = "https://www.51job.com"
+
+	@staticmethod
+	def _not_supported(capability: str) -> dict[str, Any]:
+		return {
+			"code": "NOT_SUPPORTED",
+			"message": f"{_NOT_SUPPORTED_MESSAGE}：{capability}",
+			"data": None,
+		}
+
+	def is_success(self, response: dict[str, Any]) -> bool:
+		return response.get("code") == 0
+
+	def unwrap_data(self, response: dict[str, Any]) -> Any:
+		return response.get("data")
+
+	def parse_error(self, response: dict[str, Any]) -> tuple[str, str]:
+		code = response.get("code")
+		message = str(response.get("message") or response.get("msg") or "")
+		if code == "NOT_SUPPORTED":
+			return "NOT_SUPPORTED", message
+		return self._classify_platform_error(response)
+
+	def search_jobs(self, query: str, **filters: Any) -> dict[str, Any]:
+		return self._not_supported("search_jobs")
+
+	def job_detail(self, job_id: str) -> dict[str, Any]:
+		return self._not_supported("job_detail")
+
+	def recommend_jobs(self, page: int = 1) -> dict[str, Any]:
+		return self._not_supported("recommend_jobs")
+
+	def user_info(self) -> dict[str, Any]:
+		return self._not_supported("user_info")

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -31,6 +31,7 @@ EXPECTED_EXPORTS = {
 	"ResumeFile",
 	"Platform",
 	"BossPlatform",
+	"QianchengPlatform",
 	"ZhilianPlatform",
 	"get_platform",
 	"list_platforms",

--- a/tests/test_qiancheng_stub.py
+++ b/tests/test_qiancheng_stub.py
@@ -1,0 +1,85 @@
+"""51job/QianchengPlatform 占位适配器契约测试。"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+from urllib.parse import urlparse
+
+from click.testing import CliRunner
+
+from boss_agent_cli.main import cli
+from boss_agent_cli.platforms import Platform, get_platform, list_platforms
+from boss_agent_cli.platforms.qiancheng import QianchengPlatform
+
+
+class TestQianchengRegistration:
+	def test_list_platforms_contains_aliases(self) -> None:
+		platforms = list_platforms()
+		assert "qiancheng" in platforms
+		assert "51job" in platforms
+
+	def test_get_platform_returns_qiancheng_class(self) -> None:
+		assert get_platform("qiancheng") is QianchengPlatform
+		assert get_platform("51job") is QianchengPlatform
+
+	def test_qiancheng_subclasses_platform(self) -> None:
+		assert issubclass(QianchengPlatform, Platform)
+
+
+class TestQianchengMetadata:
+	def setup_method(self) -> None:
+		self.plat = QianchengPlatform(MagicMock())
+
+	def test_name_is_qiancheng(self) -> None:
+		assert self.plat.name == "qiancheng"
+
+	def test_display_name_mentions_51job(self) -> None:
+		assert "51job" in self.plat.display_name
+		assert "前程无忧" in self.plat.display_name
+
+	def test_base_url_points_to_51job(self) -> None:
+		assert urlparse(self.plat.base_url).hostname == "www.51job.com"
+
+
+class TestQianchengNotSupportedEnvelope:
+	def setup_method(self) -> None:
+		self.client = MagicMock()
+		self.plat = QianchengPlatform(self.client)
+
+	def test_required_capabilities_return_not_supported(self) -> None:
+		for raw in (
+			self.plat.search_jobs("Python", city="广州"),
+			self.plat.job_detail("job-id"),
+			self.plat.recommend_jobs(page=1),
+			self.plat.user_info(),
+		):
+			assert raw["code"] == "NOT_SUPPORTED"
+			assert self.plat.is_success(raw) is False
+			code, message = self.plat.parse_error(raw)
+			assert code == "NOT_SUPPORTED"
+			assert "research backlog" in message
+			assert self.plat.unwrap_data(raw) is None
+
+	def test_stub_does_not_delegate_to_client(self) -> None:
+		self.plat.search_jobs("Python")
+		self.plat.job_detail("job-id")
+		self.plat.recommend_jobs()
+		self.plat.user_info()
+		self.client.assert_not_called()
+
+
+class TestQianchengCliVisibility:
+	def test_schema_lists_qiancheng_candidate_platform(self, tmp_path) -> None:
+		runner = CliRunner()
+		result = runner.invoke(cli, ["--data-dir", str(tmp_path), "schema"])
+		assert result.exit_code == 0
+		payload = json.loads(result.output)
+		choices = payload["data"]["global_options"]["--platform"]["choices"]
+		assert "qiancheng" in choices
+		assert "51job" in choices
+
+	def test_platform_argument_accepts_qiancheng(self, tmp_path) -> None:
+		runner = CliRunner()
+		result = runner.invoke(cli, ["--data-dir", str(tmp_path), "--platform", "qiancheng", "schema"])
+		assert result.exit_code == 0


### PR DESCRIPTION
## What
- Add a registered 51job/Qiancheng candidate platform stub and public export.
- Keep real 51job capabilities disabled via stable `NOT_SUPPORTED` envelopes.
- Expose `qiancheng`/`51job` as selectable platform aliases while keeping command availability limited to currently implemented platforms.
- Add contract tests for registration, metadata, NOT_SUPPORTED behavior, CLI schema visibility, and public API exports.

## Why
- Continues Issue #230 by landing a low-risk platform boundary before wiring real 51job search/detail behavior.
- Gives upstream agents a deterministic way to identify the platform as known but not yet supported.

Fixes #230

## Testing
- `uv run pytest tests/test_qiancheng_stub.py tests/test_public_api.py tests/test_stats.py::test_stats_registered_in_main_and_schema -q`
- `uv run boss --data-dir /tmp/boss-qiancheng-schema --platform qiancheng schema`
- `uv run boss --data-dir /tmp/boss-qiancheng-smoke --platform qiancheng --json search Python`
- `uv run pytest -q` (1413 passed)