### PR TITLE
ci: 确保Docs必选检查稳定触发

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,18 +3,6 @@ name: Docs
 "on":
   push:
     branches: [master]
-    paths:
-      - "README.md"
-      - "README.en.md"
-      - "CONTRIBUTING.md"
-      - "CONTRIBUTING.en.md"
-      - "SECURITY.md"
-      - "docs/**"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/PULL_REQUEST_TEMPLATE.md"
-      - "tests/test_agent_docs.py"
-      - "tests/test_open_source_docs.py"
-      - ".github/workflows/docs.yml"
   pull_request:
     branches: [master]
   workflow_dispatch:

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -342,7 +342,11 @@ def test_docs_workflow_runs_open_source_doc_checks():
 	triggers = workflow["on"]
 	assert {"push", "pull_request", "workflow_dispatch"} <= set(triggers)
 	assert triggers["push"]["branches"] == ["master"]
-	assert set(expected_paths) <= set(triggers["push"]["paths"])
+	assert "paths" not in triggers["push"]
+	assert "push" in raw_workflow
+	assert "paths:" not in raw_workflow.split("pull_request:", 1)[0]
+	for path in expected_paths:
+		assert path not in raw_workflow.split("pull_request:", 1)[0]
 	assert triggers["pull_request"]["branches"] == ["master"]
 	assert "paths" not in triggers["pull_request"]
 


### PR DESCRIPTION
## 变更内容
- 移除 `Docs` workflow 在 `push` 到 `master` 时的 `paths` 过滤。
- 同步文档 workflow 结构测试，断言 `push` 触发不再受 paths 限制。

## 原因
`docs` 当前是 master 分支 required check。若 `push` 事件带 paths 过滤，非文档路径变更合入 master 时可能不会创建 `Docs / docs` check-run，从而让 required check 出现 Expected/Pending 歧义。让 `push` 到 `master` 始终触发 Docs workflow，可保证 required check 稳定产生。

## 验证
- [x] `git diff --check`
- [x] `uv run pytest tests/test_agent_docs.py tests/test_open_source_docs.py -q`（36 passed）

## 安全与规范 / Safety & Convention
- [x] commit message 格式: `type: 中文描述`
- [x] 无敏感信息（Token / 密码 / Cookie / security_id / 手机号 / 微信 / 真实账号）
- [x] 无新增外部 CDN / script 依赖
