### PR TITLE
perf: 削减搜索浏览器通道冷启动的无效等待

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased]
 
 ### Fixed
+- `boss search` 浏览器通道冷启动削减两处无效等待（CDP 自动探测超时 3s→1s、headless 首页 networkidle 宽限 3s→0.8s），普通搜索实测 14.3s→10.0s（约 -30%），惠及全部搜索；零新增请求、不触碰风控节流。
 - `boss export` 缺少关键词时的 `INVALID_PARAM` 信封补充可执行 `recovery_action`，Agent 可程序化恢复。
 
 ## [1.13.0] - 2026-06-11

--- a/docs/maintainer/branch-protection.md
+++ b/docs/maintainer/branch-protection.md
@@ -32,7 +32,7 @@ The project may also require documentation checks when `.github/workflows/docs.y
 
 ## Verification
 
-Run:
+Run the full branch protection check first:
 
 ```bash
 gh api repos/can4hou6joeng4/boss-agent-cli/branches/master/protection
@@ -42,15 +42,26 @@ The response should show:
 
 ```json
 {
-	"required_pull_request_reviews": {
-		"required_approving_review_count": 1
-	},
 	"allow_force_pushes": {
 		"enabled": false
 	},
 	"allow_deletions": {
 		"enabled": false
 	}
+}
+```
+
+Then verify the pull request review gate through its dedicated endpoint:
+
+```bash
+gh api repos/can4hou6joeng4/boss-agent-cli/branches/master/protection/required_pull_request_reviews
+```
+
+The response should show:
+
+```json
+{
+	"required_approving_review_count": 1
 }
 ```
 

--- a/src/boss_agent_cli/api/browser_client.py
+++ b/src/boss_agent_cli/api/browser_client.py
@@ -9,6 +9,7 @@ Supports two modes:
   1. CDP mode: connects to user's existing Chrome via DevTools Protocol
   2. Patchright mode (fallback): launches a headless Chromium instance
 """
+
 import sys
 import time
 from pathlib import Path
@@ -38,16 +39,20 @@ class RecruiterChatTabRequired(RuntimeError):
 			"Chrome (CDP-attached) and retry."
 		)
 
+
 # 超时常量
-_CDP_PROBE_TIMEOUT = 3           # CDP 探测 HTTP 超时（秒）
-_NAV_TIMEOUT_MS = 15000          # 页面导航超时（毫秒）
-_HEADLESS_NETWORKIDLE_GRACE_MS = 3000  # headless 预热的额外宽限，避免卡满 30s
+_CDP_PROBE_TIMEOUT = 3  # 显式 --cdp-url 的 CDP 探测 HTTP 超时（秒）
+_CDP_AUTO_PROBE_TIMEOUT = 1  # 默认自动探测 localhost:9222 的超时（无调试端口时快速失败，省 ~2s）
+_NAV_TIMEOUT_MS = 15000  # 页面导航超时（毫秒）
+# zhipin 首页常驻请求多、headless 下基本进不了 networkidle；domcontentloaded 后 JS
+# 环境即可发 fetch，故宽限缩到 0.8s（实测每次都会耗满，缩短直接省 ~2s/搜索）。
+_HEADLESS_NETWORKIDLE_GRACE_MS = 800
 
 # macOS / Linux / Windows Chrome user data 默认路径
 _CHROME_USER_DATA_CANDIDATES = [
-	Path.home() / "Library/Application Support/Google/Chrome",              # macOS
-	Path.home() / ".config/google-chrome",                                  # Linux
-	Path.home() / "AppData/Local/Google/Chrome/User Data",                  # Windows
+	Path.home() / "Library/Application Support/Google/Chrome",  # macOS
+	Path.home() / ".config/google-chrome",  # Linux
+	Path.home() / "AppData/Local/Google/Chrome/User Data",  # Windows
 ]
 
 
@@ -57,7 +62,15 @@ class BrowserSession:
 	Tries CDP connection to user's Chrome first; falls back to headless patchright.
 	"""
 
-	def __init__(self, cookies: dict[str, Any], user_agent: str, *, delay: tuple[float, float] = (1.5, 3.0), cdp_url: str | None = None, logger: Any = None) -> None:
+	def __init__(
+		self,
+		cookies: dict[str, Any],
+		user_agent: str,
+		*,
+		delay: tuple[float, float] = (1.5, 3.0),
+		cdp_url: str | None = None,
+		logger: Any = None,
+	) -> None:
 		self._throttle = RequestThrottle(delay)
 		# patchright / BridgeClient 运行时创建；注解为 Any 让 mypy 对外部依赖放行
 		self._pw: Any = None
@@ -102,6 +115,7 @@ class BrowserSession:
 		"""尝试通过 Browser Bridge（Chrome 扩展 + daemon）连接。"""
 		try:
 			from boss_agent_cli.bridge.client import BridgeClient
+
 			client = BridgeClient()
 			if not client.is_running():
 				return False
@@ -138,9 +152,12 @@ class BrowserSession:
 		for url in urls_to_try:
 			if self._try_connect(url):
 				return True
-			# HTTP URL 连接失败时，尝试从 /json/version 获取 WS URL
+			# HTTP URL 连接失败时，尝试从 /json/version 获取 WS URL。
+			# 仅对用户显式提供的 --cdp-url 用较长超时；默认 localhost:9222 自动探测
+			# 用短超时快速失败（无调试端口时避免白等 ~2s）。
 			if url.startswith("http"):
-				ws = self._fetch_ws_url(url)
+				probe_timeout = _CDP_PROBE_TIMEOUT if url == self._cdp_url else _CDP_AUTO_PROBE_TIMEOUT
+				ws = self._fetch_ws_url(url, timeout=probe_timeout)
 				if ws and self._try_connect(ws):
 					return True
 		return False
@@ -164,10 +181,12 @@ class BrowserSession:
 				# 没有已存在 context，创建新的并注入 cookies
 				self._context = self._browser.new_context()
 				if self._cookies:
-					self._context.add_cookies([
-						{"name": name, "value": value, "domain": ".zhipin.com", "path": "/"}
-						for name, value in self._cookies.items()
-					])
+					self._context.add_cookies(
+						[
+							{"name": name, "value": value, "domain": ".zhipin.com", "path": "/"}
+							for name, value in self._cookies.items()
+						]
+					)
 				self._own_context = True
 
 			self._page = self._context.new_page()
@@ -191,11 +210,12 @@ class BrowserSession:
 			return False
 
 	@staticmethod
-	def _fetch_ws_url(http_url: str) -> str | None:
+	def _fetch_ws_url(http_url: str, timeout: float = _CDP_PROBE_TIMEOUT) -> str | None:
 		"""Fetch WebSocket debugger URL from Chrome's /json/version endpoint."""
 		import httpx
+
 		try:
-			resp = httpx.get(f"{http_url}/json/version", timeout=_CDP_PROBE_TIMEOUT)
+			resp = httpx.get(f"{http_url}/json/version", timeout=timeout)
 			payload = resp.json()
 			if not isinstance(payload, dict):
 				return None
@@ -229,10 +249,12 @@ class BrowserSession:
 			timezone_id="Asia/Shanghai",
 		)
 		self._own_context = True
-		self._context.add_cookies([
-			{"name": name, "value": value, "domain": ".zhipin.com", "path": "/"}
-			for name, value in self._cookies.items()
-		])
+		self._context.add_cookies(
+			[
+				{"name": name, "value": value, "domain": ".zhipin.com", "path": "/"}
+				for name, value in self._cookies.items()
+			]
+		)
 		self._page = self._context.new_page()
 		self._page.goto(HOME_URL, wait_until="domcontentloaded", timeout=_NAV_TIMEOUT_MS)
 		try:
@@ -243,11 +265,15 @@ class BrowserSession:
 			self._log(f"[boss] headless 首页未进入 networkidle（{e}），继续直接发起请求")
 		self._started = True
 		self._is_cdp = False
-		self._log("[boss] CDP 不可用（提示：需以 --remote-debugging-port=9222 启动 Chrome），降级到 headless patchright")
+		self._log(
+			"[boss] CDP 不可用（提示：需以 --remote-debugging-port=9222 启动 Chrome），降级到 headless patchright"
+		)
 
 	# ── Core request via browser fetch() ─────────────────────────────
 
-	def request(self, method: str, url: str, *, params: dict[str, Any] | None = None, data: dict[str, Any] | None = None) -> dict[str, Any]:
+	def request(
+		self, method: str, url: str, *, params: dict[str, Any] | None = None, data: dict[str, Any] | None = None
+	) -> dict[str, Any]:
 		self._ensure_started()
 		self._throttle.wait()
 
@@ -256,6 +282,7 @@ class BrowserSession:
 		# Bridge 模式：通过扩展 fetch
 		if self._is_bridge and self._bridge_client:
 			import urllib.parse
+
 			full_url = url
 			if params:
 				full_url = f"{url}?{urllib.parse.urlencode(params)}"
@@ -269,7 +296,8 @@ class BrowserSession:
 			return cast("dict[str, Any]", result)
 
 		# Playwright 模式（CDP 或 headless）
-		result = self._page.evaluate("""
+		result = self._page.evaluate(
+			"""
 			async ({method, url, params, data, referer}) => {
 				try {
 					let fetchUrl = url;
@@ -306,7 +334,9 @@ class BrowserSession:
 					return {code: -1, message: e.message, zpData: {}};
 				}
 			}
-		""", {"method": method, "url": url, "params": params or {}, "data": data, "referer": referer})
+		""",
+			{"method": method, "url": url, "params": params or {}, "data": data, "referer": referer},
+		)
 
 		self._throttle.mark()
 		return cast("dict[str, Any]", result)
@@ -350,7 +380,9 @@ class BrowserSession:
 		from UI-only draft mutation or suggestion traffic.
 		"""
 		if self._is_bridge:
-			raise RuntimeError("evaluate_js_with_chat_events requires CDP mode (bridge mode has no access to user Chrome)")
+			raise RuntimeError(
+				"evaluate_js_with_chat_events requires CDP mode (bridge mode has no access to user Chrome)"
+			)
 		cdp_url = self._cdp_url or CDP_DEFAULT_URL
 		return _cdp_evaluate_with_chat_events_in_chat_tab(cdp_url, script, arg, listen_ms=listen_ms)
 
@@ -411,6 +443,7 @@ class BrowserSession:
 
 # ─── Raw CDP helper for evaluate_js ──────────────────────────────────────
 
+
 def _pick_chat_target_ws(cdp_http_url: str) -> str:
 	import json as _json
 	import urllib.request
@@ -455,6 +488,7 @@ def _carve_utf8_bits(bs: bytes) -> list[str]:
 			i += 1
 	return out
 
+
 def _cdp_evaluate_in_chat_tab(cdp_http_url: str, script: str, arg: Any) -> Any:
 	"""Send Runtime.evaluate to the BOSS recruiter chat tab via raw CDP.
 
@@ -472,15 +506,19 @@ def _cdp_evaluate_in_chat_tab(cdp_http_url: str, script: str, arg: Any) -> Any:
 	expression = _build_eval_expression(script, arg)
 
 	with _ws_client.connect(target_ws, max_size=8 * 1024 * 1024) as ws:
-		ws.send(_json.dumps({
-			"id": 1,
-			"method": "Runtime.evaluate",
-			"params": {
-				"expression": expression,
-				"returnByValue": True,
-				"awaitPromise": True,
-			},
-		}))
+		ws.send(
+			_json.dumps(
+				{
+					"id": 1,
+					"method": "Runtime.evaluate",
+					"params": {
+						"expression": expression,
+						"returnByValue": True,
+						"awaitPromise": True,
+					},
+				}
+			)
+		)
 		deadline = time.time() + 30.0
 		while time.time() < deadline:
 			raw = ws.recv(timeout=max(0.1, deadline - time.time()))
@@ -496,7 +534,9 @@ def _cdp_evaluate_in_chat_tab(cdp_http_url: str, script: str, arg: Any) -> Any:
 			# Exception in JS side
 			exc_details = msg.get("result", {}).get("exceptionDetails")
 			if exc_details:
-				raise RuntimeError(f"JS exception: {exc_details.get('text')} — {exc_details.get('exception', {}).get('description', '')[:300]}")
+				raise RuntimeError(
+					f"JS exception: {exc_details.get('text')} — {exc_details.get('exception', {}).get('description', '')[:300]}"
+				)
 			return result
 		raise RuntimeError("CDP Runtime.evaluate timed out after 30s")
 
@@ -514,15 +554,19 @@ def _cdp_evaluate_with_chat_events_in_chat_tab(
 
 	with _ws_client.connect(target_ws, max_size=8 * 1024 * 1024) as ws:
 		ws.send(_json.dumps({"id": 1, "method": "Network.enable"}))
-		ws.send(_json.dumps({
-			"id": 2,
-			"method": "Runtime.evaluate",
-			"params": {
-				"expression": expression,
-				"returnByValue": True,
-				"awaitPromise": True,
-			},
-		}))
+		ws.send(
+			_json.dumps(
+				{
+					"id": 2,
+					"method": "Runtime.evaluate",
+					"params": {
+						"expression": expression,
+						"returnByValue": True,
+						"awaitPromise": True,
+					},
+				}
+			)
+		)
 
 		events: list[dict[str, Any]] = []
 		eval_value: Any = None
@@ -576,9 +620,11 @@ def _cdp_evaluate_with_chat_events_in_chat_tab(
 			if len(bs) < 30:
 				continue
 
-			events.append({
-				"ts": time.time(),
-				"kind": "ws_send" if method.endswith("Sent") else "ws_recv",
-				"bytes": len(bs),
-				"utf8_bits": _carve_utf8_bits(bs)[:10],
-			})
+			events.append(
+				{
+					"ts": time.time(),
+					"kind": "ws_send" if method.endswith("Sent") else "ws_recv",
+					"bytes": len(bs),
+					"utf8_bits": _carve_utf8_bits(bs)[:10],
+				}
+			)

--- a/tests/test_browser_client.py
+++ b/tests/test_browser_client.py
@@ -246,11 +246,10 @@ def test_start_headless_tolerates_networkidle_timeout():
 		"networkidle",
 		timeout=_HEADLESS_NETWORKIDLE_GRACE_MS,
 	)
-	logger.info.assert_any_call("[boss] CDP 不可用（提示：需以 --remote-debugging-port=9222 启动 Chrome），降级到 headless patchright")
-	assert any(
-		"headless 首页未进入 networkidle" in call.args[0]
-		for call in logger.info.call_args_list
+	logger.info.assert_any_call(
+		"[boss] CDP 不可用（提示：需以 --remote-debugging-port=9222 启动 Chrome），降级到 headless patchright"
 	)
+	assert any("headless 首页未进入 networkidle" in call.args[0] for call in logger.info.call_args_list)
 
 
 def test_ensure_started_falls_back_to_patchright_when_bridge_and_cdp_fail():
@@ -286,8 +285,12 @@ def test_try_cdp_attempts_http_ws_and_devtools_urls_before_falling_back():
 
 	with (
 		patch.object(session, "_try_connect", return_value=False) as mock_try_connect,
-		patch.object(BrowserSession, "_fetch_ws_url", side_effect=[None, "ws://127.0.0.1:9222/devtools/browser/default"]) as mock_fetch_ws_url,
-		patch.object(BrowserSession, "_read_devtools_active_port", return_value="ws://127.0.0.1:9222/devtools/browser/file") as mock_read_port,
+		patch.object(
+			BrowserSession, "_fetch_ws_url", side_effect=[None, "ws://127.0.0.1:9222/devtools/browser/default"]
+		) as mock_fetch_ws_url,
+		patch.object(
+			BrowserSession, "_read_devtools_active_port", return_value="ws://127.0.0.1:9222/devtools/browser/file"
+		) as mock_read_port,
 	):
 		result = session._try_cdp()
 
@@ -332,3 +335,29 @@ def test_request_returns_browser_evaluation_json_and_marks_throttle():
 		"data": {"city": "101020100"},
 		"referer": "https://www.zhipin.com/web/geek/job",
 	}
+
+
+def test_cold_start_wait_constants_stay_lean():
+	"""回归护栏：冷启动两处等待须保持精简（曾各浪费 ~3s/搜索）。
+
+	- 自动探测默认 localhost:9222 的超时必须短于显式 --cdp-url 的超时；
+	- headless 首页 networkidle 宽限须 <=1s（zhipin 首页基本进不了 networkidle，
+	  domcontentloaded 后 JS 环境即可发请求，长宽限是纯浪费）。
+	"""
+	from boss_agent_cli.api.browser_client import (
+		_CDP_AUTO_PROBE_TIMEOUT,
+		_CDP_PROBE_TIMEOUT,
+		_HEADLESS_NETWORKIDLE_GRACE_MS,
+	)
+
+	assert _CDP_AUTO_PROBE_TIMEOUT < _CDP_PROBE_TIMEOUT
+	assert _CDP_AUTO_PROBE_TIMEOUT <= 1
+	assert _HEADLESS_NETWORKIDLE_GRACE_MS <= 1000
+
+
+def test_fetch_ws_url_honors_short_auto_probe_timeout():
+	"""默认自动探测应以短超时调用 httpx，避免无调试端口时白等。"""
+	with patch("httpx.get") as mock_get:
+		mock_get.return_value = MagicMock(json=lambda: {"webSocketDebuggerUrl": "ws://x"})
+		BrowserSession._fetch_ws_url("http://127.0.0.1:9222", timeout=1)
+		assert mock_get.call_args.kwargs["timeout"] == 1

--- a/uv.lock
+++ b/uv.lock
@@ -208,7 +208,7 @@ wheels = [
 
 [[package]]
 name = "boss-agent-cli"
-version = "1.12.0"
+version = "1.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },


### PR DESCRIPTION
## 变更说明 / Summary

`boss search` 始终走浏览器通道（BOSS wapi 需浏览器内 JS 签名，httpx 裸 cookie 被风控拒——合规设计，不改）。实测一次普通搜索 14.3s，其中约 6s 是可证明的无效等待。本 PR 削掉两处：

1. **CDP 自动探测**：无 `--cdp-url` 时探测默认 `localhost:9222` 的 httpx 超时 3s→1s（实测死端口白等 3.06s）。显式 `--cdp-url` 仍保留 3s。
2. **headless 首页 networkidle 宽限**：3s→0.8s（代码自述 zhipin 首页基本进不了 networkidle，domcontentloaded 后 JS 即可发请求，长宽限每次必然耗满）。

实测 14.28s → 9.99s（约 -30%），惠及全部搜索（普通 + welfare）。零新增请求、不触碰风控节流。

诊断方法见任务记录：逐项隔离冷启动子开销（httpx 探测 3.06s / connect_over_cdp 0.05s / launch 0.70s / nav 1.26s / networkidle 1.5-3s）。

## 变更类型 / Type

- [x] perf: 性能优化

## Breaking Change

- [x] 本 PR **不包含** 破坏性变更

## 测试 / Test Plan

- [x] `uv run pytest tests/ -q` 全部通过
- [x] `uv run ruff check src/ tests/` 无报错
- [x] `uv run mypy src/boss_agent_cli` 无报错
- [x] 新增 2 个回归护栏测试（冷启动等待常量须保持精简、自动探测用短超时）
- [x] 真实账号实测前后耗时对比（14.28s → 9.99s）

## 文档与契约 / Docs & Contracts

- [x] 已更新 `CHANGELOG.md` 的 `[Unreleased]` 段落

## 安全与规范 / Safety & Convention

- [x] commit message 格式: `type: 中文描述`
- [x] 无 `Co-authored-by` 尾注或 AI 署名行
- [x] 无敏感信息
- [x] 涉及 CDP/patchright/请求频率：本 PR 只删减等待，不增加请求频率、不规避风控