### PR TITLE
chore: mypy 严格白名单扩至 128 并修正其暴露的招聘者契约缺口

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
 ### Added
 - 容器化落地：仓库自带的 `Dockerfile` 重写为多阶段 uv 构建（`uv sync --frozen` 严格按 `uv.lock` 安装，依赖不再漂移）+ 非 root 运行 + `.dockerignore` + `docker-compose.yml` + [Docker 接入文档](docs/integrations/docker.md)，并在 CI 新增 `docker` job 每次构建并验证 CLI 信封、MCP stdio 握手与非 root 身份。镜像定位刻意收窄为**只跑 MCP server 与只读 / 本地命令**：不含浏览器内核，`boss login` 仍在宿主机完成后挂载 `~/.boss-agent`（容器内 `HOME=/data`，故默认数据目录解析为 `/data/.boss-agent`）。不发布 registry 镜像。
 
+### Fixed
+- `RecruiterPlatform` 抽象基类补齐两个已被命令层实际调用、却从未写进契约的方法：`send_message_by_friend`（`hr reply` 在用）与 `job_detail`（`hr jobs detail` 在用）。此前它们只存在于 `BossRecruiterPlatform` 实现里，任何新写的招聘者平台按 ABC 实现完都能通过类型检查，却会在这两条命令上运行时抛 `AttributeError`。
+- MCP 的 HTTP streaming 传输改用 `@asynccontextmanager` 声明 lifespan：此前是裸 async generator，会走 Starlette 的弃用路径并触发 `DeprecationWarning`。
+- MCP `_run_boss` 现在只接受 JSON 对象形式的 CLI 信封：解析结果非 dict 时（契约违例）返回 `CLI_ERROR` 信封，而不是把非 dict 结果透传给调用方。
+
+### Changed
+- mypy 逐模块严格化白名单 120 → 128：纳入 `crawler/` 全部子模块、`commands/crawl.py`、`commands/_recruiter_platform.py` 与 `mcp_server.py`（此前 #339 引入的整个 crawl 子系统与最大的 `mcp_server.py` 都在严格检查之外）。
+
 ## [1.17.0] - 2026-07-27
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,6 +228,14 @@ module = [
 	"boss_agent_cli.commands.register",
 	"boss_agent_cli.commands.contact_lookup",
 	"boss_agent_cli.commands.friend_list_pages",
+	"boss_agent_cli.commands._recruiter_platform",
+	"boss_agent_cli.commands.crawl",
+	"boss_agent_cli.crawler.exporter",
+	"boss_agent_cli.crawler.hooks",
+	"boss_agent_cli.crawler.operations",
+	"boss_agent_cli.crawler.service",
+	"boss_agent_cli.crawler.transport",
+	"boss_agent_cli.mcp_server",
 ]
 disallow_untyped_defs = true
 disallow_any_generics = true

--- a/src/boss_agent_cli/commands/_recruiter_platform.py
+++ b/src/boss_agent_cli/commands/_recruiter_platform.py
@@ -5,13 +5,14 @@ from typing import TYPE_CHECKING
 
 from boss_agent_cli.api.recruiter_client import BossRecruiterClient
 from boss_agent_cli.platforms import get_recruiter_platform
+from boss_agent_cli.platforms.recruiter_base import RecruiterPlatform
 
 if TYPE_CHECKING:
 	import click
 	from boss_agent_cli.auth.manager import AuthManager
 
 
-def get_recruiter_platform_instance(ctx: "click.Context", auth: "AuthManager"):
+def get_recruiter_platform_instance(ctx: "click.Context", auth: "AuthManager") -> RecruiterPlatform:
 	obj = ctx.obj or {}
 	name = obj.get("platform") or "zhipin"
 	recruiter_name = f"{name}-recruiter"

--- a/src/boss_agent_cli/mcp_server.py
+++ b/src/boss_agent_cli/mcp_server.py
@@ -5,7 +5,8 @@ import asyncio
 import copy
 import json
 import subprocess
-from typing import Any
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
@@ -18,6 +19,15 @@ from boss_agent_cli.compliance import (
 	restricted_commands,
 )
 from boss_agent_cli.platforms import list_platforms, list_recruiter_platforms
+
+if TYPE_CHECKING:
+	# SSE / HTTP 传输是可选路径，starlette 与 session manager 只在对应工厂函数里
+	# 惰性导入；这里仅为类型标注引入，不影响 stdio 传输的启动开销。
+	from collections.abc import AsyncIterator
+
+	from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+	from starlette.applications import Starlette
+	from starlette.types import Receive, Scope, Send
 
 SERVER_INSTRUCTIONS = (
 	"boss-agent-cli over MCP: a local-assist BOSS Zhipin job-search toolset in assisted mode by default — "
@@ -76,9 +86,21 @@ def _build_schema_with_availability() -> dict[str, Any]:
 _SCHEMA_WITH_AVAILABILITY = _build_schema_with_availability()
 
 
+def _availability_of(command: Any) -> dict[str, Any] | None:
+	"""从单个 schema 命令条目里取 availability，非 dict 一律按「无」处理。
+
+	`SCHEMA_DATA` 是 `dict[str, Any]`，直接 `.get("availability")` 会把 `Any`
+	一路带到返回值上；这里收敛成一处运行时校验，调用点就都是有类型的了。
+	"""
+	if not isinstance(command, dict):
+		return None
+	availability = command.get("availability")
+	return availability if isinstance(availability, dict) else None
+
+
 def _tool_availability(tool_name: str) -> dict[str, Any] | None:
 	name = tool_name.removeprefix("boss_")
-	commands = _SCHEMA_WITH_AVAILABILITY["commands"]
+	commands: dict[str, Any] = _SCHEMA_WITH_AVAILABILITY["commands"]
 
 	direct_map = {
 		"chat_summary": "chat-summary",
@@ -86,31 +108,32 @@ def _tool_availability(tool_name: str) -> dict[str, Any] | None:
 		"follow_up": "follow-up",
 	}
 	if name in direct_map:
-		return commands[direct_map[name]].get("availability")
+		return _availability_of(commands[direct_map[name]])
 	if name in commands:
-		return commands[name].get("availability")
+		return _availability_of(commands[name])
 
-	if name.startswith("ai_"):
-		sub_name = name.removeprefix("ai_").replace("_", "-")
-		return commands["ai"].get("availability")
-	if name.startswith("agent_"):
-		return commands["agent"].get("availability")
-	if name.startswith("resume_"):
-		return commands["resume"].get("availability")
-	if name.startswith("watch_"):
-		return commands["watch"].get("availability")
-	if name.startswith("preset_"):
-		return commands["preset"].get("availability")
-	if name.startswith("shortlist_"):
-		return commands["shortlist"].get("availability")
-	if name.startswith("favorites_"):
-		return commands["favorites"].get("availability")
-	if name.startswith("crawl_"):
-		return commands["crawl"].get("availability")
+	for prefix, command_name in (
+		("ai_", "ai"),
+		("agent_", "agent"),
+		("resume_", "resume"),
+		("watch_", "watch"),
+		("preset_", "preset"),
+		("shortlist_", "shortlist"),
+		("favorites_", "favorites"),
+		("crawl_", "crawl"),
+	):
+		if name.startswith(prefix):
+			return _availability_of(commands[command_name])
+
 	if name.startswith("hr_"):
 		sub_name = name.removeprefix("hr_").replace("_", "-")
-		hr_availability = commands["hr"].get("availability") or {}
-		return hr_availability.get("subcommands", {}).get(sub_name, hr_availability)
+		hr_availability = _availability_of(commands["hr"]) or {}
+		subcommands = hr_availability.get("subcommands")
+		if isinstance(subcommands, dict):
+			sub_availability = subcommands.get(sub_name)
+			if isinstance(sub_availability, dict):
+				return sub_availability
+		return hr_availability
 	return None
 
 
@@ -992,15 +1015,20 @@ def _run_boss(*args: str) -> dict[str, Any]:
 		stdin=subprocess.DEVNULL,
 	)
 	try:
-		return json.loads(result.stdout)
+		parsed = json.loads(result.stdout)
 	except json.JSONDecodeError:
-		return {
-			"ok": False,
-			"error": {"code": "CLI_ERROR", "message": result.stderr or "命令执行失败"},
-		}
+		parsed = None
+	if isinstance(parsed, dict):
+		return parsed
+	# CLI 契约保证 stdout 是 JSON 信封对象；拿到别的形状（解析失败或非对象）
+	# 一律按命令失败处理，而不是把非 dict 结果透传给调用方。
+	return {
+		"ok": False,
+		"error": {"code": "CLI_ERROR", "message": result.stderr or "命令执行失败"},
+	}
 
 
-def _build_args(tool_name: str, arguments: dict) -> list[str]:
+def _build_args(tool_name: str, arguments: dict[str, Any]) -> list[str]:
 	"""根据 tool name 和参数构建 CLI 参数列表。"""
 	name = tool_name.replace("boss_", "")
 
@@ -1436,7 +1464,7 @@ async def list_tools() -> list[Tool]:
 
 
 @server.call_tool()
-async def call_tool(name: str, arguments: dict) -> list[TextContent]:
+async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
 	if name in _LOW_RISK_BLOCKED_TOOLS:
 		result = {
 			"ok": False,
@@ -1466,7 +1494,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
 # ── 入口 ──────────────────────────────────────────────────────────
 
 
-async def main():
+async def main() -> None:
 	async with stdio_server() as (read_stream, write_stream):
 		await server.run(read_stream, write_stream, server.create_initialization_options())
 
@@ -1477,7 +1505,7 @@ def _normalize_path(path: str) -> str:
 	return path
 
 
-def _create_sse_app(*, sse_path: str = DEFAULT_SSE_PATH, message_path: str = DEFAULT_MESSAGE_PATH):
+def _create_sse_app(*, sse_path: str = DEFAULT_SSE_PATH, message_path: str = DEFAULT_MESSAGE_PATH) -> "Starlette":
 	from mcp.server.sse import SseServerTransport
 	from starlette.applications import Starlette
 	from starlette.requests import Request
@@ -1488,7 +1516,7 @@ def _create_sse_app(*, sse_path: str = DEFAULT_SSE_PATH, message_path: str = DEF
 	message_path = _normalize_path(message_path)
 	sse = SseServerTransport(message_path)
 
-	async def handle_sse(scope, receive, send):
+	async def handle_sse(scope: "Scope", receive: "Receive", send: "Send") -> Response:
 		async with sse.connect_sse(scope, receive, send) as streams:
 			await server.run(
 				streams[0],
@@ -1509,14 +1537,14 @@ def _create_sse_app(*, sse_path: str = DEFAULT_SSE_PATH, message_path: str = DEF
 
 
 class _StreamableHTTPASGIApp:
-	def __init__(self, session_manager):
+	def __init__(self, session_manager: "StreamableHTTPSessionManager") -> None:
 		self.session_manager = session_manager
 
-	async def __call__(self, scope, receive, send) -> None:
+	async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
 		await self.session_manager.handle_request(scope, receive, send)
 
 
-def _create_streamable_http_app(*, path: str = DEFAULT_HTTP_PATH):
+def _create_streamable_http_app(*, path: str = DEFAULT_HTTP_PATH) -> "Starlette":
 	from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 	from starlette.applications import Starlette
 	from starlette.routing import Route
@@ -1525,7 +1553,10 @@ def _create_streamable_http_app(*, path: str = DEFAULT_HTTP_PATH):
 	session_manager = StreamableHTTPSessionManager(app=server)
 	http_app = _StreamableHTTPASGIApp(session_manager)
 
-	async def lifespan(app):
+	# 必须是 asynccontextmanager：Starlette 对裸 async generator lifespan 会走
+	# 弃用路径并发 DeprecationWarning。
+	@asynccontextmanager
+	async def lifespan(app: "Starlette") -> "AsyncIterator[None]":
 		async with session_manager.run():
 			yield
 
@@ -1535,7 +1566,7 @@ def _create_streamable_http_app(*, path: str = DEFAULT_HTTP_PATH):
 	)
 
 
-def _serve_asgi_app(app, *, host: str, port: int) -> None:
+def _serve_asgi_app(app: "Starlette", *, host: str, port: int) -> None:
 	import uvicorn
 
 	uvicorn.run(app, host=host, port=port, log_level="info")

--- a/src/boss_agent_cli/platforms/recruiter_base.py
+++ b/src/boss_agent_cli/platforms/recruiter_base.py
@@ -134,6 +134,10 @@ class RecruiterPlatform(ABC):
 		"""进入聊天会话。"""
 		raise NotImplementedError(f"{self.name} does not implement session_enter")
 
+	def send_message_by_friend(self, friend_id: int, content: str) -> dict[str, Any]:
+		"""按 friend_id 发送消息（issue #217 A' 路径，`hr reply` 在用）。"""
+		raise NotImplementedError(f"{self.name} does not implement send_message_by_friend")
+
 	def job_offline(self, job_id: str) -> dict[str, Any]:
 		"""下线职位。"""
 		raise NotImplementedError(f"{self.name} does not implement job_offline")
@@ -141,6 +145,10 @@ class RecruiterPlatform(ABC):
 	def job_online(self, job_id: str) -> dict[str, Any]:
 		"""上线职位。"""
 		raise NotImplementedError(f"{self.name} does not implement job_online")
+
+	def job_detail(self, enc_job_id: str) -> dict[str, Any]:
+		"""查看职位详情（`hr jobs detail` 在用）。"""
+		raise NotImplementedError(f"{self.name} does not implement job_detail")
 
 	def exchange_request(self, exchange_type: int, uid: int, job_id: int, gid: int) -> dict[str, Any]:
 		"""请求交换联系方式。DEPRECATED — 见 exchange_request_by_friend (issue #217)。"""

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -1,4 +1,5 @@
 import json
+import socket
 import sqlite3
 import sys
 import types
@@ -16,6 +17,19 @@ from boss_agent_cli.crawler.operations import crawl_results, import_crawl_shortl
 from boss_agent_cli.crawler.service import CrawlBudget, CrawlService, CrawlSettings, CrawlStopRequested
 from boss_agent_cli.crawler.transport import JOBLIST_TARGET, DrissionCrawlerSession
 from boss_agent_cli.main import cli
+
+
+def _free_port() -> int:
+	"""取一个当前空闲的本地端口。
+
+	不能写死 9222：`DrissionCrawlerSession.open()` 会真的检查端口占用并拒绝复用
+	（crawl 只允许启动自己的独立浏览器），而 9222 正是本项目 CDP 模式的默认调试
+	端口——开发者按文档开着 CDP Chrome 时，写死 9222 会让这些用例在本机必挂，
+	CI 上却因端口空闲而常绿。
+	"""
+	with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as connection:
+		connection.bind(("127.0.0.1", 0))
+		return int(connection.getsockname()[1])
 
 
 def _job(job_id: str, security_id: str) -> dict:
@@ -108,7 +122,7 @@ def _settings(
 		with_detail=with_detail,
 		profile_path=tmp_path / "profile",
 		chrome_path=None,
-		cdp_port=9222,
+		cdp_port=_free_port(),
 		hook_profile="none",
 		max_requests=max_requests,
 		max_details=max_details,
@@ -211,7 +225,7 @@ def test_hook_registration_happens_before_first_navigation(monkeypatch, tmp_path
 	session = DrissionCrawlerSession(
 		profile_path=tmp_path / "profile",
 		chrome_path=None,
-		cdp_port=9222,
+		cdp_port=_free_port(),
 		hook_profile="screenshot-full",
 		hook_dir=_write_hooks(tmp_path / "hooks"),
 	)
@@ -250,7 +264,7 @@ def test_listener_parses_string_json_response(monkeypatch, tmp_path):
 	page = Page()
 	monkeypatch.setitem(sys.modules, "DrissionPage", types.SimpleNamespace(ChromiumOptions=Options, ChromiumPage=lambda options: page))
 	session = DrissionCrawlerSession(
-		profile_path=tmp_path / "profile", chrome_path=None, cdp_port=9222, hook_profile="none", hook_dir=None,
+		profile_path=tmp_path / "profile", chrome_path=None, cdp_port=_free_port(), hook_profile="none", hook_dir=None,
 	)
 	session.open()
 	assert session.fetch_page("AI", "101210100", 1)["zpData"]["jobList"][0]["encryptJobId"] == "job-1"


### PR DESCRIPTION
## 背景

`pyproject.toml` 里有一份 mypy 逐模块严格化白名单，项目约定是「新模块达到全注解后应加进该列表」。实际有 8 个真实模块从未加入——其中包括 **#339 引入的整个 `crawler/` 子系统**，以及仓库最大的单文件 `mcp_server.py`（1592 行，Agent 通过 MCP 消费的那个面）。

## 变更

**白名单 120 → 128**，新增：`commands/crawl.py`、`commands/_recruiter_platform.py`、`crawler/{exporter,hooks,operations,service,transport}.py`、`mcp_server.py`。

其中 6 个 `crawler/` + `crawl.py` 模块**零改动直接通过**严格检查，说明当初写得就是全注解的，只是漏登记。另外两个需要修，而修的过程暴露了下面几个真问题。

## 严格化暴露出的问题（本 PR 一并修掉）

### 1. `RecruiterPlatform` ABC 少了两个正在被调用的方法

给 `get_recruiter_platform_instance` 补上 `-> RecruiterPlatform` 返回类型后，mypy 立刻报：

```
recruiter/reply.py:27  "RecruiterPlatform" has no attribute "send_message_by_friend"
recruiter/jobs.py:83   "RecruiterPlatform" has no attribute "job_detail"
```

此前该函数无注解、返回 `Any`，mypy 无从检查其属性访问。两个方法只存在于 `BossRecruiterPlatform` 实现里，**契约里没有**——任何新写的招聘者平台照 ABC 实现完都能通过类型检查，却会在 `hr reply` 和 `hr jobs detail` 上运行时抛 `AttributeError`。

已按 ABC 既有的「可选操作，默认抛 NotImplementedError」范式补入。

### 2. Starlette lifespan 走的是弃用路径

`_create_streamable_http_app` 的 lifespan 是裸 async generator。Starlette 对这种形式会内部包一层 `asynccontextmanager` 并发 `DeprecationWarning`。已改为直接用 `@asynccontextmanager`——类型正确，同时消除弃用警告。

### 3. `_run_boss` 声明返回 dict，实际可能返回任意 JSON

`return json.loads(result.stdout)` 在拿到 JSON 数组时会把 list 透传给调用方，违反自身签名。改为 isinstance 校验，非 dict 一律按 `CLI_ERROR` 信封处理。CLI 契约保证 stdout 是信封对象，所以这个分支本就是契约违例场景——返回错误信封比透传更诚实。

### 4. `_tool_availability` 的 11 处 Any 泄漏

抽出 `_availability_of()` 收敛为一处运行时校验，顺带把 8 个 `startswith` 分支合并为表驱动，并删掉一个赋值后从未使用的 `sub_name`。

## 另修一个与类型无关、但同一轮跑出来的测试缺陷

`tests/test_crawl.py` 有三处写死 `cdp_port=9222`。`DrissionCrawlerSession.open()` 会**真的**检查端口占用并拒绝复用（crawl 只允许启动自己的独立浏览器，这是隔离保证，生产代码没问题）。而 9222 正是本项目 CDP 模式的默认调试端口——**开发者按文档开着 CDP Chrome 时，这两个用例在本机必挂**，CI 上却因端口空闲而长期常绿。

已改为 `_free_port()` 动态取空闲端口。本机在 9222 被真实 Chrome 占用的情况下重跑，1680 全过。

## 验证

- `uv run mypy src/boss_agent_cli` → **Success: no issues found in 136 source files**
- `uv run python scripts/quality_baseline.py` → ruff / 1680 passed / mypy 全过
- MCP 三种传输实测：stdio 握手返回 `boss-agent-cli`；`_create_sse_app()` / `_create_streamable_http_app()` 均构造出 Starlette 实例（2 / 1 条路由）；`inspect.isasyncgenfunction(lifespan_context)` 为 False，确认已走非弃用路径
- `mcp-server/server.py` wrapper 无需补符号（新增的 `_availability_of` 是私有且未经 wrapper 引用，`_tool_availability` 名称保持不变）