### PR TITLE
docs: 校正安全策略与路线图状态并加固对外数字守卫

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -183,7 +183,7 @@ CLI (Click)
             └─ output.py → JSON envelope → stdout
 ```
 
-**Invariants**: stdout is JSON-only · stderr holds logs · `exit 0/1` · errors carry `code/recoverable/recovery_action` · `boss schema` is the authoritative capability source. **Stack**: Python ≥ 3.10 · Click · httpx · patchright / CDP / Bridge (login, export, and explicit Research Mode adapters) · cryptography · sqlite3 (WAL) · pytest (1400+).
+**Invariants**: stdout is JSON-only · stderr holds logs · `exit 0/1` · errors carry `code/recoverable/recovery_action` · `boss schema` is the authoritative capability source. **Stack**: Python ≥ 3.10 · Click · httpx · patchright / CDP / Bridge (login, export, and explicit Research Mode adapters) · cryptography · sqlite3 (WAL) · pytest (1600+).
 
 ## 🔌 Local Storage
 
@@ -193,9 +193,28 @@ All state lives under `~/.boss-agent/` — encrypted tokens, cached searches, sh
 
 See [CONTRIBUTING.en.md](CONTRIBUTING.en.md) and [Getting Started](docs/getting-started.en.md). TL;DR: fork → `feat/xxx` branch → write tests → `python scripts/quality_baseline.py` (on Chinese Windows, set `$env:PYTHONUTF8='1'` first) → PR.
 
-<a href="https://github.com/can4hou6joeng4/boss-agent-cli/graphs/contributors"><img src="https://contrib.rocks/image?repo=can4hou6joeng4/boss-agent-cli" alt="contributors" /></a>
+Thanks to everyone who has made boss-agent-cli better — go follow them! ❤️
 
-If this project helps you, a [Star ⭐](https://github.com/can4hou6joeng4/boss-agent-cli) or a share goes a long way.
+<a href="https://github.com/can4hou6joeng4/boss-agent-cli/graphs/contributors">
+  <img src="./CONTRIBUTORS.svg" alt="contributors" width="1000" />
+</a>
+
+## ❤️ Support
+
+- If this project helps you, the most direct support is a [Star ⭐](https://github.com/can4hou6joeng4/boss-agent-cli), or sharing it with someone who is job hunting.
+- Hit a problem or have an idea? Open an [Issue](https://github.com/can4hou6joeng4/boss-agent-cli/issues) — or go straight to a PR.
+- Curious about the rest of the fleet? Drop anchor at the home port [bobochang.cn](https://bobochang.cn) 🧭.
+
+This project benefits from [geekgeekrun](https://github.com/geekgeekrun/geekgeekrun) · [boss-cli](https://github.com/jackwener/boss-cli) · [opencli](https://github.com/jackwener/opencli) — thanks to all of them.
+
+## ⭐ Star History
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/star-history-dark.svg">
+  <img alt="Star History" src="docs/assets/star-history.svg" width="100%">
+</picture>
+
+A static SVG generated locally with [mystarhistory](https://github.com/carsteneu/mystarhistory) — served from this repo, with no third-party dependency.
 
 ## ⚠️ Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ CLI (Click)
 `QianchengPlatform (51job 占位适配器，统一返回 NOT_SUPPORTED)`：仅用于平台注册与 schema 可见性，接真实接口前需满足只读研究门槛。
 
 **不变量**：stdout 仅 JSON 信封 · stderr 仅日志 · `exit 0/1` · 错误含 `code/recoverable/recovery_action` · `boss schema` 为能力真源。
-**选型**：Python ≥ 3.10 · Click · httpx · patchright / CDP / Bridge（登录、导出与显式 Research Mode adapter）· cryptography（Fernet）· sqlite3（WAL）· pytest（1400+ 项）。
+**选型**：Python ≥ 3.10 · Click · httpx · patchright / CDP / Bridge（登录、导出与显式 Research Mode adapter）· cryptography（Fernet）· sqlite3（WAL）· pytest（1600+ 项）。
 
 ## 🔌 本地存储
 

--- a/ROADMAP.en.md
+++ b/ROADMAP.en.md
@@ -4,9 +4,17 @@ This document tracks the medium-term and long-term direction of `boss-agent-cli`
 
 ## Released
 
-- ✅ v1.8.x (2026-04-20, rapid patch series): strict mypy whitelist expanded from 3 to 61 modules (81% coverage), Python embedding API, `ai interview-prep` / `chat-coach`, Markdown digest output, Cursor/Windsurf integration, four additional AI provider entry points, and the English contribution guide
-- ✅ v1.8.0 (2026-04-19): AI communication and interview expansion (`ai interview-prep` / `ai chat-coach`) plus protocol server growth to 43 tools
-- ✅ v1.7.0 (2026-04-17): draft chat replies, application funnel analytics, and protocol server growth to 41 tools
+- ✅ v1.17.0 (2026-07-27): `boss favorites list/sync` for syncing saved jobs, the restricted Research Mode resumable crawl workflow, and internship job-type fields plus the internship filter mapping fix
+- ✅ v1.16.0 (2026-07-17): explicit `operating_mode` two-mode contract (`assisted` / `research`) and the compliance guardrail rebuilt as an immutable capability policy registry, with CLI, schema, and MCP filtering all derived from one source of truth
+- ✅ v1.15.0 (2026-07-14): `boss ai cover-letter` drafts, removal of dead config keys and dead code, and hardened Zhilian page host validation (exact hostname matching)
+- ✅ v1.14.0 (2026-06-25): local shortlist tags / notes / offline comparison, `ai fit` / `ai suggest-keywords` / `ai resume-optimize`, the MCP-first repositioning, and search `match_score`
+- ✅ v1.13.x (2026-06-11 – 06-16): platform capability-status semantics, complete login error codes, local caching for welfare job descriptions, and the bilingual README rebuilt as a navigation hub; the Agent Skill moved to the standalone [boss-skill](https://github.com/can4hou6joeng4/boss-skill) repo (breaking change)
+- ✅ v1.12.0 (2026-06-09): MCP stdio / SSE / HTTP streaming transports, `boss_export`, and the 51job (`qiancheng`) placeholder adapter
+- ✅ v1.11.0 (2026-04-23): recruiter mode (`--role recruiter`) with the full recruiter CLI command group, the dual-channel `BossRecruiterClient`, and the `RecruiterPlatform` abstraction
+- ✅ v1.10.x (2026-04-21): the Platform abstraction landing — ABC plus registry plus the global `--platform` option, with all 20 commands migrated so nothing under `commands/` references `BossClient` directly
+- ✅ v1.9.x (2026-04-20): full mypy strict-mode rollout (66/66 business modules), the Python embedding API, and `py.typed` type exports
+- ✅ v1.8.x (2026-04-19 – 04-20): AI communication and interview expansion (`ai interview-prep` / `ai chat-coach`), Cursor / Windsurf integration, and the English contribution guide
+- ✅ v1.7.0 (2026-04-17): draft chat replies and application funnel analytics
 
 Full release history lives in [CHANGELOG.md](CHANGELOG.md).
 
@@ -32,6 +40,12 @@ Full release history lives in [CHANGELOG.md](CHANGELOG.md).
 
 ## Mid term (v2.0)
 
+### Governance and compliance
+
+- [x] default low-risk assistance mode: sensitive commands are blocked by default and handed back to the official platform (ADR 0001)
+- [x] explicit `operating_mode` two-mode contract: `assisted` / `research` drives the CLI, schema, and MCP filtering from a single source of truth (v1.16.0, ADR 0002)
+- [x] restricted Research Mode collection: fixed request / detail / wall-clock / retry budgets, SQLite checkpointing, and a stop switch (v1.17.0)
+
 ### Architecture evolution
 
 - [x] full mypy strict-mode rollout - **100% complete** (66/66 business modules now enforce `disallow_untyped_defs + disallow_any_generics + warn_return_any`, v1.9.1)
@@ -49,14 +63,15 @@ Full release history lives in [CHANGELOG.md](CHANGELOG.md).
   - [x] Week 1d: `ZhilianPlatform` stub registered in the platform registry (abstraction self-proof with full envelope adaptation; P0/P1/P2 still raise `NotImplementedError`)
   - [x] Week 2: Zhilian read-only implementation (`search`, `detail`, `recommend`, `user_info`)
   - [x] Week 3: Zhilian write operations (`greet`, `apply`) + docs + MCP adaptation
-  - [ ] Week 4: product decision on recruiter-side support and whether to onboard it at all (candidate-side support is the only runtime path today)
-  - [ ] 51job: keep it in the research backlog until the candidate-side read-only entry points and redacted fixtures are clear enough for a runtime adapter ([docs/research/platforms/51job.md](docs/research/platforms/51job.md))
+  - [x] Week 4: recruiter-side capability evaluation complete → **not onboarding for now** (0 of 4 onboarding conditions met; the `RecruiterPlatform` skeleton stays in place pending community signal, see `docs/research/platforms/zhaopin-recruiter-evaluation.md`)
+  - [ ] 51job: the placeholder adapter has landed (every capability returns a stable `NOT_SUPPORTED` envelope, v1.12.0–v1.13.0), but the real interface stays in the research backlog until the candidate-side read-only entry points and redacted fixtures are clear enough for a runtime adapter ([docs/research/platforms/51job.md](docs/research/platforms/51job.md))
 
 ### Community building
 
 - [ ] richer Chinese and English demo assets and launch materials (the repo already ships `demo/demo-zh.gif` / `demo/demo-en.gif` plus the matching `demo/demo-zh.tape` / `demo/demo-en.tape` terminal demos)
-- [ ] follow up on the review outcome of [awesome-agents](https://github.com/kyrolabs/awesome-agents) PR #423
-- [ ] decide later whether to pursue [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code)
+- [x] listed in [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) (PR #4992, merged 2026-04-26)
+- [x] [awesome-agents](https://github.com/kyrolabs/awesome-agents) PR #423 resolved — closed by a bot with no review, and the same section shows a pattern of silent closures, so the conclusion is to not resubmit for now (see `docs/marketing/awesome-submissions.md`)
+- [ ] decide later whether to pursue [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code) (that repo accepts Web UI issue forms only and forbids the gh CLI)
 - [x] English contribution guide (`CONTRIBUTING.en.md`, v1.8.3)
 
 ## Long-term vision

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,9 +4,17 @@
 
 ## 已发布
 
-- ✅ v1.8.x（2026-04-20，patch 连发）：严格类型检查白名单 3 → 61（81% 覆盖）+ Python 嵌入 API + ai interview-prep / chat-coach + digest Markdown + Cursor/Windsurf 接入 + 4 家 AI 聚合入口 + 英文贡献指南
-- ✅ v1.8.0 (2026-04-19)：AI 沟通与面试扩展（ai interview-prep / ai chat-coach）+ 协议服务扩展至 43 工具
-- ✅ v1.7.0 (2026-04-17)：聊天回复草稿 + 投递漏斗 + 协议服务扩展至 41 工具
+- ✅ v1.17.0（2026-07-27）：`boss favorites list/sync` 职位收藏同步 + 受限 Research Mode 的可恢复 crawl 工作流 + 实习岗位类型字段与筛选映射修复
+- ✅ v1.16.0（2026-07-17）：显式 `operating_mode` 双模式契约（`assisted` / `research`）+ 合规护栏升级为不可变能力策略注册表，CLI / schema / MCP 过滤从同一真源派生
+- ✅ v1.15.0（2026-07-14）：`boss ai cover-letter` 求职信草稿 + 死配置键与死码清理 + 智联页面域名校验加固（精确 hostname 匹配）
+- ✅ v1.14.0（2026-06-25）：shortlist 本地标签 / 备注 / 离线对比 + `ai fit` / `ai suggest-keywords` / `ai resume-optimize` + 转向 MCP-first + 搜索 `match_score`
+- ✅ v1.13.x（2026-06-11 ~ 06-16）：platforms 能力状态语义 + login 链路错误码补齐 + welfare 详情本地缓存 + 双语 README 重构为导航型；Agent Skill 迁出至独立仓库 [boss-skill](https://github.com/can4hou6joeng4/boss-skill)（Breaking Change）
+- ✅ v1.12.0（2026-06-09）：MCP 三种传输（stdio / SSE / HTTP streaming）+ `boss_export` + 51job / `qiancheng` 占位适配器
+- ✅ v1.11.0（2026-04-23）：招聘者模式（`--role recruiter`）全套 CLI 命令组 + `BossRecruiterClient` 双通道客户端 + `RecruiterPlatform` 抽象
+- ✅ v1.10.x（2026-04-21）：Platform 抽象落地 —— ABC + 注册表 + `--platform` 全局选项 + 20 个命令全量迁移，`commands/` 下不再直接引用 `BossClient`
+- ✅ v1.9.x（2026-04-20）：mypy 严格模式全量接入（66/66 业务模块）+ Python 嵌入 API + `py.typed` 类型导出
+- ✅ v1.8.x（2026-04-19 ~ 04-20）：AI 沟通与面试扩展（`ai interview-prep` / `ai chat-coach`）+ Cursor / Windsurf 接入 + 英文贡献指南
+- ✅ v1.7.0（2026-04-17）：聊天回复草稿 + 投递漏斗
 
 完整历史见 [CHANGELOG.md](CHANGELOG.md)。
 
@@ -29,6 +37,11 @@
 
 ## 🔮 中期（v2.0）
 
+### 治理与合规
+- [x] 默认低风险辅助模式：敏感命令默认阻断并交接回平台官网（ADR 0001）
+- [x] 显式 `operating_mode` 双模式契约：`assisted` / `research` 单一真源驱动 CLI、schema 与 MCP 过滤（v1.16.0，ADR 0002）
+- [x] 受限 Research Mode 采集：固定请求 / 详情 / 墙钟 / 重试预算 + SQLite checkpoint + 停止开关（v1.17.0）
+
 ### 架构演进
 - [x] mypy 严格模式全量接入 — **100% 完成**（66/66 业务模块全部 `disallow_untyped_defs + disallow_any_generics + warn_return_any` 严格化，v1.9.1）
 - [x] 类型签名导出到 `stubs/`，供下游 IDE 使用（v1.8.6，py.typed + canonical `__all__` + 16 条契约测试）
@@ -45,12 +58,13 @@
   - [x] Week 2：ZhilianPlatform 只读实现（search / detail / recommend / user_info）
   - [x] Week 3：ZhilianPlatform 写操作（greet / apply）+ 文档 + MCP 适配
   - [x] Week 4：招聘者侧能力评估完成 → **暂不接入**（接入条件 0/4 满足，保留 RecruiterPlatform 骨架待社区信号重启；详见 `docs/research/platforms/zhaopin-recruiter-evaluation.md`）
-  - [ ] 51job / 前程无忧：先进入 research backlog，候选者侧只读入口和脱敏测试样本明确前不进入真实运行路径（详见 `docs/research/platforms/51job.md`）
+  - [ ] 51job / 前程无忧：占位适配器已落地（全量能力返回稳定 `NOT_SUPPORTED` 包络，v1.12.0–v1.13.0），但真实接口仍在 research backlog——候选者侧只读入口和脱敏测试样本明确前不进入真实运行路径（详见 `docs/research/platforms/51job.md`）
 
 ### 社区建设
 - [ ] 更完整的中文 + 英文视频 demo / 发布素材（当前已有 `demo/demo-zh.gif` / `demo/demo-en.gif` + 对应 `demo/demo-zh.tape` / `demo/demo-en.tape` 终端演示）
-- [ ] 跟进 [awesome-agents](https://github.com/kyrolabs/awesome-agents) PR #423 审阅结果
-- [ ] 视时机决定是否进入 [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code)
+- [x] [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) 收录（PR #4992，2026-04-26 合并）
+- [x] [awesome-agents](https://github.com/kyrolabs/awesome-agents) PR #423 已闭环——由 bot 无 review 直接关闭，同分区存在批量静默关单现象，结论为暂不重投（详见 `docs/marketing/awesome-submissions.md`）
+- [ ] 视时机决定是否进入 [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code)（该仓库只接受 Web UI issue 表单，禁止 gh CLI）
 - [x] 贡献者指南英文版（`CONTRIBUTING.en.md`，v1.8.3）
 
 ## 💡 长期愿景

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,15 @@
 
 ## Supported Versions
 
+只有最新的 minor 版本会收到安全修复。项目发布频繁（见 [CHANGELOG.md](CHANGELOG.md)），
+不维护历史分支——修复以新版本形式发出，请升级到最新版而不是期待补丁回移。
+
 | Version | Supported          |
 |---------|--------------------|
-| 1.1.x   | :white_check_mark: |
-| < 1.0   | :x:                |
+| 1.17.x  | :white_check_mark: |
+| < 1.17  | :x:                |
+
+升级：`uv tool install --upgrade boss-agent-cli`（或 `pip install -U boss-agent-cli`）。
 
 ## Reporting a Vulnerability
 

--- a/docs/marketing/en-launch-story.md
+++ b/docs/marketing/en-launch-story.md
@@ -7,7 +7,7 @@
 ## Title Candidates
 
 - **A**: Show HN: I built a low-risk job-search CLI for Claude and Cursor
-- **B**: boss-agent-cli — 36 top-level commands + 46 default low-risk MCP tools
+- **B**: boss-agent-cli — 38 top-level commands + 50 default low-risk MCP tools
 - **C**: An agent-first CLI for searching, filtering, and organizing job leads
 
 Recommended: **A**. It frames the project as an agent integration without implying automated applications or outreach.
@@ -18,7 +18,7 @@ Recommended: **A**. It frames the project as an agent integration without implyi
 
 ### TL;DR
 
-`boss-agent-cli` is an open-source CLI for AI agents to handle the low-risk parts of job discovery and local organization on [BOSS Zhipin](https://www.zhipin.com/). Every command outputs a structured JSON envelope, `boss schema` is the capability source of truth, and MCP exposes 46 default low-risk tools for Claude Desktop, Cursor, and other MCP-compatible hosts.
+`boss-agent-cli` is an open-source CLI for AI agents to handle the low-risk parts of job discovery and local organization on [BOSS Zhipin](https://www.zhipin.com/). Every command outputs a structured JSON envelope, `boss schema` is the capability source of truth, and MCP exposes 50 default low-risk tools for Claude Desktop, Cursor, and other MCP-compatible hosts.
 
 ```bash
 uv tool install boss-agent-cli
@@ -67,7 +67,7 @@ After connecting MCP, an agent can run a low-risk chain such as search -> detail
 
 ### Current boundaries
 
-- `boss schema` currently exposes 36 top-level commands; `hr` has 9 first-level recruiter subcommands; MCP exposes 46 default low-risk tools
+- `boss schema` currently exposes 38 top-level commands; `hr` has 9 first-level recruiter subcommands; MCP exposes 50 default low-risk tools
 - `zhipin` covers the main candidate workflow; `zhilian` supports candidate-side read-only + local-assist parity; `qiancheng` remains a `NOT_SUPPORTED` placeholder
 - CI covers Python 3.10 / 3.11 / 3.12 / 3.13, ruff, mypy, docs consistency, and CodeQL
 - No telemetry, analytics, or cloud sync; adoption is measured through PyPI downloads and GitHub Insights only

--- a/docs/marketing/zh-launch-story.md
+++ b/docs/marketing/zh-launch-story.md
@@ -7,7 +7,7 @@
 ## 标题候选
 
 - **A**：给 Claude / Cursor 接一个低风险求职 CLI
-- **B**：boss-agent-cli：36 个顶层命令 + 46 个默认低风险 MCP 工具
+- **B**：boss-agent-cli：38 个顶层命令 + 50 个默认低风险 MCP 工具
 - **C**：Agent First 的求职 CLI：搜索、筛选、整理候选岗位
 
 推荐 A，能直接说明这是 Agent 接入工具，不暗示自动投递或自动沟通。
@@ -52,7 +52,7 @@ boss shortlist add <security_id> <job_id>
 }
 ```
 
-当前能力面以 `boss schema` 为准：36 个顶层命令，`hr` 下 9 个一级招聘者子命令，MCP 默认暴露 46 个低风险工具。
+当前能力面以 `boss schema` 为准：38 个顶层命令，`hr` 下 9 个一级招聘者子命令，MCP 默认暴露 50 个低风险工具。
 
 ### 3. 三个设计决策
 

--- a/tests/test_agent_docs.py
+++ b/tests/test_agent_docs.py
@@ -1,10 +1,13 @@
 import importlib.util
 import json
 import re
+import subprocess
 import sys
 import types
 from pathlib import Path
 from unittest.mock import MagicMock
+
+import pytest
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -307,3 +310,72 @@ def test_schema_main_and_modules_command_count_consistent():
 		f"仅在 Click: {registered_set - schema_set}，仅在 schema: {schema_set - registered_set}"
 	)
 	assert len(registered) == len(set(registered)), "Click 顶层命令存在重复注册"
+
+
+# 文档中写死的能力计数与其运行时真源的映射。
+_CAPABILITY_COUNT_PATTERNS: tuple[tuple[str, str], ...] = (
+	(r"(\d+)\s*个顶层命令", "commands"),
+	(r"(\d+)\s+top-level(?:\s+CLI)?\s+commands", "commands"),
+	(r"(\d+)\s*个(?:默认)?(?:低风险)?\s*MCP\s*工具", "tools"),
+	(r"(\d+)\s*个(?:默认)?低风险工具", "tools"),
+	(r"(\d+)\s+(?:default\s+low-risk\s+)?MCP\s+tools", "tools"),
+	(r"(\d+)\s+default\s+low-risk\s+tools", "tools"),
+	(r"MCP\s+server\s+with\s+(\d+)\s+tools", "tools"),
+)
+
+# CHANGELOG 按定义记录历史事实（如「工具计数 31 → 32」），不该跟随当前值变化。
+_CAPABILITY_COUNT_EXEMPT_DOCS = frozenset({"CHANGELOG.md"})
+
+
+def _public_markdown_docs() -> list[Path]:
+	"""仅返回被 git 跟踪的 Markdown——「对外文档」的准确语义。
+
+	不能直接 glob 文件系统：`docs/blog/linuxdo-promo.md`、`docs/superpowers/` 等
+	本地草稿在 `.gitignore` 里，glob 会让这个断言随各人工作区内容而变——本地红、
+	CI 绿的环境相关假信号。
+	"""
+	result = subprocess.run(
+		["git", "ls-files", "-z", "--", "*.md"],
+		cwd=ROOT,
+		capture_output=True,
+		text=True,
+		check=False,
+	)
+	if result.returncode != 0:
+		pytest.skip("需要 git 工作副本才能确定对外文档集合")
+	paths = [ROOT / name for name in result.stdout.split("\0") if name]
+	return [
+		path
+		for path in paths
+		if path.relative_to(ROOT).as_posix() not in _CAPABILITY_COUNT_EXEMPT_DOCS and path.exists()
+	]
+
+
+def test_docs_capability_counts_match_runtime_source():
+	"""防漂移：文档里写死的顶层命令数 / MCP 工具数必须与运行时真源一致。
+
+	`docs/marketing/` 曾两次出现计数漂移（#346 校正后两周内再次漂移），根因是此前
+	只有 README 与 capability-matrix 被断言覆盖。这里改为扫描全部对外 Markdown，
+	并从 `SCHEMA_DATA` / `TOOLS` 动态取值，避免守卫本身成为下一个硬编码漂移点。
+	"""
+	from boss_agent_cli.commands.schema import SCHEMA_DATA
+
+	expected = {
+		"commands": len(SCHEMA_DATA["commands"]),
+		"tools": len(_load_mcp_tools()),
+	}
+	mismatches: list[str] = []
+
+	for path in _public_markdown_docs():
+		content = path.read_text(encoding="utf-8")
+		relative = path.relative_to(ROOT).as_posix()
+		for pattern, kind in _CAPABILITY_COUNT_PATTERNS:
+			for match in re.finditer(pattern, content):
+				found = int(match.group(1))
+				if found != expected[kind]:
+					line = content[: match.start()].count("\n") + 1
+					mismatches.append(
+						f"{relative}:{line} 写着 {found}，当前 {kind} 实际为 {expected[kind]}（命中 {match.group(0)!r}）"
+					)
+
+	assert not mismatches, "对外文档的能力计数已漂移：\n" + "\n".join(mismatches)


### PR DESCRIPTION
## 背景

四类对外**状态性表述**与代码真源脱节，其中数字漂移已经复发过一次（#346 校正后两周内再次漂移），根因是守卫覆盖面不够。

## 变更

**修正**

- `SECURITY.md`：Supported Versions 表还写 `1.1.x ✅ / < 1.0 ❌`，当前已 1.17.0——安全报告者按表读会以为主线不受支持。改为「只有最新 minor 收安全修复」并给出升级命令
- `ROADMAP.md` / `ROADMAP.en.md`：文档自称「每次 minor 发布时更新」，实际最后改动为 2026-06-16，此后 1.14 / 1.15 / 1.16 / 1.17 四个 minor 均未回写。「已发布」段补齐 1.7 → 1.17（事实来源为 CHANGELOG，未杜撰）；新增「治理与合规」小节记录 ADR 0001/0002 与 Research Mode；51job 条目补上「占位适配器已落地、真实接口仍在 backlog」的实际状态；awesome-agents PR #423 已于 2026-04-28 关闭，从待跟进改为已闭环
- `README.en.md`：补 `❤️ Support` 与 `⭐ Star History` 两节（此前中文 22 节 / 英文 20 节）。**另修一处实质问题**——英文侧贡献者图仍在用第三方 `contrib.rocks` 外链，而中文侧在 #352/#353 已刻意换成本地 `CONTRIBUTORS.svg` 以摆脱第三方依赖，现已归位
- `en-launch-story.md` / `zh-launch-story.md`：36 → 38 顶层命令、46 → 50 MCP 工具
- 双语 README 的 `pytest (1400+)` → `1600+`（实际 1647）

**新增守卫** `test_docs_capability_counts_match_runtime_source`

扫描全部 **git 跟踪**的 Markdown，把文中出现的「N 个顶层命令 / N top-level commands / N 个 MCP 工具 / N MCP tools / MCP server with N tools」逐一与 `len(SCHEMA_DATA["commands"])` / `len(TOOLS)` 比对。

两处刻意的设计：

1. **动态取真源**，不再硬编码期望值——否则守卫本身会成为下一个漂移点
2. **只扫 git 跟踪文件**，不 glob 文件系统。`docs/blog/linuxdo-promo.md`、`docs/superpowers/` 等本地草稿在 `.gitignore` 里，glob 会让断言随各人工作区内容而变，产生本地红 / CI 绿的环境相关假信号
3. `CHANGELOG.md` 显式豁免——它按定义记录历史事实（如「工具计数 31 → 32」），不该跟随当前值变化

## 验证

- `uv run python scripts/quality_baseline.py` → ruff / **1647 passed** / mypy 全过
- 守卫**经实测有效**：向 `awesome-submissions.md` 注入 `38 → 36` 后测试失败并精确报出 `文件:行号 + 实际值`，还原后恢复绿色、无残留
- `grep -c "^#"` 双语 README 均为 22，标题数已对称
- 全仓 grep 不到 `36 个顶层` / `36 top-level` / `46 个 MCP` / `46 MCP` 残留