### PR TITLE
test: 补强前程无忧占位能力契约

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 - PR 模板补充无 `Co-authored-by` 尾注或 AI 署名行检查项，对齐贡献规范。
 - 51job/前程无忧占位适配器补齐候选者侧全量能力的稳定 `NOT_SUPPORTED` 包络，避免未启用真实适配前落入默认 `NotImplementedError`。
+- 补强 51job/前程无忧占位包络的 `capability` 明细契约，确保 Agent 可稳定区分具体未支持能力。
 
 ## [1.12.0] - 2026-06-09
 

--- a/tests/test_qiancheng_stub.py
+++ b/tests/test_qiancheng_stub.py
@@ -48,6 +48,7 @@ class TestQianchengNotSupportedEnvelope:
 		self.plat = QianchengPlatform(self.client)
 
 	def test_candidate_capabilities_return_not_supported(self) -> None:
+		capabilities = set()
 		for raw in (
 			self.plat.search_jobs("Python", city="广州"),
 			self.plat.job_detail("job-id"),
@@ -70,11 +71,31 @@ class TestQianchengNotSupportedEnvelope:
 			assert raw["error"]["code"] == "NOT_SUPPORTED"
 			assert raw["error"]["recoverable"] is True
 			assert raw["error"]["details"]["platform"] == "qiancheng"
+			capabilities.add(raw["error"]["details"]["capability"])
 			assert self.plat.is_success(raw) is False
 			code, message = self.plat.parse_error(raw)
 			assert code == "NOT_SUPPORTED"
 			assert "research backlog" in message
+			assert raw["error"]["details"]["capability"] in message
 			assert self.plat.unwrap_data(raw) is None
+		assert capabilities == {
+			"search_jobs",
+			"job_detail",
+			"recommend_jobs",
+			"user_info",
+			"resume_baseinfo",
+			"resume_expect",
+			"deliver_list",
+			"job_card",
+			"interview_data",
+			"chat_history",
+			"friend_label",
+			"exchange_contact",
+			"job_history",
+			"greet",
+			"apply",
+			"friend_list",
+		}
 
 	def test_stub_does_not_delegate_to_client(self) -> None:
 		self.plat.search_jobs("Python")


### PR DESCRIPTION
## Summary
- 补强 51job/前程无忧占位适配器的 NOT_SUPPORTED 包络测试
- 断言每个候选者侧占位能力都暴露稳定 capability 明细
- 更新 Unreleased changelog

## Tests
- uv run pytest tests/test_qiancheng_stub.py -q
- uv run ruff check tests/test_qiancheng_stub.py
- uv run pytest tests/test_open_source_docs.py -q
- uv run pytest tests/ -q
- uv run ruff check src/ tests/
- uv run mypy src/boss_agent_cli

## Checklist
- [x] 我已运行相关测试/检查
- [x] 不包含 Co-authored-by 尾注或 AI 署名行
- [x] 未发布、未打 tag、未做大范围重构
