### PR TITLE
ci: 增加P0质量基线门禁

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,26 @@ permissions:
   contents: read
 
 jobs:
+  p0_quality_gate:
+    name: P0 quality baseline
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run P0 quality baseline
+        run: uv run python scripts/quality_baseline.py
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -512,6 +512,8 @@ boss doctor --live-probe
 | `python` | Python 版本 >= 3.10 |
 | `patchright` | CLI 已安装 |
 | `patchright_chromium` | Chromium 已安装 |
+| `quality_baseline` | 源码仓库内的 P0 本地质量基线入口是否可用 |
+| `quality_tool_ruff` / `quality_tool_pytest` / `quality_tool_mypy` | 本机质量工具可用性；缺失时可通过 `uv run` 或 `uv sync --all-extras` 使用项目环境 |
 | `cookie_extract` | 本地浏览器 Cookie 可提取 |
 | `credential_file` | 登录态文件是否存在且可读取 |
 | `auth_session` | 登录态存在且可解密 |
@@ -680,8 +682,10 @@ CLI (Click)
 git clone https://github.com/can4hou6joeng4/boss-agent-cli.git
 cd boss-agent-cli
 uv sync --all-extras
-uv run pytest tests/ -v    # 运行测试
-uv run ruff check src/     # 代码检查
+python scripts/quality_baseline.py  # P0 基线/CI 门禁：ruff + 全量离线 pytest + mypy
+uv run pytest tests/ -v           # 运行完整测试
+uv run ruff check src/ tests/     # 代码检查
+uv run mypy src/boss_agent_cli    # 类型检查
 ```
 
 详见 [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/docs/maintainer/branch-protection.md
+++ b/docs/maintainer/branch-protection.md
@@ -16,12 +16,15 @@ The default branch is `master`. Keep branch protection aligned with the quality 
 
 Select the concrete check contexts emitted by `.github/workflows/ci.yml`:
 
+- `P0 quality baseline`
 - `test (3.10)`
 - `test (3.11)`
 - `test (3.12)`
 - `test (3.13)`
 - `lint`
 - `typecheck`
+
+`P0 quality baseline` is the canonical blocking quality gate. It runs `scripts/quality_baseline.py`, which covers ruff, the full offline pytest suite, and mypy with the same command used locally.
 
 The project may also require documentation checks when `.github/workflows/docs.yml` is enabled:
 

--- a/scripts/quality_baseline.py
+++ b/scripts/quality_baseline.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Run the local P0 quality baseline for boss-agent-cli.
+
+The baseline is intentionally offline and deterministic: it checks linting,
+the full offline test suite, and type checking in one place so agents, humans,
+and CI can verify a change before opening a PR.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_STEPS: tuple[tuple[str, tuple[str, ...]], ...] = (
+	("ruff", ("ruff", "check", "src/boss_agent_cli", "tests", "--output-format=concise")),
+	("pytest", ("pytest", "-q")),
+	("mypy", ("mypy", "src/boss_agent_cli")),
+)
+
+
+@dataclass(frozen=True)
+class StepResult:
+	name: str
+	command: tuple[str, ...]
+	status: str
+	returncode: int | None
+	stdout: str
+	stderr: str
+
+	def as_dict(self) -> dict[str, object]:
+		return {
+			"name": self.name,
+			"command": list(self.command),
+			"status": self.status,
+			"returncode": self.returncode,
+			"stdout": self.stdout,
+			"stderr": self.stderr,
+		}
+
+
+def _resolve_command(command: Sequence[str]) -> tuple[str, ...]:
+	if shutil.which(command[0]):
+		return tuple(command)
+	uv = shutil.which("uv")
+	if uv:
+		return (uv, "run", *command)
+	return tuple(command)
+
+
+def run_step(name: str, command: Sequence[str]) -> StepResult:
+	resolved = _resolve_command(command)
+	if not shutil.which(resolved[0]):
+		return StepResult(
+			name, tuple(command), "missing", None, "", f"{command[0]} is not installed and uv is unavailable"
+		)
+	proc = subprocess.run(
+		resolved,
+		cwd=ROOT,
+		text=True,
+		stdout=subprocess.PIPE,
+		stderr=subprocess.PIPE,
+		check=False,
+	)
+	return StepResult(
+		name, tuple(resolved), "ok" if proc.returncode == 0 else "failed", proc.returncode, proc.stdout, proc.stderr
+	)
+
+
+def run_baseline(steps: Sequence[tuple[str, tuple[str, ...]]] = DEFAULT_STEPS) -> list[StepResult]:
+	return [run_step(name, command) for name, command in steps]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+	parser = argparse.ArgumentParser(description="Run the boss-agent-cli P0 quality baseline")
+	parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+	parser.add_argument("--skip-mypy", action="store_true", help="skip the mypy step for fast local iteration")
+	args = parser.parse_args(argv)
+
+	steps = tuple(step for step in DEFAULT_STEPS if not (args.skip_mypy and step[0] == "mypy"))
+	results = run_baseline(steps)
+	failed = [item for item in results if item.status != "ok"]
+
+	if args.json:
+		print(
+			json.dumps(
+				{"ok": not failed, "results": [item.as_dict() for item in results]}, ensure_ascii=False, indent=2
+			)
+		)
+	else:
+		for item in results:
+			print(f"[{item.status}] {item.name}: {' '.join(item.command)}")
+			if item.stdout.strip():
+				print(item.stdout.rstrip())
+			if item.stderr.strip():
+				print(item.stderr.rstrip(), file=sys.stderr)
+	return 0 if not failed else 1
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/src/boss_agent_cli/commands/doctor.py
+++ b/src/boss_agent_cli/commands/doctor.py
@@ -16,6 +16,59 @@ from boss_agent_cli.commands._recruiter_platform import get_recruiter_platform_i
 from boss_agent_cli.display import handle_output, render_simple_list
 
 
+def _find_project_root() -> Path:
+	"""Return the repository root when running from a source checkout."""
+	for parent in Path(__file__).resolve().parents:
+		if (parent / "pyproject.toml").exists():
+			return parent
+	return Path.cwd()
+
+
+def _add_quality_baseline_checks(checks: list[dict[str, Any]]) -> None:
+	"""Report whether the local P0 quality baseline can be run offline."""
+	root = _find_project_root()
+	baseline = root / "scripts" / "quality_baseline.py"
+	pyproject = root / "pyproject.toml"
+	if baseline.exists() and pyproject.exists():
+		checks.append(
+			{
+				"name": "quality_baseline",
+				"status": "ok",
+				"detail": "可运行 scripts/quality_baseline.py 执行 CI 同款 P0 门禁：ruff、全量离线 pytest 和 mypy",
+				"hint": "python scripts/quality_baseline.py",
+			}
+		)
+	else:
+		checks.append(
+			{
+				"name": "quality_baseline",
+				"status": "warn",
+				"detail": "未检测到源码仓库质量基线入口（安装包运行时可忽略）",
+				"hint": "在项目根目录运行，或使用发布包自带的外部 CI",
+			}
+		)
+
+	for tool in ("ruff", "pytest", "mypy"):
+		path = shutil.which(tool)
+		if path:
+			checks.append(
+				{
+					"name": f"quality_tool_{tool}",
+					"status": "ok",
+					"detail": path,
+				}
+			)
+		else:
+			checks.append(
+				{
+					"name": f"quality_tool_{tool}",
+					"status": "warn",
+					"detail": f"未在 PATH 中发现 {tool}",
+					"hint": "运行 uv sync --all-extras 或通过 uv run 自动使用项目环境",
+				}
+			)
+
+
 @click.command("doctor")
 @click.option("--live-probe", is_flag=True, default=False, help="执行低频只读平台探测（默认仅做本地诊断）")
 @click.pass_context
@@ -30,15 +83,18 @@ def doctor_cmd(ctx: click.Context, live_probe: bool) -> None:
 	checks: list[dict[str, Any]] = []
 
 	def add_check(name: str, status: str, detail: str, hint: str | None = "") -> None:
-		checks.append({
-			"name": name,
-			"status": status,
-			"detail": detail,
-			"hint": hint,
-		})
+		checks.append(
+			{
+				"name": name,
+				"status": status,
+				"detail": detail,
+				"hint": hint,
+			}
+		)
 
 	# 1) CLI dependencies
 	import sys
+
 	py_version = sys.version_info
 	python_ok = py_version >= (3, 10)
 	py_detail = f"Python {py_version.major}.{py_version.minor}.{py_version.micro}"
@@ -68,7 +124,9 @@ def doctor_cmd(ctx: click.Context, live_probe: bool) -> None:
 	add_check(
 		"patchright_chromium",
 		"ok" if chromium_candidates else "warn",
-		f"检测到 {len(chromium_candidates)} 个 Chromium 安装" if chromium_candidates else "未检测到 patchright/Playwright Chromium 缓存",
+		f"检测到 {len(chromium_candidates)} 个 Chromium 安装"
+		if chromium_candidates
+		else "未检测到 patchright/Playwright Chromium 缓存",
 		"运行 patchright install chromium 安装浏览器内核",
 	)
 
@@ -87,6 +145,9 @@ def doctor_cmd(ctx: click.Context, live_probe: bool) -> None:
 		chrome_path or "未在 PATH 中发现 Chrome/Chromium/Edge",
 		"如需 CDP 登录，请先启动支持远程调试端口的浏览器；如仅用 patchright，可忽略此项",
 	)
+
+	# 1.5) Local source quality baseline
+	_add_quality_baseline_checks(checks)
 
 	# 2) Auth storage
 	token = auth.check_status()
@@ -162,17 +223,20 @@ def doctor_cmd(ctx: click.Context, live_probe: bool) -> None:
 	bridge_checks: list[dict[str, Any]] = []
 	try:
 		from boss_agent_cli.bridge.client import BridgeClient
+
 		bc = BridgeClient()
 		bridge_checks = bc.diagnose(workspace="boss", run_probes=True)
 		bridge_ok = any(item["name"] == "bridge_extension" and item["status"] == "ok" for item in bridge_checks)
 	except Exception as exc:
-		bridge_checks = [{
-			"name": "bridge_daemon",
-			"status": "warn",
-			"detail": f"Bridge 诊断失败: {exc}",
-			"recovery_action": "检查 Bridge daemon、扩展安装状态和本地端口占用",
-			"hint": "检查 Bridge daemon、扩展安装状态和本地端口占用",
-		}]
+		bridge_checks = [
+			{
+				"name": "bridge_daemon",
+				"status": "warn",
+				"detail": f"Bridge 诊断失败: {exc}",
+				"recovery_action": "检查 Bridge daemon、扩展安装状态和本地端口占用",
+				"hint": "检查 Bridge daemon、扩展安装状态和本地端口占用",
+			}
+		]
 	checks.extend(bridge_checks)
 
 	if cdp_ok or bridge_ok:
@@ -224,6 +288,7 @@ def doctor_cmd(ctx: click.Context, live_probe: bool) -> None:
 		next_actions.append("boss --cdp-url http://localhost:9222 doctor — 检查指定 CDP 地址")
 	if not any(item["name"] == "cookie_extract" and item["status"] == "ok" for item in checks):
 		next_actions.append(f"先在本机浏览器登录 {config.site_host}，再重试 {config.login_action}")
+	next_actions.append("python scripts/quality_baseline.py — 提交前运行本地 P0 质量基线")
 	next_actions.append("敏感操作或命中风控时，停止自动化访问并回到官方页面由用户手动完成")
 
 	data = {
@@ -260,57 +325,71 @@ def _add_live_probe_checks(ctx: click.Context, auth: AuthManager, checks: list[d
 		with get_platform_instance(ctx, auth) as platform:
 			info = platform.user_info()
 			if platform.is_success(info):
-				checks.append({
-					"name": "candidate_live_user_info",
-					"status": "ok",
-					"detail": "求职者只读 user_info 探测通过",
-				})
+				checks.append(
+					{
+						"name": "candidate_live_user_info",
+						"status": "ok",
+						"detail": "求职者只读 user_info 探测通过",
+					}
+				)
 			else:
 				code, message = platform.parse_error(info)
-				checks.append({
-					"name": "candidate_live_user_info",
-					"status": "warn",
-					"detail": f"求职者只读 user_info 探测失败: {code} {message}".strip(),
-					"recovery_action": "按错误码执行恢复；命中风控时停止自动化访问",
-				})
+				checks.append(
+					{
+						"name": "candidate_live_user_info",
+						"status": "warn",
+						"detail": f"求职者只读 user_info 探测失败: {code} {message}".strip(),
+						"recovery_action": "按错误码执行恢复；命中风控时停止自动化访问",
+					}
+				)
 	except Exception as exc:
-		checks.append({
-			"name": "candidate_live_user_info",
-			"status": "warn",
-			"detail": f"求职者只读 user_info 探测异常: {exc}",
-			"recovery_action": "先运行 boss status 检查本地登录态；命中风控时停止自动化访问",
-		})
+		checks.append(
+			{
+				"name": "candidate_live_user_info",
+				"status": "warn",
+				"detail": f"求职者只读 user_info 探测异常: {exc}",
+				"recovery_action": "先运行 boss status 检查本地登录态；命中风控时停止自动化访问",
+			}
+		)
 
 	if (ctx.obj or {}).get("platform") == "zhilian":
-		checks.append({
-			"name": "recruiter_live_read",
-			"status": "warn",
-			"detail": "zhilian 招聘者侧暂未接入；跳过招聘者只读探测",
-			"recovery_action": "切换到 boss --platform zhipin --role recruiter doctor",
-		})
+		checks.append(
+			{
+				"name": "recruiter_live_read",
+				"status": "warn",
+				"detail": "zhilian 招聘者侧暂未接入；跳过招聘者只读探测",
+				"recovery_action": "切换到 boss --platform zhipin --role recruiter doctor",
+			}
+		)
 		return
 
 	try:
 		with get_recruiter_platform_instance(ctx, auth) as recruiter:
 			result = recruiter.list_jobs()
 			if recruiter.is_success(result):
-				checks.append({
-					"name": "recruiter_live_read",
-					"status": "ok",
-					"detail": "招聘者职位列表只读探测通过",
-				})
+				checks.append(
+					{
+						"name": "recruiter_live_read",
+						"status": "ok",
+						"detail": "招聘者职位列表只读探测通过",
+					}
+				)
 			else:
 				code, message = recruiter.parse_error(result)
-				checks.append({
-					"name": "recruiter_live_read",
-					"status": "warn",
-					"detail": f"招聘者只读探测失败: {code} {message}".strip(),
-					"recovery_action": "确认当前账号具备招聘者身份；命中风控时停止自动化访问",
-				})
+				checks.append(
+					{
+						"name": "recruiter_live_read",
+						"status": "warn",
+						"detail": f"招聘者只读探测失败: {code} {message}".strip(),
+						"recovery_action": "确认当前账号具备招聘者身份；命中风控时停止自动化访问",
+					}
+				)
 	except Exception as exc:
-		checks.append({
-			"name": "recruiter_live_read",
-			"status": "warn",
-			"detail": f"招聘者只读探测异常: {exc}",
-			"recovery_action": "确认当前账号具备招聘者身份；zhilian 招聘者侧暂不支持",
-		})
+		checks.append(
+			{
+				"name": "recruiter_live_read",
+				"status": "warn",
+				"detail": f"招聘者只读探测异常: {exc}",
+				"recovery_action": "确认当前账号具备招聘者身份；zhilian 招聘者侧暂不支持",
+			}
+		)

--- a/tests/test_doctor_extended.py
+++ b/tests/test_doctor_extended.py
@@ -10,6 +10,7 @@ from boss_agent_cli.main import cli
 
 # ── 辅助 ─────────────────────────────────────────────────────────────
 
+
 def _base_patches():
 	"""返回 doctor 命令核心 mock 的 patch 路径字典。"""
 	return {
@@ -36,12 +37,14 @@ def _invoke_doctor(tmp_path=None, platform="zhipin", **overrides):
 		patch("boss_agent_cli.bridge.client.BridgeClient") as mock_bridge,
 	):
 		# BridgeClient 构造不抛异常，但 is_running 返回 False
-		mock_bridge.return_value.diagnose.return_value = [{
-			"name": "bridge_daemon",
-			"status": "warn",
-			"detail": "Bridge daemon 未运行或无法访问 http://127.0.0.1:19826",
-			"recovery_action": "运行 Bridge daemon 或检查端口占用",
-		}]
+		mock_bridge.return_value.diagnose.return_value = [
+			{
+				"name": "bridge_daemon",
+				"status": "warn",
+				"detail": "Bridge daemon 未运行或无法访问 http://127.0.0.1:19826",
+				"recovery_action": "运行 Bridge daemon 或检查端口占用",
+			}
+		]
 		# 默认值
 		mock_auth.return_value.check_status.return_value = overrides.get("token", None)
 		mock_cdp.return_value = overrides.get("cdp_ws", None)
@@ -69,6 +72,7 @@ def _find_check(checks, name):
 
 # ── 1. 所有检查项正常通过 ────────────────────────────────────────────
 
+
 def test_all_checks_pass(tmp_path):
 	"""所有检查项均为 ok 时 summary 应为 healthy（环境依赖项除外）。"""
 	token = {"cookies": {"wt2": "tok", "wbg": "1", "zp_at": "a"}, "stoken": "st_ok", "user_agent": "ua"}
@@ -91,14 +95,17 @@ def test_all_checks_pass(tmp_path):
 
 # ── 2. Python 版本不满足 ─────────────────────────────────────────────
 
+
 def test_python_version_below_310(tmp_path):
 	"""Python 版本低于 3.10 时 python 检查应为 error。"""
 
 	class FakeVersionInfo(tuple):
 		"""模拟 sys.version_info：同时支持元组比较和属性访问。"""
+
 		major = 3
 		minor = 9
 		micro = 1
+
 		def __new__(cls):
 			return tuple.__new__(cls, (3, 9, 1))
 
@@ -123,6 +130,7 @@ def test_python_version_satisfies(tmp_path):
 
 # ── 3. 依赖缺失 ─────────────────────────────────────────────────────
 
+
 @patch("boss_agent_cli.commands.doctor.shutil.which", return_value=None)
 def test_patchright_missing(mock_which, tmp_path):
 	"""patchright 可执行文件不在 PATH 中时应为 warn。"""
@@ -133,6 +141,7 @@ def test_patchright_missing(mock_which, tmp_path):
 
 
 # ── 4. 网络不通 ──────────────────────────────────────────────────────
+
 
 def test_network_failure(tmp_path):
 	"""访问 zhipin.com 抛异常时 network 应为 warn。"""
@@ -158,6 +167,7 @@ def test_network_ok(tmp_path):
 
 
 # ── 5. 登录态检查 ────────────────────────────────────────────────────
+
 
 def test_auth_logged_in_full(tmp_path):
 	"""wt2 + stoken 均在时 auth_token_quality 应为 ok。"""
@@ -225,6 +235,7 @@ def test_auth_session_file_exists_but_undecryptable(tmp_path):
 
 # ── 6. CDP 可用/不可用 ───────────────────────────────────────────────
 
+
 def test_cdp_available(tmp_path):
 	"""CDP 探测返回 ws url 时 cdp 检查应为 ok。"""
 	code, parsed = _invoke_doctor(tmp_path, cdp_ws="ws://127.0.0.1:9222/devtools/browser/abc")
@@ -269,7 +280,11 @@ def test_bridge_diagnostics_are_included(tmp_path):
 		{"name": "bridge_daemon", "status": "ok", "detail": "Bridge daemon 运行中 pid=123 uptime=7s"},
 		{"name": "bridge_extension", "status": "ok", "detail": "Chrome 扩展已连接 version=1.0.0"},
 		{"name": "bridge_protocol", "status": "ok", "detail": "扩展协议版本 1.0.0；CLI 期望 major=1"},
-		{"name": "bridge_workspace", "status": "ok", "detail": "Bridge workspace/tab 可用: https://www.zhipin.com/web/geek/job"},
+		{
+			"name": "bridge_workspace",
+			"status": "ok",
+			"detail": "Bridge workspace/tab 可用: https://www.zhipin.com/web/geek/job",
+		},
 		{"name": "bridge_exec", "status": "ok", "detail": "Bridge exec 基础能力可用"},
 		{"name": "bridge_fetch", "status": "ok", "detail": "Bridge fetch 基础能力可用"},
 		{"name": "bridge_navigate", "status": "ok", "detail": "Bridge navigate 基础能力可用"},
@@ -293,7 +308,15 @@ def test_bridge_diagnostics_are_included(tmp_path):
 
 	parsed = json.loads(result.output)
 	checks = parsed["data"]["checks"]
-	for name in ("bridge_daemon", "bridge_extension", "bridge_protocol", "bridge_workspace", "bridge_exec", "bridge_fetch", "bridge_navigate"):
+	for name in (
+		"bridge_daemon",
+		"bridge_extension",
+		"bridge_protocol",
+		"bridge_workspace",
+		"bridge_exec",
+		"bridge_fetch",
+		"bridge_navigate",
+	):
 		assert _find_check(checks, name) is not None
 	browser_channel = _find_check(checks, "browser_channel")
 	assert browser_channel["status"] == "ok"
@@ -302,12 +325,14 @@ def test_bridge_diagnostics_are_included(tmp_path):
 
 def test_bridge_diagnostics_do_not_expose_secrets(tmp_path):
 	"""doctor 输出不应泄漏 Bridge 诊断中的 cookie/header/token 字样值。"""
-	bridge_checks = [{
-		"name": "bridge_workspace",
-		"status": "ok",
-		"detail": "Bridge workspace/tab 可用: https://www.zhipin.com/web/geek/job",
-		"tab_url": "https://www.zhipin.com/web/geek/job",
-	}]
+	bridge_checks = [
+		{
+			"name": "bridge_workspace",
+			"status": "ok",
+			"detail": "Bridge workspace/tab 可用: https://www.zhipin.com/web/geek/job",
+			"tab_url": "https://www.zhipin.com/web/geek/job",
+		}
+	]
 	paths = _base_patches()
 	runner = CliRunner()
 	with (
@@ -332,6 +357,7 @@ def test_bridge_diagnostics_do_not_expose_secrets(tmp_path):
 
 
 # ── 7. 输出 JSON 格式正确性 ─────────────────────────────────────────
+
 
 def test_json_envelope_structure(tmp_path):
 	"""验证 doctor 输出的 JSON 信封结构完整。"""
@@ -383,6 +409,7 @@ def test_summary_broken_when_error_exists(tmp_path):
 
 # ── 8. browser_channel 检查 ──────────────────────────────────────────
 
+
 def test_browser_channel_ok_with_cdp(tmp_path):
 	"""CDP 可用时 browser_channel 应为 ok 且提示 CDP 模式。"""
 	code, parsed = _invoke_doctor(tmp_path, cdp_ws="ws://127.0.0.1:9222/devtools/browser/abc")
@@ -403,6 +430,7 @@ def test_browser_channel_warn_without_cdp_or_bridge(tmp_path):
 
 # ── 9. cookie 提取检查 ───────────────────────────────────────────────
 
+
 def test_cookie_extract_ok(tmp_path):
 	"""本地浏览器可提取 Cookie 时应为 ok。"""
 	code, parsed = _invoke_doctor(tmp_path, cookie={"cookies": {"wt2": "v", "token": "t"}})
@@ -419,6 +447,7 @@ def test_cookie_extract_not_available(tmp_path):
 
 
 # ── 10. next_actions 提示逻辑 ────────────────────────────────────────
+
 
 def test_next_actions_suggests_login_when_not_logged_in(tmp_path):
 	code, parsed = _invoke_doctor(tmp_path, token=None)
@@ -575,6 +604,7 @@ def test_zhilian_doctor_uses_platform_specific_cookie_and_network_messages(tmp_p
 	assert network is not None
 	assert network["detail"] == "访问 zhaopin.com 返回 HTTP 200"
 
+
 def test_doctor_login_preflight_blocks_missing_auth_before_platform_requests(tmp_path):
 	code, parsed = _invoke_doctor(tmp_path, token=None)
 	preflight = _find_check(parsed["data"]["checks"], "login_preflight")
@@ -601,3 +631,15 @@ def test_doctor_login_preflight_passes_complete_auth(tmp_path):
 	assert preflight is not None
 	assert preflight["status"] == "ok"
 	assert "登录前置通过" in preflight["detail"]
+
+
+def test_doctor_reports_quality_baseline(tmp_path):
+	code, parsed = _invoke_doctor(tmp_path)
+	assert code == 0
+	checks = parsed["data"]["checks"]
+	baseline = _find_check(checks, "quality_baseline")
+	assert baseline["status"] == "ok"
+	assert "scripts/quality_baseline.py" in baseline["detail"]
+	for tool in ("ruff", "pytest", "mypy"):
+		assert _find_check(checks, f"quality_tool_{tool}")["status"] in {"ok", "warn"}
+	assert any("quality_baseline.py" in action for action in parsed["hints"]["next_actions"])

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -180,6 +180,7 @@ def test_maintainer_docs_cover_open_source_governance():
 	labels = read("docs/maintainer/labels.md")
 
 	assert "required status checks" in branch
+	assert "P0 quality baseline" in branch
 	assert "test (3.10)" in branch
 	assert "test (3.11)" in branch
 	assert "test (3.12)" in branch
@@ -273,6 +274,33 @@ def test_issue_templates_are_valid_structured_forms():
 				assert options
 
 		assert len(ids) == len(set(ids))
+
+
+def test_ci_workflow_runs_p0_quality_gate():
+	raw_workflow = read(".github/workflows/ci.yml")
+	workflow = load_yaml(".github/workflows/ci.yml")
+
+	jobs = workflow["jobs"]
+	assert "p0_quality_gate" in jobs
+	gate = jobs["p0_quality_gate"]
+	assert gate["name"] == "P0 quality baseline"
+	assert gate["runs-on"] == "ubuntu-latest"
+	run_commands = [step["run"] for step in gate["steps"] if "run" in step]
+	assert run_commands == [
+		"uv python install 3.11",
+		"uv sync --all-extras",
+		"uv run python scripts/quality_baseline.py",
+	]
+	assert "scripts/quality_baseline.py" in raw_workflow
+
+
+def test_quality_baseline_script_matches_blocking_p0_commands():
+	content = read("scripts/quality_baseline.py")
+
+	assert '("ruff", ("ruff", "check", "src/boss_agent_cli", "tests", "--output-format=concise"))' in content
+	assert '("pytest", ("pytest", "-q"))' in content
+	assert '("mypy", ("mypy", "src/boss_agent_cli"))' in content
+	assert "--skip-mypy" in content
 
 
 def test_docs_workflow_runs_open_source_doc_checks():


### PR DESCRIPTION
## Summary
- add an offline P0 quality baseline runner for ruff, pytest, and mypy
- wire the P0 quality baseline into CI as a required-style gate
- surface the baseline in doctor/docs tests and branch protection docs

## Local validation
- python scripts/quality_baseline.py
  - ruff: ok
  - pytest: 1425 passed
  - mypy: ok