### PR TITLE
chore: 准备 1.12.0 发版

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 __pycache__/
 *.pyc
-.venv/
+.venv*/
 *.egg-info/
 dist/
 build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,32 @@
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-06-09
+
 ### Added
-- MCP server 新增 `stdio` / `sse` / `http` 三种传输模式，`boss-mcp --transport http --port 8765` 与 `boss-mcp --transport sse` 可直接启动，默认仍保持 `stdio`
-- `mcp-server/README.md` 补齐 SSE / HTTP Streaming 启动示例、默认路径和自定义路径说明
-- MCP 新增 `boss_export`：协议服务对齐 CLI `boss export`，Agent 可直接导出搜索结果为 CSV / JSON / HTML（默认脱敏 job_id/security_id/boss_name），工具计数 31 → 32
+- MCP server 新增 `stdio` / `sse` / `http` 三种传输模式，`boss-mcp --transport http --port 8765` 与 `boss-mcp --transport sse` 可直接启动，默认仍保持 `stdio`。
+- `mcp-server/README.md` 补齐 SSE / HTTP Streaming 启动示例、默认路径和自定义路径说明。
+- MCP 新增 `boss_export`：协议服务对齐 CLI `boss export`，Agent 可直接导出搜索结果为 CSV / JSON / HTML（默认脱敏 job_id/security_id/boss_name），工具计数 31 → 32。
+- 增加前程无忧 / 51job（`qiancheng`）平台占位适配器，统一返回 `NOT_SUPPORTED`，为后续多平台能力矩阵保留低风险扩展入口。
 
 ### Changed
-- 招聘者写操作收口到同一条 chat-tab Vue/CDP 链路：`boss hr reply` 现在用真实 WebSocket 帧校验发送成功，`boss hr request-resume` 不再需要 `--job-id`，`boss hr resume --exchange` 支持 `phone|wechat`
-- MCP 新增 `boss_hr_exchange`，并同步修正 `boss_hr_request_resume` 的输入契约为仅需 `friend_id`
-- 测试依赖 `pytest` 最低版本提升到 `9.0.3`，并同步更新锁文件，修复 Dependabot 报告的临时目录处理漏洞告警
-- ROADMAP / README / README.en 对齐当前主线事实：`#48` 已完成，智联候选者侧登录与读写链路已接通，招聘者侧仍保持显式拒绝
-- ROADMAP Week 4 招聘者侧能力评估落槌为「暂不接入」（接入条件 0/4 满足，保留 `RecruiterPlatform` 骨架待社区信号重启；详见 `docs/research/platforms/zhaopin-recruiter-evaluation.md`）
+- 招聘者写操作收口到同一条 chat-tab Vue/CDP 链路：`boss hr reply` 现在用真实 WebSocket 帧校验发送成功，`boss hr request-resume` 不再需要 `--job-id`，`boss hr resume --exchange` 支持 `phone|wechat`。
+- MCP 新增 `boss_hr_exchange`，并同步修正 `boss_hr_request_resume` 的输入契约为仅需 `friend_id`。
+- 测试依赖 `pytest` 最低版本提升到 `9.0.3`，并同步更新锁文件，修复 Dependabot 报告的临时目录处理漏洞告警。
+- ROADMAP / README / README.en 对齐当前主线事实：`#48` 已完成，智联候选者侧登录与读写链路已接通，招聘者侧仍保持显式拒绝。
+- ROADMAP Week 4 招聘者侧能力评估落槌为「暂不接入」（接入条件 0/4 满足，保留 `RecruiterPlatform` 骨架待社区信号重启；详见 `docs/research/platforms/zhaopin-recruiter-evaluation.md`）。
+- README 与设计文档同步前程无忧占位状态，并明确 RPA / 浏览器自动化风控边界。
 
 ### Fixed
-- `boss hr chat --label-id` 兼容招聘端沟通列表接口直接返回数组的响应形态，避免成功响应被误处理为 `NETWORK_ERROR`
-- `boss interviews` 占位实现现在经 hints 如实声明能力状态（`capability=stub` + `note`），避免 Agent 把空集合占位误读为「无真实面试邀请」
+- `boss hr chat --label-id` 兼容招聘端沟通列表接口直接返回数组的响应形态，避免成功响应被误处理为 `NETWORK_ERROR`。
+- `boss interviews` 占位实现现在经 hints 如实声明能力状态（`capability=stub` + `note`），避免 Agent 把空集合占位误读为「无真实面试邀请」。
+- 改善登录错误诊断，并补强登录合规与隐私清理契约。
+
+### Tests
+- 补强低风险合规、求职流程只读、智联客户端生命周期、招聘者平台生命周期、终端渲染、统计、简历命令、联系人查找、招聘端点和招聘端低风险阻断等回归契约。
+
+### Packaging
+- 显式排除本地虚拟环境、缓存和构建产物，避免本地 `.venv*` 目录污染 sdist。
 
 ## [1.11.0] - 2026-04-23
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "boss-agent-cli"
-version = "1.11.0"
+version = "1.12.0"
 description = "AI Agent 专用的 BOSS 直聘求职 CLI 工具"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -61,6 +61,20 @@ mcp = [
 [project.scripts]
 boss = "boss_agent_cli.main:cli"
 boss-mcp = "boss_agent_cli.mcp_server:run"
+
+[tool.hatch.build]
+exclude = [
+	"/.venv*",
+	"/.pytest_cache",
+	"/.ruff_cache",
+	"/.mypy_cache",
+	"/dist",
+	"/build",
+	"/demo/**/*.mp4",
+	"/demo/**/*.gif",
+	"/demo-en.gif",
+	"/demo-zh.gif",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/boss_agent_cli/__init__.py
+++ b/src/boss_agent_cli/__init__.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 	from boss_agent_cli.platforms import BossPlatform, Platform, ZhilianPlatform, get_platform, list_platforms
 	from boss_agent_cli.resume.models import ResumeData, ResumeFile
 
-__version__ = "1.11.0"
+__version__ = "1.12.0"
 
 _LAZY_EXPORT_MODULES = {
 	"AuthManager": "boss_agent_cli.auth.manager",

--- a/uv.lock
+++ b/uv.lock
@@ -208,7 +208,7 @@ wheels = [
 
 [[package]]
 name = "boss-agent-cli"
-version = "1.11.0"
+version = "1.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },


### PR DESCRIPTION
## What
- Bump `boss-agent-cli` to 1.12.0 in `pyproject.toml`, `__version__`, and `uv.lock`.
- Promote the current changelog entries into the 1.12.0 release section and summarize recent fixes/tests/docs.
- Add Hatch build exclusions for local virtualenvs, caches, build outputs, and large demo media; broaden `.gitignore` to `.venv*/`.

## Why
- Prepare the next coherent release after v1.11.0.
- Prevent local `.venv*` directories from contaminating source distributions.
- Keep release artifacts reasonably small by excluding non-package demo media from sdist.

## Testing
- `uv sync --all-extras`
- `uv run pytest tests/ -q` — 1414 passed
- `uv run ruff check src/ tests/`
- `uv run mypy src/boss_agent_cli`
- `uv run boss --help`
- `uv run boss schema --format native`
- `BOSS_SMOKE_DRY_RUN=1 uv run python scripts/smoke_p0.py`
- `git diff --check`
- `uv build`
- Inspected `dist/boss_agent_cli-1.12.0.tar.gz` contents; sdist reduced from ~19MB to ~1.0MB after excluding demo media.

## Release checklist notes
- No breaking changes.
- No CLI JSON envelope changes.
- Do not create/push `v1.12.0` tag until this PR is merged and CI is green.
