### PR TITLE
test: 补强Agent错误包络契约

### DIFF
--- a/src/boss_agent_cli/main.py
+++ b/src/boss_agent_cli/main.py
@@ -66,8 +66,14 @@ def cli(ctx: click.Context, data_dir: str, delay: str | None, cdp_url: str | Non
 	cfg = load_config(resolved_dir / "config.json")
 
 	if delay:
-		low, high = delay.split("-")
-		ctx.obj["delay"] = (float(low), float(high))
+		try:
+			low, high = delay.split("-", 1)
+			ctx.obj["delay"] = (float(low), float(high))
+		except ValueError as exc:
+			raise click.BadParameter(
+				"delay must be a range like 1.5-3.0",
+				param_hint="--delay",
+			) from exc
 	else:
 		ctx.obj["delay"] = tuple(cfg["request_delay"])
 

--- a/tests/test_agent_error_contract.py
+++ b/tests/test_agent_error_contract.py
@@ -1,0 +1,51 @@
+"""Agent-facing CLI error envelope contract tests."""
+
+import json
+from typing import Any
+
+import pytest
+from click.testing import CliRunner, Result
+
+from boss_agent_cli.main import cli
+
+
+_ERROR_KEYS = {"code", "message", "recoverable", "recovery_action"}
+
+
+def _assert_single_stdout_json_error(result: Result, *, command: str, code: str = "INVALID_PARAM") -> dict[str, Any]:
+	"""Agent-facing errors must stay as a single machine-consumable stdout envelope."""
+	assert result.exit_code == 1
+	assert result.stderr == ""
+	assert result.output.strip()
+	assert "\n" not in result.output.strip()
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["schema_version"] == "1.0"
+	assert parsed["command"] == command
+	assert parsed["data"] is None
+	assert parsed["pagination"] is None
+	assert set(parsed["error"]) == _ERROR_KEYS
+	assert parsed["error"]["code"] == code
+	assert isinstance(parsed["error"]["message"], str)
+	assert isinstance(parsed["error"]["recoverable"], bool)
+	return parsed
+
+
+@pytest.mark.parametrize(
+	("args", "command", "message_fragment"),
+	[
+		(("--platform", "unknown", "status"), "boss", "--platform"),
+		(("--delay", "fast", "status"), "boss", "--delay"),
+		(("--role", "admin", "status"), "boss", "--role"),
+		(("detail",), "detail", "SECURITY_ID"),
+		(("config", "get"), "get", "KEY"),
+		(("shortlist", "add"), "add", "SECURITY_ID"),
+	],
+)
+def test_agent_facing_usage_errors_emit_stdout_json_envelope(tmp_path, args, command, message_fragment):
+	"""Global parameter and high-frequency usage errors keep the JSON error contract."""
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--data-dir", str(tmp_path), *args])
+
+	parsed = _assert_single_stdout_json_error(result, command=command)
+	assert message_fragment in parsed["error"]["message"]


### PR DESCRIPTION
## 关联 Issue / Related Issue

N/A

## 变更说明 / Summary

- 新增 Agent-facing CLI 错误包络契约测试，横向覆盖全局参数错误：未知 `--platform`、非法 `--delay`、非法 `--role`
- 覆盖高频命令用法错误路径：`detail` 缺少 `SECURITY_ID`、`config get` 缺少 `KEY`、`shortlist add` 缺少 `SECURITY_ID`
- 将非法 `--delay` 从裸 `ValueError` 收敛为 Click `BadParameter`，复用现有 stdout JSON 错误信封输出路径

## 变更类型 / Type

- [ ] feat: 新功能
- [ ] fix: Bug 修复
- [ ] refactor: 重构（不改变外部行为）
- [ ] perf: 性能优化
- [ ] docs: 文档
- [x] test: 测试
- [ ] chore: 构建/依赖/配置
- [ ] ci: CI 工作流

## Breaking Change

- [x] 本 PR **不包含** 破坏性变更
- [ ] 本 PR **包含** 破坏性变更（请在下方说明迁移路径）

## 截图 / Screenshot

N/A

## 测试 / Test Plan

- [x] `uv run pytest tests/test_agent_error_contract.py tests/test_config_cmd.py -q` 全部通过（20 passed）
- [x] `uv run pytest tests/ -q` 全部通过（1431 passed）
- [x] `uv run ruff check src/boss_agent_cli tests --output-format=concise` 无报错
- [x] `uv run mypy src/boss_agent_cli` 无报错
- [x] `uv run boss --help` 可加载
- [x] `uv run boss schema --format native` 返回合法 JSON 信封
- [x] 新增/修改的功能已有对应测试覆盖
- [ ] 本地跑过涉及命令（如有可粘贴已脱敏输出）

## 文档与契约 / Docs & Contracts

- [ ] 如新增命令：已更新 `src/boss_agent_cli/commands/schema.py`
- [ ] 如变更 CLI 行为：已更新 `README.md` 和 `docs/capability-matrix.md`
- [ ] 如新增 MCP 工具：已更新 `mcp-server/server.py` 和 `mcp-server/README.md`
- [ ] 如新增错误码：已添加到 `schema.py` 的 `error_codes`
- [ ] 已更新 `CHANGELOG.md` 的 `[Unreleased]` 段落
- [ ] 如变更 Agent 主卖点或安装路径：已同步检查 `SKILL.md` / PyPI 版本 / GitHub Release 说明

说明：本 PR 不新增命令/错误码/顶层 schema，不发布不打 tag；仅补强既有错误包络契约与 `--delay` 参数错误收敛。

## 安全与规范 / Safety & Convention

- [x] commit message 格式: `type: 中文描述`
- [x] 无 `Co-authored-by` 尾注或 AI 署名行
- [x] 无敏感信息（Token / 密码 / Cookie / security_id / 手机号 / 微信 / 真实账号）
- [x] 如涉及 Cookie、CDP、patchright、请求频率或真实账号，已阅读 `docs/platform-risk.md`
- [x] 如涉及发布流程，已阅读 `docs/maintainer/release-checklist.md`
- [x] 无新增外部 CDN / script 依赖（HTML 报表类特别注意）
