### PR TITLE
fix: 修复智联页面域名校验

### DIFF
--- a/src/boss_agent_cli/auth/browser.py
+++ b/src/boss_agent_cli/auth/browser.py
@@ -1,6 +1,7 @@
 import sys
 import time
 from typing import Any, cast
+from urllib.parse import urlparse
 
 from patchright.sync_api import sync_playwright
 
@@ -29,6 +30,7 @@ _PLATFORM_BROWSER_CONFIG: dict[str, dict[str, str]] = {
 		"success_cookie": "at",
 	},
 }
+_ZHILIAN_HOST = "zhaopin.com"
 
 
 def _get_platform_config(platform: str) -> dict[str, str]:
@@ -54,13 +56,21 @@ def _extract_zhilian_client_id(page: Any) -> str:
 		return ""
 
 
+def _is_zhilian_url(url: str) -> bool:
+	host = urlparse(url).hostname
+	if host is None:
+		return False
+	host = host.rstrip(".").lower()
+	return host == _ZHILIAN_HOST or host.endswith(f".{_ZHILIAN_HOST}")
+
+
 def _find_zhilian_recruiter_page(pages: list[Any]) -> Any | None:
 	for page in pages:
 		url = getattr(page, "url", "")
-		if "zhaopin.com" in url and any(path in url for path in ("/app/im", "/app/recommend")):
+		if _is_zhilian_url(url) and any(path in url for path in ("/app/im", "/app/recommend")):
 			return page
 	for page in pages:
-		if "zhaopin.com" in getattr(page, "url", ""):
+		if _is_zhilian_url(getattr(page, "url", "")):
 			return page
 	return None
 

--- a/src/boss_agent_cli/automation/zhilian_cdp.py
+++ b/src/boss_agent_cli/automation/zhilian_cdp.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from boss_agent_cli.auth.browser import _DEFAULT_CDP_URL, probe_cdp
+from boss_agent_cli.auth.browser import _DEFAULT_CDP_URL, _is_zhilian_url, probe_cdp
 from boss_agent_cli.automation.zhilian_browser import (
 	PageLike,
 	ZhilianBrowserRecruiterSession,
@@ -46,14 +46,14 @@ def create_zhilian_browser_session_from_cdp(
 def _find_zhilian_page(pages: list[Any]) -> Any | None:
 	for page in pages:
 		url = getattr(page, "url", "")
-		if "zhaopin.com" in url and _is_zhilian_chat_url(url):
+		if _is_zhilian_url(url) and _is_zhilian_chat_url(url):
 			return page
 	for page in pages:
 		url = getattr(page, "url", "")
-		if "zhaopin.com" in url and any(token in url for token in ("im", "chat")):
+		if _is_zhilian_url(url) and any(token in url for token in ("im", "chat")):
 			return page
 	for page in pages:
-		if "zhaopin.com" in getattr(page, "url", ""):
+		if _is_zhilian_url(getattr(page, "url", "")):
 			return page
 	return None
 

--- a/tests/test_auth_browser.py
+++ b/tests/test_auth_browser.py
@@ -7,6 +7,8 @@ from boss_agent_cli.auth.browser import (
 	LOGIN_PAGE_URL,
 	_NAV_TIMEOUT_MS,
 	_NETWORKIDLE_GRACE_MS,
+	_find_zhilian_recruiter_page,
+	_is_zhilian_url,
 	login_via_cdp,
 	login_via_browser,
 	refresh_stoken,
@@ -37,6 +39,29 @@ def _mock_cdp_playwright(mock_context: MagicMock) -> tuple[MagicMock, MagicMock,
 	mock_launcher = MagicMock()
 	mock_launcher.start.return_value = mock_playwright
 	return mock_launcher, mock_playwright, mock_page
+
+
+class _UrlPage:
+	def __init__(self, url: str) -> None:
+		self.url = url
+
+
+def test_zhilian_url_host_validation_uses_exact_hostname() -> None:
+	assert _is_zhilian_url("https://zhaopin.com/")
+	assert _is_zhilian_url("https://RD6.ZHAOPIN.COM./app/im")
+	assert not _is_zhilian_url("https://rd6.zhaopin.com.evil.example/app/im")
+	assert not _is_zhilian_url("https://evil.example/app/im?next=https://rd6.zhaopin.com/app/im")
+	assert not _is_zhilian_url("not-a-url-with-zhaopin.com")
+
+
+def test_find_zhilian_recruiter_page_rejects_embedded_hostname() -> None:
+	fake_chat = _UrlPage("https://rd6.zhaopin.com.evil.example/app/im")
+	fake_recommend = _UrlPage("https://evil.example/app/recommend?next=https://rd6.zhaopin.com/app/im")
+	valid_page = _UrlPage("https://rd6.zhaopin.com/profile")
+
+	selected = _find_zhilian_recruiter_page([fake_chat, fake_recommend, valid_page])
+
+	assert selected is valid_page
 
 
 @patch("boss_agent_cli.auth.browser.probe_cdp", return_value="ws://localhost/devtools/browser")

--- a/tests/test_zhilian_browser_automation.py
+++ b/tests/test_zhilian_browser_automation.py
@@ -129,6 +129,22 @@ def test_zhilian_cdp_prefers_chat_page_over_recommend_page() -> None:
 	assert selected is chat
 
 
+def test_zhilian_cdp_rejects_embedded_zhaopin_hostname() -> None:
+	fake_chat = FakeCdpPage("https://rd6.zhaopin.com.evil.example/app/im")
+	fake_query = FakeCdpPage("https://evil.example/chat?next=https://rd6.zhaopin.com/app/im")
+	valid_page = FakeCdpPage("https://rd6.zhaopin.com/profile")
+
+	selected = _find_zhilian_page([fake_chat, fake_query, valid_page])
+
+	assert selected is valid_page
+
+
+def test_zhilian_cdp_ignores_invalid_zhaopin_like_url() -> None:
+	selected = _find_zhilian_page([FakeCdpPage("not-a-url-with-zhaopin.com")])
+
+	assert selected is None
+
+
 def test_zhilian_browser_session_sends_message_after_selector_health(tmp_path: Path) -> None:
 	page = FakePage()
 	session = ZhilianBrowserRecruiterSession(page, diagnostics_dir=tmp_path)


### PR DESCRIPTION
## Summary

- Replace substring-based Zhilian URL ownership checks with parsed hostname validation.
- Reuse the same helper in CDP login page reuse and Zhilian browser automation page selection.
- Add regressions for exact hosts, subdomains, embedded fake hosts, query-string mentions, and invalid URL strings.

## Root Cause

CodeQL flagged `py/incomplete-url-substring-sanitization` because the previous page-selection logic used substring checks such as `"zhaopin.com" in url`. A crafted hostname like `rd6.zhaopin.com.evil.example` or a query parameter containing the trusted domain could be mistaken for an official Zhilian page.

## Validation

- `uv run pytest tests/test_auth_browser.py tests/test_zhilian_browser_automation.py -q`
- `uv run ruff check src/ tests/`
- `uv run mypy src/boss_agent_cli`
- `uv run pytest tests/ -q`
- `git diff --check`

## CodeQL

Local `codeql` CLI is not installed in this checkout, so GitHub code scanning/default setup should re-run on this PR/push to verify alerts #14-#18 close.