### PR TITLE
feat: add platforms capability filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,18 @@ boss hr candidates "Golang"
 | 智联招聘 (`zhilian`) | 🟡 候选者侧登录 + 读写链路已接通 | — | 招聘者侧未接入，运行时会直接拒绝 `hr` 子命令 |
 | 前程无忧 / 51job (`qiancheng`) | 🚧 已注册占位 | — | 统一返回 `NOT_SUPPORTED`，待只读研究门槛满足后再接入真实能力 |
 
-`boss platforms` 会在 JSON 与终端输出中附带 `capability_status_legend`，用于解释能力状态：
+`boss platforms` 会在 JSON 与终端输出中附带 `capability_status_legend`，用于解释能力状态；也可以用 `--capability <capability>` 按现有本地能力矩阵反查平台状态，不会触发登录、浏览器/CDP 或网络请求：
+
+```bash
+# 查看哪些平台对 status 是 available / placeholder / blocked_by_policy / not_supported
+boss platforms --capability status
+
+# 可与平台过滤组合；51job 会解析为 qiancheng
+boss platforms --platform 51job --capability search
+```
+
+`--capability` 的 `capability_filter.status_groups` 使用 Agent 友好的归一化状态名：`available`、`placeholder`、`blocked_by_policy`、`not_supported`；每个平台的 `capability_match.raw_status` 保留矩阵原始状态（如 `placeholder_only` / `low_risk_blocked`）。
+
 
 | 状态 | 语义 |
 |------|------|

--- a/docs/platform-abstraction.md
+++ b/docs/platform-abstraction.md
@@ -152,11 +152,11 @@ class MyPlatform(Platform):
     name = "myname"
     display_name = "平台中文名"
     base_url = "https://..."
-    
+
     def is_success(self, r): ...  # 按研究报告的响应结构
     def unwrap_data(self, r): ...
     def parse_error(self, r): ...
-    
+
     # P0/P1/P2 方法全部抛 NotImplementedError("Week 2 待实现")
 ```
 

--- a/src/boss_agent_cli/commands/platforms.py
+++ b/src/boss_agent_cli/commands/platforms.py
@@ -10,6 +10,10 @@ from boss_agent_cli.platforms import get_platform, list_platforms, list_recruite
 _READONLY_CAPABILITIES = ["search", "detail", "recommend", "me", "status"]
 _WRITE_CAPABILITIES = ["greet", "apply"]
 _LOCAL_CAPABILITIES = ["shortlist", "stats", "config", "schema"]
+_CAPABILITY_STATUS_ALIASES = {
+	"placeholder_only": "placeholder",
+	"low_risk_blocked": "blocked_by_policy",
+}
 
 _PLATFORM_CAPABILITY_STATUS: dict[str, dict[str, str]] = {
 	"zhipin": {
@@ -72,6 +76,10 @@ _ALIAS_NAMES = {
 }
 
 
+def _normalize_capability_status(status: str) -> str:
+	return _CAPABILITY_STATUS_ALIASES.get(status, status)
+
+
 def _resolve_platform_filter(platform_name: str | None) -> str | None:
 	if platform_name is None:
 		return None
@@ -87,9 +95,29 @@ def _resolve_platform_filter(platform_name: str | None) -> str | None:
 	return resolved
 
 
-def platform_capability_data(platform_name: str | None = None) -> dict[str, Any]:
+def _capability_status_for_platform(platform_name: str, capability: str) -> str | None:
+	if capability in _LOCAL_CAPABILITIES:
+		return "available"
+	return _PLATFORM_CAPABILITY_STATUS[platform_name].get(capability)
+
+
+def _resolve_capability_filter(capability: str | None) -> str | None:
+	if capability is None:
+		return None
+	known_capabilities = [*_READONLY_CAPABILITIES, *_WRITE_CAPABILITIES, *_LOCAL_CAPABILITIES]
+	if capability not in known_capabilities:
+		supported = ", ".join(known_capabilities)
+		raise click.BadParameter(
+			f"unknown capability {capability!r}, supported: {supported}",
+			param_hint="--capability",
+		)
+	return capability
+
+
+def platform_capability_data(platform_name: str | None = None, capability: str | None = None) -> dict[str, Any]:
 	"""Return local-only platform capability metadata without creating clients."""
 	resolved_platform = _resolve_platform_filter(platform_name)
+	resolved_capability = _resolve_capability_filter(capability)
 	candidate_platforms = [name for name in list_platforms() if name not in _ALIAS_NAMES]
 	if resolved_platform is not None:
 		candidate_platforms = [resolved_platform]
@@ -98,7 +126,7 @@ def platform_capability_data(platform_name: str | None = None) -> dict[str, Any]
 	for name in candidate_platforms:
 		platform_cls = get_platform(name)
 		statuses = _PLATFORM_CAPABILITY_STATUS[name]
-		platforms.append({
+		item = {
 			"name": name,
 			"display_name": platform_cls.display_name,
 			"base_url": platform_cls.base_url,
@@ -111,9 +139,35 @@ def platform_capability_data(platform_name: str | None = None) -> dict[str, Any]
 				"local": {capability: "available" for capability in _LOCAL_CAPABILITIES},
 			},
 			"notes": _PLATFORM_NOTES[name],
-		})
+		}
+		if resolved_capability is not None:
+			raw_status = _capability_status_for_platform(name, resolved_capability)
+			if raw_status is None:
+				continue
+			item["capability_match"] = {
+				"capability": resolved_capability,
+				"status": _normalize_capability_status(raw_status),
+				"raw_status": raw_status,
+			}
+		platforms.append(item)
+	capability_filter = None
+	if resolved_capability is not None:
+		status_groups: dict[str, list[str]] = {
+			"available": [],
+			"placeholder": [],
+			"blocked_by_policy": [],
+			"not_supported": [],
+		}
+		for item in platforms:
+			match = item["capability_match"]
+			status_groups[match["status"]].append(item["name"])
+		capability_filter = {
+			"capability": resolved_capability,
+			"status_groups": status_groups,
+		}
 	return {
 		"count": len(platforms),
+		"capability_filter": capability_filter,
 		"default": "zhipin",
 		"aliases": {"51job": "qiancheng"},
 		"capability_status_legend": _CAPABILITY_STATUS_LEGEND,
@@ -122,11 +176,18 @@ def platform_capability_data(platform_name: str | None = None) -> dict[str, Any]
 
 
 def _render_platforms(data: dict[str, Any]) -> None:
-	lines = ["name\tdisplay_name\tstatus\tcandidate\trecruiter"]
+	if data.get("capability_filter") is not None:
+		lines = ["name\tdisplay_name\tstatus\tcandidate\trecruiter\tcapability\tcapability_status"]
+	else:
+		lines = ["name\tdisplay_name\tstatus\tcandidate\trecruiter"]
 	for item in data["platforms"]:
 		candidate = "yes" if item["candidate"] else "no"
 		recruiter = "yes" if item["recruiter"] else "no"
-		lines.append(f"{item['name']}\t{item['display_name']}\t{item['status']}\t{candidate}\t{recruiter}")
+		row = f"{item['name']}\t{item['display_name']}\t{item['status']}\t{candidate}\t{recruiter}"
+		if data.get("capability_filter") is not None:
+			match = item["capability_match"]
+			row = f"{row}\t{match['capability']}\t{match['status']}"
+		lines.append(row)
 	lines.append("")
 	lines.append("capability_status_legend")
 	for status, meta in data["capability_status_legend"].items():
@@ -136,13 +197,14 @@ def _render_platforms(data: dict[str, Any]) -> None:
 
 @click.command("platforms")
 @click.option("--platform", "platform_name", default=None, help="仅查看指定平台（支持 qiancheng / 51job 等已注册平台或别名）")
+@click.option("--capability", "capability", default=None, help="按能力反查平台状态（如 search / apply / status / schema）")
 @click.pass_context
-def platforms_cmd(ctx: click.Context, platform_name: str | None) -> None:
+def platforms_cmd(ctx: click.Context, platform_name: str | None, capability: str | None) -> None:
 	"""列出本地已注册平台与能力状态。"""
 	handle_output(
 		ctx,
 		"platforms",
-		platform_capability_data(platform_name),
+		platform_capability_data(platform_name, capability),
 		render=_render_platforms,
 		hints={
 			"next_actions": [

--- a/src/boss_agent_cli/commands/platforms.py
+++ b/src/boss_agent_cli/commands/platforms.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import click
 
@@ -122,7 +122,7 @@ def platform_capability_data(platform_name: str | None = None, capability: str |
 	if resolved_platform is not None:
 		candidate_platforms = [resolved_platform]
 	recruiter_platforms = list_recruiter_platforms()
-	platforms = []
+	platforms: list[dict[str, Any]] = []
 	for name in candidate_platforms:
 		platform_cls = get_platform(name)
 		statuses = _PLATFORM_CAPABILITY_STATUS[name]
@@ -159,8 +159,8 @@ def platform_capability_data(platform_name: str | None = None, capability: str |
 			"not_supported": [],
 		}
 		for item in platforms:
-			match = item["capability_match"]
-			status_groups[match["status"]].append(item["name"])
+			match = cast(dict[str, str], item["capability_match"])
+			status_groups[match["status"]].append(cast(str, item["name"]))
 		capability_filter = {
 			"capability": resolved_capability,
 			"status_groups": status_groups,

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -280,6 +280,12 @@ SCHEMA_DATA = {
 					"default": None,
 					"description": "仅查看指定平台（支持 qiancheng / 51job 等已注册平台或别名）",
 				},
+				"--capability": {
+					"type": "string",
+					"default": None,
+					"description": "按现有本地能力矩阵反查平台状态；返回 available / placeholder / blocked_by_policy / not_supported 分组",
+					"choices": ["search", "detail", "recommend", "me", "status", "greet", "apply", "shortlist", "stats", "config", "schema"],
+				},
 			},
 		},
 		"status": {

--- a/tests/test_platforms_cmd.py
+++ b/tests/test_platforms_cmd.py
@@ -95,6 +95,82 @@ def test_platforms_unknown_platform_uses_json_error_envelope() -> None:
 	assert "unknown platform" in payload["error"]["message"]
 
 
+def test_platforms_can_filter_by_capability_status_groups() -> None:
+	runner = CliRunner()
+	result = runner.invoke(cli, ["platforms", "--capability", "status"])
+
+	assert result.exit_code == 0, result.output
+	payload = json.loads(result.output)
+	data = payload["data"]
+	assert data["count"] == 3
+	assert data["capability_filter"] == {
+		"capability": "status",
+		"status_groups": {
+			"available": ["zhilian", "zhipin"],
+			"placeholder": ["qiancheng"],
+			"blocked_by_policy": [],
+			"not_supported": [],
+		},
+	}
+	platforms = {item["name"]: item for item in data["platforms"]}
+	assert platforms["qiancheng"]["capability_match"] == {
+		"capability": "status",
+		"status": "placeholder",
+		"raw_status": "placeholder_only",
+	}
+
+
+def test_platforms_can_filter_by_blocked_capability() -> None:
+	runner = CliRunner()
+	result = runner.invoke(cli, ["platforms", "--capability", "apply"])
+
+	assert result.exit_code == 0, result.output
+	payload = json.loads(result.output)
+	assert payload["data"]["capability_filter"]["status_groups"] == {
+		"available": [],
+		"placeholder": [],
+		"blocked_by_policy": ["zhilian", "zhipin"],
+		"not_supported": ["qiancheng"],
+	}
+
+
+def test_platforms_capability_filter_combines_with_platform_filter() -> None:
+	runner = CliRunner()
+	result = runner.invoke(cli, ["platforms", "--platform", "51job", "--capability", "search"])
+
+	assert result.exit_code == 0, result.output
+	payload = json.loads(result.output)
+	assert payload["data"]["count"] == 1
+	assert payload["data"]["capability_filter"]["status_groups"] == {
+		"available": [],
+		"placeholder": [],
+		"blocked_by_policy": [],
+		"not_supported": ["qiancheng"],
+	}
+	assert payload["data"]["platforms"][0]["capability_match"]["status"] == "not_supported"
+
+
+def test_platforms_unknown_capability_uses_json_error_envelope() -> None:
+	runner = CliRunner()
+	result = runner.invoke(cli, ["platforms", "--capability", "unknown"])
+
+	assert result.exit_code == 1, result.output
+	payload = json.loads(result.output)
+	assert payload["ok"] is False
+	assert payload["error"]["code"] == "INVALID_PARAM"
+	assert "unknown capability" in payload["error"]["message"]
+
+
+def test_platforms_terminal_render_includes_capability_columns(capsys) -> None:
+	_render_platforms(platform_capability_data(capability="apply"))
+	captured = capsys.readouterr()
+
+	rendered = captured.out + captured.err
+	assert "capability\tcapability_status" in rendered
+	assert "apply\tblocked_by_policy" in rendered
+	assert "apply\tnot_supported" in rendered
+
+
 def test_platforms_is_listed_in_schema() -> None:
 	runner = CliRunner()
 	result = runner.invoke(cli, ["schema"])
@@ -105,4 +181,9 @@ def test_platforms_is_listed_in_schema() -> None:
 	assert platforms_schema["args"] == []
 	assert "--platform" in platforms_schema["options"]
 	assert platforms_schema["options"]["--platform"]["default"] is None
+	assert "--capability" in platforms_schema["options"]
+	capability_option = platforms_schema["options"]["--capability"]
+	assert capability_option["default"] is None
+	assert "available / placeholder / blocked_by_policy / not_supported" in capability_option["description"]
+	assert "apply" in capability_option["choices"]
 	assert "不触发登录" in platforms_schema["description"]


### PR DESCRIPTION
## What
- add `boss platforms --capability <capability>` to group registered platforms by existing local capability-matrix status
- expose normalized filter groups (`available`, `placeholder`, `blocked_by_policy`, `not_supported`) while preserving each match's raw matrix status
- update schema metadata, README usage, and platforms command tests

## Why
Agents need a local, non-invasive way to discover which registered platforms expose or block a requested capability before choosing a workflow. This only reads the existing in-process matrix and does not add real platform support.

## Testing
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest tests/test_platforms_cmd.py -q`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest tests/ -q` (1443 passed)
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/boss platforms --capability apply | python -m json.tool`

## Notes
- No login, browser/CDP, or network platform probing is introduced.
- No release or tag is created.
