### PR TITLE
chore: 准备 1.14.0 发版

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+## [1.14.0] - 2026-06-25
+
 ### Added
 - `boss shortlist` 新增本地标签、备注与离线对比能力：`shortlist add --tags/--note` 可在加入候选池时记录本地整理信息，`shortlist annotate` 支持增删标签和更新备注，`shortlist compare [--tag]` 仅从 SQLite 候选池读取并按标签本地过滤；MCP 同步新增 `boss_shortlist_annotate` / `boss_shortlist_compare`，默认低风险工具数 33 → 35。
 - 新增 `boss ai fit --resume <name> [--limit N]`：基于本地简历与候选池已缓存职位详情生成逐岗匹配度、能力缺口、关键词命中和建议；缺少详情的岗位只报告本地缺口并提示先执行 `boss detail`，不发起任何新增平台请求。

--- a/docs/marketing/awesome-submissions.md
+++ b/docs/marketing/awesome-submissions.md
@@ -53,8 +53,8 @@
 - [x] README 双语（中文 + 英文）
 - [x] MIT License
 - [x] CI 全绿（pytest / ruff / mypy / CodeQL）
-- [x] 发布到 PyPI（`pip install boss-agent-cli`，当前 latest release v1.13.1）
-- [x] GitHub Release 规范（latest release v1.13.1 已发）
+- [x] 发布到 PyPI（`pip install boss-agent-cli`，当前 latest release v1.14.0）
+- [x] GitHub Release 规范（latest release v1.14.0 已发）
 - [x] CHANGELOG 完整
 - [x] Code of Conduct + Security Policy
 - [x] Issue / PR 模板

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "boss-agent-cli"
-version = "1.13.1"
+version = "1.14.0"
 description = "AI Agent 专用的 BOSS 直聘求职 CLI 工具"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/boss_agent_cli/__init__.py
+++ b/src/boss_agent_cli/__init__.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 	from boss_agent_cli.platforms import BossPlatform, Platform, ZhilianPlatform, get_platform, list_platforms
 	from boss_agent_cli.resume.models import ResumeData, ResumeFile
 
-__version__ = "1.13.1"
+__version__ = "1.14.0"
 
 _LAZY_EXPORT_MODULES = {
 	"AuthManager": "boss_agent_cli.auth.manager",

--- a/uv.lock
+++ b/uv.lock
@@ -208,7 +208,7 @@ wheels = [
 
 [[package]]
 name = "boss-agent-cli"
-version = "1.13.1"
+version = "1.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },


### PR DESCRIPTION
版本号 1.13.1 → **1.14.0**（minor，含两轮新增 AI 辅助 + 候选池增强等功能）。

## 改动
- `pyproject.toml` / `src/boss_agent_cli/__init__.py`：版本号 1.14.0（CLI `--version` 已验证）
- `CHANGELOG.md`：`[Unreleased]` 内容归入 `[1.14.0] - 2026-06-25`
- `docs/marketing/awesome-submissions.md`：latest release 引用更新到 v1.14.0
- `uv.lock`：构建同步

## 1.14.0 主要内容（摘自 CHANGELOG）
**Added**
- `boss shortlist` 本地标签/备注/离线对比（`add --tags/--note`、`annotate`、`compare`）
- `boss ai fit` — 本地简历 × 候选池缓存详情的逐岗匹配报告（零平台请求）
- `boss ai suggest-keywords` — 候选池分析推荐搜索关键词（零平台请求）
- `boss ai resume-optimize` — 基于目标岗位优化简历（零平台请求）

**Changed**
- 转向 MCP-first（MCP 列为 Agent 首选接入，退役 boss-skill）
- `boss search` 新增本地 `match_score` + `--sort score`

## 校验
- 全量测试 **1559 passed**；ruff ✓ · mypy ✓(127 files) · `uv build` 产出 1.14.0 wheel
- 版本一致性测试通过（pyproject = `__version__` = CLI `--version`）
- 文档一致性 36 passed · `git diff --check` clean

> 合并后将推送 `v1.14.0` tag 触发自动发版（GitHub Release + PyPI publish）——该步骤需另行确认。