### PR TITLE
test: 补充前程无忧只读入口契约

### DIFF
--- a/src/boss_agent_cli/commands/detail.py
+++ b/src/boss_agent_cli/commands/detail.py
@@ -10,6 +10,17 @@ from boss_agent_cli.display import error_contract_for_code, handle_auth_errors, 
 from boss_agent_cli.platforms import Platform
 
 NOT_SUPPORTED_RECOVERY_ACTION = "切换平台或调整命令参数后重试"
+DetailError = tuple[str, str, dict[str, Any] | None]
+
+
+def _platform_error_details(response: Any) -> dict[str, Any] | None:
+	if isinstance(response, dict):
+		error = response.get("error")
+		if isinstance(error, dict):
+			details = error.get("details")
+			if isinstance(details, dict):
+				return details
+	return None
 
 
 @click.command("detail")
@@ -33,7 +44,7 @@ def detail_cmd(ctx: click.Context, security_id: str, lid: str, job_id: str) -> N
 				logger.info("从缓存命中 job_id，走 httpx 快速通道")
 
 		result = None
-		last_error: tuple[str, str] | None = None
+		last_error: DetailError | None = None
 		if job_id:
 			try:
 				result, last_error = _detail_via_httpx(platform, security_id, job_id, data_dir)
@@ -60,6 +71,7 @@ def detail_cmd(ctx: click.Context, security_id: str, lid: str, job_id: str) -> N
 				message=last_error[1],
 				recoverable=recoverable,
 				recovery_action=recovery_action,
+				details=last_error[2],
 			)
 			return
 		handle_error_output(
@@ -80,12 +92,12 @@ def detail_cmd(ctx: click.Context, security_id: str, lid: str, job_id: str) -> N
 	)
 
 
-def _detail_via_httpx(platform: Platform, security_id: str, job_id: str, data_dir: Path) -> tuple[dict[str, Any] | None, tuple[str, str] | None]:
+def _detail_via_httpx(platform: Platform, security_id: str, job_id: str, data_dir: Path) -> tuple[dict[str, Any] | None, DetailError | None]:
 	"""快速通道：通过 httpx 获取职位详情（不需要浏览器）"""
 	raw = platform.job_detail(job_id)
 	if not platform.is_success(raw):
 		code, message = platform.parse_error(raw)
-		return None, (code, message or "职位详情获取失败")
+		return None, (code, message or "职位详情获取失败", _platform_error_details(raw))
 	platform_data = platform.unwrap_data(raw) or {}
 	job_info = platform_data.get("jobInfo", {})
 	boss_info = platform_data.get("bossInfo", {})
@@ -116,15 +128,15 @@ def _detail_via_httpx(platform: Platform, security_id: str, job_id: str, data_di
 	}, None
 
 
-def _detail_via_browser(platform: Platform, security_id: str, lid: str, data_dir: Path) -> tuple[dict[str, Any] | None, tuple[str, str] | None]:
+def _detail_via_browser(platform: Platform, security_id: str, lid: str, data_dir: Path) -> tuple[dict[str, Any] | None, DetailError | None]:
 	"""兜底通道：通过浏览器 job_card 获取职位详情"""
 	try:
 		raw = platform.job_card(security_id, lid)
 	except NotImplementedError as exc:
-		return None, ("NOT_SUPPORTED", str(exc) or "当前平台不支持职位详情兜底能力")
+		return None, ("NOT_SUPPORTED", str(exc) or "当前平台不支持职位详情兜底能力", None)
 	if not platform.is_success(raw):
 		code, message = platform.parse_error(raw)
-		return None, (code, message or "职位详情获取失败")
+		return None, (code, message or "职位详情获取失败", _platform_error_details(raw))
 	platform_data = platform.unwrap_data(raw) or {}
 	card = platform_data.get("jobCard", {})
 	if not card:

--- a/src/boss_agent_cli/commands/history.py
+++ b/src/boss_agent_cli/commands/history.py
@@ -3,7 +3,7 @@ import click
 from boss_agent_cli.api.models import JobItem
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import boss_command_for_ctx, error_contract_for_code, handle_auth_errors, handle_error_output, handle_output, render_job_table
+from boss_agent_cli.display import boss_command_for_ctx, handle_auth_errors, handle_error_output, handle_output, handle_platform_error_output, render_job_table
 
 NOT_SUPPORTED_RECOVERY_ACTION = "切换平台或调整命令参数后重试"
 
@@ -31,14 +31,9 @@ def history_cmd(ctx: click.Context, page: int) -> None:
 			)
 			return
 		if not platform.is_success(raw):
-			code, message = platform.parse_error(raw)
-			recoverable, recovery_action = error_contract_for_code(code)
-			handle_error_output(
-				ctx, "history",
-				code=code,
-				message=message or "浏览历史获取失败",
-				recoverable=recoverable,
-				recovery_action=recovery_action,
+			handle_platform_error_output(
+				ctx, "history", platform, raw,
+				fallback_message="浏览历史获取失败",
 			)
 			return
 		platform_data = platform.unwrap_data(raw) or {}

--- a/src/boss_agent_cli/commands/me.py
+++ b/src/boss_agent_cli/commands/me.py
@@ -3,7 +3,7 @@ import click
 from boss_agent_cli.api.client import AuthError
 from boss_agent_cli.auth.manager import AuthManager, AuthRequired, TokenRefreshFailed
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import boss_command_for_ctx, error_contract_for_code, handle_error_output, handle_output, login_action_for_ctx, render_sectioned_record
+from boss_agent_cli.display import boss_command_for_ctx, handle_error_output, handle_output, handle_platform_error_output, login_action_for_ctx, render_sectioned_record
 
 NOT_SUPPORTED_RECOVERY_ACTION = "切换平台或调整命令参数后重试"
 
@@ -30,14 +30,9 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 					logger.info("获取用户基本信息...")
 				resp = platform.user_info()
 				if not platform.is_success(resp):
-					code, message = platform.parse_error(resp)
-					recoverable, recovery_action = error_contract_for_code(code)
-					handle_error_output(
-						ctx, "me",
-						code=code,
-						message=message or "用户基本信息获取失败",
-						recoverable=recoverable,
-						recovery_action=recovery_action,
+					handle_platform_error_output(
+						ctx, "me", platform, resp,
+						fallback_message="用户基本信息获取失败",
 					)
 					return
 				zp_data = platform.unwrap_data(resp) or {}
@@ -64,14 +59,9 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 					)
 					return
 				if not platform.is_success(resp):
-					code, message = platform.parse_error(resp)
-					recoverable, recovery_action = error_contract_for_code(code)
-					handle_error_output(
-						ctx, "me",
-						code=code,
-						message=message or "简历基本信息获取失败",
-						recoverable=recoverable,
-						recovery_action=recovery_action,
+					handle_platform_error_output(
+						ctx, "me", platform, resp,
+						fallback_message="简历基本信息获取失败",
 					)
 					return
 				zp_data = platform.unwrap_data(resp) or {}
@@ -92,14 +82,9 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 					)
 					return
 				if not platform.is_success(resp):
-					code, message = platform.parse_error(resp)
-					recoverable, recovery_action = error_contract_for_code(code)
-					handle_error_output(
-						ctx, "me",
-						code=code,
-						message=message or "求职期望获取失败",
-						recoverable=recoverable,
-						recovery_action=recovery_action,
+					handle_platform_error_output(
+						ctx, "me", platform, resp,
+						fallback_message="求职期望获取失败",
 					)
 					return
 				zp_data = platform.unwrap_data(resp) or {}
@@ -120,14 +105,9 @@ def me_cmd(ctx: click.Context, section: str | None, deliver_page: int) -> None:
 					)
 					return
 				if not platform.is_success(resp):
-					code, message = platform.parse_error(resp)
-					recoverable, recovery_action = error_contract_for_code(code)
-					handle_error_output(
-						ctx, "me",
-						code=code,
-						message=message or "投递记录获取失败",
-						recoverable=recoverable,
-						recovery_action=recovery_action,
+					handle_platform_error_output(
+						ctx, "me", platform, resp,
+						fallback_message="投递记录获取失败",
 					)
 					return
 				zp_data = platform.unwrap_data(resp) or {}

--- a/src/boss_agent_cli/commands/search.py
+++ b/src/boss_agent_cli/commands/search.py
@@ -154,6 +154,7 @@ def search_cmd(ctx: click.Context, query: str | None, search_url: str | None, pr
 					code=exc.code,
 					message=exc.message or "搜索结果获取失败",
 					recoverable=False,
+					details=exc.details,
 				)
 				return
 			items = pipeline_result.items

--- a/src/boss_agent_cli/display.py
+++ b/src/boss_agent_cli/display.py
@@ -84,6 +84,7 @@ def handle_error_output(
 	message: str,
 	recoverable: bool = False,
 	recovery_action: str | None = None,
+	details: dict | None = None,
 	hints: dict | None = None,
 ) -> None:
 	"""Smart error output: TTY -> rich error, pipe -> JSON error envelope."""
@@ -93,6 +94,7 @@ def handle_error_output(
 		emit_error(
 			command, code=code, message=message,
 			recoverable=recoverable, recovery_action=recovery_action,
+			details=details,
 			hints=hints,
 		)
 	else:
@@ -113,6 +115,13 @@ def handle_platform_error_output(
 	"""Emit a schema-backed error envelope for an unsuccessful platform response."""
 	code, message = platform.parse_error(response)
 	recoverable, recovery_action = error_contract_for_code(code)
+	details = None
+	if isinstance(response, dict):
+		error = response.get("error")
+		if isinstance(error, dict):
+			raw_details = error.get("details")
+			if isinstance(raw_details, dict):
+				details = raw_details
 	handle_error_output(
 		ctx,
 		command,
@@ -120,6 +129,7 @@ def handle_platform_error_output(
 		message=message or fallback_message,
 		recoverable=recoverable,
 		recovery_action=recovery_action,
+		details=details,
 	)
 
 

--- a/src/boss_agent_cli/output.py
+++ b/src/boss_agent_cli/output.py
@@ -110,8 +110,17 @@ def envelope_error(
 	message: str,
 	recoverable: bool = False,
 	recovery_action: str | None = None,
+	details: dict[str, Any] | None = None,
 	hints: dict[str, Any] | None = None,
 ) -> str:
+	error = {
+		"code": code,
+		"message": redact_sensitive_text(message),
+		"recoverable": recoverable,
+		"recovery_action": recovery_action,
+	}
+	if details is not None:
+		error["details"] = redact_sensitive(details)
 	return json.dumps(
 		{
 			"ok": False,
@@ -119,12 +128,7 @@ def envelope_error(
 			"command": command,
 			"data": None,
 			"pagination": None,
-			"error": {
-				"code": code,
-				"message": redact_sensitive_text(message),
-				"recoverable": recoverable,
-				"recovery_action": recovery_action,
-			},
+			"error": error,
 			"hints": redact_sensitive(hints),
 		},
 		ensure_ascii=False,

--- a/src/boss_agent_cli/search_filters.py
+++ b/src/boss_agent_cli/search_filters.py
@@ -246,9 +246,10 @@ class SearchPipelineResult:
 
 
 class SearchPipelinePlatformError(Exception):
-	def __init__(self, code: str, message: str):
+	def __init__(self, code: str, message: str, details: dict[str, Any] | None = None):
 		self.code = code
 		self.message = message
+		self.details = details
 		super().__init__(message)
 
 
@@ -428,7 +429,12 @@ def run_search_pipeline(
 		)
 		if not client.is_success(raw):
 			code, message = client.parse_error(raw)
-			raise SearchPipelinePlatformError(code, message or "搜索结果获取失败")
+			details = None
+			if isinstance(raw, dict):
+				error = raw.get("error")
+				if isinstance(error, dict) and isinstance(error.get("details"), dict):
+					details = error["details"]
+			raise SearchPipelinePlatformError(code, message or "搜索结果获取失败", details=details)
 		zp_data = raw.get("zpData", {})
 		job_list = zp_data.get("jobList", [])
 		last_page_scanned = current_page

--- a/tests/test_qiancheng_stub.py
+++ b/tests/test_qiancheng_stub.py
@@ -132,11 +132,26 @@ class TestQianchengCliVisibility:
 		result = runner.invoke(cli, ["--data-dir", str(tmp_path), "--platform", "qiancheng", "schema"])
 		assert result.exit_code == 0
 
-	def test_detail_returns_qiancheng_not_supported_envelope(self, tmp_path) -> None:
+	def test_qiancheng_cli_commands_return_expected_error_envelopes(self, tmp_path) -> None:
 		runner = CliRunner()
-		result = runner.invoke(cli, ["--data-dir", str(tmp_path), "--platform", "qiancheng", "detail", "fake-id"])
-		assert result.exit_code == 1
-		payload = json.loads(result.output)
-		assert payload["error"]["code"] == "NOT_SUPPORTED"
-		assert "51job/前程无忧适配器" in payload["error"]["message"]
-		assert "job_card" in payload["error"]["message"]
+		platform_cases = [
+			(["search", "python"], "search", "search_jobs"),
+			(["me"], "me", "user_info"),
+			(["history"], "history", "job_history"),
+			(["detail", "fake-id"], "detail", "job_card"),
+		]
+
+		for args, command, capability in platform_cases:
+			result = runner.invoke(cli, ["--data-dir", str(tmp_path), "--platform", "qiancheng", *args])
+			assert result.exit_code == 1, result.output
+			payload = json.loads(result.output)
+			assert payload["ok"] is False
+			assert payload["command"] == command
+			assert payload["data"] is None
+			assert payload["error"]["code"] == "NOT_SUPPORTED"
+			assert payload["error"]["details"] == {
+				"platform": "qiancheng",
+				"capability": capability,
+			}
+			assert "51job/前程无忧适配器" in payload["error"]["message"]
+			assert capability in payload["error"]["message"]


### PR DESCRIPTION
## 关联 Issue / Related Issue

Closes #

## 变更说明 / Summary

- 为 `--platform qiancheng` 的只读入口补充 CLI 端到端契约矩阵：`search` / `me` / `history` / `detail`
- 断言占位适配器返回 `NOT_SUPPORTED`，并透传 `error.details.platform/capability`
- 保持 `recommend` / `greet` / `apply` 等合规或登录边界入口不纳入本次覆盖，不改变这些边界

## 变更类型 / Type

- [ ] feat: 新功能
- [ ] fix: Bug 修复
- [x] test: 测试补充
- [ ] docs: 文档更新
- [ ] refactor: 重构
- [ ] chore: 工程/依赖/流程

## 验证 / Validation

- [x] `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest tests/ -q`（1431 passed）
- [x] `.venv/bin/python -m pytest -q tests/test_qiancheng_stub.py tests/test_platform_cli.py tests/test_compliance.py`（37 passed）
- [x] `.venv/bin/python -m ruff check src/boss_agent_cli/commands/detail.py src/boss_agent_cli/commands/history.py src/boss_agent_cli/commands/me.py src/boss_agent_cli/commands/search.py src/boss_agent_cli/display.py src/boss_agent_cli/output.py src/boss_agent_cli/search_filters.py tests/test_qiancheng_stub.py`
- [x] `.venv/bin/python -m mypy src/boss_agent_cli`
- [x] `.venv/bin/boss --help`
- [x] `.venv/bin/boss schema --format native`

## 影响范围 / Impact

- [x] CLI 输出契约 / JSON schema
- [ ] 配置文件 / 环境变量
- [ ] 浏览器自动化 / Cookie / CDP
- [ ] AI 生成内容
- [ ] 文档 / README / docs
- [ ] CI / Release / GitHub Actions

说明：本次仅在平台错误存在 `details` 时透传到错误 envelope，不为其他错误无条件新增 `details: null`，避免扩大既有顶层错误契约。

## 截图 / 日志 / Screenshots

不适用。

## 发布注意 / Release Notes

- [ ] 需要更新 `CHANGELOG.md` / PyPI 版本 / GitHub Release 说明

## 安全与规范 / Safety & Convention

- [x] commit message 格式: `type: 中文描述`
- [x] 无 `Co-authored-by` 尾注或 AI 署名行
- [x] 无敏感信息（Token / 密码 / Cookie / security_id / 手机号 / 微信 / 真实账号）
- [x] 如涉及 Cookie、CDP、patchright、请求频率或真实账号，已阅读 `docs/platform-risk.md`
- [x] 如涉及发布流程，已阅读 `docs/maintainer/release-checklist.md`
- [x] 无新增外部 CDN / script 依赖（HTML 报表类特别注意）
