### PR TITLE
feat: 容器镜像补齐为可用产物并接入 CI 构建

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,62 @@
+# 构建上下文只需要打包 boss-agent-cli 所需的最小集合。
+# 目的有二：一是让构建更快、镜像层更稳定；二是避免把本地状态、
+# Agent 工具链目录和演示素材意外带进镜像。
+
+# 版本控制与 CI
+.git
+.gitignore
+.gitattributes
+.github
+
+# Python 构建与缓存产物
+.venv*
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+build/
+dist/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+htmlcov/
+.coverage
+.coverage.*
+coverage.xml
+coverage.json
+
+# 本地 Agent 工具链与草稿（同时也在 .gitignore 里）
+.trellis/
+.claude/
+.codex/
+.agents/
+.ace-tool/
+.worktrees/
+CLAUDE.md
+AGENTS.md
+GEMINI.md
+my-boss-profile.md
+
+# 运行期数据，绝不能进镜像
+crawl-data/
+
+# 运行时用不到的资产与开发目录
+demo/
+designs/
+docs/
+evals/
+examples/
+extension/
+mcp-server/
+scripts/
+tests/
+CONTRIBUTORS.svg
+*.gif
+*.mp4
+*.pdf
+*.html
+
+# 容器自身的定义文件（改它们不该让依赖层失效）
+Dockerfile
+.dockerignore
+docker-compose.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,3 +127,37 @@ jobs:
 
       - name: Run mypy
         run: uv run mypy src/boss_agent_cli
+
+  docker:
+    # 容器镜像必须每次构建，否则会像此前那个无人引用的 Dockerfile 一样静默腐烂。
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          load: true
+          tags: boss-agent-cli:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify the CLI entry point and JSON envelope
+        run: |
+          docker run --rm --entrypoint boss boss-agent-cli:ci --version
+          docker run --rm --entrypoint boss boss-agent-cli:ci --json schema --format native \
+            | python3 -c "import sys, json; d = json.load(sys.stdin); assert d['ok'], d; print('schema commands:', len(d['data']['commands']))"
+
+      - name: Verify the MCP server handshake over stdio
+        run: |
+          printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"ci","version":"1.0"}}}' \
+            | docker run --rm -i boss-agent-cli:ci \
+            | python3 -c "import sys, json; d = json.loads(sys.stdin.readline()); assert d['result']['serverInfo']['name'] == 'boss-agent-cli', d; print('MCP initialize ok')"
+
+      - name: Verify it runs as non-root
+        run: |
+          test "$(docker run --rm --entrypoint id boss-agent-cli:ci -u)" != "0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,21 +130,17 @@ jobs:
 
   docker:
     # 容器镜像必须每次构建，否则会像此前那个无人引用的 Dockerfile 一样静默腐烂。
+    #
+    # 刻意用 runner 自带的 docker build，不上 buildx / GHA 缓存：docker-container
+    # driver 需要额外从 Docker Hub 拉 moby/buildkit，`# syntax=` 前端又要再拉一次
+    # docker/dockerfile——两者都曾在此 job 上因 Docker Hub 超时而假红。构建本身只要
+    # 几十秒，省下的缓存收益远不及这两个外部依赖带来的偶发失败。
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@v4
-
       - name: Build image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          load: true
-          tags: boss-agent-cli:ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+        run: docker build -t boss-agent-cli:ci .
 
       - name: Verify the CLI entry point and JSON envelope
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased]
 
+### Added
+- 容器化落地：仓库自带的 `Dockerfile` 重写为多阶段 uv 构建（`uv sync --frozen` 严格按 `uv.lock` 安装，依赖不再漂移）+ 非 root 运行 + `.dockerignore` + `docker-compose.yml` + [Docker 接入文档](docs/integrations/docker.md)，并在 CI 新增 `docker` job 每次构建并验证 CLI 信封、MCP stdio 握手与非 root 身份。镜像定位刻意收窄为**只跑 MCP server 与只读 / 本地命令**：不含浏览器内核，`boss login` 仍在宿主机完成后挂载 `~/.boss-agent`（容器内 `HOME=/data`，故默认数据目录解析为 `/data/.boss-agent`）。不发布 registry 镜像。
+
 ## [1.17.0] - 2026-07-27
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,65 @@
-FROM python:3.12-slim
+# syntax=docker/dockerfile:1
 
-ENV PYTHONDONTWRITEBYTECODE=1 \
-	PYTHONUNBUFFERED=1
+# boss-agent-cli 容器镜像 —— 只用于运行 MCP server 与只读 / 本地命令。
+#
+# 刻意**不**包含浏览器内核：登录（扫码 / 浏览器 Cookie 提取）依赖真实浏览器，
+# 硬塞进容器只会得到一个「看起来能跑、实际登不上」的镜像。正确用法是先在宿主机
+# 完成 `boss login`，再把 ~/.boss-agent 挂载进来。详见 docs/integrations/docker.md。
+#
+# 数据目录：容器内 HOME=/data，因此 CLI 默认的 `~/.boss-agent` 会解析为
+# /data/.boss-agent —— 无论走 boss-mcp 还是 `--entrypoint boss` 都一致。
+
+ARG PYTHON_VERSION=3.12
+
+FROM python:${PYTHON_VERSION}-slim AS builder
+
+COPY --from=ghcr.io/astral-sh/uv:0.11 /uv /bin/uv
+
+ENV UV_COMPILE_BYTECODE=1 \
+	UV_LINK_MODE=copy \
+	UV_PYTHON_DOWNLOADS=never
 
 WORKDIR /app
 
-COPY pyproject.toml README.md /app/
-COPY src /app/src
-COPY mcp-server /app/mcp-server
+# 依赖层：只在 pyproject.toml / uv.lock 变化时失效。
+# --frozen 强制严格按 uv.lock 安装，锁不上直接构建失败，杜绝「镜像里依赖漂了」。
+COPY pyproject.toml uv.lock README.md ./
+RUN uv sync --frozen --no-dev --no-install-project --extra mcp
 
-RUN pip install --no-cache-dir ".[mcp]"
+# 项目层：--no-editable 让 .venv 自包含，运行阶段不必再带上 src/。
+COPY src ./src
+RUN uv sync --frozen --no-dev --no-editable --extra mcp
 
-CMD ["boss-mcp"]
+
+FROM python:${PYTHON_VERSION}-slim AS runtime
+
+LABEL org.opencontainers.image.title="boss-agent-cli" \
+	org.opencontainers.image.description="MCP server and read-only CLI surface for boss-agent-cli" \
+	org.opencontainers.image.source="https://github.com/can4hou6joeng4/boss-agent-cli" \
+	org.opencontainers.image.licenses="MIT"
+
+ENV PATH="/app/.venv/bin:$PATH" \
+	PYTHONDONTWRITEBYTECODE=1 \
+	PYTHONUNBUFFERED=1 \
+	HOME=/data
+
+# 非 root 运行。UID 固定 1000；宿主机 UID 不同时（macOS 通常是 501）用
+# `--user "$(id -u):$(id -g)"` 覆盖，避免挂载目录里出现属主错乱的文件。
+#
+# /data 必须对 other 保留 r-x：useradd --create-home 默认给 0700，
+# 那样一旦 --user 覆盖成非 1000 的 UID，连遍历 /data 都会被拒，
+# 挂载 /data/.boss-agent 直接 PermissionError——而挂载凭据是本镜像的主用法。
+# /data/.boss-agent 预建一份，让未挂载的默认 UID 也能开箱可用。
+RUN useradd --uid 1000 --home-dir /data --create-home --shell /usr/sbin/nologin boss \
+	&& mkdir -p /data/.boss-agent \
+	&& chown -R boss:boss /data \
+	&& chmod 0755 /data /data/.boss-agent
+
+COPY --from=builder --chown=boss:boss /app/.venv /app/.venv
+
+USER boss
+WORKDIR /data
+
+# stdio 是 MCP 宿主的默认接法；HTTP / SSE 传输见 docs/integrations/docker.md。
+ENTRYPOINT ["boss-mcp"]
+CMD ["--transport", "stdio"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1
-
 # boss-agent-cli 容器镜像 —— 只用于运行 MCP server 与只读 / 本地命令。
 #
 # 刻意**不**包含浏览器内核：登录（扫码 / 浏览器 Cookie 提取）依赖真实浏览器，

--- a/README.en.md
+++ b/README.en.md
@@ -97,6 +97,8 @@ Start here: [Agent Quickstart](docs/agent-quickstart.en.md) · [Capability Matri
 { "mcpServers": { "boss-agent": { "command": "uvx", "args": ["--from", "boss-agent-cli[mcp]", "boss-mcp"] } } }
 ```
 
+Prefer not to set up a local Python toolchain? Use the bundled container: `BOSS_UID=$(id -u) BOSS_GID=$(id -g) docker compose run --rm boss-mcp`. The image deliberately ships no browser kernel — run `boss login` on the host first, then mount `~/.boss-agent`. See [Docker integration](docs/integrations/docker.md).
+
 OpenCode can use the checked-in example directly:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ boss config set platform zhilian          # 设为默认
 { "mcpServers": { "boss-agent": { "command": "uvx", "args": ["--from", "boss-agent-cli[mcp]", "boss-mcp"] } } }
 ```
 
+不想在本机配 Python 工具链，可用仓库自带的容器：`BOSS_UID=$(id -u) BOSS_GID=$(id -g) docker compose run --rm boss-mcp`。镜像刻意不含浏览器内核 —— 先在宿主机 `boss login`，再把 `~/.boss-agent` 挂进去，详见 [Docker 接入](docs/integrations/docker.md)。
+
 OpenCode 源码项目可直接使用仓库示例：
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+# boss-agent-cli 容器编排 —— 只跑 MCP server 与只读 / 本地命令。
+#
+# 前置：登录必须在宿主机完成。容器里刻意没有浏览器内核，`boss login` 跑不起来。
+#   uv tool install boss-agent-cli && boss login
+#
+# 常用姿势（把宿主 UID 传进去，避免挂载目录出现属主错乱的文件）：
+#   BOSS_UID=$(id -u) BOSS_GID=$(id -g) docker compose run --rm boss-mcp
+#
+# 完整说明见 docs/integrations/docker.md。
+
+services:
+  boss-mcp:
+    build:
+      context: .
+    image: boss-agent-cli:local
+    # MCP stdio 传输要求 stdin 保持打开；tty 必须关闭，否则 JSON-RPC 会被终端处理干扰。
+    stdin_open: true
+    tty: false
+    # 与宿主机用户对齐。未设置时回落到镜像内的 1000，此时挂载目录若属主不同会写不进去。
+    user: "${BOSS_UID:-1000}:${BOSS_GID:-1000}"
+    volumes:
+      - ${BOSS_DATA_DIR:-~/.boss-agent}:/data/.boss-agent
+    restart: "no"

--- a/docs/agent-hosts.en.md
+++ b/docs/agent-hosts.en.md
@@ -18,6 +18,7 @@ Current example baseline:
 | Windsurf | You use Cascade Agent with MCP or `.windsurfrules` | [Windsurf](integrations/windsurf.md) |
 | Shell Agent | You have any shell-capable agent framework or a homegrown orchestrator | [Shell Agent](integrations/shell-agent.md) |
 | Python SDK | You want business code, LangGraph, or a custom agent to call model SDKs directly | [Python SDK](integrations/python-sdk.md) |
+| Docker | You would rather not set up a local Python toolchain (Apple Silicon setups in particular); login still happens on the host | [Docker](integrations/docker.md) |
 
 ## Picking the right host
 

--- a/docs/agent-hosts.md
+++ b/docs/agent-hosts.md
@@ -18,6 +18,7 @@
 | Windsurf | Cascade Agent + MCP 或 `.windsurfrules` | [Windsurf](integrations/windsurf.md) |
 | Shell Agent | 任意支持 shell tool 的 Agent 框架或自建编排器 | [Shell Agent](integrations/shell-agent.md) |
 | Python SDK 直调 | 自建 Agent / LangGraph / 业务代码直接驱动 OpenAI 或 Claude SDK | [Python SDK](integrations/python-sdk.md) |
+| Docker 容器 | 不想在本机配 Python 工具链（如 Apple Silicon 环境折腾）；登录仍在宿主机完成 | [Docker](integrations/docker.md) |
 
 ## 选型建议
 

--- a/docs/integrations/docker.md
+++ b/docs/integrations/docker.md
@@ -1,0 +1,156 @@
+# Docker Integration
+
+Applies to the `boss-agent-cli` low-risk CLI contract as of version 1.17.0.
+
+The repository ships a `Dockerfile` and a `docker-compose.yml` so you can run the MCP
+server without setting up a local Python toolchain. This is the answer to
+"environment setup is painful, especially on Apple Silicon" — with one important
+boundary spelled out below.
+
+## What the image is and is not for
+
+**It runs**: the MCP server (`boss-mcp`), plus read-only and local commands
+(`status`, `doctor`, `search`, `detail`, `shortlist`, `stats`, `schema`, …).
+
+**It does not run `boss login`.** Login needs a real browser — QR scanning or
+extracting cookies from your own browser profile — so the image deliberately ships
+**without a browser kernel**. Bundling one would produce an image that looks like it
+works and then cannot log in. Log in on the host, then mount the credentials.
+
+The same applies to any command that needs the browser channel: `resume export pdf`,
+`crawl run`, and CDP-backed automation paths stay on the host.
+
+No image is published to a registry. Building locally from this repo keeps the
+"one command to start" experience without a release-time image rebuild and
+registry-drift problem.
+
+## Prerequisites
+
+Log in once on the host:
+
+```bash
+uv tool install boss-agent-cli
+boss login
+boss status          # should report a live session
+```
+
+Credentials land in `~/.boss-agent/` (Fernet-encrypted, machine-bound key).
+
+> The encryption key is derived per machine. Credentials are portable to a container
+> on the **same** host, but copying `~/.boss-agent` to a different machine will not
+> decrypt.
+
+## Build
+
+```bash
+docker build -t boss-agent-cli:local .
+```
+
+Dependencies are installed with `uv sync --frozen`, so the image resolves exactly what
+`uv.lock` pins — a build fails rather than silently drifting. The final image is about
+495 MB, dominated by the `patchright` wheel that ships as a core dependency.
+
+## Run
+
+### Via docker compose (recommended)
+
+```bash
+BOSS_UID=$(id -u) BOSS_GID=$(id -g) docker compose run --rm boss-mcp
+```
+
+Override the data directory when you want project-level isolation:
+
+```bash
+BOSS_UID=$(id -u) BOSS_GID=$(id -g) \
+BOSS_DATA_DIR=~/projects/foo/.boss-agent \
+docker compose run --rm boss-mcp
+```
+
+### Via docker run
+
+```bash
+docker run --rm -i \
+  --user "$(id -u):$(id -g)" \
+  -v ~/.boss-agent:/data/.boss-agent \
+  boss-agent-cli:local
+```
+
+### A one-off CLI command
+
+`ENTRYPOINT` is `boss-mcp`, so override it to reach the CLI directly:
+
+```bash
+docker run --rm \
+  --user "$(id -u):$(id -g)" \
+  -v ~/.boss-agent:/data/.boss-agent \
+  --entrypoint boss boss-agent-cli:local \
+  --json search "golang" --city 101010100
+```
+
+### HTTP or SSE transport
+
+```bash
+docker run --rm -p 8765:8765 \
+  --user "$(id -u):$(id -g)" \
+  -v ~/.boss-agent:/data/.boss-agent \
+  boss-agent-cli:local \
+  --transport http --host 0.0.0.0 --port 8765
+```
+
+## Always pass `--user`
+
+The image runs as non-root `boss` (UID 1000). If your host UID differs — macOS
+typically starts at 501 — a container writing into the mounted directory would create
+files your host user does not own. Passing `--user "$(id -u):$(id -g)"` keeps
+ownership straight in both directions.
+
+Inside the container `HOME=/data`, so the CLI's default `~/.boss-agent` resolves to
+`/data/.boss-agent` for `boss-mcp` and for `--entrypoint boss` alike. `/data` is mode
+`0755` specifically so an overridden UID can still traverse it.
+
+## Wiring it into an MCP host
+
+Point the host at `docker run` instead of `uvx`:
+
+```json
+{
+  "mcpServers": {
+    "boss-agent-cli": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "--user", "1000:1000",
+        "-v", "/absolute/path/to/.boss-agent:/data/.boss-agent",
+        "boss-agent-cli:local"
+      ]
+    }
+  }
+}
+```
+
+MCP hosts generally do not expand `$(id -u)` or `~`, so use literal values and
+absolute paths there.
+
+## Compliance boundary is unchanged
+
+The container inherits the same defaults as the CLI: `assisted` mode blocks automated
+outreach, bulk actions, and candidate personal-data workflows, and MCP exposes only the
+low-risk tool surface. Running in a container does not widen what the tool will do —
+see [platform-risk.md](../platform-risk.md).
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `PermissionError: '/data/.boss-agent'` | host UID cannot traverse or write the mount | pass `--user "$(id -u):$(id -g)"` |
+| `AUTH_REQUIRED` envelope | no credentials in the mounted directory | run `boss login` on the host first, and check the mount path |
+| `BROWSER_KERNEL_MISSING` | a browser-dependent command was invoked | run that command on the host; the image ships no browser by design |
+| MCP host reports no tools | `stdin` was not kept open | `docker run` needs `-i`; compose needs `stdin_open: true` |
+
+## Verified behavior
+
+The image is built in CI on every push and pull request (`docker` job in
+`.github/workflows/ci.yml`) so it cannot rot silently the way an unreferenced
+Dockerfile does. The build was validated end to end: MCP `initialize`, `tools/list`
+returning the full low-risk tool set, and a `tools/call` round trip that shells out to
+`boss` inside the container.


### PR DESCRIPTION
Closes #340

## 背景

仓库里那个 `Dockerfile` 是孤儿：`git log -- Dockerfile` 只有一条提交（`61848b5`，2026-06-16，随一个改 ROADMAP 的 docs PR 带入），此后未再改动；全仓 `.md` 里零引用；无 `.dockerignore`；CI 从不构建。#340 的回复里也没提它已经存在。

内容上它也跑不通完整闭环：不 COPY `uv.lock`（依赖不锁）、不装 `crawl` / `bridge` extras、root 运行、没装 patchright chromium 所以 `boss login` 必失败。

## 定位（刻意收窄）

镜像**只跑 MCP server 与只读 / 本地命令**，且**不含浏览器内核**。

登录依赖真实浏览器（扫码 / 读宿主浏览器 Cookie），硬塞进容器只会得到一个「看起来能跑、实际登不上」的镜像——比没有更误导。正确用法是宿主机 `boss login`，再挂 `~/.boss-agent`。同理 `resume export pdf` / `crawl run` / CDP 链路都留在宿主机。

**不发布 registry 镜像**，仓库自带 `Dockerfile` + `docker-compose.yml`，避免每次发版重构建与镜像滞后。

## 变更

- **`Dockerfile` 重写**：多阶段 uv 构建，`uv sync --frozen` 严格按 `uv.lock` 安装（锁不上直接构建失败）；`--no-editable` 让 `.venv` 自包含，运行阶段不带 `src/`；非 root（UID 1000）；OCI labels
- **`.dockerignore`**（新增）：把构建上下文收到最小集合，顺带确保本地状态、Agent 工具链目录（`.trellis/` / `.claude/` 等）和演示素材不会进镜像
- **`docker-compose.yml`**（新增）：`stdin_open: true`（MCP stdio 必需）、`user: ${BOSS_UID:-1000}:${BOSS_GID:-1000}`、数据目录可用 `BOSS_DATA_DIR` 覆盖
- **`docs/integrations/docker.md`**（新增）：定位边界、构建运行、MCP 宿主配置、`--user` 的必要性、故障排查表
- **CI 新增 `docker` job**：每次 push / PR 构建镜像并验证三件事——CLI 入口与 JSON 信封、MCP stdio 握手、非 root 身份。这是为了让它**不能再像之前那样静默腐烂**
- `docs/agent-hosts(.en).md` 宿主表、双语 README、CHANGELOG `[Unreleased]` 同步

## 数据目录设计

容器内 `HOME=/data`，所以 CLI 默认的 `~/.boss-agent` 解析为 `/data/.boss-agent`——走 `boss-mcp` 还是 `--entrypoint boss` 都一致，覆盖 CMD 参数也不会丢。

## 实测中修掉的一个真问题

第一版用 `useradd --create-home`，它把 `/data` 建成 `drwx------`。结果一旦用 `--user` 覆盖 UID（macOS 宿主通常是 501 而非 1000），连**遍历** `/data` 都被拒，挂载 `/data/.boss-agent` 直接 `PermissionError` —— 而挂载凭据恰恰是本镜像的唯一正经用法。这就是「本机能跑、别人跑不了」的典型。现已显式 `chmod 0755 /data /data/.boss-agent` 并预建数据目录。

## 验证（本地实跑，非推断）

镜像 495 MB（大头是作为核心依赖的 patchright wheel）。

- `docker build` 成功
- 非 root：`uid=1000(boss)`
- `boss --version` → 1.17.0；`boss --json schema` → `ok=true`，38 个命令
- **MCP 端到端**：`initialize` ✓ → `tools/list` 返回 **50 个工具** ✓ → `tools/call boss_schema` 返回 `ok=true` / 38 命令 ✓（后者证明容器内 subprocess 调 `boss` 也正常）
- **挂载 + 宿主 UID(501)**：`doctor` 返回 `ok=true`；容器写入挂载目录的文件属主是宿主用户，不是 root
- **未挂载 + 默认 UID**：仍开箱可用
- `docker compose run --rm boss-mcp` 跑通；`docker compose config` 正确把 `~` 展开为绝对路径
- CI 那三条校验按原样在本地执行通过；`docker/setup-buildx-action@v4`、`docker/build-push-action@v7` 已核实为真实存在的版本
- `quality_baseline.py`（ruff / 1647 passed / mypy）、两个文档一致性测试、smoke dry-run 全过

## 后续

`docker` job 首次在 master 绿过之后，可加进分支保护的必需检查（先加会永久阻塞合并）。