### PR TITLE
feat: 新增品牌 logo 并接入双语 README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,5 +1,7 @@
 <div align="center">
 
+<img src="docs/assets/logo.svg" width="112" alt="boss-agent-cli logo">
+
 # boss-agent-cli
 
 *🤖 A local-assist BOSS Zhipin CLI for AI agents — search · welfare filtering · shortlist · JSON envelopes, low-risk by default.*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <div align="center">
 
+<img src="docs/assets/logo.svg" width="112" alt="boss-agent-cli logo">
+
 # boss-agent-cli
 
 *🤖 专为 AI Agent 设计的 BOSS 直聘本地辅助 CLI —— 搜索 · 福利筛选 · 候选池 · JSON 信封，默认 assisted，支持显式 Research Mode。*

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,0 +1,19 @@
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="boss-agent-cli logo">
+  <defs>
+    <linearGradient id="bac-bg" x1="8" y1="16" x2="120" y2="120" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#2DD4BF"/>
+      <stop offset="1" stop-color="#0D9488"/>
+    </linearGradient>
+  </defs>
+  <!-- antenna: the "agent" signal -->
+  <line x1="64" y1="18" x2="64" y2="8" stroke="#0D9488" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="64" cy="6" r="5" fill="#134E4A"/>
+  <!-- badge -->
+  <rect x="8" y="16" width="112" height="104" rx="27" fill="url(#bac-bg)"/>
+  <!-- terminal screen -->
+  <rect x="26" y="40" width="76" height="56" rx="12" fill="#0F172A"/>
+  <!-- prompt chevron ">" -->
+  <path d="M43 60 L56 70 L43 80" stroke="#5EEAD4" stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- cursor "_" -->
+  <rect x="63" y="74" width="21" height="6.5" rx="3.25" fill="#5EEAD4"/>
+</svg>


### PR DESCRIPTION
新增 `docs/assets/logo.svg`（手写矢量，无外部依赖）并接入双语 README hero 顶部。

设计：海青渐变圆角徽章 + 机器人天线（agent 信号）+ 深色终端屏内的 `>_` 命令提示符 —— 一眼即「AI Agent CLI」；海色呼应 Harbor/Beacon/Atlas 航海家族但不改名。112px，居中于 hero。

doc 一致性测试通过；不触碰命令数/合规措辞。