### PR TITLE
docs: 校正投稿模板自相矛盾的能力数字

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ## [Unreleased]
 
 ### Changed
+- 修正 `docs/marketing/awesome-submissions.md` 投稿模板内自相矛盾且陈旧的数字（命令数 34/33、招聘者子命令 7、MCP 工具 49/31、测试 1315、release 1.11.0），统一为当前准确值：35 顶层命令 / 9 招聘者子命令 / 32 默认低风险 MCP 工具 / 1455 测试 / release 1.13.1（其中"默认低风险 MCP 工具"取合规过滤后实际导出的 32 个，与 README.en 受测口径一致）。
+
+### Changed
 - 修正贡献者文档中指向已迁出路径 `skills/boss-agent-cli/SKILL.md` 的陈旧引用（`CONTRIBUTING.md` / `CONTRIBUTING.en.md` 添加新命令清单第 5 步改为 `docs/commands.md`、PR 模板指向独立仓库 boss-skill），消除迁出 SKILL 后遗留的误导。
 - 合并 `docs/blog/` 进 `docs/marketing/`：发布/推广文案归拢到单一目录，去除同类内容的双目录冗余。
 

--- a/docs/marketing/awesome-submissions.md
+++ b/docs/marketing/awesome-submissions.md
@@ -1,12 +1,12 @@
 # Awesome List Submissions
 
-本文件记录 boss-agent-cli 向各大 awesome 列表投稿的模板，供维护者提交用。最后更新：master 当前状态 (2026-05-28)。
+本文件记录 boss-agent-cli 向各大 awesome 列表投稿的模板，供维护者提交用。最后更新：master 当前状态 (2026-06-16)。
 
 ## 项目一句话介绍
 
-**中文**：专为 AI Agent 设计的 BOSS 直聘求职 CLI，34 个顶层命令 + 7 个招聘者子命令 + 49 个 MCP 工具，全部输出 JSON，支持 Claude Desktop/Cursor/Windsurf 无缝接入，覆盖求职者与招聘者双端工作流。
+**中文**：专为 AI Agent 设计的 BOSS 直聘求职 CLI，35 个顶层命令 + 9 个招聘者子命令 + 32 个默认低风险 MCP 工具，全部输出 JSON，支持 Claude Desktop/Cursor/Windsurf 无缝接入，覆盖求职者与招聘者双端工作流。
 
-**English**: AI-agent-first CLI for BOSS Zhipin. 34 top-level commands + 7 recruiter subcommands + 31 default low-risk MCP tools, JSON envelope output, typed Python SDK (PEP 561), and out-of-the-box integration for Claude Desktop / Cursor / Windsurf.
+**English**: AI-agent-first CLI for BOSS Zhipin. 35 top-level commands + 9 recruiter subcommands + 32 default low-risk MCP tools, JSON envelope output, typed Python SDK (PEP 561), and out-of-the-box integration for Claude Desktop / Cursor / Windsurf.
 
 ## 推荐投稿目标
 
@@ -15,7 +15,7 @@
 分类：Productivity / Job Search
 
 ```markdown
-- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - BOSS Zhipin (China's largest recruitment platform) integration for AI agents, exposing 31 default low-risk MCP tools covering search, detail, local shortlist, resume management, and AI-powered interview prep / chat coaching.
+- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - BOSS Zhipin (China's largest recruitment platform) integration for AI agents, exposing 32 default low-risk MCP tools covering search, detail, local shortlist, resume management, and AI-powered interview prep / chat coaching.
 ```
 
 ### 2. [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code)
@@ -23,7 +23,7 @@
 分类：CLI Tools / Skills
 
 ```markdown
-- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - Full job hunt automation on BOSS Zhipin. 33 top-level commands plus recruiter workflow subcommands, 4-tier login fallback, AI resume optimization, chat reply drafts, and interview prep generation.
+- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - Full job hunt automation on BOSS Zhipin. 35 top-level commands plus recruiter workflow subcommands, 4-tier login fallback, AI resume optimization, chat reply drafts, and interview prep generation.
 ```
 
 ### 3. [awesome-agents](https://github.com/kyrolabs/awesome-agents)
@@ -31,7 +31,7 @@
 分类：Specialized Agents
 
 ```markdown
-- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) ![](https://img.shields.io/github/stars/can4hou6joeng4/boss-agent-cli) - Job-hunt CLI purpose-built for AI agents. BOSS Zhipin integration with 33 top-level commands, recruiter workflow subcommands, 31 default low-risk MCP tools, JSON envelope output, and local-first encrypted storage.
+- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) ![](https://img.shields.io/github/stars/can4hou6joeng4/boss-agent-cli) - Job-hunt CLI purpose-built for AI agents. BOSS Zhipin integration with 35 top-level commands, recruiter workflow subcommands, 32 default low-risk MCP tools, JSON envelope output, and local-first encrypted storage.
 ```
 
 ### 4. [awesome-python-cli](https://github.com/shinokada/awesome-python-cli)
@@ -45,16 +45,16 @@
 分类：Agents & Automation
 
 ```markdown
-- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - Let your AI agent handle the job hunt. 33 top-level CLI commands + 7 recruiter subcommands + 31 default low-risk MCP tools covering search, detail, local shortlist, interview prep, and AI resume coaching on BOSS Zhipin.
+- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - Let your AI agent handle the job hunt. 35 top-level CLI commands + 9 recruiter subcommands + 32 default low-risk MCP tools covering search, detail, local shortlist, interview prep, and AI resume coaching on BOSS Zhipin.
 ```
 
 ## 投稿前 Checklist（master 当前状态）
 
 - [x] README 双语（中文 + 英文）
 - [x] MIT License
-- [x] CI 全绿 + **1315 测试**
-- [x] 发布到 PyPI（`pip install boss-agent-cli`，当前 latest release 1.11.0）
-- [x] GitHub Release 规范（latest release 1.11.0 已发）
+- [x] CI 全绿 + **1455 测试**
+- [x] 发布到 PyPI（`pip install boss-agent-cli`，当前 latest release 1.13.1）
+- [x] GitHub Release 规范（latest release 1.13.1 已发）
 - [x] CHANGELOG 完整
 - [x] Code of Conduct + Security Policy
 - [x] Issue / PR 模板
@@ -81,12 +81,12 @@
 
 ## 一句话钩子（A/B 测试素材）
 
-1. "34 个顶层命令 + 7 个招聘者子命令 + 49 个 MCP 工具，让 AI Agent 帮你打招呼、投简历、聊 HR、准备面试"
+1. "35 个顶层命令 + 9 个招聘者子命令 + 32 个默认低风险 MCP 工具，让 AI Agent 帮你打招呼、投简历、聊 HR、准备面试"
 2. "第一个 MCP 就绪、类型安全的中国招聘平台 CLI，为 Claude Desktop / Cursor / Windsurf 设计"
 3. "`boss ai interview-prep` — 把 JD 扔进 AI，秒出 10 道模拟面试题"
 4. "你只负责描述期望，AI Agent 负责搜、聊、投、跟进"
 5. "MIT License，本地加密存储，数据不出机"
-6. "1315 测试、49 个 MCP 工具、下游 Python 嵌入零学习成本"
+6. "1455 测试、32 个默认低风险 MCP 工具、下游 Python 嵌入零学习成本"
 
 ## 实际投稿记录 & 渠道约束（2026-04-28 更新）
 


### PR DESCRIPTION
## 变更说明 / Summary

审计 P3：`docs/marketing/awesome-submissions.md`（awesome-list 投稿模板，会被复制进外部列表，准确性重要）内数字自相矛盾且陈旧——同文件命令数 34/33、MCP 工具中文 49 / 英文 31、招聘者子命令 7、测试 1315、release 1.11.0 各处不一。

统一为当前准确值（逐项核准，非凭印象）：
- 顶层命令 **35**（`boss schema`）
- 招聘者一级子命令 **9**（与 capability-matrix 受测口径一致）
- 默认低风险 MCP 工具 **32**——**关键**：取合规过滤后实际导出的数（`mcp_server.py` 第 751 行 `TOOLS = [... not in _LOW_RISK_BLOCKED_TOOLS]`），与 README.en 受测断言 "MCP server with 32 tools" 一致；源码里 54 个 `Tool()` 定义是过滤前总数，不是对外暴露数
- 测试 **1455**；release **1.13.1**

仅改 awesome-submissions.md（live 投稿模板）。两个 `launch-story.md` 是 v1.11.0 发布期的**带日期叙事草稿**，改其数字会造成时代错配（v1.11.0 配 1455 测试不自洽），故保留为历史快照不动。星标数/覆盖率未验证项保持原样。

## 变更类型 / Type

- [x] docs: 文档

## Breaking Change

- [x] 本 PR **不包含** 破坏性变更

## 测试 / Test Plan

- [x] `uv run pytest tests/test_agent_docs.py tests/test_open_source_docs.py -q` 36 passed
- [x] 复查 awesome-submissions.md 无残留旧数字（34/33/49/31/7/1315/1.11.0 全清零）
- [x] 32 这一数字由 `len(导出 TOOLS)` 实测确认（合规过滤后）

## 文档与契约 / Docs & Contracts

- [x] 已更新 `CHANGELOG.md` 的 `[Unreleased]` 段落

## 安全与规范 / Safety & Convention

- [x] commit message: `type: 中文描述`
- [x] 无 `Co-authored-by` 尾注或 AI 署名行
- [x] 无敏感信息