### PR TITLE
fix: 导出缺少关键词时补充可执行恢复动作

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- `boss export` 缺少关键词时的 `INVALID_PARAM` 信封补充可执行 `recovery_action`，Agent 可程序化恢复。
+
 ## [1.13.0] - 2026-06-11
 
 ### Added

--- a/src/boss_agent_cli/commands/export.py
+++ b/src/boss_agent_cli/commands/export.py
@@ -8,7 +8,13 @@ import click
 from boss_agent_cli.api.models import JobItem
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output, render_export_summary, render_job_table
+from boss_agent_cli.display import (
+	handle_auth_errors,
+	handle_error_output,
+	handle_output,
+	render_export_summary,
+	render_job_table,
+)
 from boss_agent_cli.search_filters import SearchUrlParseError, parse_boss_search_url, resolve_search_code_params
 
 
@@ -29,10 +35,30 @@ _HTML_PUBLIC_EXPORT_FIELDS = ("title", "company", "city", "experience", "educati
 @click.option("--count", default=50, type=int, help="导出数量")
 @click.option("--format", "fmt", default="csv", type=click.Choice(["html", "csv", "json"]), help="输出格式")
 @click.option("--output", "-o", default=None, help="输出文件路径（不指定则输出到 stdout JSON 信封）")
-@click.option("--include-private", is_flag=True, help="CSV/JSON/stdout 保留明文平台标识和招聘者姓名；HTML 省略平台标识、招聘者和薪资")
+@click.option(
+	"--include-private",
+	is_flag=True,
+	help="CSV/JSON/stdout 保留明文平台标识和招聘者姓名；HTML 省略平台标识、招聘者和薪资",
+)
 @click.pass_context
 @handle_auth_errors("export")
-def export_cmd(ctx: click.Context, query: str | None, search_url: str | None, city: str | None, salary: str | None, experience: str | None, education: str | None, industry: str | None, scale: str | None, stage: str | None, job_type: str | None, count: int, fmt: str, output: str | None, include_private: bool) -> None:
+def export_cmd(
+	ctx: click.Context,
+	query: str | None,
+	search_url: str | None,
+	city: str | None,
+	salary: str | None,
+	experience: str | None,
+	education: str | None,
+	industry: str | None,
+	scale: str | None,
+	stage: str | None,
+	job_type: str | None,
+	count: int,
+	fmt: str,
+	output: str | None,
+	include_private: bool,
+) -> None:
 	"""导出搜索结果为 CSV 或 JSON 文件"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
@@ -48,20 +74,29 @@ def export_cmd(ctx: click.Context, query: str | None, search_url: str | None, ci
 		raw_params.update(parsed_url.params)
 
 	if not query and not search_url:
-		handle_error_output(ctx, "export", code="INVALID_PARAM", message="未提供 query，请传入搜索关键词或 --url")
+		handle_error_output(
+			ctx,
+			"export",
+			code="INVALID_PARAM",
+			message="未提供 query，请传入搜索关键词或 --url",
+			recoverable=True,
+			recovery_action="boss export <query> 或 boss export --url <搜索页URL>",
+		)
 		return
 	query = query or ""
 
 	try:
-		raw_params.update(resolve_search_code_params(
-			salary=salary,
-			experience=experience,
-			education=education,
-			industry=industry,
-			scale=scale,
-			stage=stage,
-			job_type=job_type,
-		))
+		raw_params.update(
+			resolve_search_code_params(
+				salary=salary,
+				experience=experience,
+				education=education,
+				industry=industry,
+				scale=scale,
+				stage=stage,
+				job_type=job_type,
+			)
+		)
 	except ValueError as exc:
 		handle_error_output(ctx, "export", code="INVALID_PARAM", message=str(exc))
 		return
@@ -74,7 +109,9 @@ def export_cmd(ctx: click.Context, query: str | None, search_url: str | None, ci
 		page = 1
 		max_pages = (count + 14) // 15  # 每页约 15 条
 
-		while _export_item_count(all_items, html_items, html_file_output=html_file_output) < count and page <= max_pages:
+		while (
+			_export_item_count(all_items, html_items, html_file_output=html_file_output) < count and page <= max_pages
+		):
 			logger.info(f"正在获取第 {page} 页...")
 			search_filters: dict[str, Any] = {"page": page}
 			for key, value in {
@@ -95,7 +132,8 @@ def export_cmd(ctx: click.Context, query: str | None, search_url: str | None, ci
 			if not platform.is_success(raw):
 				code, message = platform.parse_error(raw)
 				handle_error_output(
-					ctx, "export",
+					ctx,
+					"export",
 					code=code,
 					message=message or "搜索结果获取失败",
 					recoverable=False,
@@ -135,7 +173,9 @@ def export_cmd(ctx: click.Context, query: str | None, search_url: str | None, ci
 				"private_fields": _private_fields_state(fmt=fmt, include_private=include_private),
 			}
 			handle_output(
-				ctx, "export", data,
+				ctx,
+				"export",
+				data,
 				render=lambda d: render_export_summary(d),
 				hints={
 					"next_actions": [
@@ -152,7 +192,9 @@ def export_cmd(ctx: click.Context, query: str | None, search_url: str | None, ci
 				"jobs": write_items,
 			}
 			handle_output(
-				ctx, "export", data,
+				ctx,
+				"export",
+				data,
 				render=lambda d: render_job_table(d.get("jobs", []), "export"),
 				hints={
 					"next_actions": [
@@ -162,7 +204,9 @@ def export_cmd(ctx: click.Context, query: str | None, search_url: str | None, ci
 			)
 
 
-def _export_item_count(all_items: list[dict[str, Any]], html_items: list[dict[str, Any]], *, html_file_output: bool) -> int:
+def _export_item_count(
+	all_items: list[dict[str, Any]], html_items: list[dict[str, Any]], *, html_file_output: bool
+) -> int:
 	if html_file_output:
 		return len(html_items)
 	return len(all_items)
@@ -209,9 +253,23 @@ def _write_to_file(items: list[dict[str, Any]], fmt: str, path: str) -> None:
 			with open(path, "w") as f:
 				f.write("")
 			return
-		fields = ["title", "company", "salary", "city", "district", "experience",
-				"education", "skills", "welfare", "industry", "scale", "boss_name",
-				"boss_title", "job_id", "security_id"]
+		fields = [
+			"title",
+			"company",
+			"salary",
+			"city",
+			"district",
+			"experience",
+			"education",
+			"skills",
+			"welfare",
+			"industry",
+			"scale",
+			"boss_name",
+			"boss_title",
+			"job_id",
+			"security_id",
+		]
 		with open(path, "w", encoding="utf-8", newline="") as f:
 			writer = csv.DictWriter(f, fieldnames=fields, extrasaction="ignore")
 			writer.writeheader()
@@ -295,7 +353,7 @@ def _write_html(items: list[dict[str, Any]], path: str) -> None:
     <th>#</th><th>岗位</th><th>公司</th><th>城市</th>
     <th>经验</th><th>学历</th><th>技能</th><th>福利</th>
   </tr></thead>
-  <tbody>{''.join(rows)}</tbody>
+  <tbody>{"".join(rows)}</tbody>
 </table>
 </body></html>"""
 

--- a/tests/test_export_extended.py
+++ b/tests/test_export_extended.py
@@ -16,12 +16,16 @@ def _ctx_mock(mock_cls):
 	instance = mock_cls.return_value
 	instance.__enter__ = lambda self: self
 	instance.__exit__ = lambda self, *a: None
-	instance.unwrap_data.side_effect = lambda response: response.get("zpData") if "zpData" in response else response.get("data")
+	instance.unwrap_data.side_effect = lambda response: (
+		response.get("zpData") if "zpData" in response else response.get("data")
+	)
 	instance.is_success.side_effect = lambda response: response.get("code", 0) in (0, 200)
 	return instance
 
 
-def _make_raw_job(name: str = "Go 开发", skills: list | None = None, welfare: list | None = None, security_id: str = "sec_x") -> dict:
+def _make_raw_job(
+	name: str = "Go 开发", skills: list | None = None, welfare: list | None = None, security_id: str = "sec_x"
+) -> dict:
 	return {
 		"encryptJobId": f"j_{security_id}",
 		"jobName": name,
@@ -80,7 +84,7 @@ def test_export_csv_to_file(mock_auth_cls, mock_client_cls, tmp_path: Path):
 def test_export_csv_formula_injection_sanitized(mock_auth_cls, mock_client_cls, tmp_path: Path):
 	"""CSV 公式注入防护：以 =+@- 开头的值应前置单引号。"""
 	mock_client = _ctx_mock(mock_client_cls)
-	evil_job = _make_raw_job(name="=HYPERLINK(\"https://evil\")")
+	evil_job = _make_raw_job(name='=HYPERLINK("https://evil")')
 	evil_job["brandName"] = "+7060035"
 	mock_client.search_jobs.return_value = _api_response([evil_job])
 
@@ -117,10 +121,12 @@ def test_export_csv_empty_result_writes_empty_file(mock_auth_cls, mock_client_cl
 @patch("boss_agent_cli.commands.export.AuthManager")
 def test_export_json_to_file(mock_auth_cls, mock_client_cls, tmp_path: Path):
 	mock_client = _ctx_mock(mock_client_cls)
-	mock_client.search_jobs.return_value = _api_response([
-		_make_raw_job("Go 1", security_id="s1"),
-		_make_raw_job("Go 2", security_id="s2"),
-	])
+	mock_client.search_jobs.return_value = _api_response(
+		[
+			_make_raw_job("Go 1", security_id="s1"),
+			_make_raw_job("Go 2", security_id="s2"),
+		]
+	)
 
 	out_path = tmp_path / "jobs.json"
 	runner = CliRunner()
@@ -161,9 +167,11 @@ def test_export_json_include_private_keeps_routing_fields(mock_auth_cls, mock_cl
 @patch("boss_agent_cli.commands.export.AuthManager")
 def test_export_html_to_file(mock_auth_cls, mock_client_cls, tmp_path: Path):
 	mock_client = _ctx_mock(mock_client_cls)
-	mock_client.search_jobs.return_value = _api_response([
-		_make_raw_job("Full-Stack", skills=["Python", "React"], welfare=["双休", "五险"]),
-	])
+	mock_client.search_jobs.return_value = _api_response(
+		[
+			_make_raw_job("Full-Stack", skills=["Python", "React"], welfare=["双休", "五险"]),
+		]
+	)
 
 	out_path = tmp_path / "jobs.html"
 	runner = CliRunner()
@@ -193,9 +201,13 @@ def test_export_html_to_file(mock_auth_cls, mock_client_cls, tmp_path: Path):
 def test_export_html_include_private_still_omits_private_fields(mock_auth_cls, mock_client_cls, tmp_path: Path):
 	"""HTML 文件是可分享报表，即使显式 include_private 也不写路由/招聘者私有字段。"""
 	mock_client = _ctx_mock(mock_client_cls)
-	mock_client.search_jobs.return_value = _api_response([
-		_make_raw_job("Full-Stack", skills=["Python", "React"], welfare=["双休", "五险"], security_id="sec_private"),
-	])
+	mock_client.search_jobs.return_value = _api_response(
+		[
+			_make_raw_job(
+				"Full-Stack", skills=["Python", "React"], welfare=["双休", "五险"], security_id="sec_private"
+			),
+		]
+	)
 
 	out_path = tmp_path / "jobs-private.html"
 	runner = CliRunner()
@@ -224,9 +236,11 @@ def test_export_html_include_private_still_omits_private_fields(mock_auth_cls, m
 def test_export_html_to_file_uses_public_api_projection(mock_auth_cls, mock_client_cls, mock_from_api, tmp_path: Path):
 	"""HTML 文件导出不经过包含薪资和路由字段的 JobItem.to_dict 路径。"""
 	mock_client = _ctx_mock(mock_client_cls)
-	mock_client.search_jobs.return_value = _api_response([
-		_make_raw_job("Full-Stack", skills=["Python"], welfare=["双休"], security_id="sec_private"),
-	])
+	mock_client.search_jobs.return_value = _api_response(
+		[
+			_make_raw_job("Full-Stack", skills=["Python"], welfare=["双休"], security_id="sec_private"),
+		]
+	)
 	mock_from_api.side_effect = AssertionError("HTML export should not build full JobItem")
 
 	out_path = tmp_path / "jobs-public.html"
@@ -315,19 +329,22 @@ def test_export_supports_url_and_multiselect_filters(mock_auth_cls, mock_client_
 
 	out_path = tmp_path / "url.json"
 	runner = CliRunner()
-	result = runner.invoke(cli, [
-		"export",
-		"--url",
-		"https://www.zhipin.com/web/geek/jobs?query=Go&city=101280100&degree=203",
-		"--experience",
-		"应届,3-5年",
-		"--count",
-		"1",
-		"--format",
-		"json",
-		"-o",
-		str(out_path),
-	])
+	result = runner.invoke(
+		cli,
+		[
+			"export",
+			"--url",
+			"https://www.zhipin.com/web/geek/jobs?query=Go&city=101280100&degree=203",
+			"--experience",
+			"应届,3-5年",
+			"--count",
+			"1",
+			"--format",
+			"json",
+			"-o",
+			str(out_path),
+		],
+	)
 
 	assert result.exit_code == 0
 	_, kwargs = mock_client.search_jobs.call_args
@@ -438,3 +455,15 @@ def test_export_stdout_include_private_keeps_raw(mock_auth_cls, mock_client_cls)
 	assert jobs[0]["security_id"] == "s1"
 	assert jobs[0]["boss_name"] == "李"
 	assert jobs[0]["job_id"] == "j_s1"
+
+
+def test_export_without_query_returns_actionable_recovery():
+	"""空参导出应返回 INVALID_PARAM 且带可执行 recovery_action。"""
+	runner = CliRunner()
+	result = runner.invoke(cli, ["--json", "export"])
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["error"]["code"] == "INVALID_PARAM"
+	assert parsed["error"]["recoverable"] is True
+	assert "boss export" in parsed["error"]["recovery_action"]


### PR DESCRIPTION
空参导出的 INVALID_PARAM 信封补充 recoverable=true 与可执行 recovery_action（v1.13.0 真实验证遗留改进项），含回归测试。门禁全绿：ruff/pytest/mypy。commit 符合 type: 中文描述 规范，无 Co-authored-by 尾注。