### PR TITLE
perf: welfare详情按job_id缓存并加固节流并发安全

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Changed
+- `--welfare` 搜索的职位描述详情新增本地缓存（按稳定的 `job_id`/`encryptJobId` 键，TTL 24h）：重复或微调条件的 welfare 搜索复用已取描述，跳过对应 `job_card` 请求，减少平台请求量并加速重跑；不改变请求间隔与并发上限（合规姿态不变）。
+- `RequestThrottle` 改为线程安全：welfare 详情线程池并发调用下，加锁并预占下一次发送时刻，杜绝竞态导致的请求突发（突发更像爬虫，是合规风险）。
+
 ### Fixed
 - `boss search` 浏览器通道冷启动削减两处无效等待（CDP 自动探测超时 3s→1s、headless 首页 networkidle 宽限 3s→0.8s），普通搜索实测 14.3s→10.0s（约 -30%），惠及全部搜索；零新增请求、不触碰风控节流。
 - `boss export` 缺少关键词时的 `INVALID_PARAM` 信封补充可执行 `recovery_action`，Agent 可程序化恢复。

--- a/src/boss_agent_cli/api/throttle.py
+++ b/src/boss_agent_cli/api/throttle.py
@@ -1,8 +1,13 @@
 """Shared request throttling — Gaussian delay + burst penalty.
 
 Used by both httpx and browser channels to avoid triggering BOSS anti-scraping.
+线程安全：welfare 详情风暴会用线程池并发调用，wait()/mark() 共享可变状态
+（_last_request_time / _recent_times），故全程加锁，避免竞态导致的请求突发
+（突发更像爬虫，是合规风险）。
 """
+
 import random
+import threading
 import time
 from collections import deque
 
@@ -14,31 +19,43 @@ class RequestThrottle:
 		self._delay = delay
 		self._last_request_time = 0.0
 		self._recent_times: deque[float] = deque(maxlen=12)
+		self._lock = threading.Lock()
 
 	def wait(self) -> None:
-		"""Block until it's safe to send the next request."""
-		elapsed = time.time() - self._last_request_time
-		mean = sum(self._delay) / 2
-		std = (self._delay[1] - self._delay[0]) / 4
-		base_sleep = max(0, random.gauss(mean, std) - elapsed)
+		"""Block until it's safe to send the next request.
 
-		# 5% chance of a longer pause — mimics human hesitation
-		if random.random() < 0.05:
-			base_sleep += random.uniform(2.0, 5.0)
+		并发安全：在锁内基于"已预约的下一次发送时刻"计算等待并预占该时刻，
+		使后到的线程读到的是未来时间而被迫顺延，从而真正串行化、杜绝突发；
+		实际 sleep 在锁外进行，不阻塞其他线程的预约计算。
+		"""
+		with self._lock:
+			now = time.time()
+			elapsed = now - self._last_request_time
+			mean = sum(self._delay) / 2
+			std = (self._delay[1] - self._delay[0]) / 4
+			base_sleep = max(0, random.gauss(mean, std) - elapsed)
 
-		burst = self._burst_penalty()
-		total = max(0, base_sleep + burst)
+			# 5% chance of a longer pause — mimics human hesitation
+			if random.random() < 0.05:
+				base_sleep += random.uniform(2.0, 5.0)
+
+			burst = self._burst_penalty()
+			total = max(0, base_sleep + burst)
+			# 预占下一次发送时刻：并发线程会据此顺延，避免读到旧值而突发
+			self._last_request_time = now + total
+
 		if total > 0:
 			time.sleep(total)
 
 	def mark(self) -> None:
 		"""Record that a request was just sent."""
-		now = time.time()
-		self._last_request_time = now
-		self._recent_times.append(now)
+		with self._lock:
+			now = time.time()
+			self._last_request_time = now
+			self._recent_times.append(now)
 
 	def _burst_penalty(self) -> float:
-		"""Extra delay when requests arrive in bursts."""
+		"""Extra delay when requests arrive in bursts. 调用方须已持锁。"""
 		if not self._recent_times:
 			return 0.0
 		now = time.time()

--- a/src/boss_agent_cli/cache/store.py
+++ b/src/boss_agent_cli/cache/store.py
@@ -31,6 +31,11 @@ class CacheStore:
 				response TEXT NOT NULL,
 				created_at REAL NOT NULL
 			);
+			CREATE TABLE IF NOT EXISTS job_desc_cache (
+				job_id TEXT PRIMARY KEY,
+				description TEXT NOT NULL,
+				created_at REAL NOT NULL
+			);
 			CREATE TABLE IF NOT EXISTS saved_searches (
 				name TEXT PRIMARY KEY,
 				params TEXT NOT NULL,
@@ -140,6 +145,38 @@ class CacheStore:
 		)
 		self._conn.commit()
 		self._evict_old_search_cache()
+
+	# ── 职位描述缓存（welfare 详情比对复用，降低重复搜索的取详情请求量）──
+	# 键用 job_id（encryptJobId，跨搜索稳定）；securityId 是每次请求重新生成的
+	# 临时令牌、跨搜索不稳定，不能做缓存键。
+	# 线程安全注意：sqlite 连接非线程安全，这两个方法只可在主线程调用，
+	# 不要在 welfare 详情线程池的 worker 内访问。
+
+	def get_job_desc(self, job_id: str) -> str | None:
+		"""返回缓存的职位描述（命中且未过期），否则 None。"""
+		if not job_id:
+			return None
+		row = self._conn.execute(
+			"SELECT description, created_at FROM job_desc_cache WHERE job_id = ?",
+			(job_id,),
+		).fetchone()
+		if row is None:
+			return None
+		if time.time() - row[1] > self._search_ttl:
+			self._conn.execute("DELETE FROM job_desc_cache WHERE job_id = ?", (job_id,))
+			self._conn.commit()
+			return None
+		return cast("str", row[0])
+
+	def put_job_desc(self, job_id: str, description: str) -> None:
+		"""缓存职位描述（仅当 job_id 与描述非空时写入）。"""
+		if not job_id or not description:
+			return
+		self._conn.execute(
+			"INSERT OR REPLACE INTO job_desc_cache (job_id, description, created_at) VALUES (?, ?, ?)",
+			(job_id, description, time.time()),
+		)
+		self._conn.commit()
 
 	def _evict_old_search_cache(self) -> None:
 		count = self._conn.execute("SELECT COUNT(*) FROM search_cache").fetchone()[0]

--- a/src/boss_agent_cli/search_filters.py
+++ b/src/boss_agent_cli/search_filters.py
@@ -2,6 +2,7 @@
 
 Centralizes filtering logic shared by search, batch-greet, and export commands.
 """
+
 import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
@@ -14,11 +15,22 @@ from boss_agent_cli.api.models import JobItem
 # ── Ordinal lookups for threshold comparisons ───────────────────────
 
 _EXPERIENCE_ORDER: dict[str, int] = {
-	"应届": 0, "1年以内": 1, "1-3年": 2, "3-5年": 3, "5-10年": 4, "10年以上": 5,
+	"应届": 0,
+	"1年以内": 1,
+	"1-3年": 2,
+	"3-5年": 3,
+	"5-10年": 4,
+	"10年以上": 5,
 }
 
 _EDUCATION_ORDER: dict[str, int] = {
-	"初中及以下": 0, "中专/中技": 1, "高中": 2, "大专": 3, "本科": 4, "硕士": 5, "博士": 6,
+	"初中及以下": 0,
+	"中专/中技": 1,
+	"高中": 2,
+	"大专": 3,
+	"本科": 4,
+	"硕士": 5,
+	"博士": 6,
 }
 
 # ── Welfare keywords ────────────────────────────────────────────────
@@ -162,6 +174,7 @@ def resolve_search_code_params(
 		params["jobType"] = code
 	return params
 
+
 # ── Salary parsing ──────────────────────────────────────────────────
 
 _SALARY_RE = re.compile(r"(\d+)(?:\s*[-~]\s*(\d+))?\s*K", re.IGNORECASE)
@@ -184,6 +197,7 @@ def parse_salary_range(value: str) -> tuple[int, int] | None:
 
 
 # ── Threshold comparisons ───────────────────────────────────────────
+
 
 def meets_experience_threshold(candidate: str, required: str | None) -> bool:
 	"""Check if candidate experience meets or exceeds required threshold."""
@@ -212,6 +226,7 @@ def meets_education_threshold(candidate: str, required: str | None) -> bool:
 
 
 # ── Data structures ─────────────────────────────────────────────────
+
 
 @dataclass(frozen=True)
 class SearchFilterCriteria:
@@ -255,6 +270,7 @@ class SearchPipelinePlatformError(Exception):
 
 # ── List-page prefilter ─────────────────────────────────────────────
 
+
 def prefilter_job(raw_item: dict[str, Any], criteria: SearchFilterCriteria) -> tuple[bool, list[str]]:
 	"""Fast prefilter using list-page fields only. Returns (pass, rejection_reasons)."""
 	reasons: list[str] = []
@@ -290,6 +306,7 @@ def prefilter_job(raw_item: dict[str, Any], criteria: SearchFilterCriteria) -> t
 
 # ── Welfare matching ────────────────────────────────────────────────
 
+
 def resolve_welfare_keywords(label: str) -> list[str]:
 	"""Resolve a welfare label to matching keywords."""
 	return WELFARE_KEYWORDS.get(label, [label])
@@ -318,33 +335,47 @@ def match_all_welfare(
 	return results
 
 
-def _fetch_and_check(client: Any, welfare_conditions: list[tuple[str, list[str]]], raw_item: dict[str, Any]) -> dict[str, Any] | None:
-	"""Single job: fetch detail + welfare match. 不访问 cache（线程安全）。"""
+def _fetch_and_check(
+	client: Any,
+	welfare_conditions: list[tuple[str, list[str]]],
+	raw_item: dict[str, Any],
+	cached_desc: str | None = None,
+) -> tuple[dict[str, Any] | None, str | None]:
+	"""Single job: (复用缓存或取详情) + 福利匹配。不访问 cache（线程安全）。
+
+	返回 (匹配结果或 None, 需写回缓存的描述或 None)。
+	cached_desc 命中时跳过 job_card 请求（省一次平台请求 + throttle 等待）。
+	"""
 	welfare_list = raw_item.get("welfareList", [])
-	try:
-		card_raw = client.job_card(
-			raw_item.get("securityId", ""),
-			raw_item.get("lid", ""),
-		)
-		if not client.is_success(card_raw):
-			code, message = client.parse_error(card_raw)
-			raise SearchPipelinePlatformError(code, message or "职位详情获取失败")
-		desc = card_raw.get("zpData", {}).get("jobCard", {}).get("postDescription", "")
-	except NotImplementedError:
-		raise SearchPipelinePlatformError(
-			"NOT_SUPPORTED",
-			"当前平台暂不支持福利详情筛选，请去掉 --welfare 后重试",
-		)
-	except (OSError, KeyError, TypeError):
-		desc = ""
+	fresh_desc: str | None = None
+	if isinstance(cached_desc, str):
+		desc = cached_desc
+	else:
+		try:
+			card_raw = client.job_card(
+				raw_item.get("securityId", ""),
+				raw_item.get("lid", ""),
+			)
+			if not client.is_success(card_raw):
+				code, message = client.parse_error(card_raw)
+				raise SearchPipelinePlatformError(code, message or "职位详情获取失败")
+			desc = card_raw.get("zpData", {}).get("jobCard", {}).get("postDescription", "")
+			fresh_desc = desc  # 仅新取到的描述需写回缓存（主线程处理）
+		except NotImplementedError:
+			raise SearchPipelinePlatformError(
+				"NOT_SUPPORTED",
+				"当前平台暂不支持福利详情筛选，请去掉 --welfare 后重试",
+			)
+		except (OSError, KeyError, TypeError):
+			desc = ""
 
 	match_results = match_all_welfare(welfare_conditions, welfare_list, desc)
 	if match_results:
 		item = JobItem.from_api(raw_item)
 		d = item.to_dict()
 		d["welfare_match"] = "✅ " + ", ".join(match_results)
-		return d
-	return None
+		return d, fresh_desc
+	return None, fresh_desc
 
 
 def _check_details_parallel(
@@ -355,10 +386,21 @@ def _check_details_parallel(
 	items: list[dict[str, Any]],
 	matched: list[dict[str, Any]],
 ) -> None:
-	"""Parallel detail check, append matched to list. cache 操作在主线程完成。"""
+	"""Parallel detail check, append matched to list. cache 操作在主线程完成。
+
+	主线程先查职位描述缓存命中者跳过取详情；未命中者入线程池取详，
+	取回的新描述由主线程写回缓存——所有 cache I/O 留在主线程（sqlite 非线程安全）。
+	"""
+	# 主线程预取缓存：命中的描述随提交一并传入 worker，避免 worker 触网。
+	# 键用 encryptJobId（跨搜索稳定）；securityId 每次搜索都变，不能做键。
+	cached_by_item = {id(raw_item): cache.get_job_desc(raw_item.get("encryptJobId", "")) for raw_item in items}
+	cache_hits = sum(1 for v in cached_by_item.values() if isinstance(v, str))
+	if cache_hits:
+		logger.info(f"  详情缓存命中 {cache_hits}/{len(items)}，跳过对应取详情请求")
+
 	with ThreadPoolExecutor(max_workers=_WELFARE_WORKERS) as pool:
 		futures = {
-			pool.submit(_fetch_and_check, client, welfare_conditions, raw_item): raw_item
+			pool.submit(_fetch_and_check, client, welfare_conditions, raw_item, cached_by_item[id(raw_item)]): raw_item
 			for raw_item in items
 		}
 		for future in as_completed(futures):
@@ -366,7 +408,10 @@ def _check_details_parallel(
 			company = raw_item.get("brandName", "")
 			title = raw_item.get("jobName", "")
 			try:
-				result = future.result()
+				result, fresh_desc = future.result()
+				# 写回缓存（主线程，sqlite 安全）：仅新取到的描述，键用稳定的 encryptJobId
+				if fresh_desc:
+					cache.put_job_desc(raw_item.get("encryptJobId", ""), fresh_desc)
 				if result:
 					# is_greeted 在主线程中安全访问 cache
 					sid = result.get("security_id", "")
@@ -384,6 +429,7 @@ def _check_details_parallel(
 
 
 # ── Main pipeline ───────────────────────────────────────────────────
+
 
 def run_search_pipeline(
 	client: Any,

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -149,3 +149,25 @@ def test_resume_job_link_multiple(tmp_path):
 	store.link_resume_to_job("v2", "sec_001", "job_001", "后端", "公司甲")
 	resumes = store.get_job_resumes("sec_001", "job_001")
 	assert len(resumes) == 2
+
+
+def test_job_desc_cache_roundtrip(tmp_path):
+	store = CacheStore(tmp_path / "test.db")
+	assert store.get_job_desc("sec_001") is None
+	store.put_job_desc("sec_001", "提供双休和五险一金")
+	assert store.get_job_desc("sec_001") == "提供双休和五险一金"
+
+
+def test_job_desc_cache_expires(tmp_path):
+	store = CacheStore(tmp_path / "test.db", search_ttl_seconds=0)
+	store.put_job_desc("sec_001", "提供双休")
+	time.sleep(0.01)
+	assert store.get_job_desc("sec_001") is None
+
+
+def test_job_desc_cache_ignores_empty(tmp_path):
+	store = CacheStore(tmp_path / "test.db")
+	store.put_job_desc("", "非空描述")
+	store.put_job_desc("sec_001", "")
+	assert store.get_job_desc("sec_001") is None
+	assert store.get_job_desc("") is None

--- a/tests/test_search_pipeline.py
+++ b/tests/test_search_pipeline.py
@@ -1,6 +1,11 @@
 import pytest
 
-from boss_agent_cli.search_filters import SearchFilterCriteria, SearchPipelinePlatformError, resolve_welfare_keywords, run_search_pipeline
+from boss_agent_cli.search_filters import (
+	SearchFilterCriteria,
+	SearchPipelinePlatformError,
+	resolve_welfare_keywords,
+	run_search_pipeline,
+)
 
 
 class FakeLogger:
@@ -12,11 +17,20 @@ class FakeLogger:
 
 
 class FakeCache:
-	def __init__(self, greeted_ids: set[str] | None = None):
+	def __init__(self, greeted_ids: set[str] | None = None, descs: dict[str, str] | None = None):
 		self.greeted_ids = greeted_ids or set()
+		self.descs = descs or {}
+		self.put_calls: list[tuple[str, str]] = []
 
 	def is_greeted(self, security_id: str) -> bool:
 		return security_id in self.greeted_ids
+
+	def get_job_desc(self, security_id: str) -> str | None:
+		return self.descs.get(security_id)
+
+	def put_job_desc(self, security_id: str, description: str) -> None:
+		self.put_calls.append((security_id, description))
+		self.descs[security_id] = description
 
 
 class FakeClient:
@@ -304,3 +318,41 @@ def test_pipeline_reports_welfare_not_supported():
 
 	assert exc_info.value.code == "NOT_SUPPORTED"
 	assert "不支持福利详情筛选" in exc_info.value.message
+
+
+def test_pipeline_caches_fresh_job_desc_after_fetch():
+	"""首次取详情后应把描述写回缓存（put_job_desc 被调用）。"""
+	client = FakeClient(
+		pages=[{"zpData": {"hasMore": False, "jobList": [_make_job_raw(security_id="sec-1", job_id="job-1")]}}],
+		descriptions={"sec-1": "这里提供双休和五险一金"},
+	)
+	cache = FakeCache()
+	result = run_search_pipeline(
+		client,
+		cache,
+		FakeLogger(),
+		criteria=SearchFilterCriteria(query="python"),
+		welfare_conditions=_welfare_conditions(),
+	)
+	assert len(result.items) == 1
+	assert client.detail_calls == [("sec-1", "")]  # 取了一次详情（按 securityId 取）
+	assert ("job-1", "这里提供双休和五险一金") in cache.put_calls  # 写回缓存（按稳定的 job_id）
+
+
+def test_pipeline_cache_hit_skips_job_card_request():
+	"""描述缓存命中（按 job_id）时应跳过 job_card 请求（不触网、不计请求）。"""
+	client = FakeClient(
+		pages=[{"zpData": {"hasMore": False, "jobList": [_make_job_raw(security_id="sec-1", job_id="job-1")]}}],
+		descriptions={"sec-1": "不应被调用"},
+	)
+	cache = FakeCache(descs={"job-1": "这里提供双休和五险一金"})
+	result = run_search_pipeline(
+		client,
+		cache,
+		FakeLogger(),
+		criteria=SearchFilterCriteria(query="python"),
+		welfare_conditions=_welfare_conditions(),
+	)
+	assert len(result.items) == 1
+	assert client.detail_calls == []  # 命中缓存，零取详情请求
+	assert cache.put_calls == []  # 命中无需写回


### PR DESCRIPTION
## 变更说明 / Summary

search 优化"下半场":攻 `--welfare` 搜索的 detail 风暴与无锁并发隐患。用户明确此处合规敏感——**优化只许减少请求,不许提频**。

诊断(代码级+实验,修正上一任务初判):
- job_card 已是 httpx 优先+浏览器降级,详情多走 httpx(非浏览器风暴)
- 4 分钟根因:welfare 搜索对每个标签未命中 job 逐个取详情,数量无上界;实测首跑 239s
- 3 worker 已被共享 throttle 串行化(并发实验 12 请求 28.2s),提速≈0 且 throttle 无锁(潜在竞态)

实现 A+B(均"减少请求"方向):
1. **A 详情缓存**:按 `job_id`/`encryptJobId` 键(实测跨搜索稳定 10/10;`securityId` 每次请求重生成、0/10 不可做键)的 TTL(24h)缓存。重复/微调 welfare 搜索复用描述,跳过对应 job_card 请求 → 减请求量+加速重跑。cache I/O 全留主线程(sqlite 非线程安全)。
2. **B throttle 加锁**:wait()/mark() 持锁 + 预占下次发送时刻,杜绝竞态突发;并发实验证明行为保持(28.6s≈28.2s,不提频)。

## 变更类型 / Type

- [x] perf: 性能优化
- [x] fix: 并发安全加固

## Breaking Change

- [x] 本 PR **不包含** 破坏性变更（job_desc_cache 为新增缓存表,纯本地、可丢弃）

## 测试 / Test Plan

- [x] `uv run pytest tests/ -q` 全通过(1455)
- [x] ruff / mypy 无报错
- [x] 新增测试:缓存命中跳过取详情、新取写回、job_id 键、TTL 过期、空值守卫、加锁并发行为
- [x] 实测 job_id 跨搜索稳定性 10/10 vs securityId 0/10(缓存有效性依据)

## 合规 / Compliance

- [x] **不降低请求间隔、不增并发上限**——A/B 均为"减少请求"方向;并发实验佐证不提频
- [x] 涉及请求频率:已阅读 docs/platform-risk.md
- [x] 诚实披露:本轮密集真实测试触发 ACCOUNT_RISK,已即时停止真实请求(印证合规边界有效);live 重跑 before/after 未跑完,缓存功效以 job_id 稳定性实测+单测为据

## 安全与规范

- [x] commit message: type: 中文描述,无 Co-authored-by / AI 署名
- [x] 无敏感信息