### PR TITLE
docs: 精简重构 README（参考 Mole 风格），收敛冗余章节

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -2,11 +2,7 @@
 
 # boss-agent-cli
 
-**A local-assist CLI for AI Agents working around BOSS Zhipin**
-
-> Default low-risk mode: local assistance · read-only first · user-triggered · no risk-control bypass · no bulk outreach · no platform-data scraping
->
-> Job-seeker: search · welfare filtering · detail review · shortlist · local resume and AI assistance
+*🤖 A local-assist BOSS Zhipin CLI for AI agents — search · welfare filtering · shortlist · JSON envelopes, low-risk by default.*
 
 [![CI](https://github.com/can4hou6joeng4/boss-agent-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/can4hou6joeng4/boss-agent-cli/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/can4hou6joeng4/boss-agent-cli/branch/master/graph/badge.svg)](https://codecov.io/gh/can4hou6joeng4/boss-agent-cli)
@@ -14,241 +10,122 @@
 [![License](https://img.shields.io/badge/License-MIT-green.svg?style=flat-square)](LICENSE)
 [![GitHub Release](https://img.shields.io/github/v/release/can4hou6joeng4/boss-agent-cli?style=flat-square)](https://github.com/can4hou6joeng4/boss-agent-cli/releases)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/boss-agent-cli?style=flat-square)](https://pypi.org/project/boss-agent-cli/)
-[![Contributors](https://img.shields.io/github/contributors/can4hou6joeng4/boss-agent-cli?style=flat-square)](https://github.com/can4hou6joeng4/boss-agent-cli/graphs/contributors)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](https://github.com/can4hou6joeng4/boss-agent-cli/pulls)
-[![Open in Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/can4hou6joeng4/boss-agent-cli)
 
-[Getting Started](docs/getting-started.en.md) · [Install](#-install) · [Quickstart](#-quickstart) · [Roles & Platforms](#-roles--platforms) · [Agent Integration](#-agent-integration) · [Commands](#-commands) · [Troubleshooting](docs/troubleshooting.en.md) · [Architecture](#-architecture) · [Changelog](CHANGELOG.md) · [Roadmap](ROADMAP.en.md)
-
-[中文](README.md) | **English**
+[Getting Started](docs/getting-started.en.md) · [Agent Integration](#-agent-integration) · [Commands](#-commands) · [Troubleshooting](docs/troubleshooting.en.md) · [Roadmap](ROADMAP.en.md) · [中文](README.md) | **English**
 
 <a href="demo/showcase/boss-agent-cli-showcase.mp4" title="Watch the full project showcase video">
   <img src="demo/showcase/boss-agent-cli-showcase.gif" alt="boss-agent-cli project showcase animation" width="100%">
 </a>
 
-**[Watch the full showcase video](demo/showcase/boss-agent-cli-showcase.mp4)** · [view the terminal demo](demo/demo-en.gif) · schema-driven · welfare filtering · JSON envelope · open-source engineering quality
-
-<p align="center">
-  <img src="demo/demo-en.gif" alt="boss-agent-cli terminal demo (1280×720 / 30fps)" width="100%">
-</p>
+**[Watch the full showcase video](demo/showcase/boss-agent-cli-showcase.mp4)** · [terminal demo](demo/demo-en.gif) · schema-driven · welfare filtering · JSON envelope
 
 </div>
 
 ## ⚠️ Compliance Boundary
 
-The project enables Low-Risk Assistance Mode by default. It is intentionally scoped to local assistance, read-only-first workflows, and user-triggered actions. CLI commands that would greet, batch-greet, apply, exchange contacts, search recruiter candidates, read candidate resumes/chats, request attachments, or reply to candidates are blocked by default and return the `COMPLIANCE_BLOCKED` error code; users should perform those actions manually on the official website.
+Low-Risk Assistance Mode is on by default: local assistance · read-only first · user-triggered · no risk-control bypass · no bulk outreach · no platform-data scraping. Commands that greet (greet / batch-greet), apply, exchange contacts, search recruiter candidates, read candidate resumes / chats, or reply are blocked by default and return the `COMPLIANCE_BLOCKED` error code; perform those actions manually on the official website.
 
-## 💡 Why boss-agent-cli?
+## ✨ Features
 
-Traditional job hunting: open a web page → flip through dozens of pages → check each detail → organize shortlists manually → forget who to follow up with.
-
-With AI Agents: `boss search` -> `boss detail` -> `boss shortlist` -> `boss stats` — one local-assist chain for organizing work while sensitive actions stay on the official website.
-
-Every command outputs **structured JSON** that AI Agents parse directly. Default low-risk mode blocks automated outreach, bulk actions, contact exchange, recruiter candidate data workflows, and risk-control retries.
-
-## 🧭 Table of Contents
-
-- [Why boss-agent-cli?](#-why-boss-agent-cli)
-- [Demo Assets](#-demo-assets)
-- [Core Capabilities](#-core-capabilities)
-- [Install](#-install)
-- [Quickstart](#-quickstart)
-- [Roles & Platforms](#-roles--platforms)
-- [Agent Integration](#-agent-integration)
-- [Commands](#-commands)
-- [Troubleshooting](#-troubleshooting)
-- [Configuration](#-configuration)
-- [Architecture](#-architecture)
-- [Local Storage](#-local-storage)
-- [Contributing](#-contributing)
-
-## 🎬 Demo Assets
-
-| Type | Entry | Best for |
-|------|-------|----------|
-| Project showcase animation | [Homepage autoplay GIF](demo/showcase/boss-agent-cli-showcase.gif) | Quickly understanding the project positioning, schema-driven workflow, JSON envelope, and open-source engineering quality |
-| Full showcase video | [31-second MP4](demo/showcase/boss-agent-cli-showcase.mp4) | Viewing the clearer, complete project narrative |
-| Terminal interaction demo | [Terminal GIF](demo/demo-en.gif) · [VHS tape](demo/demo-en.tape) | Seeing the CLI commands and output shape directly (1280×720 / 30fps) |
-| Reproducible source | [HTML timeline source](demo/promo-showcase/) | Maintaining or iterating the README homepage animation |
-
-## 🌟 Core Capabilities
-
-### Job-seeker workflow
-
-- **Discovery**: keyword search, layered filters, and cached `show` navigation. Commands: `search` `show`
-- **Welfare-aware search**: `--welfare "双休,五险一金"` runs real AND matching by paging, fetching details, and checking text fallback. Command: `search --welfare`
-- **Local shortlist**: inspect details and organize candidate jobs locally; apply and messaging stay on the official website. Commands: `detail` `show` `shortlist`
-- **Pipeline control**: local shortlist and funnel stats from local state. Commands: `shortlist` `stats`
-- **Conversation support**: low-risk local organization only by default; message history, labels, and contact exchange are sensitive workflows and blocked by default.
-- **AI job-hunting assist**: JD analysis, resume polish, role-targeted optimization, interview prep, and chat coaching. Commands: `ai analyze-jd` `ai polish` `ai optimize` `ai interview-prep` `ai chat-coach`
-
-### Recruiter workflow
-
-- **Recruiter boundary**: candidate search, applications, resumes, chat records, attachment requests, contact exchange, and replies are blocked by default; use the official recruiter UI for those actions.
-- **Job lifecycle management**: list, bring online, and take offline recruiter postings. Commands: `hr jobs list` `hr jobs online` `hr jobs offline`
-
-### Platform & integration foundation
-
-- **Schema-first integration**: `boss schema` is the capability source of truth for shell agents, SDKs, and tool-export formats
-- **Structured transport**: stdout is JSON-only, stderr is logs-only, which keeps automation stable
-- **Platform-aware login**: user-triggered login state is stored locally and encrypted; it is not a risk-control bypass workflow
-- **Cross-platform adapter layer**: `Platform` / `RecruiterPlatform` registries are live, with low-risk mode governing sensitive capabilities
-- **MCP server with 32 tools**: exposes only the low-risk tool surface by default
-
-## 📦 Install
-
-```bash
-# Recommended: install via uv (fast, isolated)
-uv tool install boss-agent-cli
-patchright install chromium
-
-# Or pipx
-pipx install boss-agent-cli
-patchright install chromium
-
-# From source
-git clone https://github.com/can4hou6joeng4/boss-agent-cli.git
-cd boss-agent-cli && uv sync --all-extras
-uv run patchright install chromium
-```
+- **Job discovery**: keyword search + layered filters, with cached `show` navigation — `search` `show` `detail`
+- **Welfare filtering (the differentiator)**: `--welfare "双休,五险一金"` pages, fetches details, and runs **real AND matching** — not keyword hits — `search --welfare`
+- **Local shortlist & stats**: inspect details, organize and review candidate jobs locally, see funnel stats; apply and messaging stay on the official website — `shortlist` `stats` `watch` `preset`
+- **AI job-hunting assist**: JD analysis, resume polish, role-targeted optimization, interview prep, chat coaching — `ai analyze-jd` `ai polish` `ai optimize` `ai interview-prep` `ai chat-coach`
+- **Schema-first + JSON envelope**: stdout is a JSON-only `{ok, data, pagination, error, hints}` envelope, `boss schema` is the capability source of truth, and an **MCP server with 32 tools** exposes the low-risk surface
+- **Recruiter loop**: list and bring postings online / offline (`hr jobs list/online/offline`); candidate personal-data workflows are blocked by default
+- **Cross-platform layer**: live `Platform` / `RecruiterPlatform` registries, `--platform zhipin|zhilian|qiancheng`
 
 ## 🚀 Quickstart
 
 ```bash
-# 1. Environment check
-boss doctor
+# Install (uv recommended; the browser core is only for user-triggered login / local export)
+uv tool install boss-agent-cli
+patchright install chromium
 
-# 2. Login (platform-aware fallback chain)
-boss login
+# Run the low-risk loop
+boss doctor                                                   # environment check
+boss login                                                    # user-triggered login (platform-aware chain)
+boss status                                                   # verify login
+boss search "Golang" --city 广州 --welfare "双休,五险一金"     # search + welfare filtering
+boss detail <security_id>                                     # view detail
+boss shortlist add <security_id> <job_id>                     # add to local shortlist
+boss stats                                                    # local stats
 
-# 3. Verify login
-boss status
-
-# Optional: inspect local platform capability status (no network)
-boss platforms
-boss platforms --platform qiancheng  # Inspect one platform; 51job alias is supported
-
-# 4. Search Golang jobs in Guangzhou with 双休 + 五险一金
-boss search "Golang" --city 广州 --welfare "双休,五险一金"
-
-# 5. View detail → add to local shortlist
-boss detail <security_id>
-boss shortlist add <security_id> <job_id>
-
-# 6. Export + local stats
-boss export "Golang" --city 广州 --count 50 -o jobs.csv
-boss stats
-
-# 7. Recruiter mode
-boss hr jobs list                       # my job postings
-# Candidate search, resumes, chat, replies, attachments, and contact exchange are blocked by default.
+# Recruiter mode (candidate-data workflows blocked by default)
+boss hr jobs list
 ```
+
+Every command outputs structured JSON (`ok` for success, `exit 0/1`). Full walk-through: [Getting Started](docs/getting-started.en.md).
 
 ## 🎭 Roles & Platforms
 
-| Role | Flag | Entry commands |
-|------|------|----------------|
-| Candidate *(default)* | `--role candidate` | `search` / `detail` / `shortlist` |
-| Recruiter | `--role recruiter`, or `boss hr <sub>` shortcut | `hr jobs list`; candidate-data workflows are blocked by default |
-
 | Platform | Candidate | Recruiter | Status |
-|----------|:---------:|:---------:|--------|
+|----------|:--:|:--:|--------|
 | BOSS Zhipin (`zhipin`) | ✅ | ✅ | default |
-| Zhaopin (`zhilian`)    | 🟡 candidate-side login + read/write flow wired | — | recruiter side is still intentionally unavailable at runtime |
-| 51job (`qiancheng`)     | 🚧 registered placeholder | — | returns `NOT_SUPPORTED` until the read-only research gate is satisfied |
-
-`boss platforms` includes `capability_status_legend` in both JSON and terminal output so agents can interpret capability states clearly:
-
-| State | Meaning |
-|-------|---------|
-| `available` | The local CLI has wired this capability; login requirements still follow the concrete command contract |
-| `not_supported` | The current platform adapter does not implement this real workflow; the CLI returns a stable `NOT_SUPPORTED` envelope |
-| `placeholder_only` | Registered only for platform identity, aliases, schema/config visibility; it does not mean a real platform capability is wired |
-| `low_risk_blocked` | Write actions, sensitive data, or platform-risk boundaries are involved; default low-risk mode blocks the action and points users back to the official UI |
+| Zhaopin (`zhilian`) | 🟡 candidate-side login + read/write wired | — | recruiter side intentionally rejected at runtime |
+| 51job (`qiancheng`) | 🚧 registered placeholder | — | returns `NOT_SUPPORTED` until the read-only research gate is satisfied |
 
 ```bash
-boss --platform zhilian search "Python"   # pick a platform
+boss --platform zhilian search "Python"   # pick a platform (also --platform zhipin|zhilian|qiancheng)
 boss config set platform zhilian          # set as default
-boss --platform qiancheng status          # 51job is currently identity-only
 ```
 
-Notes: `boss hr ...` currently supports only the default recruiter platform `zhipin-recruiter`; `boss --platform zhilian hr ...` is intentionally rejected at runtime. Architecture notes: [docs/platform-abstraction.en.md](docs/platform-abstraction.en.md).
+`boss hr ...` currently supports only the default recruiter platform `zhipin-recruiter`. Architecture notes: [docs/platform-abstraction.en.md](docs/platform-abstraction.en.md).
 
 ## 🤖 Agent Integration
 
-The point of this tool is to let AI Agents help organize job-hunting context without automating sensitive platform actions.
-
-### Option 1: Skill install (recommended)
+Start here: [Agent Quickstart](docs/agent-quickstart.en.md) · [Capability Matrix](docs/capability-matrix.en.md) · [Host Examples](docs/agent-hosts.en.md)
 
 ```bash
+# Option 1: Skill install (recommended) — the Agent gains the ability to call boss
 npx skills add can4hou6joeng4/boss-skill
 ```
 
-> The Agent Skill for this CLI is managed in the standalone [boss-skill](https://github.com/can4hou6joeng4/boss-skill) repository (the repository itself is the skill), decoupled from the CLI release cadence.
-
-### Option 2: subprocess + JSON parse
+> The Agent Skill is maintained in the standalone [boss-skill](https://github.com/can4hou6joeng4/boss-skill) repository (the repo itself is the skill), decoupled from the CLI release cadence.
 
 ```bash
-# Step 1: let the Agent read the tool self-description
+# Option 2: subprocess — let the Agent read the self-description, then parse stdout JSON
 boss schema
 ```
 
 ```python
-# Step 2: chain commands via subprocess (Python example)
-import subprocess, json
-result = subprocess.run(["boss", "search", "Python", "--city", "北京"],
-                        capture_output=True, text=True)
-jobs = json.loads(result.stdout)["data"]["items"]
+# Option 3: embed in Python (ships with py.typed)
+from boss_agent_cli import AuthManager, BossClient, AuthRequired
+with BossClient(AuthManager(...)) as client:
+    result = client.search_jobs("Golang", city="北京")
 ```
-
-### Option 3: MCP integration (Claude Desktop / Cursor)
 
 ```json
-{
-  "mcpServers": {
-    "boss-agent": {
-      "command": "uvx",
-      "args": ["--from", "boss-agent-cli[mcp]", "boss-mcp"]
-    }
-  }
-}
+// Option 4: MCP (Claude Desktop / Cursor)
+{ "mcpServers": { "boss-agent": { "command": "uvx", "args": ["--from", "boss-agent-cli[mcp]", "boss-mcp"] } } }
 ```
-
-See [Agent Quickstart](docs/agent-quickstart.en.md) and [Capability Matrix](docs/capability-matrix.en.md) for the full picture.
 
 ## 📚 Commands
 
-`boss schema` currently exposes 35 top-level commands, plus 9 first-level recruiter subcommands under `hr`, grouped below by workflow:
+`boss schema` exposes 35 top-level commands + 9 first-level recruiter subcommands, grouped by workflow:
 
-| Stage | Commands |
-|-------|----------|
-| **Auth** | `login` · `logout` · `status` · `doctor` |
-| **Discover** | `search` · `detail` · `show` · `cities` · `history` |
-| **Restricted Actions** | `greet` · `batch-greet` · `apply` · `exchange` · `mark` are blocked by default |
-| **Restricted Track** | `chat` · `chatmsg` · `chat-summary` · `pipeline` · `follow-up` · `digest` are blocked by default; use `stats` for local state |
-| **Organize** | `watch` · `preset` · `shortlist` |
-| **Resume** | `resume` · `me` |
-| **AI** | `ai config` · `ai analyze-jd` · `ai polish` · `ai optimize` · `ai suggest` · `ai reply` · `ai interview-prep` · `ai chat-coach` |
-| **Utility** | `schema` · `platforms` · `export` · `config` · `clean` |
-| **Recruiter** | `hr jobs list/offline/online`; candidate-data and messaging workflows are blocked by default |
+- **Auth**: `login` · `logout` · `status` · `doctor`
+- **Discover**: `search` · `detail` · `show` · `cities` · `history`
+- **Organize**: `watch` · `preset` · `shortlist` · `stats`
+- **Resume / AI**: `resume` · `me` · `ai analyze-jd` · `ai polish` · `ai optimize` · `ai interview-prep` · `ai chat-coach`
+- **Utility**: `schema` · `platforms` · `export` · `config` · `clean`
+- **Recruiter**: `hr jobs list/online/offline`
+- **Restricted (blocked by default in low-risk mode)**: `greet` · `batch-greet` · `apply` · `exchange` · `chat*` · `pipeline` · `digest`
 
-Full command tables, filter parameters, and welfare-matching internals: **[Command Reference](docs/commands.en.md)**. The capability source of truth is `boss schema` (with `--format openai-tools` / `anthropic-tools` exports for any agent framework).
+Full command tables, parameters, and welfare-matching internals: **[Command Reference](docs/commands.en.md)**. The capability source of truth is `boss schema` (with `--format openai-tools` / `anthropic-tools` exports).
 
 ## 🩺 Troubleshooting
 
 ```bash
-boss doctor
-boss status
-# Optional: run an explicit low-frequency read-only live probe
-boss status --live
+boss doctor             # environment check
+boss status --live      # optional low-frequency read-only probe
 boss doctor --live-probe
 ```
 
-Every error envelope carries `code` + `recoverable` + `recovery_action`, so agents can react programmatically.
+Every error envelope carries `code` + `recoverable` + `recovery_action`, so agents can react programmatically. Browser Bridge local diagnostics cover `bridge_daemon` / `bridge_extension` / `bridge_protocol` / `bridge_workspace` / `bridge_exec` / `bridge_fetch` / `bridge_navigate`; start the daemon with `python -m boss_agent_cli.bridge.daemon --serve`. Bridge is only for local diagnostics, user-triggered login compatibility, and read-only assistance — do not use it to retry platform risk-control blocks.
 
-Browser Bridge local diagnostics: the `bridge_daemon`, `bridge_extension`, `bridge_protocol`, `bridge_workspace`, `bridge_exec`, `bridge_fetch`, and `bridge_navigate` checks cover daemon, extension, tab, and basic browser-command health; start the daemon with `python -m boss_agent_cli.bridge.daemon --serve`. Bridge is only for local diagnostics, user-triggered login compatibility, and read-only assistance — do not use it to retry platform risk-control blocks.
-
-Full check reference, CDP launch examples, common fixes, error codes, and the glossary: **[Troubleshooting](docs/troubleshooting.en.md)**. For Cookie, CDP, patchright, real-account, request-rate, or platform-drift issues, read [Platform Risk Boundaries](docs/platform-risk.en.md) first.
+Full checks, CDP launch examples, and error codes: **[Troubleshooting](docs/troubleshooting.en.md)**. For Cookie / CDP / patchright / request-rate / drift issues, read [Platform Risk Boundaries](docs/platform-risk.en.md) first.
 
 ## ⚙️ Configuration
 
@@ -258,31 +135,34 @@ boss config set default_city 广州     # set the default city
 boss config reset                     # restore defaults
 ```
 
-Settings live in `~/.boss-agent/config.json` (default city/salary, request delays, log level, login timeout, CDP URL, export dir). See [Command Reference](docs/commands.en.md) for the full surface.
+Settings live in `~/.boss-agent/config.json`: default city / salary, request delays, log level, login timeout, CDP URL, export dir.
 
-## 🏗 Architecture
+## 🏗️ Architecture
 
-See the [中文版 README](README.md#-技术架构) for the full architecture diagram.
+```
+CLI (Click)
+  └─ Compliance Guardrails (low-risk by default; blocks sensitive writes & candidate personal-data flows)
+       └─ AuthManager ── user-triggered login state (Fernet + PBKDF2 machine-bound encryption)
+       └─ Platform registries ── zhipin / zhilian / qiancheng placeholder
+       └─ BossClient ── httpx + throttle; CDP / Bridge / patchright compatible for login & export
+       └─ CacheStore (SQLite WAL) · AIService (OpenAI / Anthropic)
+            └─ output.py → JSON envelope → stdout
+```
 
-Short version: Click CLI → Compliance Guardrails → AuthManager (Fernet-encrypted tokens) → Platform registries (`zhipin` / `zhilian` / `qiancheng` placeholder) → BossClient → JSON envelope on stdout.
-
-Invariant contracts:
-- stdout is JSON-only; stderr holds logs (controlled by `--log-level`)
-- Error objects always carry `code` + `recoverable` + `recovery_action`
-- `boss schema` is the authoritative capability source for Agents
+**Invariants**: stdout is JSON-only · stderr holds logs · `exit 0/1` · errors carry `code/recoverable/recovery_action` · `boss schema` is the authoritative capability source. **Stack**: Python ≥ 3.10 · Click · httpx · patchright / CDP / Bridge (login & export only, **never a risk-control bypass**) · cryptography · sqlite3 (WAL) · pytest (1400+).
 
 ## 🔌 Local Storage
 
-All state lives under `~/.boss-agent/` — encrypted tokens, cached searches, chat history snapshots, resumes, AI config. Nothing leaves your machine except explicit API calls.
+All state lives under `~/.boss-agent/` — encrypted tokens, cached searches, shortlist, local resumes, AI config. Nothing leaves your machine except explicit API calls.
 
 ## 🤝 Contributing
 
-See [CONTRIBUTING.en.md](CONTRIBUTING.en.md) (English) or [CONTRIBUTING.md](CONTRIBUTING.md) (中文), and [docs/getting-started.en.md](docs/getting-started.en.md) for the happy path. TL;DR: fork → `feat/xxx` branch → write tests → `python scripts/quality_baseline.py` → PR.
+See [CONTRIBUTING.en.md](CONTRIBUTING.en.md) and [Getting Started](docs/getting-started.en.md). TL;DR: fork → `feat/xxx` branch → write tests → `python scripts/quality_baseline.py` (ruff + offline pytest + mypy) → PR.
 
-## 📄 License
+## ⚠️ Disclaimer
 
-MIT © [can4hou6joeng4](https://github.com/can4hou6joeng4)
+This project is for learning and local assistance only; follow applicable laws, the BOSS Zhipin user agreement, and its privacy policy. Default low-risk mode blocks automated outreach, bulk actions, risk-control bypass, and candidate personal-data workflows; any apply, messaging, contact exchange, or recruiter candidate handling should be completed manually on the official website.
 
-## 👭 Related Communities
+## 📑 License & Communities
 
-- [LINUX DO - a new community for tech enthusiasts](https://linux.do/)
+[MIT](LICENSE) © [can4hou6joeng4](https://github.com/can4hou6joeng4) · [LINUX DO](https://linux.do/)

--- a/README.md
+++ b/README.md
@@ -2,11 +2,7 @@
 
 # boss-agent-cli
 
-**专为 AI Agent 设计的 BOSS 直聘本地辅助 CLI 工具**
-
-> 默认低风险模式：本地辅助 · 只读优先 · 用户主动触发 · 不规避风控 · 不批量触达 · 不抓取平台数据
->
-> 求职者：搜索 · 福利筛选 · 详情查看 · 候选池 · 本地简历与 AI 辅助
+*🤖 专为 AI Agent 设计的 BOSS 直聘本地辅助 CLI —— 搜索 · 福利筛选 · 候选池 · JSON 信封，默认低风险合规。*
 
 [![CI](https://github.com/can4hou6joeng4/boss-agent-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/can4hou6joeng4/boss-agent-cli/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/can4hou6joeng4/boss-agent-cli/branch/master/graph/badge.svg)](https://codecov.io/gh/can4hou6joeng4/boss-agent-cli)
@@ -14,23 +10,15 @@
 [![License](https://img.shields.io/badge/License-MIT-green.svg?style=flat-square)](LICENSE)
 [![GitHub Release](https://img.shields.io/github/v/release/can4hou6joeng4/boss-agent-cli?style=flat-square)](https://github.com/can4hou6joeng4/boss-agent-cli/releases)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/boss-agent-cli?style=flat-square)](https://pypi.org/project/boss-agent-cli/)
-[![Contributors](https://img.shields.io/github/contributors/can4hou6joeng4/boss-agent-cli?style=flat-square)](https://github.com/can4hou6joeng4/boss-agent-cli/graphs/contributors)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](https://github.com/can4hou6joeng4/boss-agent-cli/pulls)
-[![Open in Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/can4hou6joeng4/boss-agent-cli)
 
-[快速上手](docs/getting-started.md) · [安装](#-安装) · [快速开始](#-快速开始) · [角色模式](#-角色模式与多平台) · [Agent 集成](#-ai-agent-集成) · [命令速查](#-命令速查) · [排障](docs/troubleshooting.md) · [架构](#-技术架构) · [更新日志](CHANGELOG.md) · [路线图](ROADMAP.md)
-
-**中文** | [English](README.en.md)
+[快速上手](docs/getting-started.md) · [Agent 集成](#-agent-集成) · [命令](#-命令) · [排障](docs/troubleshooting.md) · [路线图](ROADMAP.md) · **中文** | [English](README.en.md)
 
 <a href="demo/showcase/boss-agent-cli-showcase.mp4" title="观看完整项目展示视频">
   <img src="demo/showcase/boss-agent-cli-showcase.gif" alt="boss-agent-cli 项目展示动图" width="100%">
 </a>
 
-**[观看完整展示视频](demo/showcase/boss-agent-cli-showcase.mp4)** · [查看终端交互演示](demo/demo-zh.gif) · schema 驱动 · 福利筛选 · JSON 信封 · 开源工程质量
-
-<p align="center">
-  <img src="demo/demo-zh.gif" alt="boss-agent-cli 终端交互演示（1280×720 / 30fps）" width="100%">
-</p>
+**[观看完整展示视频](demo/showcase/boss-agent-cli-showcase.mp4)** · [终端交互演示](demo/demo-zh.gif) · schema 驱动 · 福利筛选 · JSON 信封
 
 </div>
 
@@ -41,444 +29,152 @@
 >
 > 💡 **极速订阅**： [专属链接](https://doloffer.com/friend/BEv3yvKS)（输入优惠码 `AI8888` 享 9 折特惠）
 
-> A local-assist CLI for AI Agents working around [BOSS Zhipin](https://www.zhipin.com/) data already available to the user. Default low-risk mode is read-only first, user-triggered, and does not automate outreach, bulk actions, risk-control bypasses, or candidate personal-data workflows. See [README.en.md](README.en.md) for the English version.
-
 ## ⚠️ 合规边界
 
-本项目默认启用低风险辅助模式，目标是收缩为"本地辅助 / 只读优先 / 用户主动触发 / 不规避风控 / 不批量触达 / 不抓取平台数据"的低风险工具。CLI 默认会阻断打招呼（greet / batch-greet）、投递、联系方式交换、招聘者候选人搜索、候选人简历、聊天记录、附件简历请求和消息回复等敏感能力，被阻断的命令返回 `COMPLIANCE_BLOCKED` 错误码。需要投递、沟通、候选人处理或联系方式交换时，请回到 BOSS 直聘平台官网由用户手动完成。
+默认启用**低风险辅助模式**：本地辅助 · 只读优先 · 用户主动触发 · 不规避风控 · 不批量触达 · 不抓取数据。打招呼（greet / batch-greet）、投递、联系方式交换、招聘者候选人搜索 / 简历 / 聊天、消息回复等敏感能力默认阻断并返回 `COMPLIANCE_BLOCKED`；需要时请回到 BOSS 直聘平台官网由用户手动完成。
 
----
+## ✨ 核心能力
 
-## 💡 为什么用 boss-agent-cli？
-
-传统求职：打开网页 → 翻几十页 → 逐个看详情 → 手动整理候选岗位 → 忘了跟进谁。
-
-**boss-agent-cli 让 AI Agent 帮你做本地整理和只读辅助**：
-
-```bash
-boss search "Golang" --city 广州 --welfare "双休,五险一金"   # 搜索 + 福利筛选
-boss detail <security_id>                                    # 查看详情
-boss shortlist add <security_id> <job_id>                    # 加入本地候选池
-boss stats                                                   # 本地统计
-```
-
-所有输出为 **结构化 JSON**，Agent 一调用就能理解；涉及投递、沟通和候选人个人信息处理的动作默认回到平台官网手动完成。
-
----
-
-## 🧭 导航目录
-
-- [为什么用 boss-agent-cli](#-为什么用-boss-agent-cli)
-- [演示素材](#-演示素材)
-- [核心能力](#-核心能力)
-- [安装](#-安装)
-- [快速开始](#-快速开始)
-- [登录链路](#-登录链路)
-- [角色模式与多平台](#-角色模式与多平台)
-- [AI Agent 集成](#-ai-agent-集成)
-- [命令速查](#-命令速查)
-- [诊断与排障](#-诊断与排障)
-- [配置](#-配置)
-- [技术架构](#-技术架构)
-- [本地存储](#-本地存储)
-- [贡献](#-贡献)
-
----
-
-## 🎬 演示素材
-
-| 类型 | 入口 | 适合场景 |
-|------|------|----------|
-| 项目展示动图 | [首页自动播放 GIF](demo/showcase/boss-agent-cli-showcase.gif) | 快速理解项目定位、schema 驱动、JSON 信封与开源工程质量 |
-| 完整展示视频 | [31 秒 MP4](demo/showcase/boss-agent-cli-showcase.mp4) | 查看更清晰、更完整的项目叙事 |
-| 终端交互演示 | [终端 GIF](demo/demo-zh.gif) · [VHS 录制脚本](demo/demo-zh.tape) | 直接观察 CLI 命令和输出形态（1280×720 / 30fps） |
-| 可复现源工程 | [HTML 时间轴源工程](demo/promo-showcase/) | 维护或迭代 README 首页展示动画 |
-
----
-
-## 🌟 核心能力
-
-### 求职者工作流
-
-- `🔍 职位发现`：关键词搜索、8 维筛选、按编号回看同一条结果。命令：`search` `show`
-- `🎯 福利筛选`：`--welfare "双休,五险一金"` 会自动翻页、补抓详情、按 AND 逻辑做真实匹配。命令：`search --welfare`
-- `📌 本地候选池`：查看详情后保存、移除、复盘候选岗位；投递和沟通回到平台官网手动完成。命令：`detail` `show` `shortlist`
-- `📊 本地统计`：基于本地缓存查看候选池、投递记录和清理结果。命令：`stats` `shortlist` `clean`
-- `👀 本地预设`：保存搜索条件和候选池；自动增量拉取默认阻断。命令：`watch add/list/remove` `preset` `shortlist`
-- `💬 沟通边界`：聊天记录、会话摘要、标签和联系方式交换等敏感链路默认阻断；沟通请回到平台官网手动完成。
-- `🤖 AI 求职增强`：JD 分析、简历润色、定向优化、模拟面试、沟通指导。命令：`ai analyze-jd` `ai polish` `ai optimize` `ai interview-prep` `ai chat-coach`
-
-### 招聘者工作流
-
-- `👔 招聘者边界`：候选人搜索、投递申请、在线简历、沟通记录、附件简历请求、联系方式交换和消息回复默认阻断，请回到 BOSS 直聘官方招聘者页面手动处理。
-- `📌 职位管理`：查看职位、上架、下架，作为招聘者端的最小可操作闭环。命令：`hr jobs list` `hr jobs online` `hr jobs offline`
-
-### 平台与集成基础
-
-- `🔌 多平台抽象`：`Platform` / `RecruiterPlatform` 双注册表已落地；默认低风险模式优先暴露只读和本地辅助链路。命令：`--platform zhipin|zhilian|qiancheng`
-- `📤 结构化输出`：stdout 只输出 JSON 信封，适合 CLI 编排、Shell Agent、MCP 和 Python SDK。命令：`schema` `export`
-- `🧩 Agent 接入`：同一套能力可通过 Skill、subprocess、MCP、Python SDK 四种路径暴露给 Agent。文档：`docs/agent-quickstart.md` `docs/agent-hosts.md`
-
----
-
-## 📦 安装
-
-```bash
-# 推荐：通过 uv 安装（秒级，自动隔离）
-uv tool install boss-agent-cli
-
-# 安装浏览器（仅用于用户主动登录和本地导出场景）
-patchright install chromium
-```
-
-<details>
-<summary>📋 其他安装方式</summary>
-
-```bash
-# pipx（隔离环境）
-pipx install boss-agent-cli
-patchright install chromium
-
-# pip
-pip install boss-agent-cli
-patchright install chromium
-
-# 从源码（开发用）
-git clone https://github.com/can4hou6joeng4/boss-agent-cli.git
-cd boss-agent-cli
-uv sync --all-extras
-uv run patchright install chromium
-```
-
-</details>
-
----
+- **职位发现**：关键词搜索 + 8 维筛选，按编号回看缓存结果 —— `search` `show` `detail`
+- **福利筛选（核心差异化）**：`--welfare "双休,五险一金"` 自动翻页补抓、按 AND 逻辑做**真实匹配**，而非关键词命中 —— `search --welfare`
+- **本地候选池与统计**：查看详情后本地保存 / 复盘候选岗位、查看漏斗统计；投递与沟通回到官网手动完成 —— `shortlist` `stats` `watch` `preset`
+- **AI 求职增强**：JD 分析、简历润色、定向优化、模拟面试、沟通指导 —— `ai analyze-jd` `ai polish` `ai optimize` `ai interview-prep` `ai chat-coach`
+- **Schema 驱动 + JSON 信封**：stdout 只输出 `{ok, data, pagination, error, hints}` 信封，`boss schema` 是能力真源，适合 CLI 编排 / Shell Agent / MCP / Python SDK
+- **招聘者最小闭环**：职位列表与上下架（`hr jobs list/online/offline`）；候选人个人数据链路默认阻断
+- **多平台抽象**：`Platform` / `RecruiterPlatform` 双注册表，`--platform zhipin|zhilian|qiancheng`
 
 ## 🚀 快速开始
 
 ```bash
-# 1. 环境自检
-boss doctor
+# 安装（uv 推荐；浏览器内核仅用于用户主动登录 / 本地导出）
+uv tool install boss-agent-cli
+patchright install chromium
 
-# 2. 登录（按平台选择链路）
-boss login
+# 跑通低风险闭环
+boss doctor                                                   # 环境自检
+boss login                                                    # 用户主动登录（按平台选择链路）
+boss status                                                   # 验证登录态
+boss search "Golang" --city 广州 --welfare "双休,五险一金"     # 搜索 + 福利筛选
+boss detail <security_id>                                     # 查看详情
+boss shortlist add <security_id> <job_id>                     # 加入本地候选池
+boss stats                                                    # 本地统计
 
-# 3. 验证登录态
-boss status
-
-# 可选：查看本地平台注册与能力状态（不触网）
-boss platforms
-boss platforms --platform qiancheng  # 仅查看单个平台；也支持 51job 别名
-
-# 4. 搜索广州的 Golang 职位，要求双休+五险一金
-boss search "Golang" --city 广州 --welfare "双休,五险一金"
-
-# 5. 查看详情 → 加入本地候选池
-boss detail <security_id>
-boss shortlist add <security_id> <job_id>
-
-# 6. 导出 + 本地统计
-boss export "Golang" --city 广州 --count 50 -o jobs.csv
-boss stats
-
-# 7. 招聘者模式
-boss hr jobs list                     # 我发布的职位（只读）
-# 候选人搜索、简历、聊天、回复、联系方式交换等默认低风险模式会阻断
+# 招聘者模式（候选人数据链路默认阻断）
+boss hr jobs list
 ```
 
----
+所有命令输出结构化 JSON（`ok` 判断成败，`exit 0/1`）。完整上手见 [快速上手](docs/getting-started.md)。
 
-## 🔐 登录链路
-
-`boss login` 会按当前平台选择登录链路：
-
-| 平台 | 登录链路 | 说明 |
-|------|----------|------|
-| `zhipin` | 用户主动登录链路（Cookie / CDP / QR / 浏览器兜底） | 仅用于低风险辅助，不用于规避平台风控 |
-| `zhilian` | 用户主动登录链路（Cookie / CDP / 浏览器兜底） | 当前优先复用本地浏览器登录态 |
-
-补充说明：
-- `boss login` 默认按当前 `--platform` / 配置文件里的 `platform` 工作
-- `boss --platform zhilian login` 已可用，当前覆盖**求职者侧**认证链路；推荐流和写操作默认受低风险模式阻断
-- CDP 启动示例与登录类故障见 [诊断与排障](docs/troubleshooting.md)
-
-涉及 Cookie、CDP、patchright、真实账号、请求频率或平台接口漂移的问题，请先阅读 [平台风险边界](docs/platform-risk.md)。
-
----
-
-## 🎭 角色模式与多平台
-
-| 角色 | 选项 | 典型命令 |
-|------|------|----------|
-| 求职者（默认） | `--role candidate` | `search` / `detail` / `shortlist` |
-| 招聘者 | `--role recruiter`，或 `boss hr <子命令>` 快捷组（自动切换角色） | `hr jobs list`；候选人相关敏感命令默认阻断 |
+## 🎭 角色与多平台
 
 | 平台 | 求职者 | 招聘者 | 状态 |
-|------|:------:|:------:|------|
+|------|:--:|:--:|------|
 | BOSS 直聘 (`zhipin`) | ✅ | ✅ | 默认 |
-| 智联招聘 (`zhilian`) | 🟡 候选者侧登录 + 读写链路已接通 | — | 招聘者侧未接入，运行时会直接拒绝 `hr` 子命令 |
-| 前程无忧 / 51job (`qiancheng`) | 🚧 已注册占位 | — | 统一返回 `NOT_SUPPORTED`，待只读研究门槛满足后再接入真实能力 |
-
-`boss platforms` 会在 JSON 与终端输出中附带 `capability_status_legend`，用于解释能力状态；也可以用 `--capability <capability>` 按现有本地能力矩阵反查平台状态，不会触发登录、浏览器/CDP 或网络请求：
+| 智联招聘 (`zhilian`) | 🟡 候选者侧登录 + 读写链路已接通 | — | 招聘者侧未接入，运行时直接拒绝 `hr` 子命令 |
+| 前程无忧 / 51job (`qiancheng`) | 🚧 已注册占位 | — | 统一返回 `NOT_SUPPORTED`，待只读研究门槛满足后再接入 |
 
 ```bash
-# 查看哪些平台对 status 是 available / placeholder / blocked_by_policy / not_supported
-boss platforms --capability status
-
-# 可与平台过滤组合；51job 会解析为 qiancheng
-boss platforms --platform 51job --capability search
-```
-
-`--capability` 的 `capability_filter.status_groups` 使用 Agent 友好的归一化状态名：`available`、`placeholder`、`blocked_by_policy`、`not_supported`；每个平台的 `capability_match.raw_status` 保留矩阵原始状态（如 `placeholder_only` / `low_risk_blocked`）。
-
-
-| 状态 | 语义 |
-|------|------|
-| `available` | 本地 CLI 已接入该能力；是否需要登录仍以具体命令契约为准 |
-| `not_supported` | 当前平台适配器没有实现该真实工作流；CLI 会稳定返回 `NOT_SUPPORTED` |
-| `placeholder_only` | 仅用于平台注册、别名、schema/config 可见性；不代表真实平台能力已接入 |
-| `low_risk_blocked` | 涉及写操作、敏感数据或平台风险边界；默认低风险模式阻断并提示回到官方页面手动处理 |
-
-```bash
-boss --platform zhilian search "Python"   # 指定平台
+boss --platform zhilian search "Python"   # 指定平台（也支持 --platform zhipin|zhilian|qiancheng）
 boss config set platform zhilian          # 设为默认
-boss --platform qiancheng status          # 51job 当前仅用于识别平台身份
 ```
 
-注意：`boss hr ...` 当前仅支持默认招聘者平台 `zhipin-recruiter`；若当前平台是 `zhilian`，CLI 会在入口直接提示切回 `boss --platform zhipin hr ...`。设计细节见 [docs/platform-abstraction.md](docs/platform-abstraction.md)。
+`boss hr ...` 当前仅支持默认招聘者平台 `zhipin-recruiter`。设计细节见 [docs/platform-abstraction.md](docs/platform-abstraction.md)。
 
----
+## 🤖 Agent 集成
 
-## 🤖 AI Agent 集成
-
-推荐先阅读：[Agent Quickstart](docs/agent-quickstart.md) · [Host Examples](docs/agent-hosts.md) · [Capability Matrix](docs/capability-matrix.md)
-
-### 方式一：Skill 安装（推荐）
+推荐先读：[Agent Quickstart](docs/agent-quickstart.md) · [Capability Matrix](docs/capability-matrix.md) · [Host Examples](docs/agent-hosts.md)
 
 ```bash
+# 方式一：Skill 安装（推荐）—— Agent 自动获得调用 boss 的能力
 npx skills add can4hou6joeng4/boss-skill
 ```
 
-安装后 Agent 自动获得调用 `boss` 命令的能力，无需手动配置。
-
-> 本 CLI 的 Agent Skill 在独立仓库 [boss-skill](https://github.com/can4hou6joeng4/boss-skill) 中管理（仓库本身即 Skill），与 CLI 发版节奏解耦。
-
-### 方式二：手动配置
-
-在 AI Agent 的规则文件中添加：
-
-```markdown
-当用户要求搜索职位、整理候选岗位等 BOSS 直聘辅助操作时，通过 Bash 调用 `boss` CLI：
-1. 运行 `boss status` 检查登录态
-2. 若未登录，运行 `boss login` 提示用户扫码
-3. 根据用户意图调用 search / detail / show / shortlist
-4. 解析 stdout JSON，`ok` 字段判断成败
-5. 用户提到福利要求时使用 `--welfare` 参数
-6. 投递、打招呼、交换联系方式、招聘者候选人处理和消息回复必须回到平台官网由用户手动完成
-```
-
-### 方式三：Python 直接嵌入（不走 subprocess）
-
-包已随 `py.typed` 标记发布，可直接作为类型化的 Python 库使用：
-
-```python
-from boss_agent_cli import AuthManager, BossClient, AuthRequired
-
-auth = AuthManager(data_dir=Path("~/.boss-agent").expanduser())
-try:
-    with BossClient(auth) as client:
-        result = client.search_jobs("Golang", city="广州")
-except AuthRequired:
-    ...  # 提示用户 boss login
-```
-
-公开 API（详见 `boss_agent_cli.__all__`）：`AuthManager` / `BossClient` / `CacheStore` / `JobItem` / `JobDetail` / `AIService` / `ResumeData` 等核心类型。
-
-### 输出协议
-
-所有命令输出 JSON 到 stdout，统一信封格式：
-
-```json
-{
-  "ok": true,
-  "schema_version": "1.0",
-  "command": "search",
-  "data": [...],
-  "pagination": {"page": 1, "has_more": true, "total": 15},
-  "error": null,
-  "hints": {"next_actions": ["boss detail <security_id>"]}
-}
-```
-
-| 约定 | 说明 |
-|------|------|
-| `stdout` | 仅 JSON 结构化数据 |
-| `stderr` | 日志和进度信息 |
-| `exit 0` | 命令成功 (`ok=true`) |
-| `exit 1` | 命令失败 (`ok=false`) |
-
----
-
-## 📚 命令速查
-
-`boss schema` 当前暴露 35 个顶层命令和 9 个一级招聘者子命令，按工作流分组：
-
-| 阶段 | 命令 |
-|------|------|
-| **认证** | `login` · `logout` · `status` · `doctor` |
-| **职位发现** | `search` · `detail` · `show` · `cities` · `history` |
-| **受限动作** | `greet` · `batch-greet` · `apply` · `exchange` · `mark` 默认低风险模式阻断 |
-| **受限跟进链路** | `chat` · `chatmsg` · `chat-summary` · `pipeline` · `follow-up` · `digest` 默认阻断；本地状态用 `stats` |
-| **本地整理** | `watch` · `preset` · `shortlist` |
-| **简历** | `resume` · `me` |
-| **AI** | `ai config` · `ai analyze-jd` · `ai polish` · `ai optimize` · `ai suggest` · `ai reply` · `ai interview-prep` · `ai chat-coach` |
-| **系统** | `schema` · `platforms` · `export` · `config` · `clean` |
-| **招聘者** | `hr jobs list/offline/online`；候选人数据与消息链路默认阻断 |
-
-完整命令表、参数详解与福利筛选原理见 **[命令参考](docs/commands.md)**；能力真源是 `boss schema`（支持 `--format openai-tools` / `anthropic-tools` 导出工具定义）。
-
----
-
-## 🔧 诊断与排障
+> Agent Skill 在独立仓库 [boss-skill](https://github.com/can4hou6joeng4/boss-skill) 维护（仓库本身即 Skill），与 CLI 发版节奏解耦。
 
 ```bash
-boss doctor
-boss status
-# 可选：执行一次低频只读平台验证
-boss status --live
+# 方式二：subprocess —— 先让 Agent 读能力自描述，再解析 stdout JSON
+boss schema
+```
+
+```python
+# 方式三：Python 直接嵌入（随 py.typed 发布，可作类型化库）
+from boss_agent_cli import AuthManager, BossClient, AuthRequired
+with BossClient(AuthManager(...)) as client:
+    result = client.search_jobs("Golang", city="广州")
+```
+
+```json
+// 方式四：MCP（Claude Desktop / Cursor）
+{ "mcpServers": { "boss-agent": { "command": "uvx", "args": ["--from", "boss-agent-cli[mcp]", "boss-mcp"] } } }
+```
+
+## 📚 命令
+
+`boss schema` 暴露 35 个顶层命令 + 9 个一级招聘者子命令，按工作流分组：
+
+- **认证**：`login` · `logout` · `status` · `doctor`
+- **职位发现**：`search` · `detail` · `show` · `cities` · `history`
+- **本地整理**：`watch` · `preset` · `shortlist` · `stats`
+- **简历 / AI**：`resume` · `me` · `ai analyze-jd` · `ai polish` · `ai optimize` · `ai interview-prep` · `ai chat-coach`
+- **系统**：`schema` · `platforms` · `export` · `config` · `clean`
+- **招聘者**：`hr jobs list/online/offline`
+- **受限动作（默认低风险模式阻断）**：`greet` · `batch-greet` · `apply` · `exchange` · `chat*` · `pipeline` · `digest`
+
+完整命令表、参数与福利筛选原理见 **[命令参考](docs/commands.md)**；能力真源是 `boss schema`（支持 `--format openai-tools` / `anthropic-tools` 导出工具定义）。
+
+## 🩺 诊断与排障
+
+```bash
+boss doctor             # 环境自检
+boss status --live      # 可选：一次低频只读探测
 boss doctor --live-probe
 ```
 
-错误信封统一携带 `code` + `recoverable` + `recovery_action`，Agent 可程序化恢复。
+错误信封统一携带 `code` + `recoverable` + `recovery_action`，可程序化恢复。Browser Bridge 本地诊断覆盖 `bridge_daemon` / `bridge_extension` / `bridge_protocol` / `bridge_workspace` / `bridge_exec` / `bridge_fetch` / `bridge_navigate` 七项，daemon 用 `python -m boss_agent_cli.bridge.daemon --serve` 启动。Bridge 只用于本地诊断、用户主动登录兼容和只读辅助，命中平台风控时停止自动化访问，不切换通道重试。
 
-Browser Bridge 本地诊断：`bridge_daemon` / `bridge_extension` / `bridge_protocol` / `bridge_workspace` / `bridge_exec` / `bridge_fetch` / `bridge_navigate` 七项检查覆盖 daemon、扩展、tab 与基础浏览器命令健康度，daemon 用 `python -m boss_agent_cli.bridge.daemon --serve` 启动。Bridge 只用于本地诊断、用户主动登录兼容和只读辅助，命中平台风控时停止自动化访问，不要切换通道重试。
-
-完整检查项说明、CDP 启动示例、常见故障修复与错误码表见 **[诊断与排障](docs/troubleshooting.md)**。
-
----
+完整检查项、CDP 启动示例与错误码见 **[诊断与排障](docs/troubleshooting.md)**；涉及 Cookie / CDP / patchright / 请求频率 / 接口漂移的问题先读 [平台风险边界](docs/platform-risk.md)。
 
 ## ⚙️ 配置
 
 ```bash
-boss config list            # 查看所有配置
+boss config list                    # 查看所有配置
 boss config set default_city 广州   # 设置默认城市
-boss config reset           # 恢复默认
+boss config reset                   # 恢复默认
 ```
 
-<details>
-<summary>📖 完整配置项</summary>
-
-`~/.boss-agent/config.json`：
-
-```json
-{
-  "default_city": null,
-  "default_salary": null,
-  "request_delay": [1.5, 3.0],
-  "batch_greet_delay": [2.0, 5.0],
-  "batch_greet_max": 10,
-  "log_level": "error",
-  "login_timeout": 120,
-  "cdp_url": null,
-  "export_dir": null
-}
-```
-
-| 配置项 | 说明 |
-|--------|------|
-| `default_city` | 默认城市 |
-| `default_salary` | 默认薪资范围 |
-| `request_delay` | 请求间隔（秒），`[min, max]` |
-| `batch_greet_delay` | 批量打招呼间隔 |
-| `batch_greet_max` | 批量打招呼上限 |
-| `log_level` | 日志级别（error/warning/info/debug） |
-| `login_timeout` | 登录超时（秒） |
-| `cdp_url` | CDP 地址 |
-| `export_dir` | 导出目录 |
-
-</details>
-
----
+配置位于 `~/.boss-agent/config.json`：默认城市 / 薪资、请求间隔、日志级别、登录超时、CDP 地址、导出目录。
 
 ## 🏗️ 技术架构
 
 ```
 CLI (Click)
-    │
-    ├── AuthManager ── 用户主动登录态管理（本地加密）
-    │       └── TokenStore (Fernet + PBKDF2 机器绑定加密)
-    │
-    ├── Platform 抽象层（多平台注册表）
-    │       ├── BossPlatform (求职者) / BossRecruiterPlatform (招聘者)
-    │       ├── ZhilianPlatform (求职者侧登录 + 读写链路已接通，招聘者侧未接入)
-    │       └── QianchengPlatform (51job 占位适配器，统一返回 NOT_SUPPORTED)
-    │
-    ├── Compliance Guardrails ── 默认低风险模式，阻断敏感写操作和候选人个人信息链路
-    │
-    ├── BossClient / BossRecruiterClient ── httpx + 浏览器兼容通道
-    │       ├── RequestThrottle (高斯延迟 + 突发惩罚)
-    │       ├── BrowserSession (CDP / Bridge / patchright，兼容保留)
-    │       └── BOSS 直聘 wapi (求职者 30 端点 + 招聘者 24 端点，共 54 端点)
-    │
-    ├── CacheStore (SQLite WAL)
-    ├── AIService (OpenAI / Anthropic / 兼容 API)
-    └── output.py → JSON 信封 → stdout
+  └─ 合规护栏（默认低风险模式，阻断敏感写操作与候选人个人信息链路）
+       └─ AuthManager ── 用户主动登录态（Fernet + PBKDF2 机器绑定加密）
+       └─ Platform 双注册表 ── BossPlatform / ZhilianPlatform / QianchengPlatform
+       └─ BossClient ── httpx + 节流（高斯延迟）；兼容 CDP / Bridge / patchright 登录与导出
+       └─ CacheStore（SQLite WAL） · AIService（OpenAI / Anthropic）
+            └─ output.py → JSON 信封 → stdout
 ```
 
-| 层级 | 选型 |
-|------|------|
-| 语言 | Python >= 3.10 |
-| CLI | Click |
-| HTTP | httpx |
-| 浏览器 | patchright / CDP / Bridge（兼容登录和导出；不得用于规避平台风控） |
-| Cookie | browser-cookie3（10+ 浏览器） |
-| 加密 | cryptography (Fernet + PBKDF2) |
-| 数据库 | sqlite3 (WAL 模式) |
-| 渲染 | rich |
-| AI | OpenAI / Anthropic Chat Completions API |
-| 测试 | pytest（1400+ 项） |
+`QianchengPlatform (51job 占位适配器，统一返回 NOT_SUPPORTED)`：仅用于平台注册与 schema 可见性，接真实接口前需满足只读研究门槛。
 
----
+**不变量**：stdout 仅 JSON 信封 · stderr 仅日志 · `exit 0/1` · 错误含 `code/recoverable/recovery_action` · `boss schema` 为能力真源。
+**选型**：Python ≥ 3.10 · Click · httpx · patchright / CDP / Bridge（仅登录与导出，**不得规避风控**）· cryptography（Fernet）· sqlite3（WAL）· pytest（1400+ 项）。
 
 ## 🔌 本地存储
 
-所有状态都在 `~/.boss-agent/` 下：加密登录态、搜索缓存、候选池、本地简历与 AI 配置。除显式发起的 API 调用外，数据不离开本机。
+所有状态在 `~/.boss-agent/`：加密登录态、搜索缓存、候选池、本地简历与 AI 配置。除显式发起的 API 调用外，数据不离开本机。
 
----
+## 🤝 贡献 & 致谢
 
-## 🤝 贡献
+欢迎 Issue / PR：`git clone` → `feat/xxx` 分支 → 写测试 → `python scripts/quality_baseline.py`（ruff + 离线 pytest + mypy）→ PR。详见 [CONTRIBUTING.md](CONTRIBUTING.md)，上手路径见 [快速上手](docs/getting-started.md)。
 
-欢迎提交 Issue 和 Pull Request。
-
-```bash
-git clone https://github.com/can4hou6joeng4/boss-agent-cli.git
-cd boss-agent-cli
-uv sync --all-extras
-python scripts/quality_baseline.py  # P0 基线/CI 门禁：ruff + 全量离线 pytest + mypy
-```
-
-详见 [CONTRIBUTING.md](CONTRIBUTING.md)，上手路径见 [docs/getting-started.md](docs/getting-started.md)。
-
----
-
-## 🙏 致谢
-
-- [geekgeekrun](https://github.com/geekgeekrun/geekgeekrun) — 早期浏览器自动化经验参考
-- [boss-cli](https://github.com/jackwener/boss-cli) — CLI 结构化输出 + Agent 友好设计
-- [opencli](https://github.com/jackwener/opencli) — Browser Bridge 架构理念
-
----
+致谢 [geekgeekrun](https://github.com/geekgeekrun/geekgeekrun) · [boss-cli](https://github.com/jackwener/boss-cli) · [opencli](https://github.com/jackwener/opencli)。
 
 ## ⚠️ 免责声明
 
 本项目仅用于学习交流和本地辅助，使用时请遵守相关法律法规、BOSS 直聘平台用户协议和隐私政策。默认低风险模式会阻断自动触达、批量操作、规避风控和候选人个人信息处理链路；任何投递、沟通、联系方式交换、招聘者候选人处理都应回到平台官网由用户手动完成。因不当使用产生的一切后果由使用者自行承担，与本项目作者无关。
 
----
+## 📑 许可证 & 友情链接
 
-## 📑 许可证
-
-[MIT](LICENSE)
-
-## 👭 友情链接
-
-- [LINUX DO - 新的理想型社区](https://linux.do/)
+[MIT](LICENSE) © [can4hou6joeng4](https://github.com/can4hou6joeng4) · 友链 [LINUX DO](https://linux.do/)


### PR DESCRIPTION
参考 [tw93/Mole](https://github.com/tw93/Mole) 的简洁风格重构双语 README，收敛过度冗余的章节。

## 变更
- 首页：精简 badge（9→7，中英对称）、单行导航、保留 showcase hero；移除冗余的内联终端 GIF（改为链接）与重复的 TOC / 演示素材表。
- 正文：把「为什么用 / 核心能力 / 登录链路 / 角色 / 命令大表」收敛为 **bold-led 能力清单 + 单一 Quick Start + 紧凑平台表 + 分组命令速览**，深度内容下沉到 `docs/`。
- 体量：`README.md` 485 → 180 行，`README.en.md` 289 → 168 行。

## 不变量（全部保留）
- 合规边界、`COMPLIANCE_BLOCKED`、官网交接、低风险定位、受限命令（greet/batch-greet…）
- `qiancheng` 占位契约、`--platform zhipin|zhilian|qiancheng`、Browser Bridge 七项诊断、JSON 信封不变量
- 必需文档链接（getting-started / platform-risk / agent-quickstart / capability-matrix / platform-abstraction / roadmap）、MCP 工具数、双语 badge 对称

## 校验
- `uv run pytest tests/test_agent_docs.py tests/test_open_source_docs.py -q` → 36 passed
- `git diff --check` 无空白问题