### PR TITLE
docs: 校正 marketing 文档的 MCP 工具数与顶层命令数至当前值

### DIFF
--- a/docs/marketing/awesome-submissions.md
+++ b/docs/marketing/awesome-submissions.md
@@ -1,12 +1,12 @@
 # Awesome List Submissions
 
-本文件记录 boss-agent-cli 向各大 awesome 列表投稿的模板，供维护者提交用。最后更新：master 当前状态 (2026-06-24)。
+本文件记录 boss-agent-cli 向各大 awesome 列表投稿的模板，供维护者提交用。最后更新：master 当前状态 (2026-07-17)。
 
 ## 项目一句话介绍
 
-**中文**：专为 AI Agent 设计的 BOSS 直聘求职 CLI，36 个顶层命令 + 9 个招聘者子命令 + 43 个 MCP 工具，全部输出 JSON，支持 Claude Desktop/Cursor/Windsurf/OpenCode 接入，聚焦职位发现、本地候选池整理、AI 辅助与显式入口下的招聘者辅助。
+**中文**：专为 AI Agent 设计的 BOSS 直聘求职 CLI，36 个顶层命令 + 9 个招聘者子命令 + 46 个 MCP 工具，全部输出 JSON，支持 Claude Desktop/Cursor/Windsurf/OpenCode 接入，聚焦职位发现、本地候选池整理、AI 辅助与显式入口下的招聘者辅助。
 
-**English**: AI-agent-first CLI for BOSS Zhipin. 36 top-level commands + 9 recruiter subcommands + 43 MCP tools, JSON envelope output, typed Python SDK (PEP 561), and MCP-first integration for Claude Desktop / Cursor / Windsurf / OpenCode.
+**English**: AI-agent-first CLI for BOSS Zhipin. 36 top-level commands + 9 recruiter subcommands + 46 MCP tools, JSON envelope output, typed Python SDK (PEP 561), and MCP-first integration for Claude Desktop / Cursor / Windsurf / OpenCode.
 
 ## 推荐投稿目标
 
@@ -15,7 +15,7 @@
 分类：Productivity / Job Search
 
 ```markdown
-- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - BOSS Zhipin integration for AI agents, exposing 35 default low-risk MCP tools for read-only job discovery, job detail inspection, local shortlists, resume helpers, and AI interview preparation.
+- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - BOSS Zhipin integration for AI agents, exposing 46 default low-risk MCP tools for read-only job discovery, job detail inspection, local shortlists, resume helpers, and AI interview preparation.
 ```
 
 ### 2. [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code)
@@ -31,7 +31,7 @@
 分类：Specialized Agents
 
 ```markdown
-- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) ![](https://img.shields.io/github/stars/can4hou6joeng4/boss-agent-cli) - Job-search CLI purpose-built for AI agents. BOSS Zhipin integration with 36 top-level commands, recruiter workflow subcommands, 43 MCP tools, JSON envelope output, and local-first encrypted storage.
+- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) ![](https://img.shields.io/github/stars/can4hou6joeng4/boss-agent-cli) - Job-search CLI purpose-built for AI agents. BOSS Zhipin integration with 36 top-level commands, recruiter workflow subcommands, 46 MCP tools, JSON envelope output, and local-first encrypted storage.
 ```
 
 ### 4. [awesome-python-cli](https://github.com/shinokada/awesome-python-cli)
@@ -45,7 +45,7 @@
 分类：Agents & Automation
 
 ```markdown
-- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - Let your AI agent organize the low-risk parts of a job search. 35 top-level CLI commands + 9 recruiter subcommands + 35 default low-risk MCP tools covering search, detail, local shortlist, interview prep, and AI resume coaching on BOSS Zhipin.
+- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - Let your AI agent organize the low-risk parts of a job search. 36 top-level CLI commands + 9 recruiter subcommands + 46 default low-risk MCP tools covering search, detail, local shortlist, interview prep, and AI resume coaching on BOSS Zhipin.
 ```
 
 ## 投稿前 Checklist（master 当前状态）
@@ -81,12 +81,12 @@
 
 ## 一句话钩子（A/B 测试素材）
 
-1. "36 个顶层命令 + 9 个招聘者子命令 + 43 个 MCP 工具，让 AI Agent 帮你完成职位发现、本地整理、招聘者辅助和面试准备"
+1. "36 个顶层命令 + 9 个招聘者子命令 + 46 个 MCP 工具，让 AI Agent 帮你完成职位发现、本地整理、招聘者辅助和面试准备"
 2. "第一个 MCP 就绪、类型安全的中国招聘平台 CLI，为 Claude Desktop / Cursor / Windsurf 设计"
 3. "`boss ai interview-prep` — 把 JD 扔进 AI，秒出 10 道模拟面试题"
 4. "你只负责描述期望，AI Agent 负责搜索、筛选、整理候选岗位；投递和沟通回到官方页面手动完成"
 5. "MIT License，本地加密存储，数据不出机"
-6. "CI 质量门禁、43 个 MCP 工具、下游 Python 嵌入零学习成本"
+6. "CI 质量门禁、46 个 MCP 工具、下游 Python 嵌入零学习成本"
 
 ## 实际投稿记录 & 渠道约束（2026-04-28 更新）
 

--- a/docs/marketing/en-launch-story.md
+++ b/docs/marketing/en-launch-story.md
@@ -7,7 +7,7 @@
 ## Title Candidates
 
 - **A**: Show HN: I built a low-risk job-search CLI for Claude and Cursor
-- **B**: boss-agent-cli — 35 top-level commands + 35 default low-risk MCP tools
+- **B**: boss-agent-cli — 36 top-level commands + 46 default low-risk MCP tools
 - **C**: An agent-first CLI for searching, filtering, and organizing job leads
 
 Recommended: **A**. It frames the project as an agent integration without implying automated applications or outreach.
@@ -18,7 +18,7 @@ Recommended: **A**. It frames the project as an agent integration without implyi
 
 ### TL;DR
 
-`boss-agent-cli` is an open-source CLI for AI agents to handle the low-risk parts of job discovery and local organization on [BOSS Zhipin](https://www.zhipin.com/). Every command outputs a structured JSON envelope, `boss schema` is the capability source of truth, and MCP exposes 35 default low-risk tools for Claude Desktop, Cursor, and other MCP-compatible hosts.
+`boss-agent-cli` is an open-source CLI for AI agents to handle the low-risk parts of job discovery and local organization on [BOSS Zhipin](https://www.zhipin.com/). Every command outputs a structured JSON envelope, `boss schema` is the capability source of truth, and MCP exposes 46 default low-risk tools for Claude Desktop, Cursor, and other MCP-compatible hosts.
 
 ```bash
 uv tool install boss-agent-cli
@@ -67,7 +67,7 @@ After connecting MCP, an agent can run a low-risk chain such as search -> detail
 
 ### Current boundaries
 
-- `boss schema` currently exposes 35 top-level commands; `hr` has 9 first-level recruiter subcommands; MCP exposes 35 default low-risk tools
+- `boss schema` currently exposes 36 top-level commands; `hr` has 9 first-level recruiter subcommands; MCP exposes 46 default low-risk tools
 - `zhipin` covers the main candidate workflow; `zhilian` supports candidate-side read-only + local-assist parity; `qiancheng` remains a `NOT_SUPPORTED` placeholder
 - CI covers Python 3.10 / 3.11 / 3.12 / 3.13, ruff, mypy, docs consistency, and CodeQL
 - No telemetry, analytics, or cloud sync; adoption is measured through PyPI downloads and GitHub Insights only

--- a/docs/marketing/zh-launch-story.md
+++ b/docs/marketing/zh-launch-story.md
@@ -7,7 +7,7 @@
 ## 标题候选
 
 - **A**：给 Claude / Cursor 接一个低风险求职 CLI
-- **B**：boss-agent-cli：35 个顶层命令 + 35 个默认低风险 MCP 工具
+- **B**：boss-agent-cli：36 个顶层命令 + 46 个默认低风险 MCP 工具
 - **C**：Agent First 的求职 CLI：搜索、筛选、整理候选岗位
 
 推荐 A，能直接说明这是 Agent 接入工具，不暗示自动投递或自动沟通。
@@ -52,7 +52,7 @@ boss shortlist add <security_id> <job_id>
 }
 ```
 
-当前能力面以 `boss schema` 为准：35 个顶层命令，`hr` 下 9 个一级招聘者子命令，MCP 默认暴露 35 个低风险工具。
+当前能力面以 `boss schema` 为准：36 个顶层命令，`hr` 下 9 个一级招聘者子命令，MCP 默认暴露 46 个低风险工具。
 
 ### 3. 三个设计决策
 


### PR DESCRIPTION
## 定向订正：marketing 文档数值漂移

`boss schema` 当前真值：**MCP 工具 46（= `len(TOOLS)`）/ 顶层命令 36**。marketing 文档里这两个数漂成了 43/35 等，本 PR 统一校正，并更新 `awesome-submissions.md` 的「最后更新」日期。

### 改动（仅 3 个 marketing 文件）
- `awesome-submissions.md`：MCP 工具 43/35 → **46**；顶层命令 35 → **36**；日期 2026-06-24 → 2026-07-17。
- `zh-launch-story.md` / `en-launch-story.md`：35 顶层命令 → 36；35 低风险工具 → 46。

### 刻意不动 README / mcp-server README
这四个文件的计数由 **#339** 一并改写为 1.17.0 的 49/37；此处若同时修改只会与 #339 冲突并被覆盖，故留给 #339。

### 后续（防复发）
建议在 #339 合并、计数稳定到 49 后，把中文 README 与 mcp-server README 的计数也 test-pin 到 `len(TOOLS)`（当前仅 `README.en.md` 一处被 pin），从机制上止住每次发版的漂移。