### PR TITLE
feat: 价值主线落地——MCP 契约测试 + ai fit + 福利评分排序 + 候选池标签对比

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@
 
 ### Changed
 - 转向 MCP-first：README / landing / docs 将 MCP（`uvx --from boss-agent-cli[mcp] boss-mcp`，33 个默认低风险 MCP 工具）列为 Agent 首选接入，移除 `npx skills add` 引导；MCP server 新增 server-level `instructions` 承载低风险与错误恢复 doctrine；独立 Agent Skill 仓库 boss-skill 退役。CLI 命令、JSON 信封与错误码不变，仍以 `boss schema` 为真源。
+- `boss search` 结果新增纯本地 `match_score`，福利筛选结果可用 `--sort score` 按匹配分降序输出；评分只使用已抓取字段与福利匹配注解，不改变翻页、详情补抓、节流或并发上限。
 - 修正 ROADMAP 多平台条目的智联状态漂移：父行此前仍写"智联为 v2.0 优先接入候选（2-3 周）"，与自身已勾选的 Week 2-3 子项（只读 + 写操作已实现）及 CHANGELOG 1.12.0「候选者侧已接通」矛盾；改为如实声明"智联候选者侧已接入"，保留拉勾/猎聘不接入与 51job backlog 结论。
 
 ### Changed
-- 修正 `docs/marketing/awesome-submissions.md` 投稿模板内自相矛盾且陈旧的数字（命令数 34/33、招聘者子命令 7、MCP 工具 49/31、测试 1315、release 1.11.0），统一为当前准确值：35 顶层命令 / 9 招聘者子命令 / 33 默认低风险 MCP 工具 / 1463 测试 / release 1.13.1（其中"默认低风险 MCP 工具"取合规过滤后实际导出的 33 个，与 README.en 受测口径一致）。
+- 修正 `docs/marketing/awesome-submissions.md` 投稿模板内自相矛盾且陈旧的数字（命令数 34/33、招聘者子命令 7、MCP 工具 49/31、测试 1315、release 1.11.0），统一为当前准确值：35 顶层命令 / 9 招聘者子命令 / 33 默认低风险 MCP 工具 / 1467 测试 / release 1.13.1（其中"默认低风险 MCP 工具"取合规过滤后实际导出的 33 个，与 README.en 受测口径一致）。
 
 ### Changed
 - 修正贡献者文档中指向已迁出路径 `skills/boss-agent-cli/SKILL.md` 的陈旧引用（`CONTRIBUTING.md` / `CONTRIBUTING.en.md` 添加新命令清单第 5 步改为 `docs/commands.md`、PR 模板指向独立仓库 boss-skill），消除迁出 SKILL 后遗留的误导。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased]
 
 ### Added
+- `boss shortlist` 新增本地标签、备注与离线对比能力：`shortlist add --tags/--note` 可在加入候选池时记录本地整理信息，`shortlist annotate` 支持增删标签和更新备注，`shortlist compare [--tag]` 仅从 SQLite 候选池读取并按标签本地过滤；MCP 同步新增 `boss_shortlist_annotate` / `boss_shortlist_compare`，默认低风险工具数 33 → 35。
 - 新增 `boss ai fit --resume <name> [--limit N]`：基于本地简历与候选池已缓存职位详情生成逐岗匹配度、能力缺口、关键词命中和建议；缺少详情的岗位只报告本地缺口并提示先执行 `boss detail`，不发起任何新增平台请求。
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,15 @@
 
 ## [Unreleased]
 
+### Added
+- 新增 `boss ai fit --resume <name> [--limit N]`：基于本地简历与候选池已缓存职位详情生成逐岗匹配度、能力缺口、关键词命中和建议；缺少详情的岗位只报告本地缺口并提示先执行 `boss detail`，不发起任何新增平台请求。
+
 ### Changed
-- 转向 MCP-first：README / landing / docs 将 MCP（`uvx --from boss-agent-cli[mcp] boss-mcp`，32 个默认低风险 MCP 工具）列为 Agent 首选接入，移除 `npx skills add` 引导；MCP server 新增 server-level `instructions` 承载低风险与错误恢复 doctrine；独立 Agent Skill 仓库 boss-skill 退役。CLI 命令、JSON 信封与错误码不变，仍以 `boss schema` 为真源。
+- 转向 MCP-first：README / landing / docs 将 MCP（`uvx --from boss-agent-cli[mcp] boss-mcp`，33 个默认低风险 MCP 工具）列为 Agent 首选接入，移除 `npx skills add` 引导；MCP server 新增 server-level `instructions` 承载低风险与错误恢复 doctrine；独立 Agent Skill 仓库 boss-skill 退役。CLI 命令、JSON 信封与错误码不变，仍以 `boss schema` 为真源。
 - 修正 ROADMAP 多平台条目的智联状态漂移：父行此前仍写"智联为 v2.0 优先接入候选（2-3 周）"，与自身已勾选的 Week 2-3 子项（只读 + 写操作已实现）及 CHANGELOG 1.12.0「候选者侧已接通」矛盾；改为如实声明"智联候选者侧已接入"，保留拉勾/猎聘不接入与 51job backlog 结论。
 
 ### Changed
-- 修正 `docs/marketing/awesome-submissions.md` 投稿模板内自相矛盾且陈旧的数字（命令数 34/33、招聘者子命令 7、MCP 工具 49/31、测试 1315、release 1.11.0），统一为当前准确值：35 顶层命令 / 9 招聘者子命令 / 32 默认低风险 MCP 工具 / 1455 测试 / release 1.13.1（其中"默认低风险 MCP 工具"取合规过滤后实际导出的 32 个，与 README.en 受测口径一致）。
+- 修正 `docs/marketing/awesome-submissions.md` 投稿模板内自相矛盾且陈旧的数字（命令数 34/33、招聘者子命令 7、MCP 工具 49/31、测试 1315、release 1.11.0），统一为当前准确值：35 顶层命令 / 9 招聘者子命令 / 33 默认低风险 MCP 工具 / 1463 测试 / release 1.13.1（其中"默认低风险 MCP 工具"取合规过滤后实际导出的 33 个，与 README.en 受测口径一致）。
 
 ### Changed
 - 修正贡献者文档中指向已迁出路径 `skills/boss-agent-cli/SKILL.md` 的陈旧引用（`CONTRIBUTING.md` / `CONTRIBUTING.en.md` 添加新命令清单第 5 步改为 `docs/commands.md`、PR 模板指向独立仓库 boss-skill），消除迁出 SKILL 后遗留的误导。

--- a/README.en.md
+++ b/README.en.md
@@ -29,7 +29,7 @@ Low-Risk Assistance Mode is on by default: local assistance · read-only first �
 ## ✨ Features
 
 - **Job discovery**: keyword search + layered filters, with cached `show` navigation — `search` `show` `detail`
-- **Welfare filtering (the differentiator)**: `--welfare "双休,五险一金"` pages, fetches details, and runs **real AND matching** — not keyword hits — `search --welfare`
+- **Welfare filtering (the differentiator)**: `--welfare "双休,五险一金"` pages, fetches details, runs **real AND matching**, and can `--sort score` by local match score — `search --welfare`
 - **Local shortlist & stats**: inspect details, organize and review candidate jobs locally, see funnel stats; apply and messaging stay on the official website — `shortlist` `stats` `watch` `preset`
 - **AI job-hunting assist**: JD analysis, resume polish, role-targeted optimization, shortlist fit reports, interview prep, chat coaching — `ai analyze-jd` `ai polish` `ai optimize` `ai fit` `ai interview-prep` `ai chat-coach`
 - **Schema-first + JSON envelope**: stdout is a JSON-only `{ok, data, pagination, error, hints}` envelope, `boss schema` is the capability source of truth, and an **MCP server with 33 tools** exposes the low-risk surface

--- a/README.en.md
+++ b/README.en.md
@@ -31,8 +31,8 @@ Low-Risk Assistance Mode is on by default: local assistance · read-only first �
 - **Job discovery**: keyword search + layered filters, with cached `show` navigation — `search` `show` `detail`
 - **Welfare filtering (the differentiator)**: `--welfare "双休,五险一金"` pages, fetches details, and runs **real AND matching** — not keyword hits — `search --welfare`
 - **Local shortlist & stats**: inspect details, organize and review candidate jobs locally, see funnel stats; apply and messaging stay on the official website — `shortlist` `stats` `watch` `preset`
-- **AI job-hunting assist**: JD analysis, resume polish, role-targeted optimization, interview prep, chat coaching — `ai analyze-jd` `ai polish` `ai optimize` `ai interview-prep` `ai chat-coach`
-- **Schema-first + JSON envelope**: stdout is a JSON-only `{ok, data, pagination, error, hints}` envelope, `boss schema` is the capability source of truth, and an **MCP server with 32 tools** exposes the low-risk surface
+- **AI job-hunting assist**: JD analysis, resume polish, role-targeted optimization, shortlist fit reports, interview prep, chat coaching — `ai analyze-jd` `ai polish` `ai optimize` `ai fit` `ai interview-prep` `ai chat-coach`
+- **Schema-first + JSON envelope**: stdout is a JSON-only `{ok, data, pagination, error, hints}` envelope, `boss schema` is the capability source of truth, and an **MCP server with 33 tools** exposes the low-risk surface
 - **Recruiter loop**: list and bring postings online / offline (`hr jobs list/online/offline`); candidate personal-data workflows are blocked by default
 - **Cross-platform layer**: live `Platform` / `RecruiterPlatform` registries, `--platform zhipin|zhilian|qiancheng`
 
@@ -101,7 +101,7 @@ with BossClient(AuthManager(...)) as client:
 - **Auth**: `login` · `logout` · `status` · `doctor`
 - **Discover**: `search` · `detail` · `show` · `cities` · `history`
 - **Organize**: `watch` · `preset` · `shortlist` · `stats`
-- **Resume / AI**: `resume` · `me` · `ai analyze-jd` · `ai polish` · `ai optimize` · `ai interview-prep` · `ai chat-coach`
+- **Resume / AI**: `resume` · `me` · `ai analyze-jd` · `ai polish` · `ai optimize` · `ai fit` · `ai interview-prep` · `ai chat-coach`
 - **Utility**: `schema` · `platforms` · `export` · `config` · `clean`
 - **Recruiter**: `hr jobs list/online/offline`
 - **Restricted (blocked by default in low-risk mode)**: `greet` · `batch-greet` · `apply` · `exchange` · `chat*` · `pipeline` · `digest`

--- a/README.en.md
+++ b/README.en.md
@@ -30,9 +30,9 @@ Low-Risk Assistance Mode is on by default: local assistance · read-only first �
 
 - **Job discovery**: keyword search + layered filters, with cached `show` navigation — `search` `show` `detail`
 - **Welfare filtering (the differentiator)**: `--welfare "双休,五险一金"` pages, fetches details, runs **real AND matching**, and can `--sort score` by local match score — `search --welfare`
-- **Local shortlist & stats**: inspect details, organize and review candidate jobs locally, see funnel stats; apply and messaging stay on the official website — `shortlist` `stats` `watch` `preset`
+- **Local shortlist & stats**: inspect details, organize candidates with local tags and notes, compare jobs offline, and see funnel stats; apply and messaging stay on the official website — `shortlist` `stats` `watch` `preset`
 - **AI job-hunting assist**: JD analysis, resume polish, role-targeted optimization, shortlist fit reports, interview prep, chat coaching — `ai analyze-jd` `ai polish` `ai optimize` `ai fit` `ai interview-prep` `ai chat-coach`
-- **Schema-first + JSON envelope**: stdout is a JSON-only `{ok, data, pagination, error, hints}` envelope, `boss schema` is the capability source of truth, and an **MCP server with 33 tools** exposes the low-risk surface
+- **Schema-first + JSON envelope**: stdout is a JSON-only `{ok, data, pagination, error, hints}` envelope, `boss schema` is the capability source of truth, and an **MCP server with 35 tools** exposes the low-risk surface
 - **Recruiter loop**: list and bring postings online / offline (`hr jobs list/online/offline`); candidate personal-data workflows are blocked by default
 - **Cross-platform layer**: live `Platform` / `RecruiterPlatform` registries, `--platform zhipin|zhilian|qiancheng`
 
@@ -49,7 +49,8 @@ boss login                                                    # user-triggered l
 boss status                                                   # verify login
 boss search "Golang" --city 广州 --welfare "双休,五险一金"     # search + welfare filtering
 boss detail <security_id>                                     # view detail
-boss shortlist add <security_id> <job_id>                     # add to local shortlist
+boss shortlist add <security_id> <job_id> --tags backend,remote  # add to local shortlist with local tags
+boss shortlist compare --tag remote                           # compare shortlisted jobs offline
 boss stats                                                    # local stats
 
 # Recruiter mode (candidate-data workflows blocked by default)
@@ -78,7 +79,7 @@ boss config set platform zhilian          # set as default
 Start here: [Agent Quickstart](docs/agent-quickstart.en.md) · [Capability Matrix](docs/capability-matrix.en.md) · [Host Examples](docs/agent-hosts.en.md)
 
 ```json
-// Option 1: MCP (recommended) — Claude Desktop / Cursor and other MCP hosts; exposes 32 low-risk read-only tools
+// Option 1: MCP (recommended) — Claude Desktop / Cursor and other MCP hosts; exposes 35 low-risk read-only tools
 { "mcpServers": { "boss-agent": { "command": "uvx", "args": ["--from", "boss-agent-cli[mcp]", "boss-mcp"] } } }
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 - **职位发现**：关键词搜索 + 8 维筛选，按编号回看缓存结果 —— `search` `show` `detail`
 - **福利筛选（核心差异化）**：`--welfare "双休,五险一金"` 自动翻页补抓、按 AND 逻辑做**真实匹配**，并可 `--sort score` 按本地匹配分排序 —— `search --welfare`
-- **本地候选池与统计**：查看详情后本地保存 / 复盘候选岗位、查看漏斗统计；投递与沟通回到官网手动完成 —— `shortlist` `stats` `watch` `preset`
+- **本地候选池与统计**：查看详情后本地保存 / 用标签和备注复盘候选岗位、离线对比、查看漏斗统计；投递与沟通回到官网手动完成 —— `shortlist` `stats` `watch` `preset`
 - **AI 求职增强**：JD 分析、简历润色、定向优化、候选池匹配、模拟面试、沟通指导 —— `ai analyze-jd` `ai polish` `ai optimize` `ai fit` `ai interview-prep` `ai chat-coach`
 - **Schema 驱动 + JSON 信封**：stdout 只输出 `{ok, data, pagination, error, hints}` 信封，`boss schema` 是能力真源，适合 CLI 编排 / Shell Agent / MCP / Python SDK
 - **招聘者最小闭环**：职位列表与上下架（`hr jobs list/online/offline`）；候选人个人数据链路默认阻断
@@ -56,7 +56,8 @@ boss login                                                    # 用户主动登�
 boss status                                                   # 验证登录态
 boss search "Golang" --city 广州 --welfare "双休,五险一金"     # 搜索 + 福利筛选
 boss detail <security_id>                                     # 查看详情
-boss shortlist add <security_id> <job_id>                     # 加入本地候选池
+boss shortlist add <security_id> <job_id> --tags 后端,远程    # 加入本地候选池并打本地标签
+boss shortlist compare --tag 远程                             # 离线对比候选岗位
 boss stats                                                    # 本地统计
 
 # 招聘者模式（候选人数据链路默认阻断）
@@ -85,7 +86,7 @@ boss config set platform zhilian          # 设为默认
 推荐先读：[Agent Quickstart](docs/agent-quickstart.md) · [Capability Matrix](docs/capability-matrix.md) · [Host Examples](docs/agent-hosts.md)
 
 ```json
-// 方式一：MCP（推荐）—— Claude Desktop / Cursor 等 MCP 宿主，暴露 32 个默认低风险只读工具
+// 方式一：MCP（推荐）—— Claude Desktop / Cursor 等 MCP 宿主，暴露 35 个默认低风险只读工具
 { "mcpServers": { "boss-agent": { "command": "uvx", "args": ["--from", "boss-agent-cli[mcp]", "boss-mcp"] } } }
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 - **职位发现**：关键词搜索 + 8 维筛选，按编号回看缓存结果 —— `search` `show` `detail`
 - **福利筛选（核心差异化）**：`--welfare "双休,五险一金"` 自动翻页补抓、按 AND 逻辑做**真实匹配**，而非关键词命中 —— `search --welfare`
 - **本地候选池与统计**：查看详情后本地保存 / 复盘候选岗位、查看漏斗统计；投递与沟通回到官网手动完成 —— `shortlist` `stats` `watch` `preset`
-- **AI 求职增强**：JD 分析、简历润色、定向优化、模拟面试、沟通指导 —— `ai analyze-jd` `ai polish` `ai optimize` `ai interview-prep` `ai chat-coach`
+- **AI 求职增强**：JD 分析、简历润色、定向优化、候选池匹配、模拟面试、沟通指导 —— `ai analyze-jd` `ai polish` `ai optimize` `ai fit` `ai interview-prep` `ai chat-coach`
 - **Schema 驱动 + JSON 信封**：stdout 只输出 `{ok, data, pagination, error, hints}` 信封，`boss schema` 是能力真源，适合 CLI 编排 / Shell Agent / MCP / Python SDK
 - **招聘者最小闭环**：职位列表与上下架（`hr jobs list/online/offline`）；候选人个人数据链路默认阻断
 - **多平台抽象**：`Platform` / `RecruiterPlatform` 双注册表，`--platform zhipin|zhilian|qiancheng`
@@ -108,7 +108,7 @@ with BossClient(AuthManager(...)) as client:
 - **认证**：`login` · `logout` · `status` · `doctor`
 - **职位发现**：`search` · `detail` · `show` · `cities` · `history`
 - **本地整理**：`watch` · `preset` · `shortlist` · `stats`
-- **简历 / AI**：`resume` · `me` · `ai analyze-jd` · `ai polish` · `ai optimize` · `ai interview-prep` · `ai chat-coach`
+- **简历 / AI**：`resume` · `me` · `ai analyze-jd` · `ai polish` · `ai optimize` · `ai fit` · `ai interview-prep` · `ai chat-coach`
 - **系统**：`schema` · `platforms` · `export` · `config` · `clean`
 - **招聘者**：`hr jobs list/online/offline`
 - **受限动作（默认低风险模式阻断）**：`greet` · `batch-greet` · `apply` · `exchange` · `chat*` · `pipeline` · `digest`

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 ## ✨ 核心能力
 
 - **职位发现**：关键词搜索 + 8 维筛选，按编号回看缓存结果 —— `search` `show` `detail`
-- **福利筛选（核心差异化）**：`--welfare "双休,五险一金"` 自动翻页补抓、按 AND 逻辑做**真实匹配**，而非关键词命中 —— `search --welfare`
+- **福利筛选（核心差异化）**：`--welfare "双休,五险一金"` 自动翻页补抓、按 AND 逻辑做**真实匹配**，并可 `--sort score` 按本地匹配分排序 —— `search --welfare`
 - **本地候选池与统计**：查看详情后本地保存 / 复盘候选岗位、查看漏斗统计；投递与沟通回到官网手动完成 —— `shortlist` `stats` `watch` `preset`
 - **AI 求职增强**：JD 分析、简历润色、定向优化、候选池匹配、模拟面试、沟通指导 —— `ai analyze-jd` `ai polish` `ai optimize` `ai fit` `ai interview-prep` `ai chat-coach`
 - **Schema 驱动 + JSON 信封**：stdout 只输出 `{ok, data, pagination, error, hints}` 信封，`boss schema` 是能力真源，适合 CLI 编排 / Shell Agent / MCP / Python SDK

--- a/docs/commands.en.md
+++ b/docs/commands.en.md
@@ -31,7 +31,7 @@ subcommands under `hr`, grouped below by workflow stage.
 
 | Command | Description |
 |---------|-------------|
-| `boss search <query>` | Search jobs (`--url` web filters, comma multi-select, `--welfare` filtering, `--preset`) |
+| `boss search <query>` | Search jobs (`--url` web filters, comma multi-select, `--welfare` filtering, `--sort score` local sorting, `--preset`) |
 | `boss recommend` | Restricted: blocked by default in low-risk mode (avoids auto-reading recommendation streams) |
 | `boss detail <security_id>` | Job detail (`--job-id` uses the fast path) |
 | `boss show <#>` | Re-view a numbered result from the last search |
@@ -104,7 +104,8 @@ boss search "golang" \
   --scale 100-499人 \
   --industry 互联网 \
   --stage 已上市 \
-  --welfare "双休,五险一金"
+  --welfare "双休,五险一金" \
+  --sort score
 ```
 
 Search and export can reuse filters selected manually on the BOSS web UI:
@@ -119,4 +120,4 @@ boss export --url 'https://www.zhipin.com/web/geek/jobs?query=Golang&city=101280
 1. Check job welfare tags (`welfareList`) first
 2. Fall back to full-text search of the job description when tags don't match
 3. Auto-paginate (up to 5 pages)
-4. Every result carries `welfare_match` explaining the match source
+4. Every result carries `welfare_match` explaining the match source and `match_score` for `--sort score` local sorting

--- a/docs/commands.en.md
+++ b/docs/commands.en.md
@@ -63,7 +63,7 @@ subcommands under `hr`, grouped below by workflow stage.
 |---------|-------------|
 | `boss pipeline` / `boss follow-up` / `boss digest` | Restricted: blocked by default (depend on session/interview data) |
 | `boss watch add/list/remove/run` | add/list/remove manage local presets; run is blocked by default (avoids automated incremental pulls) |
-| `boss shortlist add/list/remove` | Local shortlist |
+| `boss shortlist add/list/annotate/compare/remove` | Local shortlist with tags, notes, and offline compare |
 | `boss preset add/list/remove` | Search presets |
 
 ## Recruiter mode

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -61,7 +61,7 @@ boss <命令> --help                      # 查看单个命令选项
 | `boss follow-up` | 受限：默认低风险模式阻断，依赖会话/面试数据 |
 | `boss digest` | 受限：默认低风险模式阻断，依赖会话/面试数据 |
 | `boss watch add/list/remove/run` | add/list/remove 为本地预设；run 默认阻断，避免自动增量拉取平台数据 |
-| `boss shortlist add/list/remove` | 候选池 |
+| `boss shortlist add/list/annotate/compare/remove` | 本地候选池：支持标签、备注和离线对比 |
 | `boss preset add/list/remove` | 搜索预设 |
 
 ## 招聘者模式

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -27,7 +27,7 @@ boss <命令> --help                      # 查看单个命令选项
 
 | 命令 | 说明 |
 |------|------|
-| `boss search <query>` | 搜索职位（支持 `--url` 网页筛选、逗号多选、`--welfare` 筛选、`--preset` 预设） |
+| `boss search <query>` | 搜索职位（支持 `--url` 网页筛选、逗号多选、`--welfare` 筛选、`--sort score` 本地排序、`--preset` 预设） |
 | `boss recommend` | 受限：默认低风险模式阻断，避免自动读取推荐流 |
 | `boss detail <security_id>` | 职位详情（`--job-id` 走快速通道） |
 | `boss show <#>` | 按编号查看上次搜索结果 |
@@ -115,7 +115,8 @@ boss search "golang" \
   --scale 100-499人 \       # 公司规模
   --industry 互联网 \       # 行业
   --stage 已上市 \          # 融资阶段
-  --welfare "双休,五险一金"  # 福利筛选（AND 逻辑）
+  --welfare "双休,五险一金" \ # 福利筛选（AND 逻辑）
+  --sort score              # 按本地 match_score 降序
 ```
 
 也可以先在 BOSS 直聘网页上手动选好筛选条件，再复制搜索页 URL 给 CLI：
@@ -130,6 +131,6 @@ boss export --url 'https://www.zhipin.com/web/geek/jobs?query=Golang&city=101280
 1. 先检查职位福利标签（`welfareList`）
 2. 标签不匹配时自动获取职位描述全文搜索
 3. 自动翻页（最多 5 页）
-4. 每个结果带 `welfare_match` 说明匹配来源
+4. 每个结果带 `welfare_match` 说明匹配来源，并带 `match_score` 供 `--sort score` 本地排序
 
 支持关键词：`双休` `五险一金` `年终奖` `餐补` `住房补贴` `定期体检` `股票期权` `加班补助` `带薪年假`

--- a/docs/marketing/awesome-submissions.md
+++ b/docs/marketing/awesome-submissions.md
@@ -4,9 +4,9 @@
 
 ## 项目一句话介绍
 
-**中文**：专为 AI Agent 设计的 BOSS 直聘求职 CLI，35 个顶层命令 + 9 个招聘者子命令 + 33 个默认低风险 MCP 工具，全部输出 JSON，支持 Claude Desktop/Cursor/Windsurf 无缝接入，覆盖求职者与招聘者双端工作流。
+**中文**：专为 AI Agent 设计的 BOSS 直聘求职 CLI，35 个顶层命令 + 9 个招聘者子命令 + 35 个默认低风险 MCP 工具，全部输出 JSON，支持 Claude Desktop/Cursor/Windsurf 无缝接入，覆盖求职者与招聘者双端工作流。
 
-**English**: AI-agent-first CLI for BOSS Zhipin. 35 top-level commands + 9 recruiter subcommands + 33 default low-risk MCP tools, JSON envelope output, typed Python SDK (PEP 561), and out-of-the-box integration for Claude Desktop / Cursor / Windsurf.
+**English**: AI-agent-first CLI for BOSS Zhipin. 35 top-level commands + 9 recruiter subcommands + 35 default low-risk MCP tools, JSON envelope output, typed Python SDK (PEP 561), and out-of-the-box integration for Claude Desktop / Cursor / Windsurf.
 
 ## 推荐投稿目标
 
@@ -15,7 +15,7 @@
 分类：Productivity / Job Search
 
 ```markdown
-- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - BOSS Zhipin (China's largest recruitment platform) integration for AI agents, exposing 33 default low-risk MCP tools covering search, detail, local shortlist, resume management, and AI-powered interview prep / chat coaching.
+- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - BOSS Zhipin (China's largest recruitment platform) integration for AI agents, exposing 35 default low-risk MCP tools covering search, detail, local shortlist, resume management, and AI-powered interview prep / chat coaching.
 ```
 
 ### 2. [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code)
@@ -31,7 +31,7 @@
 分类：Specialized Agents
 
 ```markdown
-- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) ![](https://img.shields.io/github/stars/can4hou6joeng4/boss-agent-cli) - Job-hunt CLI purpose-built for AI agents. BOSS Zhipin integration with 35 top-level commands, recruiter workflow subcommands, 33 default low-risk MCP tools, JSON envelope output, and local-first encrypted storage.
+- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) ![](https://img.shields.io/github/stars/can4hou6joeng4/boss-agent-cli) - Job-hunt CLI purpose-built for AI agents. BOSS Zhipin integration with 35 top-level commands, recruiter workflow subcommands, 35 default low-risk MCP tools, JSON envelope output, and local-first encrypted storage.
 ```
 
 ### 4. [awesome-python-cli](https://github.com/shinokada/awesome-python-cli)
@@ -45,7 +45,7 @@
 分类：Agents & Automation
 
 ```markdown
-- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - Let your AI agent handle the job hunt. 35 top-level CLI commands + 9 recruiter subcommands + 33 default low-risk MCP tools covering search, detail, local shortlist, interview prep, and AI resume coaching on BOSS Zhipin.
+- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - Let your AI agent handle the job hunt. 35 top-level CLI commands + 9 recruiter subcommands + 35 default low-risk MCP tools covering search, detail, local shortlist, interview prep, and AI resume coaching on BOSS Zhipin.
 ```
 
 ## 投稿前 Checklist（master 当前状态）
@@ -81,12 +81,12 @@
 
 ## 一句话钩子（A/B 测试素材）
 
-1. "35 个顶层命令 + 9 个招聘者子命令 + 33 个默认低风险 MCP 工具，让 AI Agent 帮你打招呼、投简历、聊 HR、准备面试"
+1. "35 个顶层命令 + 9 个招聘者子命令 + 35 个默认低风险 MCP 工具，让 AI Agent 帮你打招呼、投简历、聊 HR、准备面试"
 2. "第一个 MCP 就绪、类型安全的中国招聘平台 CLI，为 Claude Desktop / Cursor / Windsurf 设计"
 3. "`boss ai interview-prep` — 把 JD 扔进 AI，秒出 10 道模拟面试题"
 4. "你只负责描述期望，AI Agent 负责搜、聊、投、跟进"
 5. "MIT License，本地加密存储，数据不出机"
-6. "1467 测试、33 个默认低风险 MCP 工具、下游 Python 嵌入零学习成本"
+6. "1467 测试、35 个默认低风险 MCP 工具、下游 Python 嵌入零学习成本"
 
 ## 实际投稿记录 & 渠道约束（2026-04-28 更新）
 

--- a/docs/marketing/awesome-submissions.md
+++ b/docs/marketing/awesome-submissions.md
@@ -4,9 +4,9 @@
 
 ## 项目一句话介绍
 
-**中文**：专为 AI Agent 设计的 BOSS 直聘求职 CLI，35 个顶层命令 + 9 个招聘者子命令 + 32 个默认低风险 MCP 工具，全部输出 JSON，支持 Claude Desktop/Cursor/Windsurf 无缝接入，覆盖求职者与招聘者双端工作流。
+**中文**：专为 AI Agent 设计的 BOSS 直聘求职 CLI，35 个顶层命令 + 9 个招聘者子命令 + 33 个默认低风险 MCP 工具，全部输出 JSON，支持 Claude Desktop/Cursor/Windsurf 无缝接入，覆盖求职者与招聘者双端工作流。
 
-**English**: AI-agent-first CLI for BOSS Zhipin. 35 top-level commands + 9 recruiter subcommands + 32 default low-risk MCP tools, JSON envelope output, typed Python SDK (PEP 561), and out-of-the-box integration for Claude Desktop / Cursor / Windsurf.
+**English**: AI-agent-first CLI for BOSS Zhipin. 35 top-level commands + 9 recruiter subcommands + 33 default low-risk MCP tools, JSON envelope output, typed Python SDK (PEP 561), and out-of-the-box integration for Claude Desktop / Cursor / Windsurf.
 
 ## 推荐投稿目标
 
@@ -15,7 +15,7 @@
 分类：Productivity / Job Search
 
 ```markdown
-- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - BOSS Zhipin (China's largest recruitment platform) integration for AI agents, exposing 32 default low-risk MCP tools covering search, detail, local shortlist, resume management, and AI-powered interview prep / chat coaching.
+- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - BOSS Zhipin (China's largest recruitment platform) integration for AI agents, exposing 33 default low-risk MCP tools covering search, detail, local shortlist, resume management, and AI-powered interview prep / chat coaching.
 ```
 
 ### 2. [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code)
@@ -31,7 +31,7 @@
 分类：Specialized Agents
 
 ```markdown
-- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) ![](https://img.shields.io/github/stars/can4hou6joeng4/boss-agent-cli) - Job-hunt CLI purpose-built for AI agents. BOSS Zhipin integration with 35 top-level commands, recruiter workflow subcommands, 32 default low-risk MCP tools, JSON envelope output, and local-first encrypted storage.
+- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) ![](https://img.shields.io/github/stars/can4hou6joeng4/boss-agent-cli) - Job-hunt CLI purpose-built for AI agents. BOSS Zhipin integration with 35 top-level commands, recruiter workflow subcommands, 33 default low-risk MCP tools, JSON envelope output, and local-first encrypted storage.
 ```
 
 ### 4. [awesome-python-cli](https://github.com/shinokada/awesome-python-cli)
@@ -45,14 +45,14 @@
 分类：Agents & Automation
 
 ```markdown
-- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - Let your AI agent handle the job hunt. 35 top-level CLI commands + 9 recruiter subcommands + 32 default low-risk MCP tools covering search, detail, local shortlist, interview prep, and AI resume coaching on BOSS Zhipin.
+- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - Let your AI agent handle the job hunt. 35 top-level CLI commands + 9 recruiter subcommands + 33 default low-risk MCP tools covering search, detail, local shortlist, interview prep, and AI resume coaching on BOSS Zhipin.
 ```
 
 ## 投稿前 Checklist（master 当前状态）
 
 - [x] README 双语（中文 + 英文）
 - [x] MIT License
-- [x] CI 全绿 + **1455 测试**
+- [x] CI 全绿 + **1463 测试**
 - [x] 发布到 PyPI（`pip install boss-agent-cli`，当前 latest release 1.13.1）
 - [x] GitHub Release 规范（latest release 1.13.1 已发）
 - [x] CHANGELOG 完整
@@ -81,12 +81,12 @@
 
 ## 一句话钩子（A/B 测试素材）
 
-1. "35 个顶层命令 + 9 个招聘者子命令 + 32 个默认低风险 MCP 工具，让 AI Agent 帮你打招呼、投简历、聊 HR、准备面试"
+1. "35 个顶层命令 + 9 个招聘者子命令 + 33 个默认低风险 MCP 工具，让 AI Agent 帮你打招呼、投简历、聊 HR、准备面试"
 2. "第一个 MCP 就绪、类型安全的中国招聘平台 CLI，为 Claude Desktop / Cursor / Windsurf 设计"
 3. "`boss ai interview-prep` — 把 JD 扔进 AI，秒出 10 道模拟面试题"
 4. "你只负责描述期望，AI Agent 负责搜、聊、投、跟进"
 5. "MIT License，本地加密存储，数据不出机"
-6. "1455 测试、32 个默认低风险 MCP 工具、下游 Python 嵌入零学习成本"
+6. "1463 测试、33 个默认低风险 MCP 工具、下游 Python 嵌入零学习成本"
 
 ## 实际投稿记录 & 渠道约束（2026-04-28 更新）
 

--- a/docs/marketing/awesome-submissions.md
+++ b/docs/marketing/awesome-submissions.md
@@ -52,7 +52,7 @@
 
 - [x] README 双语（中文 + 英文）
 - [x] MIT License
-- [x] CI 全绿 + **1463 测试**
+- [x] CI 全绿 + **1467 测试**
 - [x] 发布到 PyPI（`pip install boss-agent-cli`，当前 latest release 1.13.1）
 - [x] GitHub Release 规范（latest release 1.13.1 已发）
 - [x] CHANGELOG 完整
@@ -86,7 +86,7 @@
 3. "`boss ai interview-prep` — 把 JD 扔进 AI，秒出 10 道模拟面试题"
 4. "你只负责描述期望，AI Agent 负责搜、聊、投、跟进"
 5. "MIT License，本地加密存储，数据不出机"
-6. "1463 测试、33 个默认低风险 MCP 工具、下游 Python 嵌入零学习成本"
+6. "1467 测试、33 个默认低风险 MCP 工具、下游 Python 嵌入零学习成本"
 
 ## 实际投稿记录 & 渠道约束（2026-04-28 更新）
 

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -11,6 +11,7 @@ if str(SRC) not in sys.path:
 
 _impl = importlib.import_module("boss_agent_cli.mcp_server")
 
+SERVER_INSTRUCTIONS = _impl.SERVER_INSTRUCTIONS
 TOOLS = _impl.TOOLS
 _build_args = _impl._build_args
 _compliance_command_for_tool = _impl._compliance_command_for_tool

--- a/src/boss_agent_cli/cache/store.py
+++ b/src/boss_agent_cli/cache/store.py
@@ -64,6 +64,8 @@ class CacheStore:
 				city TEXT NOT NULL,
 				salary TEXT NOT NULL,
 				source TEXT NOT NULL,
+				tags TEXT DEFAULT '',
+				note TEXT DEFAULT '',
 				created_at REAL NOT NULL,
 				PRIMARY KEY (security_id, job_id)
 			);
@@ -96,6 +98,49 @@ class CacheStore:
 				cached_at TEXT
 			);
 		""")
+		self._migrate_shortlist_records()
+
+	def _migrate_shortlist_records(self) -> None:
+		columns = {
+			row[1]
+			for row in self._conn.execute("PRAGMA table_info(shortlist_records)").fetchall()
+		}
+		if "tags" not in columns:
+			self._conn.execute("ALTER TABLE shortlist_records ADD COLUMN tags TEXT DEFAULT ''")
+		if "note" not in columns:
+			self._conn.execute("ALTER TABLE shortlist_records ADD COLUMN note TEXT DEFAULT ''")
+		self._conn.commit()
+
+	@staticmethod
+	def _normalize_shortlist_tags(tags: list[str]) -> list[str]:
+		normalized: list[str] = []
+		seen: set[str] = set()
+		for tag in tags:
+			clean = str(tag).strip()
+			if not clean or clean in seen:
+				continue
+			normalized.append(clean)
+			seen.add(clean)
+		return normalized
+
+	@classmethod
+	def _serialize_shortlist_tags(cls, tags: list[str]) -> str:
+		normalized = cls._normalize_shortlist_tags(tags)
+		if not normalized:
+			return ""
+		return json.dumps(normalized, ensure_ascii=False, sort_keys=True)
+
+	@classmethod
+	def _deserialize_shortlist_tags(cls, raw: str | None) -> list[str]:
+		if not raw:
+			return []
+		try:
+			parsed = json.loads(raw)
+		except json.JSONDecodeError:
+			return cls._normalize_shortlist_tags(raw.split(","))
+		if not isinstance(parsed, list):
+			return []
+		return cls._normalize_shortlist_tags([str(tag) for tag in parsed])
 
 	@staticmethod
 	def _make_search_key(params: dict[str, Any]) -> str:
@@ -305,7 +350,9 @@ class CacheStore:
 
 	def add_shortlist(self, item: dict[str, Any]) -> None:
 		self._conn.execute(
-			"INSERT OR REPLACE INTO shortlist_records (security_id, job_id, title, company, city, salary, source, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+			"INSERT OR REPLACE INTO shortlist_records "
+			"(security_id, job_id, title, company, city, salary, source, tags, note, created_at) "
+			"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
 			(
 				item.get("security_id", ""),
 				item.get("job_id", ""),
@@ -314,6 +361,8 @@ class CacheStore:
 				item.get("city", ""),
 				item.get("salary", ""),
 				item.get("source", ""),
+				self._serialize_shortlist_tags(item.get("tags", [])),
+				item.get("note", ""),
 				time.time(),
 			),
 		)
@@ -321,7 +370,8 @@ class CacheStore:
 
 	def list_shortlist(self) -> list[dict[str, Any]]:
 		rows = self._conn.execute(
-			"SELECT security_id, job_id, title, company, city, salary, source, created_at FROM shortlist_records ORDER BY created_at DESC"
+			"SELECT security_id, job_id, title, company, city, salary, source, tags, note, created_at "
+			"FROM shortlist_records ORDER BY created_at DESC"
 		).fetchall()
 		return [
 			{
@@ -332,10 +382,28 @@ class CacheStore:
 				"city": row[4],
 				"salary": row[5],
 				"source": row[6],
-				"created_at": row[7],
+				"tags": self._deserialize_shortlist_tags(row[7]),
+				"note": row[8] or "",
+				"created_at": row[9],
 			}
 			for row in rows
 		]
+
+	def set_shortlist_tags(self, security_id: str, job_id: str, tags: list[str]) -> bool:
+		cursor = self._conn.execute(
+			"UPDATE shortlist_records SET tags = ? WHERE security_id = ? AND job_id = ?",
+			(self._serialize_shortlist_tags(tags), security_id, job_id),
+		)
+		self._conn.commit()
+		return cursor.rowcount > 0
+
+	def set_shortlist_note(self, security_id: str, job_id: str, note: str) -> bool:
+		cursor = self._conn.execute(
+			"UPDATE shortlist_records SET note = ? WHERE security_id = ? AND job_id = ?",
+			(note, security_id, job_id),
+		)
+		self._conn.commit()
+		return cursor.rowcount > 0
 
 	def remove_shortlist(self, security_id: str, job_id: str) -> bool:
 		cursor = self._conn.execute(

--- a/src/boss_agent_cli/commands/ai_cmd.py
+++ b/src/boss_agent_cli/commands/ai_cmd.py
@@ -20,6 +20,7 @@ from boss_agent_cli.ai.prompts import (
 	RESUME_SUGGEST_PROMPT,
 )
 from boss_agent_cli.ai.service import AIService, AIServiceError
+from boss_agent_cli.cache.store import CacheStore
 from boss_agent_cli.display import handle_error_output, handle_output
 from boss_agent_cli.resume.models import resume_to_text
 from boss_agent_cli.resume.store import ResumeStore
@@ -120,6 +121,43 @@ def _call_ai(ctx: click.Context, svc: AIService, prompt: str) -> dict[str, Any] 
 		)
 		ctx.exit(1)
 		return None
+
+
+def _fit_missing_detail_item(item: dict[str, Any]) -> dict[str, Any]:
+	security_id = str(item.get("security_id") or "")
+	hint = f"先 boss detail {security_id}" if security_id else "先 boss detail <security_id>"
+	return {
+		"job_id": item.get("job_id", ""),
+		"security_id": security_id,
+		"title": item.get("title", ""),
+		"company": item.get("company", ""),
+		"status": "缺详情",
+		"hint": hint,
+	}
+
+
+def _build_fit_prompt(resume_text: str, jobs: list[dict[str, Any]]) -> str:
+	payload = {
+		"resume": resume_text,
+		"jobs": jobs,
+		"output_schema": {
+			"results": [
+				{
+					"job_id": "string",
+					"title": "string",
+					"match_score": "0-100 integer",
+					"gaps": ["string"],
+					"keyword_hits": ["string"],
+					"recommendation": "string",
+				},
+			],
+		},
+	}
+	return (
+		"请基于本地简历和已缓存职位详情，逐岗评估匹配度。"
+		"只返回 JSON，不要包含 markdown。字段必须符合 output_schema。\n\n"
+		f"{json.dumps(payload, ensure_ascii=False)}"
+	)
 
 
 @click.group("ai")
@@ -310,6 +348,76 @@ def ai_suggest_cmd(ctx: click.Context, resume_name: str, jd_text: str) -> None:
 			f"boss ai optimize {resume_name} --jd <jd_text>",
 			f"boss resume show {resume_name}",
 		]},
+	)
+
+
+@ai_group.command("fit")
+@click.option("--resume", "resume_name", required=True, help="本地简历名称")
+@click.option("--limit", default=20, type=click.IntRange(min=1), help="最多分析的候选池职位数")
+@click.pass_context
+def ai_fit_cmd(ctx: click.Context, resume_name: str, limit: int) -> None:
+	"""基于本地简历和候选池缓存详情生成逐岗匹配报告。"""
+	svc = _require_ai_service(ctx)
+	if svc is None:
+		return
+
+	resume_text = _load_resume_text(ctx, resume_name)
+	if resume_text is None:
+		return
+
+	with CacheStore(ctx.obj["data_dir"] / "cache" / "boss_agent.db") as cache:
+		shortlist = cache.list_shortlist()[:limit]
+		jobs: list[dict[str, Any]] = []
+		missing: list[dict[str, Any]] = []
+		for item in shortlist:
+			job_id = str(item.get("job_id") or "")
+			description = cache.get_job_desc(job_id)
+			if description:
+				jobs.append({
+					"job_id": job_id,
+					"security_id": item.get("security_id", ""),
+					"title": item.get("title", ""),
+					"company": item.get("company", ""),
+					"city": item.get("city", ""),
+					"salary": item.get("salary", ""),
+					"description": description,
+				})
+			else:
+				missing.append(_fit_missing_detail_item(item))
+
+	if not shortlist:
+		handle_output(
+			ctx,
+			"ai-fit",
+			{"results": [], "missing": [], "summary": {"analyzed": 0, "missing_details": 0}},
+			hints={"next_actions": ["boss shortlist add <security_id> <job_id>"]},
+		)
+		return
+
+	if not jobs:
+		handle_output(
+			ctx,
+			"ai-fit",
+			{"results": [], "missing": missing, "summary": {"analyzed": 0, "missing_details": len(missing)}},
+			hints={"next_actions": ["先对候选池职位执行 boss detail <security_id> 缓存详情后重试"]},
+		)
+		return
+
+	result = _call_ai(ctx, svc, _build_fit_prompt(resume_text, jobs))
+	if result is None:
+		return
+
+	result.setdefault("results", [])
+	result["missing"] = missing
+	result["summary"] = {
+		"analyzed": len(jobs),
+		"missing_details": len(missing),
+	}
+	handle_output(
+		ctx,
+		"ai-fit",
+		result,
+		hints={"next_actions": [f"boss ai optimize {resume_name} --jd <jd_text>"]},
 	)
 
 

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -46,6 +46,8 @@ def _command_to_json_schema(cmd_name: str, cmd_spec: dict[str, Any]) -> dict[str
 			required.append(arg_name)
 
 	for opt_key, opt_spec in cmd_spec.get("options", {}).items():
+		if not opt_key.startswith("-"):
+			continue
 		# 去掉短/长选项前缀，保留长选项作为参数名
 		primary_name = opt_key.split(",")[-1].strip().lstrip("-").replace("-", "_")
 		properties[primary_name] = _option_to_json_schema_property(opt_spec)
@@ -753,9 +755,29 @@ SCHEMA_DATA = {
 			},
 		},
 		"shortlist": {
-			"description": "管理职位候选池（子命令：add/list/remove）",
+			"description": "管理本地职位候选池（子命令：add/list/annotate/compare/remove），支持本地标签、备注和离线对比",
 			"args": [],
-			"options": {},
+			"options": {
+				"add": {
+					"--tags": {"type": "string", "default": "", "description": "本地标签，逗号分隔"},
+					"--note": {"type": "string", "default": "", "description": "本地备注"},
+				},
+				"annotate": {
+					"--add-tag": {"type": "string", "default": None, "description": "添加本地标签，可重复"},
+					"--remove-tag": {"type": "string", "default": None, "description": "移除本地标签，可重复"},
+					"--note": {"type": "string", "default": None, "description": "替换本地备注"},
+				},
+				"compare": {
+					"--tag": {"type": "string", "default": None, "description": "只比较包含该本地标签的候选职位"},
+				},
+			},
+			"subcommands": {
+				"add": "加入本地候选池，可附加本地标签和备注",
+				"list": "列出本地候选池职位",
+				"annotate": "更新候选职位的本地标签和备注",
+				"compare": "本地对比候选职位，可按标签过滤",
+				"remove": "从本地候选池移除职位",
+			},
 		},
 		"digest": {
 			"description": "受限能力：汇总新增职位、待跟进会话和面试项的日报。默认低风险模式会阻断。",

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -419,6 +419,12 @@ SCHEMA_DATA = {
 					"default": False,
 					"description": "附加匹配分和原因",
 				},
+				"--sort": {
+					"type": "string",
+					"default": "relevance",
+					"description": "排序方式：relevance 保持平台返回顺序；score 按本地 match_score 降序",
+					"choices": ["relevance", "score"],
+				},
 				"--no-cache": {
 					"type": "bool",
 					"default": False,

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -824,7 +824,7 @@ SCHEMA_DATA = {
 			},
 		},
 		"ai": {
-			"description": "AI 简历优化与聊天回复（子命令：config/analyze-jd/polish/optimize/suggest/reply/interview-prep/chat-coach）",
+			"description": "AI 简历优化与聊天回复（子命令：config/analyze-jd/polish/optimize/suggest/fit/reply/interview-prep/chat-coach）",
 			"args": [],
 			"options": {},
 			"subcommands": {
@@ -833,6 +833,7 @@ SCHEMA_DATA = {
 				"polish": "通用简历润色",
 				"optimize": "基于目标职位描述优化简历",
 				"suggest": "基于目标职位描述给出优化建议（不修改简历）",
+				"fit": "fit --resume <name> [--limit N]：本地简历 × 候选池缓存详情的匹配报告",
 				"reply": "基于招聘者消息生成回复草稿（2-3 条候选）",
 				"interview-prep": "基于目标职位生成模拟面试题与准备建议",
 				"chat-coach": "基于聊天记录诊断沟通状态并给出下一步建议",

--- a/src/boss_agent_cli/commands/search.py
+++ b/src/boss_agent_cli/commands/search.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any
 
 import click
 
@@ -22,6 +23,12 @@ from boss_agent_cli.search_filters import (
 )
 
 
+def _sort_search_items(items: list[dict[str, Any]], sort: str) -> list[dict[str, Any]]:
+	if sort == "score":
+		return sorted(items, key=lambda item: item.get("match_score", 0), reverse=True)
+	return items
+
+
 @click.command("search")
 @click.argument("query", required=False)
 @click.option("--url", "search_url", default=None, help="BOSS 直聘搜索页 URL（可从网页复制完整筛选条件）")
@@ -38,9 +45,28 @@ from boss_agent_cli.search_filters import (
 @click.option("--page", default=1, help="页码")
 @click.option("--no-cache", is_flag=True, default=False, help="跳过缓存")
 @click.option("--with-score", is_flag=True, default=False, help="附加匹配分和原因")
+@click.option("--sort", "sort_mode", default="relevance", type=click.Choice(["relevance", "score"]), help="排序方式")
 @click.pass_context
 @handle_auth_errors("search")
-def search_cmd(ctx: click.Context, query: str | None, search_url: str | None, preset: str | None, city: str | None, salary: str | None, experience: str | None, education: str | None, industry: str | None, scale: str | None, stage: str | None, job_type: str | None, welfare: str | None, page: int, no_cache: bool, with_score: bool) -> None:
+def search_cmd(
+	ctx: click.Context,
+	query: str | None,
+	search_url: str | None,
+	preset: str | None,
+	city: str | None,
+	salary: str | None,
+	experience: str | None,
+	education: str | None,
+	industry: str | None,
+	scale: str | None,
+	stage: str | None,
+	job_type: str | None,
+	welfare: str | None,
+	page: int,
+	no_cache: bool,
+	with_score: bool,
+	sort_mode: str,
+) -> None:
 	"""按关键词和筛选条件搜索职位列表"""
 	data_dir = ctx.obj["data_dir"]
 	logger = ctx.obj["logger"]
@@ -130,8 +156,9 @@ def search_cmd(ctx: click.Context, query: str | None, search_url: str | None, pr
 			if cached is not None:
 				logger.debug("搜索命中缓存")
 				result = json.loads(cached)
+				items = _sort_search_items(result["data"], sort_mode)
 				handle_output(
-					ctx, "search", result["data"],
+					ctx, "search", items,
 					render=lambda data: render_job_table(data, f"search: {query}"),
 					pagination=result.get("pagination"), hints=result.get("hints"),
 				)
@@ -160,7 +187,9 @@ def search_cmd(ctx: click.Context, query: str | None, search_url: str | None, pr
 			items = pipeline_result.items
 			if with_score:
 				items = [score_job_dict(item, criteria=criteria, expect_data=None) for item in items]
-			try_save_index(data_dir, items, source=f"search:{query}", logger=logger)
+			cache_items = items
+			output_items = _sort_search_items(items, sort_mode)
+			try_save_index(data_dir, output_items, source=f"search:{query}", logger=logger)
 
 			# Emit search_completed hook
 			hooks = ctx.obj.get("hooks")
@@ -169,7 +198,7 @@ def search_cmd(ctx: click.Context, query: str | None, search_url: str | None, pr
 					"query": query,
 					"url": search_url,
 					"page": page,
-					"result_count": len(items),
+					"result_count": len(output_items),
 					"stats": {
 						"pages_scanned": pipeline_result.stats.pages_scanned,
 						"jobs_seen": pipeline_result.stats.jobs_seen,
@@ -203,12 +232,12 @@ def search_cmd(ctx: click.Context, query: str | None, search_url: str | None, pr
 					"industry": industry, "scale": scale, "stage": stage,
 					"job_type": job_type, "url": search_url, "raw_params": raw_params, "page": page,
 				}
-				cache_data = {"data": items, "pagination": pagination, "hints": hints}
+				cache_data = {"data": cache_items, "pagination": pagination, "hints": hints}
 				cache.put_search(search_params, json.dumps(cache_data, ensure_ascii=False))
 
 			title_suffix = " (welfare filter)" if welfare_conditions else ""
 			handle_output(
-				ctx, "search", items,
+				ctx, "search", output_items,
 				render=lambda data: render_job_table(
 					data, f"search: {query}{title_suffix}",
 					page=page,

--- a/src/boss_agent_cli/commands/shortlist.py
+++ b/src/boss_agent_cli/commands/shortlist.py
@@ -1,7 +1,46 @@
 import click
+from typing import Any
 
 from boss_agent_cli.cache.store import CacheStore
 from boss_agent_cli.display import boss_command_for_ctx, handle_output, render_simple_list
+
+
+def _parse_tags(value: str) -> list[str]:
+	tags: list[str] = []
+	seen: set[str] = set()
+	for raw in value.split(","):
+		tag = raw.strip()
+		if not tag or tag in seen:
+			continue
+		tags.append(tag)
+		seen.add(tag)
+	return tags
+
+
+def _merge_tags(current: list[str], add_tags: tuple[str, ...], remove_tags: tuple[str, ...]) -> list[str]:
+	tags = _parse_tags(",".join([*current, *add_tags]))
+	remove = set(_parse_tags(",".join(remove_tags)))
+	return [tag for tag in tags if tag not in remove]
+
+
+def _find_shortlist_item(items: list[dict[str, Any]], security_id: str, job_id: str) -> dict[str, Any] | None:
+	for item in items:
+		if item.get("security_id") == security_id and item.get("job_id") == job_id:
+			return item
+	return None
+
+
+def _compare_item(item: dict[str, Any]) -> dict[str, Any]:
+	return {
+		"security_id": item.get("security_id", ""),
+		"job_id": item.get("job_id", ""),
+		"title": item.get("title", ""),
+		"company": item.get("company", ""),
+		"city": item.get("city", ""),
+		"salary": item.get("salary", ""),
+		"tags": item.get("tags", []),
+		"note": item.get("note", ""),
+	}
 
 
 @click.group("shortlist")
@@ -17,8 +56,22 @@ def shortlist_group() -> None:
 @click.option("--city", default="", help="城市")
 @click.option("--salary", default="", help="薪资")
 @click.option("--source", default="manual", help="来源，如 search/recommend/show/manual")
+@click.option("--tags", default="", help="本地标签，逗号分隔")
+@click.option("--note", default="", help="本地备注")
 @click.pass_context
-def shortlist_add_cmd(ctx: click.Context, security_id: str, job_id: str, title: str, company: str, city: str, salary: str, source: str) -> None:
+def shortlist_add_cmd(
+	ctx: click.Context,
+	security_id: str,
+	job_id: str,
+	title: str,
+	company: str,
+	city: str,
+	salary: str,
+	source: str,
+	tags: str,
+	note: str,
+) -> None:
+	parsed_tags = _parse_tags(tags)
 	with CacheStore(ctx.obj["data_dir"] / "cache" / "boss_agent.db") as cache:
 		cache.add_shortlist(
 			{
@@ -29,6 +82,8 @@ def shortlist_add_cmd(ctx: click.Context, security_id: str, job_id: str, title: 
 				"city": city,
 				"salary": salary,
 				"source": source,
+				"tags": parsed_tags,
+				"note": note,
 			}
 		)
 	handle_output(
@@ -43,6 +98,8 @@ def shortlist_add_cmd(ctx: click.Context, security_id: str, job_id: str, title: 
 			"city": city,
 			"salary": salary,
 			"source": source,
+			"tags": parsed_tags,
+			"note": note,
 		},
 		hints={
 			"next_actions": [
@@ -70,10 +127,83 @@ def shortlist_list_cmd(ctx: click.Context) -> None:
 				("company", "company", "green"),
 				("city", "city", "yellow"),
 				("salary", "salary", "dim"),
+				("tags", "tags", "blue"),
+				("note", "note", "white"),
 				("source", "source", "magenta"),
 			],
 		),
 		hints={"next_actions": [boss_command_for_ctx(ctx, "detail <security_id> --job-id <job_id>")]},
+	)
+
+
+@shortlist_group.command("annotate")
+@click.argument("security_id")
+@click.argument("job_id")
+@click.option("--add-tag", multiple=True, help="添加本地标签，可重复")
+@click.option("--remove-tag", multiple=True, help="移除本地标签，可重复")
+@click.option("--note", default=None, help="替换本地备注")
+@click.pass_context
+def shortlist_annotate_cmd(
+	ctx: click.Context,
+	security_id: str,
+	job_id: str,
+	add_tag: tuple[str, ...],
+	remove_tag: tuple[str, ...],
+	note: str | None,
+) -> None:
+	with CacheStore(ctx.obj["data_dir"] / "cache" / "boss_agent.db") as cache:
+		current = _find_shortlist_item(cache.list_shortlist(), security_id, job_id)
+		updated = current is not None
+		if current:
+			tags = _merge_tags(current.get("tags", []), add_tag, remove_tag)
+			cache.set_shortlist_tags(security_id, job_id, tags)
+			if note is not None:
+				cache.set_shortlist_note(security_id, job_id, note)
+			current = _find_shortlist_item(cache.list_shortlist(), security_id, job_id)
+	handle_output(
+		ctx,
+		"shortlist",
+		{
+			"action": "annotate",
+			"security_id": security_id,
+			"job_id": job_id,
+			"updated": updated,
+			"item": current,
+		},
+		hints={"next_actions": [boss_command_for_ctx(ctx, "shortlist compare")]},
+	)
+
+
+@shortlist_group.command("compare")
+@click.option("--tag", default=None, help="只比较包含该本地标签的候选职位")
+@click.pass_context
+def shortlist_compare_cmd(ctx: click.Context, tag: str | None) -> None:
+	normalized_tag = tag.strip() if tag else None
+	with CacheStore(ctx.obj["data_dir"] / "cache" / "boss_agent.db") as cache:
+		items = cache.list_shortlist()
+	if normalized_tag:
+		items = [item for item in items if normalized_tag in item.get("tags", [])]
+	compare_items = [_compare_item(item) for item in items]
+	handle_output(
+		ctx,
+		"shortlist",
+		{
+			"tag": normalized_tag,
+			"count": len(compare_items),
+			"items": compare_items,
+		},
+		render=lambda data: render_simple_list(
+			data["items"],
+			"shortlist compare",
+			[
+				("title", "title", "bold cyan"),
+				("company", "company", "green"),
+				("salary", "salary", "yellow"),
+				("tags", "tags", "blue"),
+				("note", "note", "white"),
+			],
+		),
+		hints={"next_actions": [boss_command_for_ctx(ctx, "shortlist annotate <security_id> <job_id>")]},
 	)
 
 

--- a/src/boss_agent_cli/mcp_server.py
+++ b/src/boss_agent_cli/mcp_server.py
@@ -143,6 +143,7 @@ TOOLS = [
 				"education": {"type": "string", "description": "学历要求（如 本科）"},
 				"welfare": {"type": "string", "description": "福利筛选，逗号分隔 AND 逻辑（如 双休,五险一金）"},
 				"page": {"type": "integer", "description": "页码", "default": 1},
+				"sort": {"type": "string", "enum": ["relevance", "score"], "description": "排序方式", "default": "relevance"},
 			},
 			"required": ["query"],
 		},
@@ -811,6 +812,8 @@ def _build_args(tool_name: str, arguments: dict) -> list[str]:
 				args.extend([f"--{opt}", str(arguments[opt])])
 		if "page" in arguments:
 			args.extend(["--page", str(arguments["page"])])
+		if arguments.get("sort"):
+			args.extend(["--sort", str(arguments["sort"])])
 		return args
 
 	if name == "recommend":

--- a/src/boss_agent_cli/mcp_server.py
+++ b/src/boss_agent_cli/mcp_server.py
@@ -502,6 +502,18 @@ TOOLS = [
 		},
 	),
 	Tool(
+		name="boss_ai_fit",
+		description="基于本地简历和候选池已缓存职位详情生成逐岗匹配度、能力缺口和关键词命中报告",
+		inputSchema={
+			"type": "object",
+			"properties": {
+				"resume": {"type": "string", "description": "简历名称"},
+				"limit": {"type": "integer", "description": "最多分析的候选池职位数", "default": 20},
+			},
+			"required": ["resume"],
+		},
+	),
+	Tool(
 		name="boss_watch_list",
 		description="列出所有已保存的监控条件",
 		inputSchema={"type": "object", "properties": {}, "required": []},
@@ -969,6 +981,12 @@ def _build_args(tool_name: str, arguments: dict) -> list[str]:
 
 	if name == "ai_suggest":
 		return ["ai", "suggest", arguments["resume"], "--jd", arguments["jd_text"]]
+
+	if name == "ai_fit":
+		args = ["ai", "fit", "--resume", arguments["resume"]]
+		if "limit" in arguments:
+			args.extend(["--limit", str(arguments["limit"])])
+		return args
 
 	if name == "watch_list":
 		return ["watch", "list"]

--- a/src/boss_agent_cli/mcp_server.py
+++ b/src/boss_agent_cli/mcp_server.py
@@ -19,18 +19,20 @@ from boss_agent_cli.compliance import (
 )
 from boss_agent_cli.platforms import list_platforms, list_recruiter_platforms
 
+SERVER_INSTRUCTIONS = (
+	"boss-agent-cli over MCP: a local-assist BOSS Zhipin job-search toolset, low-risk by default — "
+	"read-only first, user-triggered, no risk-control bypass, no bulk outreach, no platform-data scraping. "
+	"Sensitive actions (greet, batch-greet, apply, contact exchange, recruiter candidate data, replies) "
+	"are not exposed and return COMPLIANCE_BLOCKED at the CLI layer; for those the user acts manually on "
+	"the official BOSS Zhipin website. Every tool returns the same JSON envelope "
+	"{ok, data, pagination, error, hints}; when ok is false, read error.code and error.recovery_action and "
+	"act on it (for example AUTH_REQUIRED means the user runs boss login). boss schema is the capability "
+	"source of truth — do not hardcode command tables."
+)
+
 server = Server(
 	"boss-agent-cli",
-	instructions=(
-		"boss-agent-cli over MCP: a local-assist BOSS Zhipin job-search toolset, low-risk by default — "
-		"read-only first, user-triggered, no risk-control bypass, no bulk outreach, no platform-data scraping. "
-		"Sensitive actions (greet, batch-greet, apply, contact exchange, recruiter candidate data, replies) "
-		"are not exposed and return COMPLIANCE_BLOCKED at the CLI layer; for those the user acts manually on "
-		"the official BOSS Zhipin website. Every tool returns the same JSON envelope "
-		"{ok, data, pagination, error, hints}; when ok is false, read error.code and error.recovery_action and "
-		"act on it (for example AUTH_REQUIRED means the user runs boss login). boss schema is the capability "
-		"source of truth — do not hardcode command tables."
-	),
+	instructions=SERVER_INSTRUCTIONS,
 )
 DEFAULT_TRANSPORT = "stdio"
 DEFAULT_HOST = "127.0.0.1"

--- a/src/boss_agent_cli/mcp_server.py
+++ b/src/boss_agent_cli/mcp_server.py
@@ -542,14 +542,42 @@ TOOLS = [
 	),
 	Tool(
 		name="boss_shortlist_add",
-		description="将职位加入候选池",
+		description="将职位加入本地候选池，可附加本地标签和备注",
 		inputSchema={
 			"type": "object",
 			"properties": {
 				"security_id": {"type": "string", "description": "职位安全 ID"},
 				"job_id": {"type": "string", "description": "加密职位 ID"},
+				"tags": {"type": "string", "description": "本地标签，逗号分隔"},
+				"note": {"type": "string", "description": "本地备注"},
 			},
 			"required": ["security_id", "job_id"],
+		},
+	),
+	Tool(
+		name="boss_shortlist_annotate",
+		description="更新本地候选池职位的标签和备注",
+		inputSchema={
+			"type": "object",
+			"properties": {
+				"security_id": {"type": "string", "description": "职位安全 ID"},
+				"job_id": {"type": "string", "description": "加密职位 ID"},
+				"add_tags": {"type": "array", "items": {"type": "string"}, "description": "要添加的本地标签"},
+				"remove_tags": {"type": "array", "items": {"type": "string"}, "description": "要移除的本地标签"},
+				"note": {"type": "string", "description": "替换本地备注"},
+			},
+			"required": ["security_id", "job_id"],
+		},
+	),
+	Tool(
+		name="boss_shortlist_compare",
+		description="本地对比候选池职位，可按标签过滤",
+		inputSchema={
+			"type": "object",
+			"properties": {
+				"tag": {"type": "string", "description": "只比较包含该标签的本地候选职位"},
+			},
+			"required": [],
 		},
 	),
 	Tool(
@@ -1004,7 +1032,28 @@ def _build_args(tool_name: str, arguments: dict) -> list[str]:
 		return ["shortlist", "list"]
 
 	if name == "shortlist_add":
-		return ["shortlist", "add", arguments["security_id"], arguments["job_id"]]
+		args = ["shortlist", "add", arguments["security_id"], arguments["job_id"]]
+		if arguments.get("tags"):
+			args.extend(["--tags", str(arguments["tags"])])
+		if arguments.get("note"):
+			args.extend(["--note", str(arguments["note"])])
+		return args
+
+	if name == "shortlist_annotate":
+		args = ["shortlist", "annotate", arguments["security_id"], arguments["job_id"]]
+		for tag in arguments.get("add_tags") or []:
+			args.extend(["--add-tag", str(tag)])
+		for tag in arguments.get("remove_tags") or []:
+			args.extend(["--remove-tag", str(tag)])
+		if arguments.get("note"):
+			args.extend(["--note", str(arguments["note"])])
+		return args
+
+	if name == "shortlist_compare":
+		args = ["shortlist", "compare"]
+		if arguments.get("tag"):
+			args.extend(["--tag", str(arguments["tag"])])
+		return args
 
 	if name == "shortlist_remove":
 		return ["shortlist", "remove", arguments["security_id"], arguments["job_id"]]

--- a/src/boss_agent_cli/search_filters.py
+++ b/src/boss_agent_cli/search_filters.py
@@ -335,9 +335,50 @@ def match_all_welfare(
 	return results
 
 
+def compute_match_score(item: dict[str, Any], welfare_results: list[str], criteria: SearchFilterCriteria) -> int:
+	"""Compute a local 0-100 match score from already-fetched item fields."""
+	score = 0
+
+	for result in welfare_results:
+		if result.endswith("(标签)"):
+			score += 12
+		elif result.endswith("(描述)"):
+			score += 8
+
+	if criteria.city and criteria.city in str(item.get("city", "")):
+		score += 12
+
+	if criteria.salary:
+		item_range = parse_salary_range(str(item.get("salary", "")))
+		criteria_range = parse_salary_range(criteria.salary)
+		if item_range and criteria_range and item_range[1] >= criteria_range[0]:
+			score += 12
+
+	if criteria.experience and meets_experience_threshold(str(item.get("experience", "")), criteria.experience):
+		score += 10
+
+	if criteria.education and meets_education_threshold(str(item.get("education", "")), criteria.education):
+		score += 10
+
+	if criteria.query:
+		query = criteria.query.lower()
+		skills = item.get("skills", [])
+		if not isinstance(skills, list):
+			skills = []
+		searchable = f"{item.get('title', '')} {' '.join(str(skill) for skill in skills)}".lower()
+		if query and query in searchable:
+			score += 10
+
+	if item.get("welfare"):
+		score += 4
+
+	return min(score, 100)
+
+
 def _fetch_and_check(
 	client: Any,
 	welfare_conditions: list[tuple[str, list[str]]],
+	criteria: SearchFilterCriteria,
 	raw_item: dict[str, Any],
 	cached_desc: str | None = None,
 ) -> tuple[dict[str, Any] | None, str | None]:
@@ -374,6 +415,7 @@ def _fetch_and_check(
 		item = JobItem.from_api(raw_item)
 		d = item.to_dict()
 		d["welfare_match"] = "✅ " + ", ".join(match_results)
+		d["match_score"] = compute_match_score(d, match_results, criteria)
 		return d, fresh_desc
 	return None, fresh_desc
 
@@ -383,6 +425,7 @@ def _check_details_parallel(
 	cache: Any,
 	logger: Any,
 	welfare_conditions: list[tuple[str, list[str]]],
+	criteria: SearchFilterCriteria,
 	items: list[dict[str, Any]],
 	matched: list[dict[str, Any]],
 ) -> None:
@@ -400,7 +443,7 @@ def _check_details_parallel(
 
 	with ThreadPoolExecutor(max_workers=_WELFARE_WORKERS) as pool:
 		futures = {
-			pool.submit(_fetch_and_check, client, welfare_conditions, raw_item, cached_by_item[id(raw_item)]): raw_item
+			pool.submit(_fetch_and_check, client, welfare_conditions, criteria, raw_item, cached_by_item[id(raw_item)]): raw_item
 			for raw_item in items
 		}
 		for future in as_completed(futures):
@@ -513,6 +556,7 @@ def run_search_pipeline(
 						continue
 					d = item.to_dict()
 					d["welfare_match"] = "✅ " + ", ".join(match_results)
+					d["match_score"] = compute_match_score(d, match_results, criteria)
 					matched.append(d)
 					stats.jobs_matched += 1
 					logger.info(f"  ✅ {item.company} - {item.title}（标签匹配）")
@@ -522,7 +566,7 @@ def run_search_pipeline(
 			if need_detail:
 				logger.info(f"  标签未命中 {len(need_detail)} 个，并行查详情...")
 				before = len(matched)
-				_check_details_parallel(client, cache, logger, welfare_conditions, need_detail, matched)
+				_check_details_parallel(client, cache, logger, welfare_conditions, criteria, need_detail, matched)
 				stats.detail_checks += len(need_detail)
 				stats.jobs_matched += len(matched) - before
 
@@ -535,7 +579,9 @@ def run_search_pipeline(
 				item.greeted = cache.is_greeted(item.security_id)
 				if skip_greeted and item.greeted:
 					continue
-				matched.append(item.to_dict())
+				d = item.to_dict()
+				d["match_score"] = compute_match_score(d, [], criteria)
+				matched.append(d)
 				stats.jobs_matched += 1
 
 		has_more = zp_data.get("hasMore", False)

--- a/tests/test_ai_fit.py
+++ b/tests/test_ai_fit.py
@@ -1,0 +1,147 @@
+"""Tests for boss ai fit."""
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from boss_agent_cli.cache.store import CacheStore
+from boss_agent_cli.main import cli
+
+
+class FakeAIService:
+	def __init__(self, payload: dict[str, Any]) -> None:
+		self.payload = payload
+		self.messages: list[dict[str, str]] = []
+
+	def chat(self, messages: list[dict[str, str]], *, temperature: float | None = None, max_tokens: int | None = None) -> str:
+		self.messages = messages
+		return json.dumps(self.payload, ensure_ascii=False)
+
+
+def _invoke(runner: CliRunner, tmp_path, args: list[str]):
+	return runner.invoke(cli, ["--data-dir", str(tmp_path), "--json", "ai"] + args)
+
+
+def _setup_resume(tmp_path) -> None:
+	runner = CliRunner()
+	result = runner.invoke(
+		cli,
+		[
+			"--data-dir",
+			str(tmp_path),
+			"--json",
+			"resume",
+			"init",
+			"--name",
+			"test-resume",
+			"--template",
+			"default",
+		],
+	)
+	assert result.exit_code == 0, result.output
+
+
+def _seed_shortlist(tmp_path) -> None:
+	with CacheStore(tmp_path / "cache" / "boss_agent.db") as cache:
+		cache.add_shortlist({
+			"security_id": "sec-1",
+			"job_id": "job-1",
+			"title": "Python 后端",
+			"company": "Acme",
+			"city": "广州",
+			"salary": "20-30K",
+			"source": "zhipin",
+		})
+		cache.add_shortlist({
+			"security_id": "sec-2",
+			"job_id": "job-2",
+			"title": "Go 后端",
+			"company": "Beta",
+			"city": "深圳",
+			"salary": "25-35K",
+			"source": "zhipin",
+		})
+		cache.put_job_desc("job-1", "负责 Python API、SQLite 缓存和自动化测试。")
+
+
+def test_ai_fit_uses_local_resume_and_cached_job_details(tmp_path):
+	_setup_resume(tmp_path)
+	_seed_shortlist(tmp_path)
+	runner = CliRunner()
+	service = FakeAIService({
+		"results": [
+			{
+				"job_id": "job-1",
+				"title": "Python 后端",
+				"match_score": 86,
+				"gaps": ["补充云服务经验"],
+				"keyword_hits": ["Python", "SQLite"],
+				"recommendation": "值得优先准备",
+			},
+		],
+	})
+
+	with (
+		patch("boss_agent_cli.commands.ai_cmd._create_ai_service", return_value=service),
+		patch("boss_agent_cli.commands._platform.get_platform_instance") as get_platform,
+		patch("boss_agent_cli.api.client.BossClient") as boss_client,
+	):
+		result = _invoke(runner, tmp_path, ["fit", "--resume", "test-resume", "--limit", "5"])
+
+	assert result.exit_code == 0, result.output
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["command"] == "ai-fit"
+	assert parsed["data"]["results"][0]["match_score"] == 86
+	assert parsed["data"]["missing"] == [
+		{
+			"job_id": "job-2",
+			"security_id": "sec-2",
+			"title": "Go 后端",
+			"company": "Beta",
+			"status": "缺详情",
+			"hint": "先 boss detail sec-2",
+		},
+	]
+	assert parsed["data"]["summary"] == {"analyzed": 1, "missing_details": 1}
+	assert "Python API" in service.messages[1]["content"]
+	get_platform.assert_not_called()
+	boss_client.assert_not_called()
+
+
+def test_ai_fit_requires_ai_configuration(tmp_path, monkeypatch):
+	monkeypatch.setenv("BOSS_AGENT_MACHINE_ID", "test-machine")
+	runner = CliRunner()
+	result = _invoke(runner, tmp_path, ["fit", "--resume", "test-resume"])
+
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["error"]["code"] == "AI_NOT_CONFIGURED"
+
+
+def test_ai_fit_reports_missing_resume(tmp_path):
+	runner = CliRunner()
+	with patch("boss_agent_cli.commands.ai_cmd._create_ai_service", return_value=FakeAIService({"results": []})):
+		result = _invoke(runner, tmp_path, ["fit", "--resume", "ghost"])
+
+	assert result.exit_code == 1
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is False
+	assert parsed["error"]["code"] == "RESUME_NOT_FOUND"
+
+
+def test_ai_fit_empty_shortlist_returns_empty_report(tmp_path):
+	_setup_resume(tmp_path)
+	runner = CliRunner()
+	service = FakeAIService({"results": [{"job_id": "unexpected"}]})
+	with patch("boss_agent_cli.commands.ai_cmd._create_ai_service", return_value=service):
+		result = _invoke(runner, tmp_path, ["fit", "--resume", "test-resume"])
+
+	assert result.exit_code == 0, result.output
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"] == {"results": [], "missing": [], "summary": {"analyzed": 0, "missing_details": 0}}
+	assert service.messages == []

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,4 +1,5 @@
 import time
+import sqlite3
 
 from boss_agent_cli.cache.store import CacheStore
 
@@ -106,6 +107,8 @@ def test_shortlist_crud(tmp_path):
 		"city": "广州",
 		"salary": "20-30K",
 		"source": "search",
+		"tags": ["远程", "双休"],
+		"note": "优先沟通",
 	}
 	assert store.is_shortlisted("sec_001", "job_001") is False
 	store.add_shortlist(item)
@@ -113,8 +116,44 @@ def test_shortlist_crud(tmp_path):
 	items = store.list_shortlist()
 	assert len(items) == 1
 	assert items[0]["title"] == "Go 开发"
+	assert items[0]["tags"] == ["远程", "双休"]
+	assert items[0]["note"] == "优先沟通"
 	assert store.remove_shortlist("sec_001", "job_001") is True
 	assert store.is_shortlisted("sec_001", "job_001") is False
+
+
+def test_shortlist_migration_adds_tags_note_without_data_loss(tmp_path):
+	db_path = tmp_path / "old.db"
+	conn = sqlite3.connect(db_path)
+	conn.execute("""
+		CREATE TABLE shortlist_records (
+			security_id TEXT NOT NULL,
+			job_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			company TEXT NOT NULL,
+			city TEXT NOT NULL,
+			salary TEXT NOT NULL,
+			source TEXT NOT NULL,
+			created_at REAL NOT NULL,
+			PRIMARY KEY (security_id, job_id)
+		)
+	""")
+	conn.execute(
+		"INSERT INTO shortlist_records (security_id, job_id, title, company, city, salary, source, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+		("sec_001", "job_001", "Go 开发", "TestCo", "广州", "20-30K", "search", 1.0),
+	)
+	conn.commit()
+	conn.close()
+
+	store = CacheStore(db_path)
+	items = store.list_shortlist()
+	assert len(items) == 1
+	assert items[0]["title"] == "Go 开发"
+	assert items[0]["tags"] == []
+	assert items[0]["note"] == ""
+
+	columns = {row[1] for row in store._conn.execute("PRAGMA table_info(shortlist_records)").fetchall()}
+	assert {"tags", "note"} <= columns
 
 
 def test_resume_job_link_crud(tmp_path):

--- a/tests/test_cache_extended.py
+++ b/tests/test_cache_extended.py
@@ -161,12 +161,29 @@ def test_shortlist_add_and_list(store):
 		"title": "前端工程师", "company": "字节",
 		"city": "北京", "salary": "25-40K",
 		"source": "search",
+		"tags": ["前端", "远程", "前端", ""],
+		"note": "复盘薪资结构",
 	}
 	store.add_shortlist(item)
 	result = store.list_shortlist()
 	assert len(result) == 1
 	assert result[0]["title"] == "前端工程师"
 	assert result[0]["security_id"] == "s1"
+	assert result[0]["tags"] == ["前端", "远程"]
+	assert result[0]["note"] == "复盘薪资结构"
+
+
+def test_shortlist_set_tags_and_note(store):
+	"""候选池标签和备注应能独立更新。"""
+	store.add_shortlist({"security_id": "s1", "job_id": "j1", "title": "", "company": "", "city": "", "salary": "", "source": ""})
+	assert store.set_shortlist_tags("s1", "j1", ["远程", "双休", "远程"]) is True
+	assert store.set_shortlist_note("s1", "j1", "等待 HR 回复") is True
+
+	result = store.list_shortlist()
+	assert result[0]["tags"] == ["远程", "双休"]
+	assert result[0]["note"] == "等待 HR 回复"
+	assert store.set_shortlist_tags("missing", "j1", ["x"]) is False
+	assert store.set_shortlist_note("missing", "j1", "x") is False
 
 
 def test_shortlist_is_shortlisted(store):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -527,6 +527,39 @@ def test_search_with_score(mock_client_cls, mock_auth_cls, mock_cache_cls, mock_
 @patch("boss_agent_cli.commands.search.CacheStore")
 @patch("boss_agent_cli.commands.search.AuthManager")
 @patch("boss_agent_cli.commands.search.get_platform_instance")
+def test_search_sort_score_orders_by_local_match_score(mock_client_cls, mock_auth_cls, mock_cache_cls, mock_pipeline):
+	mock_cache = _ctx_mock(mock_cache_cls)
+	mock_cache.get_search.return_value = None
+	_ctx_mock(mock_client_cls)
+	mock_pipeline.return_value = SimpleNamespace(
+		items=[
+			{"job_id": "low", "title": "低分", "security_id": "s1", "match_score": 10},
+			{"job_id": "high", "title": "高分", "security_id": "s2", "match_score": 90},
+		],
+		has_more=False,
+		total=2,
+		stats=SimpleNamespace(
+			pages_scanned=1,
+			jobs_seen=2,
+			jobs_prefiltered=0,
+			detail_checks=0,
+		),
+	)
+
+	runner = CliRunner()
+	result = runner.invoke(cli, ["search", "golang", "--sort", "score"])
+
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert [item["job_id"] for item in parsed["data"]] == ["high", "low"]
+	assert mock_pipeline.call_count == 1
+	assert mock_pipeline.call_args.kwargs["max_pages"] == 1
+
+
+@patch("boss_agent_cli.commands.search.run_search_pipeline")
+@patch("boss_agent_cli.commands.search.CacheStore")
+@patch("boss_agent_cli.commands.search.AuthManager")
+@patch("boss_agent_cli.commands.search.get_platform_instance")
 def test_search_supports_url_and_multiselect_filters(mock_client_cls, mock_auth_cls, mock_cache_cls, mock_pipeline):
 	mock_cache = _ctx_mock(mock_cache_cls)
 	mock_cache.get_search.return_value = None

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -134,6 +134,7 @@ def test_required_tools_present():
 		"boss_ai_interview_prep", "boss_ai_chat_coach",
 		"boss_resume_list", "boss_resume_show",
 		"boss_ai_analyze_jd", "boss_ai_optimize", "boss_ai_suggest",
+		"boss_ai_fit",
 		"boss_watch_list",
 		"boss_preset_list", "boss_shortlist_list",
 		"boss_hr_jobs",
@@ -145,7 +146,7 @@ def test_required_tools_present():
 
 def test_tool_count():
 	"""工具总数应与当前注册一致。"""
-	assert len(TOOLS) == 32
+	assert len(TOOLS) == 33
 
 
 def test_mcp_tool_count_matches_readme():
@@ -629,6 +630,11 @@ def test_build_args_ai_suggest():
 	assert args == ["ai", "suggest", "my", "--jd", "后端岗位"]
 
 
+def test_build_args_ai_fit():
+	args = _build_args("boss_ai_fit", {"resume": "my", "limit": 3})
+	assert args == ["ai", "fit", "--resume", "my", "--limit", "3"]
+
+
 def test_build_args_watch_list():
 	assert _build_args("boss_watch_list", {}) == ["watch", "list"]
 
@@ -647,7 +653,7 @@ def test_build_args_shortlist_list():
 
 def test_tool_count_after_pr41():
 	"""协议服务工具总数应与当前 MCP 暴露能力完全一致。"""
-	assert len(TOOLS) == 32
+	assert len(TOOLS) == 33
 
 
 def test_build_args_shortlist_add():

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -137,6 +137,7 @@ def test_required_tools_present():
 		"boss_ai_fit",
 		"boss_watch_list",
 		"boss_preset_list", "boss_shortlist_list",
+		"boss_shortlist_annotate", "boss_shortlist_compare",
 		"boss_hr_jobs",
 		"boss_hr_jobs_detail",
 	}
@@ -146,7 +147,7 @@ def test_required_tools_present():
 
 def test_tool_count():
 	"""工具总数应与当前注册一致。"""
-	assert len(TOOLS) == 33
+	assert len(TOOLS) == 35
 
 
 def test_mcp_tool_count_matches_readme():
@@ -658,12 +659,30 @@ def test_build_args_shortlist_list():
 
 def test_tool_count_after_pr41():
 	"""协议服务工具总数应与当前 MCP 暴露能力完全一致。"""
-	assert len(TOOLS) == 33
+	assert len(TOOLS) == 35
 
 
 def test_build_args_shortlist_add():
-	args = _build_args("boss_shortlist_add", {"security_id": "s1", "job_id": "j1"})
-	assert args == ["shortlist", "add", "s1", "j1"]
+	args = _build_args("boss_shortlist_add", {"security_id": "s1", "job_id": "j1", "tags": "远程,双休", "note": "优先"})
+	assert args == ["shortlist", "add", "s1", "j1", "--tags", "远程,双休", "--note", "优先"]
+
+
+def test_build_args_shortlist_annotate():
+	args = _build_args(
+		"boss_shortlist_annotate",
+		{"security_id": "s1", "job_id": "j1", "add_tags": ["远程", "双休"], "remove_tags": ["外包"], "note": "优先"},
+	)
+	assert args == [
+		"shortlist", "annotate", "s1", "j1",
+		"--add-tag", "远程", "--add-tag", "双休",
+		"--remove-tag", "外包",
+		"--note", "优先",
+	]
+
+
+def test_build_args_shortlist_compare():
+	args = _build_args("boss_shortlist_compare", {"tag": "远程"})
+	assert args == ["shortlist", "compare", "--tag", "远程"]
 
 
 def test_build_args_shortlist_remove():

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,5 +1,6 @@
 """模型上下文协议服务测试 — 覆盖工具定义、参数构建和调用逻辑。"""
 import inspect
+import re
 import sys
 import types
 from pathlib import Path
@@ -26,6 +27,7 @@ sys.modules.setdefault("mcp.types", _mcp_types)
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "mcp-server"))
 import server  # noqa: E402
 from server import (  # noqa: E402
+	SERVER_INSTRUCTIONS,
 	TOOLS,
 	_build_args,
 	_compliance_command_for_tool,
@@ -38,6 +40,37 @@ from server import (  # noqa: E402
 	run,
 )
 from boss_agent_cli.compliance import low_risk_blocked_commands  # noqa: E402
+from boss_agent_cli.main import cli  # noqa: E402
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(path: str) -> str:
+	return (ROOT / path).read_text(encoding="utf-8")
+
+
+def _placeholder_value(schema: dict) -> object:
+	if "default" in schema:
+		return schema["default"]
+	if schema.get("enum"):
+		return schema["enum"][0]
+	if schema.get("type") == "integer":
+		return 1
+	if schema.get("type") == "boolean":
+		return False
+	if schema.get("type") == "array":
+		item_schema = schema.get("items") or {}
+		return [_placeholder_value(item_schema)]
+	return "placeholder"
+
+
+def _required_arguments(tool) -> dict[str, object]:
+	properties = tool.inputSchema.get("properties", {})
+	return {
+		name: _placeholder_value(properties.get(name, {}))
+		for name in tool.inputSchema.get("required", [])
+	}
 
 
 # ── 工具定义完整性 ──────────────────────────────────────────────────
@@ -113,6 +146,27 @@ def test_required_tools_present():
 def test_tool_count():
 	"""工具总数应与当前注册一致。"""
 	assert len(TOOLS) == 32
+
+
+def test_mcp_tool_count_matches_readme():
+	content = _read("README.en.md")
+	match = re.search(r"MCP server with (\d+) tools", content)
+	assert match
+	assert int(match.group(1)) == len(TOOLS)
+
+
+def test_server_instructions_carry_doctrine():
+	assert SERVER_INSTRUCTIONS
+	assert "COMPLIANCE_BLOCKED" in SERVER_INSTRUCTIONS
+	assert "boss schema" in SERVER_INSTRUCTIONS
+
+
+def test_every_tool_maps_to_registered_command():
+	registered_commands = set(cli.commands)
+	for tool in TOOLS:
+		args = _build_args(tool.name, _required_arguments(tool))
+		assert args, tool.name
+		assert args[0] in registered_commands, tool.name
 
 
 def test_search_tool_requires_query():

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -265,6 +265,11 @@ def test_build_args_search_with_options():
 	assert "2" in args
 
 
+def test_build_args_search_with_score_sort():
+	args = _build_args("boss_search", {"query": "python", "sort": "score"})
+	assert args == ["search", "python", "--sort", "score"]
+
+
 def test_build_args_search_ignores_empty_options():
 	"""空选项不应出现在参数中。"""
 	args = _build_args("boss_search", {"query": "java", "city": "", "salary": None})

--- a/tests/test_schema_formats.py
+++ b/tests/test_schema_formats.py
@@ -81,6 +81,15 @@ def test_tool_formats_keep_search_welfare_parameter():
 	assert "福利筛选" in anth_search["properties"]["welfare"]["description"]
 
 
+def test_tool_formats_ignore_nested_shortlist_option_groups():
+	"""分组命令的子命令 option 元数据不应被误导出为顶层工具参数。"""
+	oai = _format_openai_tools(SCHEMA_DATA)
+	shortlist = next(t["function"]["parameters"] for t in oai if t["function"]["name"] == "boss_shortlist")
+	assert "add" not in shortlist["properties"]
+	assert "annotate" not in shortlist["properties"]
+	assert "compare" not in shortlist["properties"]
+
+
 def test_command_to_json_schema_required_args():
 	"""required=True 的参数应出现在 required 数组中。"""
 	cmd_spec = {

--- a/tests/test_search_filters.py
+++ b/tests/test_search_filters.py
@@ -4,6 +4,7 @@ import pytest
 from boss_agent_cli.search_filters import (
 	SearchFilterCriteria,
 	SearchUrlParseError,
+	compute_match_score,
 	parse_salary_range,
 	parse_boss_search_url,
 	meets_experience_threshold,
@@ -183,3 +184,52 @@ class TestPrefilterJob:
 		criteria = SearchFilterCriteria(query="go")
 		ok, reasons = prefilter_job(raw, criteria)
 		assert ok is True
+
+
+class TestComputeMatchScore:
+	def test_welfare_tag_scores_higher_than_description(self):
+		item = {
+			"title": "Golang 后端",
+			"salary": "20-30K",
+			"city": "广州",
+			"experience": "3-5年",
+			"education": "本科",
+			"skills": ["Golang"],
+			"welfare": ["双休"],
+		}
+		criteria = SearchFilterCriteria(
+			query="golang",
+			city="广州",
+			salary="20-50K",
+			experience="3-5年",
+			education="本科",
+		)
+
+		tag_score = compute_match_score(item, ["双休(标签)"], criteria)
+		desc_score = compute_match_score(item, ["双休(描述)"], criteria)
+
+		assert 0 <= desc_score < tag_score <= 100
+
+	def test_welfare_more_matches_score_higher(self):
+		item = {
+			"title": "Python 后端",
+			"salary": "20-30K",
+			"city": "广州",
+			"experience": "3-5年",
+			"education": "本科",
+			"skills": ["Python"],
+			"welfare": ["双休", "五险一金"],
+		}
+		criteria = SearchFilterCriteria(
+			query="python",
+			city="广州",
+			salary="20-50K",
+			experience="3-5年",
+			education="本科",
+		)
+
+		one = compute_match_score(item, ["双休(标签)"], criteria)
+		two = compute_match_score(item, ["双休(标签)", "五险一金(标签)"], criteria)
+
+		assert two > one
+		assert compute_match_score(item, ["双休(标签)", "五险一金(标签)"], criteria) == two

--- a/tests/test_shortlist.py
+++ b/tests/test_shortlist.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import patch
 
 from click.testing import CliRunner
 
@@ -7,7 +8,47 @@ from boss_agent_cli.main import cli
 
 def test_shortlist_add_list_remove(tmp_path):
 	runner = CliRunner()
-	result = runner.invoke(
+	with patch("boss_agent_cli.commands._platform.get_platform_instance") as platform:
+		result = runner.invoke(
+			cli,
+			[
+				"--data-dir", str(tmp_path),
+				"--json",
+				"shortlist", "add", "sec_001", "job_001",
+				"--title", "Go 开发",
+				"--company", "TestCo",
+				"--city", "广州",
+				"--salary", "20-30K",
+				"--source", "search",
+				"--tags", "后端, 双休,后端",
+				"--note", "优先沟通",
+			],
+		)
+		platform.assert_not_called()
+	assert result.exit_code == 0
+	parsed = json.loads(result.output)
+	assert parsed["ok"] is True
+	assert parsed["data"]["security_id"] == "sec_001"
+	assert parsed["data"]["tags"] == ["后端", "双休"]
+	assert parsed["data"]["note"] == "优先沟通"
+
+	list_result = runner.invoke(cli, ["--data-dir", str(tmp_path), "--json", "shortlist", "list"])
+	assert list_result.exit_code == 0
+	list_parsed = json.loads(list_result.output)
+	assert len(list_parsed["data"]) == 1
+	assert list_parsed["data"][0]["company"] == "TestCo"
+	assert list_parsed["data"][0]["tags"] == ["后端", "双休"]
+	assert list_parsed["data"][0]["note"] == "优先沟通"
+
+	remove_result = runner.invoke(cli, ["--data-dir", str(tmp_path), "--json", "shortlist", "remove", "sec_001", "job_001"])
+	assert remove_result.exit_code == 0
+	remove_parsed = json.loads(remove_result.output)
+	assert remove_parsed["data"]["removed"] is True
+
+
+def test_shortlist_annotate_updates_tags_and_note(tmp_path):
+	runner = CliRunner()
+	runner.invoke(
 		cli,
 		[
 			"--data-dir", str(tmp_path),
@@ -15,26 +56,100 @@ def test_shortlist_add_list_remove(tmp_path):
 			"shortlist", "add", "sec_001", "job_001",
 			"--title", "Go 开发",
 			"--company", "TestCo",
-			"--city", "广州",
-			"--salary", "20-30K",
-			"--source", "search",
+			"--tags", "后端,双休",
 		],
 	)
-	assert result.exit_code == 0
+
+	with patch("boss_agent_cli.commands._platform.get_platform_instance") as platform:
+		result = runner.invoke(
+			cli,
+			[
+				"--data-dir", str(tmp_path),
+				"--json",
+				"shortlist", "annotate", "sec_001", "job_001",
+				"--add-tag", "远程",
+				"--add-tag", "双休",
+				"--remove-tag", "双休",
+				"--note", "等年终奖确认",
+			],
+		)
+		platform.assert_not_called()
+
+	assert result.exit_code == 0, result.output
 	parsed = json.loads(result.output)
-	assert parsed["ok"] is True
-	assert parsed["data"]["security_id"] == "sec_001"
+	assert parsed["data"]["updated"] is True
+	assert parsed["data"]["item"]["tags"] == ["后端", "远程"]
+	assert parsed["data"]["item"]["note"] == "等年终奖确认"
 
-	list_result = runner.invoke(cli, ["--data-dir", str(tmp_path), "--json", "shortlist", "list"])
-	assert list_result.exit_code == 0
-	list_parsed = json.loads(list_result.output)
-	assert len(list_parsed["data"]) == 1
-	assert list_parsed["data"][0]["company"] == "TestCo"
 
-	remove_result = runner.invoke(cli, ["--data-dir", str(tmp_path), "--json", "shortlist", "remove", "sec_001", "job_001"])
-	assert remove_result.exit_code == 0
-	remove_parsed = json.loads(remove_result.output)
-	assert remove_parsed["data"]["removed"] is True
+def test_shortlist_compare_filters_by_tag_locally(tmp_path):
+	runner = CliRunner()
+	for args in (
+		[
+			"shortlist", "add", "sec_001", "job_001",
+			"--title", "Go 开发", "--company", "TestCo",
+			"--city", "广州", "--salary", "20-30K",
+			"--tags", "后端,远程", "--note", "优先",
+		],
+		[
+			"shortlist", "add", "sec_002", "job_002",
+			"--title", "Python 开发", "--company", "OtherCo",
+			"--city", "深圳", "--salary", "25-35K",
+			"--tags", "后端",
+		],
+	):
+		result = runner.invoke(cli, ["--data-dir", str(tmp_path), "--json", *args])
+		assert result.exit_code == 0, result.output
+
+	with patch("boss_agent_cli.commands._platform.get_platform_instance") as platform:
+		result = runner.invoke(cli, ["--data-dir", str(tmp_path), "--json", "shortlist", "compare", "--tag", "远程"])
+		platform.assert_not_called()
+
+	assert result.exit_code == 0, result.output
+	parsed = json.loads(result.output)
+	assert parsed["data"]["tag"] == "远程"
+	assert parsed["data"]["count"] == 1
+	assert parsed["data"]["items"] == [
+		{
+			"security_id": "sec_001",
+			"job_id": "job_001",
+			"title": "Go 开发",
+			"company": "TestCo",
+			"city": "广州",
+			"salary": "20-30K",
+			"tags": ["后端", "远程"],
+			"note": "优先",
+		}
+	]
+
+
+def test_shortlist_local_flows_do_not_construct_platform_clients(tmp_path):
+	runner = CliRunner()
+	with (
+		patch("boss_agent_cli.auth.manager.AuthManager") as auth_manager,
+		patch("boss_agent_cli.api.client.BossClient") as boss_client,
+		patch("boss_agent_cli.commands._platform.get_platform_instance") as platform,
+	):
+		commands = [
+			[
+				"--data-dir", str(tmp_path), "--json",
+				"shortlist", "add", "sec_001", "job_001", "--tags", "后端", "--note", "本地备注",
+			],
+			["--data-dir", str(tmp_path), "--json", "shortlist", "list"],
+			[
+				"--data-dir", str(tmp_path), "--json",
+				"shortlist", "annotate", "sec_001", "job_001", "--add-tag", "远程",
+			],
+			["--data-dir", str(tmp_path), "--json", "shortlist", "compare", "--tag", "远程"],
+			["--data-dir", str(tmp_path), "--json", "shortlist", "remove", "sec_001", "job_001"],
+		]
+		for args in commands:
+			result = runner.invoke(cli, args)
+			assert result.exit_code == 0, result.output
+
+		auth_manager.assert_not_called()
+		boss_client.assert_not_called()
+		platform.assert_not_called()
 
 
 def test_shortlist_zhilian_hints_use_platform_specific_commands(tmp_path):
@@ -72,4 +187,10 @@ def test_shortlist_schema_is_exposed():
 	result = runner.invoke(cli, ["schema"])
 	assert result.exit_code == 0
 	parsed = json.loads(result.output)
+	shortlist = parsed["data"]["commands"]["shortlist"]
 	assert "shortlist" in parsed["data"]["commands"]
+	assert "annotate" in shortlist["subcommands"]
+	assert "compare" in shortlist["subcommands"]
+	assert "--tags" in shortlist["options"]["add"]
+	assert "--note" in shortlist["options"]["add"]
+	assert "--tag" in shortlist["options"]["compare"]

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -40,7 +40,9 @@ def _seed_cache(
 		)
 	for i in range(shortlist):
 		conn.execute(
-			"INSERT OR REPLACE INTO shortlist_records VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+			"INSERT OR REPLACE INTO shortlist_records "
+			"(security_id, job_id, title, company, city, salary, source, created_at) "
+			"VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
 			(f"sid-{i}", f"jid-{i}", "职位", "公司", "北京", "20-30K", "search", now),
 		)
 	for i in range(watch_hits):


### PR DESCRIPTION
落地 `.trellis/tasks/` 规划中按优先级先做的价值主线四项（由 Codex 实现，整理为本 PR 正式过 CI）。

- **T1 MCP 契约测试**：抽出 `SERVER_INSTRUCTIONS` 常量；`tests/test_mcp_server.py` 断言只暴露低风险工具、工具数与 README 一致、instructions 含 `COMPLIANCE_BLOCKED`/`boss schema`、每工具映射到真实命令。
- **T2 `boss ai fit`**：本地简历 × 候选池已缓存详情的逐岗匹配报告；**零平台请求**（测试显式 `get_platform.assert_not_called()` + `boss_client.assert_not_called()`），经 MCP 暴露（只读）。
- **T3 福利评分排序**：`search_filters` 本地 `match_score` + `search --sort score`，只读已抓字段、不改节流/页数。
- **T6 候选池标签/备注/对比**：`shortlist` 增 annotate/compare；`cache/store.py` 用 `PRAGMA table_info` + `ALTER TABLE ADD COLUMN` 做**向后兼容**迁移。

## 校验
- 本地 `scripts/quality_baseline.py` 全绿：ruff ✓ · **pytest 1475 passed** · mypy ✓(104 文件)。
- 护栏抽查：`ai fit` 零平台请求（测试断言）✓；`_SENSITIVE_COMMANDS` 未放宽（greet/apply… 仍阻断）✓；候选池迁移幂等不破旧库 ✓。

> 余下 T4 / T5 / T7 / T8 / T9 仍在 `.trellis/tasks/` 队列，交回 Codex 继续。