### PR TITLE
fix: 恢复 #323 误删的 Atlas Cloud provider 接入与 README 展示

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -22,6 +22,14 @@
 
 </div>
 
+<p align="center">
+  <a href="https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=boss-agent-cli">
+    <img src="docs/assets/atlas-cloud-logo.png" alt="Atlas Cloud" width="180">
+  </a>
+</p>
+
+> 🎁 **[Atlas Cloud](https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=boss-agent-cli)** gives `boss ai` a full-modal, OpenAI-compatible backend — one key for DeepSeek, Qwen, GLM, Kimi, MiniMax, Claude, GPT, and more, with no per-vendor wiring. Just pick `--provider atlas` in `boss ai config` (`base_url=https://api.atlascloud.ai/v1`, default model `deepseek-ai/deepseek-v4-pro`); see [AI model integration](docs/integrations/ai-models.en.md#atlas-cloud-one-key-across-many-model-families) for setup. Budget-friendly [coding plan](https://www.atlascloud.ai/console/coding-plan).
+
 ## ⚠️ Compliance Boundary
 
 Low-Risk Assistance Mode is on by default: local assistance · read-only first · user-triggered · no risk-control bypass · no bulk outreach · no platform-data scraping. Commands that greet (greet / batch-greet), apply, exchange contacts, search recruiter candidates, read candidate resumes / chats, or reply are blocked by default and return the `COMPLIANCE_BLOCKED` error code; perform those actions manually on the official website.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@
 
 </div>
 
+<p align="center">
+  <a href="https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=boss-agent-cli">
+    <img src="docs/assets/atlas-cloud-logo.png" alt="Atlas Cloud" width="180">
+  </a>
+</p>
+
+> 🎁 **[Atlas Cloud](https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=boss-agent-cli)** 为 `boss ai` 提供了一个全模态、OpenAI 兼容的推理入口 —— 一个 key 即可访问 DeepSeek、Qwen、GLM、Kimi、MiniMax、Claude、GPT 等模型，无需逐家接入。在 `boss ai config` 里选用 `--provider atlas`（`base_url=https://api.atlascloud.ai/v1`、默认模型 `deepseek-ai/deepseek-v4-pro`）即可，配置详见 [AI 模型接入](docs/integrations/ai-models.md#atlas-cloud一个-key-覆盖多家模型)；预算友好的 [coding plan](https://www.atlascloud.ai/console/coding-plan)。
+
 > [!TIP]
 > <img src="https://github.com/peterfei/ai-agent-team/raw/main/examples/doloffer.png" alt="Doloffer logo" width="220">
 >

--- a/src/boss_agent_cli/ai/config.py
+++ b/src/boss_agent_cli/ai/config.py
@@ -24,6 +24,7 @@ PROVIDER_BASE_URLS: dict[str, str | None] = {
 	"qwen": "https://dashscope.aliyuncs.com/compatible-mode/v1",
 	"zhipu": "https://open.bigmodel.cn/api/paas/v4",
 	"siliconflow": "https://api.siliconflow.cn/v1",
+	"atlas": "https://api.atlascloud.ai/v1",
 	"ollama": "http://localhost:11434/v1",
 	"vllm": "http://localhost:8000/v1",
 	"custom": None,

--- a/src/boss_agent_cli/commands/ai_cmd.py
+++ b/src/boss_agent_cli/commands/ai_cmd.py
@@ -168,7 +168,7 @@ def ai_group() -> None:
 
 
 @ai_group.command("config")
-@click.option("--provider", default=None, help="AI 提供商（openai/deepseek/moonshot/openrouter/qwen/zhipu/siliconflow/ollama/vllm/custom）")
+@click.option("--provider", default=None, help="AI 提供商（openai/deepseek/moonshot/openrouter/qwen/zhipu/siliconflow/atlas/ollama/vllm/custom）")
 @click.option("--model", default=None, help="模型名称（如 gpt-4o / claude-sonnet-4.5 / deepseek-chat）")
 @click.option("--api-key", default=None, help="API 密钥（将加密存储）")
 @click.option("--base-url", default=None, help="自定义 API 基础地址（provider=custom 或自建代理时使用）")

--- a/tests/test_ai_config.py
+++ b/tests/test_ai_config.py
@@ -152,6 +152,13 @@ def test_base_url_siliconflow(tmp_path, monkeypatch):
 	assert store.get_base_url() == "https://api.siliconflow.cn/v1"
 
 
+def test_base_url_atlas(tmp_path, monkeypatch):
+	"""Atlas Cloud 全模态聚合入口。"""
+	store = _make_store(tmp_path, monkeypatch)
+	store.save_config(ai_provider="atlas")
+	assert store.get_base_url() == "https://api.atlascloud.ai/v1"
+
+
 def test_base_url_ollama(tmp_path, monkeypatch):
 	"""Ollama 本地 OpenAI 兼容入口。"""
 	store = _make_store(tmp_path, monkeypatch)
@@ -212,6 +219,8 @@ def test_provider_base_urls_completeness():
 	assert "qwen" in PROVIDER_BASE_URLS
 	assert "zhipu" in PROVIDER_BASE_URLS
 	assert "siliconflow" in PROVIDER_BASE_URLS
+	assert "atlas" in PROVIDER_BASE_URLS
+	assert PROVIDER_BASE_URLS["atlas"] == "https://api.atlascloud.ai/v1"
 	assert "ollama" in PROVIDER_BASE_URLS
 	assert "vllm" in PROVIDER_BASE_URLS
 	assert "custom" in PROVIDER_BASE_URLS


### PR DESCRIPTION
## 背景

#320 引入 Atlas Cloud（OpenAI 兼容 provider），#322 在 README 加入 Atlas Cloud 展示块。但 #323（`d03c468` 招聘自动化打包并接入 OpenCode）因分支基线陈旧，合并时把 Atlas Cloud 的接入整片回退掉了：

- `ai/config.py` 的 `atlas` provider 条目被删
- `tests/test_ai_config.py` 的 atlas 断言被删
- README 中英文的 Atlas Cloud 展示块被删

而 `docs/integrations/ai-models.md` 未被波及，仍在引导用户使用 `--provider atlas`，导致**文档与代码不一致**（照文档配置会拿不到 base_url）。

## 改动

恢复被误删的部分，并**保留 #323 自身新增的 `ollama`/`vllm`**：

- `ai/config.py`：`PROVIDER_BASE_URLS` 补回 `atlas`（置于 `siliconflow` 与 `ollama` 之间）
- `ai_cmd.py`：`--provider` 帮助文案补回 `atlas`
- `tests/test_ai_config.py`：completeness 断言 + 新增 `test_base_url_atlas`
- `README.md` / `README.en.md`：恢复 Atlas Cloud 展示块

## 验证

- `ruff check src tests` ✓
- `pytest` — 1560 passed ✓
- `mypy src/boss_agent_cli` — 127 files, no issues ✓
- 文档一致性测试（test_agent_docs / test_open_source_docs）— 36 passed ✓
