### PR TITLE
test: 补齐前程无忧占位能力契约

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased]
 
+### Changed
+- 51job/前程无忧占位适配器补齐候选者侧全量能力的稳定 `NOT_SUPPORTED` 包络，避免未启用真实适配前落入默认 `NotImplementedError`。
+
 ## [1.12.0] - 2026-06-09
 
 ### Added

--- a/src/boss_agent_cli/platforms/qiancheng.py
+++ b/src/boss_agent_cli/platforms/qiancheng.py
@@ -79,5 +79,39 @@ class QianchengPlatform(Platform):
 	def user_info(self) -> dict[str, Any]:
 		return self._not_supported("user_info")
 
+
+	def resume_baseinfo(self) -> dict[str, Any]:
+		return self._not_supported("resume_baseinfo")
+
+	def resume_expect(self) -> dict[str, Any]:
+		return self._not_supported("resume_expect")
+
+	def deliver_list(self, page: int = 1) -> dict[str, Any]:
+		return self._not_supported("deliver_list")
+
 	def job_card(self, security_id: str, lid: str = "") -> dict[str, Any]:
 		return self._not_supported("job_card")
+
+	def interview_data(self) -> dict[str, Any]:
+		return self._not_supported("interview_data")
+
+	def chat_history(self, gid: str, security_id: str, page: int = 1, count: int = 20) -> dict[str, Any]:
+		return self._not_supported("chat_history")
+
+	def friend_label(self, friend_id: str, label_id: int, friend_source: int = 0, remove: bool = False) -> dict[str, Any]:
+		return self._not_supported("friend_label")
+
+	def exchange_contact(self, security_id: str, uid: str, friend_name: str, exchange_type: int = 1) -> dict[str, Any]:
+		return self._not_supported("exchange_contact")
+
+	def job_history(self, page: int = 1) -> dict[str, Any]:
+		return self._not_supported("job_history")
+
+	def greet(self, security_id: str, job_id: str, message: str = "") -> dict[str, Any]:
+		return self._not_supported("greet")
+
+	def apply(self, security_id: str, job_id: str, lid: str = "") -> dict[str, Any]:
+		return self._not_supported("apply")
+
+	def friend_list(self, page: int = 1) -> dict[str, Any]:
+		return self._not_supported("friend_list")

--- a/tests/test_qiancheng_stub.py
+++ b/tests/test_qiancheng_stub.py
@@ -47,13 +47,24 @@ class TestQianchengNotSupportedEnvelope:
 		self.client = MagicMock()
 		self.plat = QianchengPlatform(self.client)
 
-	def test_required_capabilities_return_not_supported(self) -> None:
+	def test_candidate_capabilities_return_not_supported(self) -> None:
 		for raw in (
 			self.plat.search_jobs("Python", city="广州"),
 			self.plat.job_detail("job-id"),
 			self.plat.recommend_jobs(page=1),
 			self.plat.user_info(),
+			self.plat.resume_baseinfo(),
+			self.plat.resume_expect(),
+			self.plat.deliver_list(page=1),
 			self.plat.job_card("security-id"),
+			self.plat.interview_data(),
+			self.plat.chat_history("gid", "security-id"),
+			self.plat.friend_label("friend-id", 1),
+			self.plat.exchange_contact("security-id", "uid", "friend"),
+			self.plat.job_history(page=1),
+			self.plat.greet("security-id", "job-id", "你好"),
+			self.plat.apply("security-id", "job-id"),
+			self.plat.friend_list(page=1),
 		):
 			assert raw["code"] == -1
 			assert raw["error"]["code"] == "NOT_SUPPORTED"
@@ -70,7 +81,18 @@ class TestQianchengNotSupportedEnvelope:
 		self.plat.job_detail("job-id")
 		self.plat.recommend_jobs()
 		self.plat.user_info()
+		self.plat.resume_baseinfo()
+		self.plat.resume_expect()
+		self.plat.deliver_list()
 		self.plat.job_card("security-id")
+		self.plat.interview_data()
+		self.plat.chat_history("gid", "security-id")
+		self.plat.friend_label("friend-id", 1)
+		self.plat.exchange_contact("security-id", "uid", "friend")
+		self.plat.job_history()
+		self.plat.greet("security-id", "job-id")
+		self.plat.apply("security-id", "job-id")
+		self.plat.friend_list()
 		self.client.assert_not_called()
 
 


### PR DESCRIPTION
## 关联 Issue / Related Issue

Closes #

## 变更说明 / Summary

- 补齐 51job/前程无忧占位适配器的候选者侧能力方法
- 统一返回稳定 `NOT_SUPPORTED` 包络，避免真实适配启用前落入默认 `NotImplementedError`
- 扩展占位契约测试，覆盖全量候选者侧能力且确认不触发 client/网络调用
- 更新 `CHANGELOG.md` 的 `[Unreleased]` 记录

## 变更类型 / Type

- [ ] feat: 新功能
- [ ] fix: Bug 修复
- [ ] refactor: 重构（不改变外部行为）
- [ ] perf: 性能优化
- [ ] docs: 文档
- [x] test: 测试
- [ ] chore: 构建/依赖/配置
- [ ] ci: CI 工作流

## Breaking Change

- [x] 本 PR **不包含** 破坏性变更
- [ ] 本 PR **包含** 破坏性变更（请在下方说明迁移路径）

## 截图 / Screenshot

不涉及 UI / HTML / Terminal 输出变化。

## 测试 / Test Plan

- [x] `uv run pytest tests/ -q` 全部通过（1422 passed）
- [x] `uv run ruff check src/ tests/` 无报错
- [x] `uv run mypy src/boss_agent_cli` 无报错
- [x] `uv run boss --help` 可加载
- [x] `uv run boss schema --format native` 返回合法 JSON 信封
- [x] 新增/修改的功能已有对应测试覆盖
- [ ] 本地跑过涉及命令（如有可粘贴已脱敏输出）

## 文档与契约 / Docs & Contracts

- [x] 如新增命令：不适用
- [x] 如变更 CLI 行为：不适用，仍保持 qiancheng 真实能力 `NOT_SUPPORTED`
- [x] 如新增 MCP 工具：不适用
- [x] 如新增错误码：不适用，复用 `NOT_SUPPORTED`
- [x] 已更新 `CHANGELOG.md` 的 `[Unreleased]` 段落
- [x] 如变更 Agent 主卖点或安装路径：不适用

## 安全与规范 / Safety & Convention

- [x] commit message 格式: `type: 中文描述`
- [x] 无敏感信息（Token / 密码 / Cookie / security_id / 手机号 / 微信 / 真实账号）
- [x] 如涉及 Cookie、CDP、patchright、请求频率或真实账号：不适用，无真实平台/网络调用
- [x] 如涉及发布流程：不适用
- [x] 无新增外部 CDN / script 依赖（HTML 报表类特别注意）
