### PR TITLE
chore: 准备 1.15.0 发版

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+## [1.15.0] - 2026-07-14
+
 ### Added
 - 新增 `boss ai cover-letter <resume> [--jd <文本|@文件>|--job-id <id>] [--tone 简洁专业|热情积极|谨慎稳重] [--lang zh|en]`：基于本地简历与目标岗位起草求职信/自我介绍草稿，纯本地 + AIService、零平台请求，draft-only（只产出文本、不发送、不进敏感命令）；MCP 同步新增 `boss_ai_cover_letter`。
 
@@ -15,6 +17,7 @@
 - 命令层错误信封统一改用既有 `handle_platform_error_output`：当平台响应携带 `error.details`（主要是 `qiancheng` 占位响应）时，错误信封现在会带上 `details` 字段（新增字段，与已在用该 helper 的 `me` / `history` / hr `jobs` 命令口径一致）；BOSS 直聘 / 智联的真实响应不含该字段，输出不变。
 
 ### Fixed
+- 修复智联招聘 CDP / 浏览器页面选择的域名校验：此前用 `"zhaopin.com" in url` 子串判断，可能被 `zhaopin.com.evil.example` 等伪造 hostname 误判为可信页面；改为 `urlparse().hostname` 精确匹配 `zhaopin.com` 及其子域（CodeQL `py/incomplete-url-substring-sanitization`，两处页面查找共用同一 host 判断）。
 - 修复 #334：CDP 模式下每次搜索/推荐等高风险操作都会在用户 Chrome 新开一个 BOSS 首页标签页并导航（观感为“反复自动新开/刷新页面”）。现优先复用用户已打开的 zhipin 标签页（精确 hostname 校验），不再多余新开与导航，`close()` 也不再关闭被复用的用户标签页；无已打开 zhipin 页时回退原新建行为。风控即停（code 36）逻辑不变。
 
 ## [1.14.0] - 2026-06-25

--- a/docs/marketing/awesome-submissions.md
+++ b/docs/marketing/awesome-submissions.md
@@ -53,8 +53,8 @@
 - [x] README 双语（中文 + 英文）
 - [x] MIT License
 - [x] CI 全绿（pytest / ruff / mypy / CodeQL）
-- [x] 发布到 PyPI（`pip install boss-agent-cli`，当前 latest release v1.14.0）
-- [x] GitHub Release 规范（latest release v1.14.0 已发）
+- [x] 发布到 PyPI（`pip install boss-agent-cli`，当前 latest release v1.15.0）
+- [x] GitHub Release 规范（latest release v1.15.0 已发）
 - [x] CHANGELOG 完整
 - [x] Code of Conduct + Security Policy
 - [x] Issue / PR 模板

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "boss-agent-cli"
-version = "1.14.0"
+version = "1.15.0"
 description = "AI Agent 专用的 BOSS 直聘求职 CLI 工具"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/boss_agent_cli/__init__.py
+++ b/src/boss_agent_cli/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 	)
 	from boss_agent_cli.resume.models import ResumeData, ResumeFile
 
-__version__ = "1.14.0"
+__version__ = "1.15.0"
 
 _LAZY_EXPORT_MODULES = {
 	"AuthManager": "boss_agent_cli.auth.manager",

--- a/uv.lock
+++ b/uv.lock
@@ -208,7 +208,7 @@ wheels = [
 
 [[package]]
 name = "boss-agent-cli"
-version = "1.14.0"
+version = "1.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },


### PR DESCRIPTION
## 变更说明 / Summary

准备 `1.15.0` 发版（仅可逆部分，**不含打 tag**）：

- **版本 bump**：`pyproject.toml` / `src/boss_agent_cli/__init__.py` / `uv.lock` 均 `1.14.0 → 1.15.0`。
- **CHANGELOG 定版**：`[Unreleased]` → `[1.15.0] - 2026-07-14`，并补记此前已入库但漏记的 `daf8455`（智联页面域名校验，CodeQL `py/incomplete-url-substring-sanitization`）。
- **文档**：`docs/marketing/awesome-submissions.md` 的 latest release 引用同步到 v1.15.0。

## 1.15.0 包含（自 v1.14.0 起）

- **Added**：`boss ai cover-letter`（求职信/自我介绍草稿，纯本地 + AIService、零平台请求、draft-only）；MCP `boss_ai_cover_letter`。
- **Fixed**：#334（CDP 反复自动新开/刷新页面 → 复用已开 zhipin 标签页）；智联页面域名精确校验（daf8455）。
- **Removed**：6 个死配置键（`config set` 改为明确拒绝）；interviews 死 `_stub` 分支。
- **Changed**：命令层错误信封在含 `error.details` 时浮现 `details` 字段（additive）。

## 变更类型 / Type

- [x] chore: 构建/依赖/配置（发版准备）

## 测试计划 / Test Plan

- P0 baseline 全绿：ruff(src+tests) · pytest **1583 passed** · mypy 128 文件；版本一致性测试 `tests/test_public_api.py` 24 passed。

## 后续（本 PR 合并后）

合并到 master 后再打 **`v1.15.0`** annotated tag 推送 → CI 自动 pytest→build→GitHub Release→PyPI。**打 tag 触发 PyPI 发布不可逆**，将在维护者确认后执行。
