### PR TITLE
chore: 新增赞助配置与 triage 标签自动清理工作流

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# 赞助配置：GitHub 需先为账号开通 Sponsors，赞助按钮才会显示；未开通时此项静默无按钮、无副作用。
+# 若使用爱发电 / Ko-fi 等平台，改用下方 custom / ko_fi 字段（可删除 github 行）。
+github: [can4hou6joeng4]
+# custom: ["https://afdian.com/a/<your-id>"]
+# ko_fi: <username>

--- a/.github/workflows/triage-cleanup.yml
+++ b/.github/workflows/triage-cleanup.yml
@@ -1,0 +1,25 @@
+name: Triage cleanup
+
+# Issue 表单已在开 issue 时自动贴 triage（blank issue 已关闭），这里补上另一半：
+# 当维护者（OWNER / MEMBER / COLLABORATOR）评论一个仍挂着 triage 的 issue 时，自动摘掉该标签。
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  remove-triage:
+    if: >-
+      github.event.issue.pull_request == null &&
+      contains(github.event.issue.labels.*.name, 'triage') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove triage label after maintainer response
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: gh issue edit "$NUMBER" --repo "$REPO" --remove-label triage


### PR DESCRIPTION
## 仓库设置小优化（两项）

### 新增
- `.github/FUNDING.yml`：赞助入口（默认 `github: [can4hou6joeng4]`，需为账号开通 GitHub Sponsors 后按钮才显示；未开通无副作用。可改用 `custom`/`ko_fi` 指向爱发电 / Ko-fi 等）。
- `.github/workflows/triage-cleanup.yml`：Issue 表单已在开单时自动贴 `triage`（blank issue 已关闭），本工作流补上另一半——当维护者（`OWNER`/`MEMBER`/`COLLABORATOR`）评论一个仍挂着 `triage` 的 issue 时，自动摘掉该标签。

### 约束
- 仅对 issue 生效（`github.event.issue.pull_request == null` 保护，PR 评论不触发）。
- 仅在 `triage` 标签存在且评论者为维护者时执行；权限限 `issues: write`。