### PR TITLE
test: 补强前程无忧占位契约

### DIFF
--- a/src/boss_agent_cli/commands/_platform.py
+++ b/src/boss_agent_cli/commands/_platform.py
@@ -31,6 +31,8 @@ if TYPE_CHECKING:
 
 def _build_client(name: str, auth: "AuthManager", delay: tuple[float, float], cdp_url: str | None) -> Any:
 	"""按平台名构造对应的内部 client。"""
+	if name in {"qiancheng", "51job"}:
+		return None
 	if name == "zhilian":
 		return ZhilianClient(auth, delay=delay, cdp_url=cdp_url)
 	# 默认 zhipin 走 BossClient

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -98,6 +98,14 @@ _CANDIDATE_COMMANDS = {
 	"ai",
 }
 
+_QIANCHENG_PLACEHOLDER_COMMANDS = {
+	"search",
+	"detail",
+	"recommend",
+	"me",
+	"show",
+}
+
 
 def _availability_note(availability: dict[str, Any]) -> str:
 	roles = ", ".join(availability.get("roles", [])) or "none"
@@ -136,29 +144,43 @@ def _command_availability(
 			"recruiter_platforms": recruiter_platforms,
 			"subcommands": subcommand_availability,
 		}
+	availability_candidate_platforms = list(candidate_platforms)
+	placeholder_note = "qiancheng/51job 当前为稳定 NOT_SUPPORTED 占位适配器，列入候选平台仅表示可选择与可发现。"
+	include_qiancheng_placeholder = cmd_name in _QIANCHENG_PLACEHOLDER_COMMANDS
+	if include_qiancheng_placeholder and "qiancheng" not in availability_candidate_platforms:
+		availability_candidate_platforms = ["qiancheng", *availability_candidate_platforms]
 	if cmd_name in _ROLE_BOTH_COMMANDS:
-		return {
+		availability: dict[str, Any] = {
 			"roles": ["candidate", "recruiter"],
-			"candidate_platforms": candidate_platforms,
+			"candidate_platforms": availability_candidate_platforms,
 			"recruiter_platforms": recruiter_platforms,
 		}
+		if include_qiancheng_placeholder:
+			availability["note"] = placeholder_note
+		return availability
 	if cmd_name in _CANDIDATE_COMMANDS:
-		return {
+		availability = {
 			"roles": ["candidate"],
-			"candidate_platforms": candidate_platforms,
+			"candidate_platforms": availability_candidate_platforms,
 			"recruiter_platforms": [],
 		}
-	return {
+		if include_qiancheng_placeholder:
+			availability["note"] = placeholder_note
+		return availability
+	availability = {
 		"roles": ["candidate"],
-		"candidate_platforms": candidate_platforms,
+		"candidate_platforms": availability_candidate_platforms,
 		"recruiter_platforms": [],
 	}
+	if include_qiancheng_placeholder:
+		availability["note"] = placeholder_note
+	return availability
 
 
 def _inject_availability(data: dict[str, Any]) -> dict[str, Any]:
 	# supported_platforms 表示“已注册 / 可选择”的平台；availability 表示命令真实可用的
-	# 平台。qiancheng/51job 当前是 NOT_SUPPORTED 占位 adapter，不能注入到
-	# search/detail/stats 等命令的可用性列表，避免误导上层 agent 调度。
+	# 候选者平台。qiancheng/51job 当前仍是 NOT_SUPPORTED 占位 adapter，仅在
+	# 对应占位能力命令中通过 availability.note 明示不可调度真实平台能力。
 	candidate_platforms = ["zhilian", "zhipin"]
 	recruiter_platforms = data.get("supported_recruiter_platforms", [])
 	commands: dict[str, Any] = {}

--- a/src/boss_agent_cli/platforms/qiancheng.py
+++ b/src/boss_agent_cli/platforms/qiancheng.py
@@ -25,12 +25,30 @@ class QianchengPlatform(Platform):
 	display_name = "前程无忧（51job）"
 	base_url = "https://www.51job.com"
 
+	def __init__(self, client: Any | None = None) -> None:
+		# 占位 adapter 不需要也不应构造真实网络 client。
+		super().__init__(client)
+
+	@property
+	def client(self) -> Any | None:
+		return self._client
+
 	@staticmethod
 	def _not_supported(capability: str) -> dict[str, Any]:
+		message = f"{_NOT_SUPPORTED_MESSAGE}：{capability}"
 		return {
-			"code": "NOT_SUPPORTED",
-			"message": f"{_NOT_SUPPORTED_MESSAGE}：{capability}",
+			"code": -1,
 			"data": None,
+			"error": {
+				"code": "NOT_SUPPORTED",
+				"message": message,
+				"recoverable": True,
+				"recovery_action": None,
+				"details": {
+					"platform": "qiancheng",
+					"capability": capability,
+				},
+			},
 		}
 
 	def is_success(self, response: dict[str, Any]) -> bool:
@@ -40,6 +58,9 @@ class QianchengPlatform(Platform):
 		return response.get("data")
 
 	def parse_error(self, response: dict[str, Any]) -> tuple[str, str]:
+		error = response.get("error")
+		if isinstance(error, dict) and error.get("code") == "NOT_SUPPORTED":
+			return "NOT_SUPPORTED", str(error.get("message") or "")
 		code = response.get("code")
 		message = str(response.get("message") or response.get("msg") or "")
 		if code == "NOT_SUPPORTED":

--- a/tests/test_platform_cli.py
+++ b/tests/test_platform_cli.py
@@ -151,6 +151,77 @@ class TestGetPlatformInstanceHelper:
 		with pytest.raises(ValueError, match="unknown platform"):
 			get_platform_instance(ctx, auth)
 
+	def test_helper_returns_qiancheng_placeholder_without_network_client(self) -> None:
+		"""51job 占位适配器应可通过全局 --platform 被实例化，且不构造真实 client。"""
+		from boss_agent_cli.commands._platform import get_platform_instance
+		from boss_agent_cli.platforms import QianchengPlatform
+
+		ctx = MagicMock()
+		ctx.obj = {"platform": "qiancheng", "delay": (0.0, 0.0), "cdp_url": None}
+		auth = MagicMock()
+
+		with patch("boss_agent_cli.commands._platform.BossClient") as mock_boss_client_cls:
+			plat = get_platform_instance(ctx, auth)
+
+		assert isinstance(plat, QianchengPlatform)
+		mock_boss_client_cls.assert_not_called()
+		assert plat.client is None
+
+
+class TestQianchengPlaceholderContract:
+	"""51job 占位平台必须保持可发现、只读安全且统一 NOT_SUPPORTED。"""
+
+	def test_registry_exposes_qiancheng_aliases(self) -> None:
+		from boss_agent_cli.platforms import QianchengPlatform, get_platform, list_platforms
+
+		assert get_platform("qiancheng") is QianchengPlatform
+		assert get_platform("51job") is QianchengPlatform
+		assert "qiancheng" in list_platforms()
+		assert "51job" in list_platforms()
+
+	def test_schema_exposes_qiancheng_as_candidate_placeholder(self, runner: CliRunner) -> None:
+		from boss_agent_cli.main import cli
+
+		result = runner.invoke(cli, ["--platform", "qiancheng", "schema"])
+		assert result.exit_code == 0
+		payload = json.loads(result.output)
+		meta = payload["data"]
+
+		assert meta["current_platform"] == "qiancheng"
+		assert "qiancheng" in meta["supported_platforms"]
+		assert "qiancheng" in meta["commands"]["search"]["availability"]["candidate_platforms"]
+		assert "51job" in meta["commands"]["search"]["availability"]["note"]
+
+	def test_qiancheng_methods_return_stable_not_supported_envelope(self) -> None:
+		from boss_agent_cli.platforms import QianchengPlatform
+
+		plat = QianchengPlatform()
+		for method_name, args in [
+			("search_jobs", ("python",)),
+			("job_detail", ("security-id",)),
+			("recommend_jobs", ()),
+			("user_info", ()),
+			("job_card", ("security-id",)),
+		]:
+			result = getattr(plat, method_name)(*args)
+			assert result["code"] == -1
+			assert result["error"]["code"] == "NOT_SUPPORTED"
+			assert result["error"]["recoverable"] is True
+			assert result["error"]["details"]["platform"] == "qiancheng"
+			assert result["error"]["details"]["capability"] == method_name
+			assert "51job" in result["error"]["message"]
+			assert "research backlog" in result["error"]["message"]
+
+	def test_qiancheng_envelope_helpers_parse_not_supported(self) -> None:
+		from boss_agent_cli.platforms import QianchengPlatform
+
+		plat = QianchengPlatform()
+		result = plat.search_jobs("python")
+
+		assert plat.is_success(result) is False
+		assert plat.unwrap_data(result) is None
+		assert plat.parse_error(result) == ("NOT_SUPPORTED", result["error"]["message"])
+
 
 class TestConfigPlatformDefault:
 	"""config.json 新增 platform 字段默认值。"""

--- a/tests/test_qiancheng_stub.py
+++ b/tests/test_qiancheng_stub.py
@@ -55,7 +55,10 @@ class TestQianchengNotSupportedEnvelope:
 			self.plat.user_info(),
 			self.plat.job_card("security-id"),
 		):
-			assert raw["code"] == "NOT_SUPPORTED"
+			assert raw["code"] == -1
+			assert raw["error"]["code"] == "NOT_SUPPORTED"
+			assert raw["error"]["recoverable"] is True
+			assert raw["error"]["details"]["platform"] == "qiancheng"
 			assert self.plat.is_success(raw) is False
 			code, message = self.plat.parse_error(raw)
 			assert code == "NOT_SUPPORTED"


### PR DESCRIPTION
## What
- Add regression coverage for the qiancheng/51job placeholder platform contract.
- Make qiancheng instantiation avoid constructing a real network client.
- Return a stable nested `NOT_SUPPORTED` error envelope from qiancheng placeholder capabilities.
- Keep qiancheng discoverable in schema while limiting availability injection to explicit placeholder commands with a note.

## Why
The 51job adapter is intentionally a safe placeholder. Its CLI/schema contract should be explicit, test-covered, and should not mislead higher-level agents into treating all commands as truly supported.

## Testing
- `git diff --check`
- `uv run ruff check .`
- `uv run pytest -q` (1422 passed)

Note: `uv run mypy src tests` still reports existing test-suite typing issues unrelated to this change (67 errors in 9 files).