### PR TITLE
docs: 接入转向 MCP-first，MCP server 补 instructions doctrine 并移除 skill 引导

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -53,7 +53,7 @@ Closes #
 - [ ] 如新增 MCP 工具：已更新 `mcp-server/server.py` 和 `mcp-server/README.md`
 - [ ] 如新增错误码：已添加到 `schema.py` 的 `error_codes`
 - [ ] 已更新 `CHANGELOG.md` 的 `[Unreleased]` 段落
-- [ ] 如变更 Agent 主卖点或安装路径：已同步检查独立仓库 [boss-skill](https://github.com/can4hou6joeng4/boss-skill) 的 `SKILL.md` / PyPI 版本 / GitHub Release 说明
+- [ ] 如变更 Agent 主卖点或安装路径：已同步更新 README / landing 的 MCP 接入说明、PyPI 版本与 GitHub Release 说明
 
 ## 安全与规范 / Safety & Convention
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased]
 
 ### Changed
+- 转向 MCP-first：README / landing / docs 将 MCP（`uvx --from boss-agent-cli[mcp] boss-mcp`，32 个默认低风险 MCP 工具）列为 Agent 首选接入，移除 `npx skills add` 引导；MCP server 新增 server-level `instructions` 承载低风险与错误恢复 doctrine；独立 Agent Skill 仓库 boss-skill 退役。CLI 命令、JSON 信封与错误码不变，仍以 `boss schema` 为真源。
 - 修正 ROADMAP 多平台条目的智联状态漂移：父行此前仍写"智联为 v2.0 优先接入候选（2-3 周）"，与自身已勾选的 Week 2-3 子项（只读 + 写操作已实现）及 CHANGELOG 1.12.0「候选者侧已接通」矛盾；改为如实声明"智联候选者侧已接入"，保留拉勾/猎聘不接入与 51job backlog 结论。
 
 ### Changed

--- a/README.en.md
+++ b/README.en.md
@@ -77,12 +77,10 @@ boss config set platform zhilian          # set as default
 
 Start here: [Agent Quickstart](docs/agent-quickstart.en.md) · [Capability Matrix](docs/capability-matrix.en.md) · [Host Examples](docs/agent-hosts.en.md)
 
-```bash
-# Option 1: Skill install (recommended) — the Agent gains the ability to call boss
-npx skills add can4hou6joeng4/boss-skill
+```json
+// Option 1: MCP (recommended) — Claude Desktop / Cursor and other MCP hosts; exposes 32 low-risk read-only tools
+{ "mcpServers": { "boss-agent": { "command": "uvx", "args": ["--from", "boss-agent-cli[mcp]", "boss-mcp"] } } }
 ```
-
-> The Agent Skill is maintained in the standalone [boss-skill](https://github.com/can4hou6joeng4/boss-skill) repository (the repo itself is the skill), decoupled from the CLI release cadence.
 
 ```bash
 # Option 2: subprocess — let the Agent read the self-description, then parse stdout JSON
@@ -94,11 +92,6 @@ boss schema
 from boss_agent_cli import AuthManager, BossClient, AuthRequired
 with BossClient(AuthManager(...)) as client:
     result = client.search_jobs("Golang", city="北京")
-```
-
-```json
-// Option 4: MCP (Claude Desktop / Cursor)
-{ "mcpServers": { "boss-agent": { "command": "uvx", "args": ["--from", "boss-agent-cli[mcp]", "boss-mcp"] } } }
 ```
 
 ## 📚 Commands

--- a/README.md
+++ b/README.md
@@ -84,12 +84,10 @@ boss config set platform zhilian          # 设为默认
 
 推荐先读：[Agent Quickstart](docs/agent-quickstart.md) · [Capability Matrix](docs/capability-matrix.md) · [Host Examples](docs/agent-hosts.md)
 
-```bash
-# 方式一：Skill 安装（推荐）—— Agent 自动获得调用 boss 的能力
-npx skills add can4hou6joeng4/boss-skill
+```json
+// 方式一：MCP（推荐）—— Claude Desktop / Cursor 等 MCP 宿主，暴露 32 个默认低风险只读工具
+{ "mcpServers": { "boss-agent": { "command": "uvx", "args": ["--from", "boss-agent-cli[mcp]", "boss-mcp"] } } }
 ```
-
-> Agent Skill 在独立仓库 [boss-skill](https://github.com/can4hou6joeng4/boss-skill) 维护（仓库本身即 Skill），与 CLI 发版节奏解耦。
 
 ```bash
 # 方式二：subprocess —— 先让 Agent 读能力自描述，再解析 stdout JSON
@@ -101,11 +99,6 @@ boss schema
 from boss_agent_cli import AuthManager, BossClient, AuthRequired
 with BossClient(AuthManager(...)) as client:
     result = client.search_jobs("Golang", city="广州")
-```
-
-```json
-// 方式四：MCP（Claude Desktop / Cursor）
-{ "mcpServers": { "boss-agent": { "command": "uvx", "args": ["--from", "boss-agent-cli[mcp]", "boss-mcp"] } } }
 ```
 
 ## 📚 命令

--- a/demo/index.html
+++ b/demo/index.html
@@ -291,7 +291,7 @@ footer.foot{margin-top:56px;padding-top:40px;border-top:1px solid var(--border-s
 			<div class="metric"><span class="metric-value">4</span><span class="metric-label" data-zh="Agent 接入方式" data-en="agent integrations">Agent 接入方式</span></div>
 		</div>
 		<div class="hero-cta qs-cta">
-			<a class="btn-ghost" href="https://github.com/can4hou6joeng4/boss-skill" data-zh="作为 Skill 安装" data-en="Install as a Skill">作为 Skill 安装</a>
+			<a class="btn-ghost" href="https://github.com/can4hou6joeng4/boss-agent-cli/blob/master/docs/commands.md" data-zh="命令参考" data-en="Command reference">命令参考</a>
 			<a class="btn-primary" href="https://github.com/can4hou6joeng4/boss-agent-cli#-agent-集成" data-zh="Agent 集成" data-en="Agent integration">Agent 集成</a>
 		</div>
 	</section>
@@ -338,7 +338,7 @@ footer.foot{margin-top:56px;padding-top:40px;border-top:1px solid var(--border-s
 			<div class="links">
 				<a href="https://github.com/can4hou6joeng4/boss-agent-cli">GitHub</a> &middot;
 				<a href="https://pypi.org/project/boss-agent-cli/">PyPI</a> &middot;
-				<a href="https://github.com/can4hou6joeng4/boss-skill">boss-skill</a> &middot;
+				<a href="https://github.com/can4hou6joeng4/boss-agent-cli/blob/master/docs/commands.md">Docs</a> &middot;
 				<a href="https://github.com/can4hou6joeng4/boss-agent-cli/blob/master/ROADMAP.md" data-zh="路线图" data-en="Roadmap">路线图</a>
 			</div>
 			<p class="ethos" data-zh="好的求职，值得交给你信任的 Agent。" data-en="Good job-hunting deserves an agent you trust.">好的求职，值得交给你信任的 Agent。</p>

--- a/demo/llms.txt
+++ b/demo/llms.txt
@@ -16,15 +16,13 @@ Unlike scraping or auto-apply bots, boss-agent-cli is intentionally scoped to lo
 - Four agent integrations: Skill, subprocess, MCP server, Python SDK.
 
 ## Install
-- uv: `uv tool install boss-agent-cli`
-- Agent Skill: `npx skills add can4hou6joeng4/boss-skill`
-- MCP: `uvx --from boss-agent-cli[mcp] boss-mcp`
+- MCP (recommended for agents): `uvx --from boss-agent-cli[mcp] boss-mcp`
+- uv (CLI): `uv tool install boss-agent-cli`
 
 ## License & environment
 MIT. Python >= 3.10. Browser core (patchright) only for user-triggered login and local export.
 
 ## Links
 - GitHub: https://github.com/can4hou6joeng4/boss-agent-cli
-- Agent Skill: https://github.com/can4hou6joeng4/boss-skill
 - PyPI: https://pypi.org/project/boss-agent-cli/
 - Homepage: https://can4hou6joeng4.github.io/boss-agent-cli/

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -4,16 +4,16 @@ Applies to the current `boss-agent-cli` low-risk CLI contract as of May 18, 2026
 
 ## Good fit when
 
-- your team distributes job-hunt capability through Skills
+- your team distributes job-hunt capability to agents via MCP
 - you want Claude Code rules to enforce a stable BOSS Zhipin workflow
 - you want `boss` exposed as a reliable shell capability for Claude Code
 
 ## Minimal integration
 
-Preferred path: install the Skill.
+Preferred path: connect the MCP server (Claude Code supports MCP).
 
 ```bash
-npx skills add can4hou6joeng4/boss-skill
+claude mcp add boss-agent -- uvx --from boss-agent-cli[mcp] boss-mcp
 ```
 
 If you prefer a rules-file workflow, you can add guidance like this:

--- a/docs/marketing/promotion-article.md
+++ b/docs/marketing/promotion-article.md
@@ -70,13 +70,13 @@ boss shortlist add <security_id> <job_id>
 
 Agent 调用 `boss schema` 一次，就能理解命令参数、返回格式和默认低风险阻断边界。`hints.next_actions` 告诉 Agent 下一步该做什么。错误响应包含 `recovery_action`，Agent 可以自动修复。
 
-### Claude Code 一键集成
+### Claude Code / MCP 一键集成
 
 ```bash
-npx skills add can4hou6joeng4/boss-skill
+claude mcp add boss-agent -- uvx --from boss-agent-cli[mcp] boss-mcp
 ```
 
-安装后 Agent 自动获得调用能力。你只需要说：
+接入后 Agent 自动获得调用能力。你只需要说：
 
 > "帮我搜广州的 Golang 职位，要双休五险一金，找到合适的加入候选池"
 

--- a/src/boss_agent_cli/mcp_server.py
+++ b/src/boss_agent_cli/mcp_server.py
@@ -19,7 +19,19 @@ from boss_agent_cli.compliance import (
 )
 from boss_agent_cli.platforms import list_platforms, list_recruiter_platforms
 
-server = Server("boss-agent-cli")
+server = Server(
+	"boss-agent-cli",
+	instructions=(
+		"boss-agent-cli over MCP: a local-assist BOSS Zhipin job-search toolset, low-risk by default — "
+		"read-only first, user-triggered, no risk-control bypass, no bulk outreach, no platform-data scraping. "
+		"Sensitive actions (greet, batch-greet, apply, contact exchange, recruiter candidate data, replies) "
+		"are not exposed and return COMPLIANCE_BLOCKED at the CLI layer; for those the user acts manually on "
+		"the official BOSS Zhipin website. Every tool returns the same JSON envelope "
+		"{ok, data, pagination, error, hints}; when ok is false, read error.code and error.recovery_action and "
+		"act on it (for example AUTH_REQUIRED means the user runs boss login). boss schema is the capability "
+		"source of truth — do not hardcode command tables."
+	),
+)
 DEFAULT_TRANSPORT = "stdio"
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8765


### PR DESCRIPTION
将 Agent 接入定位为 MCP-first，清理所有 `npx skills add` / boss-skill 引导，为退役 boss-skill 仓库做准备。

- README×2：MCP 列为方式一（推荐，32 个默认低风险只读工具），subprocess/Python 顺延，删除 Skill 项与 boss-skill 说明。
- MCP server：`Server(...)` 增加 server-level `instructions`，承载低风险边界 + COMPLIANCE_BLOCKED 交接 + 错误恢复 + 以 boss schema 为真源的 doctrine（MCP 宿主无 skill 也拿得到指引）。
- landing/llms.txt/claude-code.md/promotion-article.md 改 MCP 接入；PR 模板去掉 boss-skill 同步项；CHANGELOG 记录。

校验：ruff/mypy/compileall ✓；test_agent_docs + test_open_source_docs 36 passed；git diff --check 干净；landing 0 处 boss-skill、无报错。合并部署后删除 boss-skill 仓库。