### PR TITLE
fix: 修复贡献者工作流检查触发

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Create PR if changed
         uses: peter-evans/create-pull-request@v8
         with:
-          commit-message: "chore: update contributors [skip ci]"
+          commit-message: "chore: 更新贡献者名单"
           title: "chore: update contributors"
           body: "每周自动刷新 CONTRIBUTORS.svg(scripts/update_contributors.py)。"
           branch: chore/update-contributors

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -228,6 +228,14 @@ def test_pull_request_template_requires_quality_and_risk_checks():
 	assert "（或英文等价）" not in template
 
 
+def test_update_contributors_pr_runs_required_checks():
+	workflow = load_yaml(".github/workflows/update-contributors.yml")
+	create_pr = workflow["jobs"]["update-contributors"]["steps"][2]["with"]
+
+	assert create_pr["commit-message"] == "chore: 更新贡献者名单"
+	assert "skip ci" not in create_pr["commit-message"].lower()
+
+
 def test_issue_templates_collect_contract_and_platform_context():
 	bug = read(".github/ISSUE_TEMPLATE/bug_report.yml")
 	feature = read(".github/ISSUE_TEMPLATE/feature_request.yml")


### PR DESCRIPTION
## 变更说明 / Summary

移除贡献者自动提交中的 `[skip ci]`，使生成的 PR 正常触发分支保护要求的 CI 与 Docs checks。同步将自动 commit message 调整为项目要求的 `type: 中文描述`，并增加治理回归测试。

## 变更类型 / Type

- [x] fix: Bug 修复
- [x] ci: CI 工作流

## Breaking Change

- [x] 本 PR **不包含** 破坏性变更

## 测试 / Test Plan

- [x] `uv run pytest tests/test_open_source_docs.py tests/test_agent_docs.py -q`（37 passed）
- [x] `uv run ruff check tests/test_open_source_docs.py`
- [x] `git diff --check`
- [x] 新增回归测试，约束自动 commit message 且禁止重新引入 `skip ci`

## 文档与契约 / Docs & Contracts

- [x] 不涉及 CLI、schema、MCP 或用户文档契约

## 安全与规范 / Safety & Convention

- [x] commit message 格式: `type: 中文描述`
- [x] 无 `Co-authored-by` 尾注或 AI 署名行
- [x] 无敏感信息
- [x] 无新增外部依赖