### PR TITLE
test: 补强配置错误包络契约

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased]
 
 ### Changed
+- 补强 `boss config` 未知配置项错误路径的 stdout 单行 JSON 包络契约测试，确保 Agent 可稳定解析 `INVALID_PARAM`。
 - PR 模板补充无 `Co-authored-by` 尾注或 AI 署名行检查项，对齐贡献规范。
 - 51job/前程无忧占位适配器补齐候选者侧全量能力的稳定 `NOT_SUPPORTED` 包络，避免未启用真实适配前落入默认 `NotImplementedError`。
 - 补强 51job/前程无忧占位包络的 `capability` 明细契约，确保 Agent 可稳定区分具体未支持能力。

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -1,10 +1,33 @@
 """config 命令测试 — 覆盖查看、设置、重置配置项。"""
 
 import json
+from typing import Any
 
-from click.testing import CliRunner
+from click.testing import CliRunner, Result
 
 from boss_agent_cli.main import cli
+
+
+_ERROR_KEYS = {"code", "message", "recoverable", "recovery_action"}
+
+
+def _assert_single_stdout_json_error(result: Result, *, command: str, code: str) -> dict[str, Any]:
+	"""Agent-facing error output must stay machine-consumable on stdout only."""
+	assert result.exit_code == 1
+	assert result.stderr == ""
+	assert result.output.strip()
+	assert "\n" not in result.output.strip()
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["schema_version"] == "1.0"
+	assert parsed["command"] == command
+	assert parsed["data"] is None
+	assert parsed["pagination"] is None
+	assert set(parsed["error"]) == _ERROR_KEYS
+	assert parsed["error"]["code"] == code
+	assert isinstance(parsed["error"]["message"], str)
+	assert isinstance(parsed["error"]["recoverable"], bool)
+	return parsed
 
 
 def _invoke(*args, tmp_path=None):
@@ -66,11 +89,12 @@ def test_config_get_valid_key(tmp_path):
 
 
 def test_config_get_unknown_key(tmp_path):
-	"""获取未知配置项应返回错误。"""
-	code, parsed = _invoke("config", "get", "nonexistent", tmp_path=tmp_path)
-	assert code == 1
-	assert parsed["ok"] is False
-	assert parsed["error"]["code"] == "INVALID_PARAM"
+	"""获取未知配置项应返回 Agent 可消费的 stdout JSON 错误包络。"""
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--data-dir", str(tmp_path), "config", "get", "nonexistent"])
+	parsed = _assert_single_stdout_json_error(result, command="config", code="INVALID_PARAM")
+	assert "可用项" in parsed["error"]["message"]
+	assert parsed["hints"] is None
 
 
 # ── config set ──────────────────────────────────────────────────────
@@ -113,10 +137,11 @@ def test_config_set_null_value(tmp_path):
 
 
 def test_config_set_unknown_key(tmp_path):
-	"""设置未知配置项应返回错误。"""
-	code, parsed = _invoke("config", "set", "bad_key", "val", tmp_path=tmp_path)
-	assert code == 1
-	assert parsed["error"]["code"] == "INVALID_PARAM"
+	"""设置未知配置项应返回 Agent 可消费的 stdout JSON 错误包络。"""
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--data-dir", str(tmp_path), "config", "set", "bad_key", "val"])
+	parsed = _assert_single_stdout_json_error(result, command="config", code="INVALID_PARAM")
+	assert "可用项" in parsed["error"]["message"]
 
 
 def test_config_commands_do_not_expose_internal_low_risk_policy(tmp_path):
@@ -151,10 +176,11 @@ def test_config_reset_restores_default(tmp_path):
 
 
 def test_config_reset_unknown_key(tmp_path):
-	"""重置未知配置项应返回错误。"""
-	code, parsed = _invoke("config", "reset", "bad_key", tmp_path=tmp_path)
-	assert code == 1
-	assert parsed["error"]["code"] == "INVALID_PARAM"
+	"""重置未知配置项应返回 Agent 可消费的 stdout JSON 错误包络。"""
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--data-dir", str(tmp_path), "config", "reset", "bad_key"])
+	parsed = _assert_single_stdout_json_error(result, command="config", code="INVALID_PARAM")
+	assert "可用项" in parsed["error"]["message"]
 
 
 # ── JSON 信封格式 ──────────────────────────────────────────────────


### PR DESCRIPTION
## 关联 Issue / Related Issue

Closes #

## 变更说明 / Summary

- 补强 `boss config` 未知配置项错误路径的 Agent-facing stdout JSON 契约测试
- 覆盖 `config get/set/reset` 未知键时的单行 JSON、空 stderr、`INVALID_PARAM` 错误包络字段
- 更新 `CHANGELOG.md` 的 `[Unreleased]` 段落

## 变更类型 / Type

- [ ] feat: 新功能
- [ ] fix: Bug 修复
- [ ] refactor: 重构（不改变外部行为）
- [ ] perf: 性能优化
- [ ] docs: 文档
- [x] test: 测试
- [ ] chore: 构建/依赖/配置
- [ ] ci: CI 工作流

## Breaking Change

- [x] 本 PR **不包含** 破坏性变更
- [ ] 本 PR **包含** 破坏性变更（请在下方说明迁移路径）

## 截图 / Screenshot

不涉及 UI / HTML / Terminal 输出变更。

## 测试 / Test Plan

- [ ] `uv run pytest tests/ -q` 全部通过
- [ ] `uv run ruff check src/ tests/` 无报错
- [ ] `uv run mypy src/boss_agent_cli` 无报错
- [ ] `uv run boss --help` 可加载
- [ ] `uv run boss schema --format native` 返回合法 JSON 信封
- [x] 新增/修改的功能已有对应测试覆盖
- [x] 本地跑过涉及命令（如有可粘贴已脱敏输出）

已运行：

```bash
.venv/bin/pytest tests/test_config_cmd.py tests/test_cli_invariants.py
.venv/bin/ruff check tests/test_config_cmd.py
git diff --check
```

## 文档与契约 / Docs & Contracts

- [ ] 如新增命令：已更新 `src/boss_agent_cli/commands/schema.py`
- [ ] 如变更 CLI 行为：已更新 `README.md` 和 `docs/capability-matrix.md`
- [ ] 如新增 MCP 工具：已更新 `mcp-server/server.py` 和 `mcp-server/README.md`
- [ ] 如新增错误码：已添加到 `schema.py` 的 `error_codes`
- [x] 已更新 `CHANGELOG.md` 的 `[Unreleased]` 段落
- [ ] 如变更 Agent 主卖点或安装路径：已同步检查 `SKILL.md` / PyPI 版本 / GitHub Release 说明

## 安全与规范 / Safety & Convention

- [x] commit message 格式: `type: 中文描述`
- [x] 无 `Co-authored-by` 尾注或 AI 署名行
- [x] 无敏感信息（Token / 密码 / Cookie / security_id / 手机号 / 微信 / 真实账号）
- [ ] 如涉及 Cookie、CDP、patchright、请求频率或真实账号，已阅读 `docs/platform-risk.md`
- [ ] 如涉及发布流程，已阅读 `docs/maintainer/release-checklist.md`
- [x] 无新增外部 CDN / script 依赖（HTML 报表类特别注意）
