### PR TITLE
ci: 分支保护文档补记 docker 门禁并修正 release 资产多出 default.gitignore

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,12 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
-          files: dist/*
+          # 只上传真正的分发产物。此前用 dist/* 会把构建后端生成的 dist/.gitignore
+          # 一并捞进去，GitHub 不允许资产以点开头，于是每个 release 都多出一个
+          # 名为 default.gitignore 的垃圾文件（v1.15.0 起可见）。
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
 
       - name: Publish to PyPI
         if: ${{ !contains(github.ref, 'rc') && !contains(github.ref, 'beta') }}

--- a/docs/maintainer/branch-protection.md
+++ b/docs/maintainer/branch-protection.md
@@ -28,8 +28,11 @@ Select the concrete check contexts emitted by `.github/workflows/ci.yml`:
 - `test (3.14)`
 - `lint`
 - `typecheck`
+- `docker`
 
 `P0 quality baseline` is the canonical blocking quality gate. It runs `scripts/quality_baseline.py`, which covers ruff (`src/boss_agent_cli`, `tests`, `scripts`), the full offline pytest suite, and mypy with the same command used locally. The same job also runs `scripts/smoke_p0.py` in offline dry-run mode so the JSON-envelope smoke contract is checked on every push and pull request.
+
+`docker` builds the container image and verifies the CLI entry point, the MCP stdio handshake, and that the image runs as non-root. It exists so the shipped `Dockerfile` cannot rot silently the way an unreferenced one did before.
 
 The project may also require documentation checks when `.github/workflows/docs.yml` is enabled:
 

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -189,6 +189,7 @@ def test_maintainer_docs_cover_open_source_governance():
 	assert "lint" in branch
 	assert "typecheck" in branch
 	assert "docs" in branch
+	assert "docker" in branch
 	assert "allow_force_pushes" in branch
 	assert "allow_deletions" in branch
 


### PR DESCRIPTION
两处小修，都属于「文档/配置与现实脱节」。

## 1. `branch-protection.md` 补记 `docker` 门禁

`docker` job 已在 #362 落地并加进 master 的必需检查（现共 10 项），但维护者文档还停在 9 项——正是 #361 刚修过的那类漂移。补上条目与说明，并在 `tests/test_open_source_docs.py` 加断言，让它跟其余检查项一样被钉住。

## 2. release 资产不再多出 `default.gitignore`

每个 GitHub Release 都带一个莫名其妙的 `default.gitignore` 资产（v1.15.0 起可见，1.16.0 / 1.17.0 都有）。

根因：构建后端会在 `dist/` 下生成 `.gitignore`（内容为 `*`，防止误提交产物），而 `release.yml` 用 `files: dist/*` 通配，把它一并上传；GitHub 不允许资产名以点开头，于是重命名成了 `default.gitignore`。

改为显式列出 `dist/*.whl` 与 `dist/*.tar.gz`，只上传真正的分发产物。

```console
$ cat dist/.gitignore
*
```

## 验证

- `uv run python scripts/quality_baseline.py` → ruff / 1647 passed / mypy 全过
- 两个文档一致性测试通过（含新增的 `docker` 断言）
- `release.yml` YAML 解析正常，`files` 为两条显式 glob

效果要到下一个 tag 才可见——本 PR 不触发 release 流程。