### PR TITLE
docs: README 增补 Why 叙事段与贡献者展示

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -30,6 +30,10 @@
 
 > 🎁 **[Atlas Cloud](https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=boss-agent-cli)** gives `boss ai` a full-modal, OpenAI-compatible backend — one key for DeepSeek, Qwen, GLM, Kimi, MiniMax, Claude, GPT, and more, with no per-vendor wiring. Just pick `--provider atlas` in `boss ai config` (`base_url=https://api.atlascloud.ai/v1`, default model `deepseek-ai/deepseek-v4-pro`); see [AI model integration](docs/integrations/ai-models.en.md#atlas-cloud-one-key-across-many-model-families) for setup. Budget-friendly [coding plan](https://www.atlascloud.ai/console/coding-plan).
 
+## 🧭 Why
+
+Auto-apply and batch-greet scripts automate exactly what the platform doesn't want automated — a ban is only a matter of time. boss-agent-cli goes the other way: **it hands the low-risk, read-only, user-triggered part to your terminal and your agent, and leaves the sensitive actions (greeting, applying, messaging) for you to do by hand on the official site.** You describe intent; the agent searches, filters, and organizes candidate jobs into structured JSON. `boss schema` is the source of truth, so it drops straight into Claude / Cursor and other MCP hosts. Compliance isn't a patch — it's the default posture.
+
 ## ⚠️ Compliance Boundary
 
 Assisted Mode is on by default: local assistance, read-only first, and user-triggered. Commands that greet (greet / batch-greet), apply, exchange contacts, search recruiter candidates, read candidate resumes / chats, or reply are blocked by default and return `COMPLIANCE_BLOCKED`; perform those actions manually on the official website. An explicit `boss config set operating_mode research` enables bounded browser-protocol, anti-debugging, risk-control adaptation, and controlled collection research, with redaction, checkpoints, stop controls, and auditable script provenance still required.
@@ -172,6 +176,10 @@ All state lives under `~/.boss-agent/` — encrypted tokens, cached searches, sh
 ## 🤝 Contributing
 
 See [CONTRIBUTING.en.md](CONTRIBUTING.en.md) and [Getting Started](docs/getting-started.en.md). TL;DR: fork → `feat/xxx` branch → write tests → `python scripts/quality_baseline.py` (on Chinese Windows, set `$env:PYTHONUTF8='1'` first) → PR.
+
+<a href="https://github.com/can4hou6joeng4/boss-agent-cli/graphs/contributors"><img src="https://contrib.rocks/image?repo=can4hou6joeng4/boss-agent-cli" alt="contributors" /></a>
+
+If this project helps you, a [Star ⭐](https://github.com/can4hou6joeng4/boss-agent-cli) or a share goes a long way.
 
 ## ⚠️ Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@
 >
 > 💡 **极速订阅**： [专属链接](https://doloffer.com/friend/BEv3yvKS)（输入优惠码 `AI8888` 享 9 折特惠）
 
+## 🧭 为什么
+
+自动投递、批量打招呼这类求职脚本，本质是在替平台做它不希望自动化的事——账号被封只是时间问题。boss-agent-cli 反其道而行：**把「低风险、只读、你主动触发」的那部分交给终端和 Agent，把打招呼 / 投递 / 沟通这类敏感动作留给你在官网手动完成。** 你描述期望，Agent 负责搜索、筛选、整理候选岗位并输出结构化 JSON；`boss schema` 是能力真源，天然适配 Claude / Cursor 等 MCP 宿主。合规不是事后补丁，而是默认姿态。
+
 ## ⚠️ 合规边界
 
 默认启用 **Assisted Mode**：本地辅助 · 只读优先 · 用户主动触发。打招呼（greet / batch-greet）、投递、联系方式交换、招聘者候选人搜索 / 简历 / 聊天、消息回复等敏感能力默认阻断并返回 `COMPLIANCE_BLOCKED`；需要时请回到 BOSS 直聘平台官网由用户手动完成。仓库同时允许显式 `boss config set operating_mode research` 启用 **Research Mode**，用于有界的浏览器协议、反调试、风控适配和受控采集研究；该模式仍要求脱敏、checkpoint、停止开关和可审计脚本来源。
@@ -182,6 +186,10 @@ CLI (Click)
 欢迎 Issue / PR：`git clone` → `feat/xxx` 分支 → 写测试 → `python scripts/quality_baseline.py`（Windows 中文系统可先 `$env:PYTHONUTF8='1'`）→ PR。详见 [CONTRIBUTING.md](CONTRIBUTING.md)，上手路径见 [快速上手](docs/getting-started.md)。
 
 致谢 [geekgeekrun](https://github.com/geekgeekrun/geekgeekrun) · [boss-cli](https://github.com/jackwener/boss-cli) · [opencli](https://github.com/jackwener/opencli)。
+
+<a href="https://github.com/can4hou6joeng4/boss-agent-cli/graphs/contributors"><img src="https://contrib.rocks/image?repo=can4hou6joeng4/boss-agent-cli" alt="贡献者" /></a>
+
+如果它帮到了你，欢迎 [Star ⭐](https://github.com/can4hou6joeng4/boss-agent-cli) 或分享给正在找工作的人。
 
 ## ⚠️ 免责声明
 


### PR DESCRIPTION
## README 五件套对齐（对标 tw93 house style）

flagship README 已在第一梯队；本 PR 补两处 tw93 最标志性、最贴合本项目语气的元素（双语同步）：

- **`## Why` 叙事段**（tw93 最高转化的一节）：开篇点出「自动投递脚本必被封 vs 本项目把敏感动作留给官网手动」的差异化定位，再进入合规边界与功能。
- **贡献区增强**：`contrib.rocks` 贡献者头像墙 + 轻量 Star / 分享号召。

未做（需另议）：品牌 logo SVG（设计任务）、description/topics（现状已足够好，暂不动）。

doc 一致性测试 36 passed；不触碰被 pin 的命令数与合规措辞。