### PR TITLE
fix: 统一非默认平台命令提示

### DIFF
--- a/src/boss_agent_cli/display.py
+++ b/src/boss_agent_cli/display.py
@@ -23,7 +23,7 @@ def boss_command_for_ctx(ctx: Any, command: str) -> str:
 	platform_name = "zhipin"
 	if ctx and getattr(ctx, "obj", None):
 		platform_name = ctx.obj.get("platform") or "zhipin"
-	prefix = "boss --platform zhilian" if platform_name == "zhilian" else "boss"
+	prefix = "boss" if platform_name == "zhipin" else f"boss --platform {platform_name}"
 	return f"{prefix} {command}".strip()
 
 

--- a/src/boss_agent_cli/platforms/qiancheng.py
+++ b/src/boss_agent_cli/platforms/qiancheng.py
@@ -57,3 +57,6 @@ class QianchengPlatform(Platform):
 
 	def user_info(self) -> dict[str, Any]:
 		return self._not_supported("user_info")
+
+	def job_card(self, security_id: str, lid: str = "") -> dict[str, Any]:
+		return self._not_supported("job_card")

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -186,6 +186,12 @@ class TestLoginActionForCtx:
 		ctx.obj = {"platform": "zhilian"}
 		assert login_action_for_ctx(ctx) == "boss --platform zhilian login"
 
+	def test_non_default_platform_uses_platform_specific_boss_command(self):
+		ctx = MagicMock()
+		ctx.obj = {"platform": "qiancheng"}
+		assert boss_command_for_ctx(ctx, "status") == "boss --platform qiancheng status"
+		assert login_action_for_ctx(ctx) == "boss --platform qiancheng login"
+
 
 # ── handle_error_output TTY 分支 ─────────────────────────────
 

--- a/tests/test_qiancheng_stub.py
+++ b/tests/test_qiancheng_stub.py
@@ -53,6 +53,7 @@ class TestQianchengNotSupportedEnvelope:
 			self.plat.job_detail("job-id"),
 			self.plat.recommend_jobs(page=1),
 			self.plat.user_info(),
+			self.plat.job_card("security-id"),
 		):
 			assert raw["code"] == "NOT_SUPPORTED"
 			assert self.plat.is_success(raw) is False
@@ -66,6 +67,7 @@ class TestQianchengNotSupportedEnvelope:
 		self.plat.job_detail("job-id")
 		self.plat.recommend_jobs()
 		self.plat.user_info()
+		self.plat.job_card("security-id")
 		self.client.assert_not_called()
 
 
@@ -83,3 +85,12 @@ class TestQianchengCliVisibility:
 		runner = CliRunner()
 		result = runner.invoke(cli, ["--data-dir", str(tmp_path), "--platform", "qiancheng", "schema"])
 		assert result.exit_code == 0
+
+	def test_detail_returns_qiancheng_not_supported_envelope(self, tmp_path) -> None:
+		runner = CliRunner()
+		result = runner.invoke(cli, ["--data-dir", str(tmp_path), "--platform", "qiancheng", "detail", "fake-id"])
+		assert result.exit_code == 1
+		payload = json.loads(result.output)
+		assert payload["error"]["code"] == "NOT_SUPPORTED"
+		assert "51job/前程无忧适配器" in payload["error"]["message"]
+		assert "job_card" in payload["error"]["message"]


### PR DESCRIPTION
## What
- 泛化非默认平台的 `boss --platform <name>` 命令提示
- 为 51job/qiancheng 占位适配器补齐 `job_card` NOT_SUPPORTED 包络
- 增加 display 与 qiancheng CLI/detail 契约测试

## Why
- 避免 51job detail 兜底落到基类 NotImplemented，保持 research backlog 阶段的稳定错误契约
- 让未来新增平台自动获得正确登录/状态恢复提示，不再只特判 zhilian

## Testing
- `uv run ruff check src/ tests/`
- `uv run mypy src/boss_agent_cli`
- `uv run pytest -q`