### PR TITLE
ci: scripts 纳入 lint 门禁并补齐 CI 冒烟与 Python 3.14 矩阵

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,16 @@ jobs:
       - name: Run P0 quality baseline
         run: uv run python scripts/quality_baseline.py
 
+      - name: P0 smoke contract (offline)
+        env:
+          BOSS_SMOKE_DRY_RUN: "1"
+        run: uv run python scripts/smoke_p0.py
+
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Generate contributors SVG
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: ruff
         args: [--fix]
-        files: ^(src|tests)/
+        files: ^(src|tests|scripts)/
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/docs/maintainer/branch-protection.md
+++ b/docs/maintainer/branch-protection.md
@@ -5,12 +5,16 @@ The default branch is `master`. Keep branch protection aligned with the quality 
 ## Required Settings
 
 - Require a pull request before merging.
-- Require at least 1 approving review.
 - Enforce rules for administrators.
 - Disable force pushes.
 - Disable branch deletions.
 - Require conversation resolution when review threads are used for blocking feedback.
 - Require status checks before merging.
+
+> Approving reviews are intentionally **not** required. This is a single-maintainer
+> repository with `enforce_admins` enabled, so requiring an approval would make the
+> maintainer's own release and fix PRs unmergeable. The blocking gate here is the
+> status-check set below plus admin enforcement, not human approval.
 
 ## Required status checks
 
@@ -21,10 +25,11 @@ Select the concrete check contexts emitted by `.github/workflows/ci.yml`:
 - `test (3.11)`
 - `test (3.12)`
 - `test (3.13)`
+- `test (3.14)`
 - `lint`
 - `typecheck`
 
-`P0 quality baseline` is the canonical blocking quality gate. It runs `scripts/quality_baseline.py`, which covers ruff, the full offline pytest suite, and mypy with the same command used locally.
+`P0 quality baseline` is the canonical blocking quality gate. It runs `scripts/quality_baseline.py`, which covers ruff (`src/boss_agent_cli`, `tests`, `scripts`), the full offline pytest suite, and mypy with the same command used locally. The same job also runs `scripts/smoke_p0.py` in offline dry-run mode so the JSON-envelope smoke contract is checked on every push and pull request.
 
 The project may also require documentation checks when `.github/workflows/docs.yml` is enabled:
 
@@ -51,18 +56,16 @@ The response should show:
 }
 ```
 
-Then verify the pull request review gate through its dedicated endpoint:
+Then verify that the required status check contexts match the CI matrix:
 
 ```bash
-gh api repos/can4hou6joeng4/boss-agent-cli/branches/master/protection/required_pull_request_reviews
+gh api repos/can4hou6joeng4/boss-agent-cli/branches/master/protection \
+  --jq '.required_status_checks.contexts'
 ```
 
-The response should show:
-
-```json
-{
-	"required_approving_review_count": 1
-}
-```
+Every `test (3.x)` entry in `.github/workflows/ci.yml` must appear in that list. When a
+Python version is added to the matrix, add its context **after** the new job has passed
+at least once on `master` — marking a context that has never reported as required will
+block every subsequent merge.
 
 If `required_status_checks` is missing, configure required status checks in GitHub repository settings before treating branch protection as complete.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 	"Programming Language :: Python :: 3.11",
 	"Programming Language :: Python :: 3.12",
 	"Programming Language :: Python :: 3.13",
+	"Programming Language :: Python :: 3.14",
 	"Topic :: Office/Business",
 	"Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/scripts/quality_baseline.py
+++ b/scripts/quality_baseline.py
@@ -21,7 +21,7 @@ from typing import Sequence
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_STEPS: tuple[tuple[str, tuple[str, ...]], ...] = (
-	("ruff", ("ruff", "check", "src/boss_agent_cli", "tests", "--output-format=concise")),
+	("ruff", ("ruff", "check", "src/boss_agent_cli", "tests", "scripts", "--output-format=concise")),
 	("pytest", ("pytest", "-q")),
 	("mypy", ("mypy", "src/boss_agent_cli")),
 )

--- a/scripts/update_contributors.py
+++ b/scripts/update_contributors.py
@@ -5,7 +5,12 @@
 布局参数与 tw93/Kaku 的 update-contributors workflow 保持一致:
 svgWidth=1000 avatarSize=72 avatarMargin=45 userNameHeight=20
 """
-import base64, json, math, os, urllib.request
+
+import base64
+import json
+import math
+import os
+import urllib.request
 from urllib.parse import urlparse
 
 REPO = "can4hou6joeng4/boss-agent-cli"
@@ -13,28 +18,33 @@ EXCLUDE = {"github-actions", "web-flow", "dependabot", "claude"}
 SVG_WIDTH, AVATAR, MARGIN, NAME_H = 1000, 72, 45, 20
 OUT = os.path.join(os.path.dirname(__file__), "..", "CONTRIBUTORS.svg")
 
-def fetch(url, raw=False):
-    req = urllib.request.Request(url, headers={"User-Agent": "contributors-svg"})
-    token = os.environ.get("GITHUB_TOKEN")
-    if token and urlparse(url).hostname == "api.github.com":
-        req.add_header("Authorization", f"Bearer {token}")
-    with urllib.request.urlopen(req, timeout=30) as r:
-        data = r.read()
-        return (data, r.headers.get("Content-Type", "image/png")) if raw else json.loads(data)
 
-users = [u for u in fetch(f"https://api.github.com/repos/{REPO}/contributors?per_page=100")
-         if u["type"] != "Bot" and u["login"].lower() not in EXCLUDE]
+def fetch(url, raw=False):
+	req = urllib.request.Request(url, headers={"User-Agent": "contributors-svg"})
+	token = os.environ.get("GITHUB_TOKEN")
+	if token and urlparse(url).hostname == "api.github.com":
+		req.add_header("Authorization", f"Bearer {token}")
+	with urllib.request.urlopen(req, timeout=30) as r:
+		data = r.read()
+		return (data, r.headers.get("Content-Type", "image/png")) if raw else json.loads(data)
+
+
+users = [
+	u
+	for u in fetch(f"https://api.github.com/repos/{REPO}/contributors?per_page=100")
+	if u["type"] != "Bot" and u["login"].lower() not in EXCLUDE
+]
 
 items = []
 cols = (SVG_WIDTH - MARGIN) // (AVATAR + MARGIN)
 for i, u in enumerate(users):
-    profile = fetch(u["url"])
-    name = profile.get("name") or u["login"]
-    img, ctype = fetch(u["avatar_url"] + ("&" if "?" in u["avatar_url"] else "?") + "s=144", raw=True)
-    avatar = f"data:{ctype.split(';')[0]};base64," + base64.b64encode(img).decode()
-    x = MARGIN + (i % cols) * (AVATAR + MARGIN)
-    y = MARGIN // 2 + (i // cols) * (AVATAR + NAME_H + MARGIN // 2)
-    items.append(f'''<g transform="translate({x}, {y})">
+	profile = fetch(u["url"])
+	name = profile.get("name") or u["login"]
+	img, ctype = fetch(u["avatar_url"] + ("&" if "?" in u["avatar_url"] else "?") + "s=144", raw=True)
+	avatar = f"data:{ctype.split(';')[0]};base64," + base64.b64encode(img).decode()
+	x = MARGIN + (i % cols) * (AVATAR + MARGIN)
+	y = MARGIN // 2 + (i // cols) * (AVATAR + NAME_H + MARGIN // 2)
+	items.append(f'''<g transform="translate({x}, {y})">
   <defs>
     <clipPath id="cp-{u["login"]}">
       <circle cx="36" cy="36" r="36" />
@@ -48,9 +58,12 @@ for i, u in enumerate(users):
 
 rows = math.ceil(len(users) / cols)
 height = MARGIN // 2 + rows * (AVATAR + NAME_H + MARGIN // 2)
-svg = (f'<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" '
-       f'width="{SVG_WIDTH}" height="{height}" viewBox="0 0 {SVG_WIDTH} {height}">\n'
-       + "\n".join(items) + "\n</svg>\n")
+svg = (
+	f'<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" '
+	f'width="{SVG_WIDTH}" height="{height}" viewBox="0 0 {SVG_WIDTH} {height}">\n'
+	+ "\n".join(items)
+	+ "\n</svg>\n"
+)
 with open(OUT, "w") as f:
-    f.write(svg)
-print(f"CONTRIBUTORS.svg: {len(users)} contributors, {rows} rows, {len(svg)//1024}KB")
+	f.write(svg)
+print(f"CONTRIBUTORS.svg: {len(users)} contributors, {rows} rows, {len(svg) // 1024}KB")

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -185,6 +185,7 @@ def test_maintainer_docs_cover_open_source_governance():
 	assert "test (3.11)" in branch
 	assert "test (3.12)" in branch
 	assert "test (3.13)" in branch
+	assert "test (3.14)" in branch
 	assert "lint" in branch
 	assert "typecheck" in branch
 	assert "docs" in branch
@@ -300,14 +301,16 @@ def test_ci_workflow_runs_p0_quality_gate():
 		"uv python install 3.11",
 		"uv sync --all-extras",
 		"uv run python scripts/quality_baseline.py",
+		"uv run python scripts/smoke_p0.py",
 	]
 	assert "scripts/quality_baseline.py" in raw_workflow
+	assert "BOSS_SMOKE_DRY_RUN" in raw_workflow
 
 
 def test_quality_baseline_script_matches_blocking_p0_commands():
 	content = read("scripts/quality_baseline.py")
 
-	assert '("ruff", ("ruff", "check", "src/boss_agent_cli", "tests", "--output-format=concise"))' in content
+	assert '("ruff", ("ruff", "check", "src/boss_agent_cli", "tests", "scripts", "--output-format=concise"))' in content
 	assert '("pytest", ("pytest", "-q"))' in content
 	assert '("mypy", ("mypy", "src/boss_agent_cli"))' in content
 	assert "--skip-mypy" in content


### PR DESCRIPTION
## 背景

四处「本该被拦住的问题实际没被拦住」的门禁缺口。

`scripts/` 此前四重落空——`ci.yml` 的 lint job 只查 `src/`、`quality_baseline.py` 只查 `src/boss_agent_cli` + `tests`、pre-commit 的 ruff hook 限定 `^(src|tests)/`、`.codecov.yml` 也 ignore 了它。结果是 `scripts/update_contributors.py:8` 的 `E401` 长期无人发现，而这个脚本恰恰由 `update-contributors.yml` 每周定时执行，job 权限为 `contents: write` + `pull-requests: write`。

## 变更

- **`scripts/` 纳入 lint**：`quality_baseline.py` 的 ruff 目标增加 `scripts`；pre-commit hook `files` 扩到 `^(src|tests|scripts)/`；修掉 `E401`，并把 `update_contributors.py` 从 4 空格改为 tab（与同目录其余脚本及仓库约定一致）
- **P0 冒烟进 CI**：`p0_quality_gate` 增加 `BOSS_SMOKE_DRY_RUN=1 scripts/smoke_p0.py` 步骤。此前 `docs/maintainer/release-checklist.md` 要求跑它，但没有任何 workflow 跑，只靠人肉记得
- **Python 3.14**：CI 矩阵与 classifiers 补 3.14
- **`actions/checkout`**：`update-contributors.yml` v4 → v7，与其余 5 个 workflow 齐平
- **`branch-protection.md` 修正**：文档写「Require at least 1 approving review」，但实际分支保护没有 `required_pull_request_reviews`，且验证章节指向一个 404 端点。改为记录实况（单人维护仓库 + `enforce_admins`，要求 approval 会让自己的 PR 永远合不了），并补上「新增 Python 版本要先绿过一次再设为必需」的操作提示

## 验证

- `uv run ruff check src/ tests/ scripts/ mcp-server/` → All checks passed
- `uv run python scripts/quality_baseline.py` → ruff / 1646 passed / mypy 全过
- `BOSS_SMOKE_DRY_RUN=1 uv run python scripts/smoke_p0.py` → exit 0
- Python 3.14 本地实测：`uv run --python 3.14 pytest tests/ -q` → **1646 passed**，依赖无缺 wheel
- `scripts/update_contributors.py` 重构后实跑，生成的 `CONTRIBUTORS.svg` 与重构前**字节完全一致**
- 同步更新了 `tests/test_open_source_docs.py` 中逐字钉住 ci.yml 命令序列 / quality_baseline DEFAULT_STEPS / branch-protection 检查清单的三处断言

## 后续

`test (3.14)` 需在本 PR 合并、该 job 首次在 master 绿过之后，再加进分支保护的 required status checks（先加会永久阻塞合并）。