### PR TITLE
chore: 准备 1.17.0 发版

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+## [1.17.0] - 2026-07-27
+
 ### Added
 - 新增 `boss favorites list/sync`：读取 BOSS 职位收藏（geekGetJob?tag=4）并同步到本地候选池，让 `boss ai analyze-jd/fit/resume-optimize/chat-coach` 能处理用户真正感兴趣的职位。默认只读、assisted 放行、用户主动触发；sync 远端只读拉取后本地 upsert（按稳定 job_id 去重，刷新动态 security_id 并保留首次收藏时间），list 单页预览不落库且输出脱敏 `security_id`/`job_id` 为 `[REDACTED]`（完整值落库后从 `shortlist list` 取，遵循现有导出脱敏约定）。MCP 仅暴露 `boss_favorites_list`（只读预览），sync 不对 MCP 暴露以保持 assisted 主动触发边界。查看职位详情需 sync 落库后用 `boss --json shortlist list` 取完整 `security_id`/`job_id`，再 `boss detail <security_id> --job-id <job_id>` 查看（list 预览已脱敏；detail 以 sid 为必填位置参数，httpx 快速通道只用 job_id）。
 - 搜索结果与详情输出新增原始岗位类型、规范化用工类型、每周实习天数、最短实习周期等字段；导出与索引缓存同步保留这些元数据。

--- a/docs/marketing/awesome-submissions.md
+++ b/docs/marketing/awesome-submissions.md
@@ -1,12 +1,12 @@
 # Awesome List Submissions
 
-本文件记录 boss-agent-cli 向各大 awesome 列表投稿的模板，供维护者提交用。最后更新：master 当前状态 (2026-07-17)。
+本文件记录 boss-agent-cli 向各大 awesome 列表投稿的模板，供维护者提交用。最后更新：master 当前状态 (2026-07-27)。
 
 ## 项目一句话介绍
 
-**中文**：专为 AI Agent 设计的 BOSS 直聘求职 CLI，36 个顶层命令 + 9 个招聘者子命令 + 46 个 MCP 工具，全部输出 JSON，支持 Claude Desktop/Cursor/Windsurf/OpenCode 接入，聚焦职位发现、本地候选池整理、AI 辅助与显式入口下的招聘者辅助。
+**中文**：专为 AI Agent 设计的 BOSS 直聘求职 CLI，38 个顶层命令 + 9 个招聘者子命令 + 50 个 MCP 工具，全部输出 JSON，支持 Claude Desktop/Cursor/Windsurf/OpenCode 接入，聚焦职位发现、本地候选池整理、AI 辅助与显式入口下的招聘者辅助。
 
-**English**: AI-agent-first CLI for BOSS Zhipin. 36 top-level commands + 9 recruiter subcommands + 46 MCP tools, JSON envelope output, typed Python SDK (PEP 561), and MCP-first integration for Claude Desktop / Cursor / Windsurf / OpenCode.
+**English**: AI-agent-first CLI for BOSS Zhipin. 38 top-level commands + 9 recruiter subcommands + 50 MCP tools, JSON envelope output, typed Python SDK (PEP 561), and MCP-first integration for Claude Desktop / Cursor / Windsurf / OpenCode.
 
 ## 推荐投稿目标
 
@@ -15,7 +15,7 @@
 分类：Productivity / Job Search
 
 ```markdown
-- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - BOSS Zhipin integration for AI agents, exposing 46 default low-risk MCP tools for read-only job discovery, job detail inspection, local shortlists, resume helpers, and AI interview preparation.
+- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - BOSS Zhipin integration for AI agents, exposing 50 default low-risk MCP tools for read-only job discovery, job detail inspection, local shortlists, resume helpers, and AI interview preparation.
 ```
 
 ### 2. [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code)
@@ -23,7 +23,7 @@
 分类：CLI Tools
 
 ```markdown
-- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - Low-risk job-search CLI for BOSS Zhipin agents. 36 top-level commands plus recruiter workflow subcommands, MCP-first integration, local encrypted storage, OpenCode examples, and official-platform handoff for sensitive actions.
+- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - Low-risk job-search CLI for BOSS Zhipin agents. 38 top-level commands plus recruiter workflow subcommands, MCP-first integration, local encrypted storage, OpenCode examples, and official-platform handoff for sensitive actions.
 ```
 
 ### 3. [awesome-agents](https://github.com/kyrolabs/awesome-agents)
@@ -31,7 +31,7 @@
 分类：Specialized Agents
 
 ```markdown
-- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) ![](https://img.shields.io/github/stars/can4hou6joeng4/boss-agent-cli) - Job-search CLI purpose-built for AI agents. BOSS Zhipin integration with 36 top-level commands, recruiter workflow subcommands, 46 MCP tools, JSON envelope output, and local-first encrypted storage.
+- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) ![](https://img.shields.io/github/stars/can4hou6joeng4/boss-agent-cli) - Job-search CLI purpose-built for AI agents. BOSS Zhipin integration with 38 top-level commands, recruiter workflow subcommands, 50 MCP tools, JSON envelope output, and local-first encrypted storage.
 ```
 
 ### 4. [awesome-python-cli](https://github.com/shinokada/awesome-python-cli)
@@ -45,7 +45,7 @@
 分类：Agents & Automation
 
 ```markdown
-- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - Let your AI agent organize the low-risk parts of a job search. 36 top-level CLI commands + 9 recruiter subcommands + 46 default low-risk MCP tools covering search, detail, local shortlist, interview prep, and AI resume coaching on BOSS Zhipin.
+- [boss-agent-cli](https://github.com/can4hou6joeng4/boss-agent-cli) - Let your AI agent organize the low-risk parts of a job search. 38 top-level CLI commands + 9 recruiter subcommands + 50 default low-risk MCP tools covering search, detail, local shortlist, interview prep, and AI resume coaching on BOSS Zhipin.
 ```
 
 ## 投稿前 Checklist（master 当前状态）
@@ -53,8 +53,8 @@
 - [x] README 双语（中文 + 英文）
 - [x] MIT License
 - [x] CI 全绿（pytest / ruff / mypy / CodeQL）
-- [x] 发布到 PyPI（`pip install boss-agent-cli`，当前 latest release v1.16.0）
-- [x] GitHub Release 规范（latest release v1.16.0 已发）
+- [x] 发布到 PyPI（`pip install boss-agent-cli`，当前 latest release v1.17.0）
+- [x] GitHub Release 规范（latest release v1.17.0 已发）
 - [x] CHANGELOG 完整
 - [x] Code of Conduct + Security Policy
 - [x] Issue / PR 模板
@@ -81,12 +81,12 @@
 
 ## 一句话钩子（A/B 测试素材）
 
-1. "36 个顶层命令 + 9 个招聘者子命令 + 46 个 MCP 工具，让 AI Agent 帮你完成职位发现、本地整理、招聘者辅助和面试准备"
+1. "38 个顶层命令 + 9 个招聘者子命令 + 50 个 MCP 工具，让 AI Agent 帮你完成职位发现、本地整理、招聘者辅助和面试准备"
 2. "第一个 MCP 就绪、类型安全的中国招聘平台 CLI，为 Claude Desktop / Cursor / Windsurf 设计"
 3. "`boss ai interview-prep` — 把 JD 扔进 AI，秒出 10 道模拟面试题"
 4. "你只负责描述期望，AI Agent 负责搜索、筛选、整理候选岗位；投递和沟通回到官方页面手动完成"
 5. "MIT License，本地加密存储，数据不出机"
-6. "CI 质量门禁、46 个 MCP 工具、下游 Python 嵌入零学习成本"
+6. "CI 质量门禁、50 个 MCP 工具、下游 Python 嵌入零学习成本"
 
 ## 实际投稿记录 & 渠道约束（2026-04-28 更新）
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "boss-agent-cli"
-version = "1.16.0"
+version = "1.17.0"
 description = "AI Agent 专用的 BOSS 直聘求职 CLI 工具"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/boss_agent_cli/__init__.py
+++ b/src/boss_agent_cli/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 	)
 	from boss_agent_cli.resume.models import ResumeData, ResumeFile
 
-__version__ = "1.16.0"
+__version__ = "1.17.0"
 
 _LAZY_EXPORT_MODULES = {
 	"AuthManager": "boss_agent_cli.auth.manager",

--- a/uv.lock
+++ b/uv.lock
@@ -211,7 +211,7 @@ wheels = [
 
 [[package]]
 name = "boss-agent-cli"
-version = "1.16.0"
+version = "1.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },


### PR DESCRIPTION
## 准备 1.17.0 发版

将 favorites 收藏同步、受限 Research Mode crawl 工作流与实习筛选修复固化为 1.17.0。

### 变更
- `CHANGELOG.md`：`[Unreleased]` → `[1.17.0] - 2026-07-27`（favorites list/sync + 受限 Research Mode crawl 工作流 + 实习岗位类型字段 + 实习筛选映射修复）
- 版本号 `1.16.0` → `1.17.0`：`pyproject.toml` / `src/boss_agent_cli/__init__.py` / `uv.lock`
- `docs/marketing/awesome-submissions.md`：latest release → v1.17.0；顶层命令数 36 → 38、MCP 工具数 46 → 50（对齐 `len(SCHEMA_DATA["commands"])` / `len(TOOLS)` 实际值）

### 说明
- `crawl` 与 `favorites` 已在 master 且已写进 README / `docs/commands.md`，但 v1.16.0 tag 未含，PyPI latest 仍为 1.16.0——本次发版消除「文档承诺的命令在最新发布版不存在」的落差。
- 本地已过：`quality_baseline.py`（ruff + 1646 passed + mypy）、两个文档一致性测试、`BOSS_SMOKE_DRY_RUN=1 smoke_p0.py`、`uv lock --check`、`git diff --check`、`uv build`。