### PR TITLE
fix(mcp): "int" is not valid JSON Schema type, use "integer"

### DIFF
--- a/src/boss_agent_cli/mcp_server.py
+++ b/src/boss_agent_cli/mcp_server.py
@@ -729,7 +729,7 @@ TOOLS = [
 		inputSchema={
 			"type": "object",
 			"properties": {
-				"page": {"type": "int", "description": "页码"},
+				"page": {"type": "integer", "description": "页码"},
 			},
 			"required": [],
 		},


### PR DESCRIPTION
## 问题

`boss_favorites_list` MCP tool 的 `inputSchema` 里使用了 `"type": "int"`，这不是合法的 JSON Schema 类型。

JSON Schema 规范要求整数类型必须写 `"integer"`，`"int"` 导致 MCP client（如 Claude Code）在校验 tool schema 时报错：

```
API Error: 400 Invalid schema for function "mcp__boss-agent__boss_favorites_list": "int" is not valid under any of the schemas listed in the "anyOf" keyword
```

## 根因

`schema.py` 的 `SCHEMA_DATA` 使用 `"int"` 作为 native alias —— `_command_to_json_schema()` 通过 `_JSON_SCHEMA_TYPE_MAP` 将其映射为 `"integer"`。但 `mcp_server.py` 中直接硬编码的 `inputSchema` 绕过了这个映射。

## 修复

`mcp_server.py` L732：`"type": "int"` → `"type": "integer"`

## 测试

- [x] JSON Schema 语法正确（`"integer"` 是合法类型）
- [x] 不影响其他 MCP tools（只有 `boss_favorites_list` 有这个内联定义问题）

🤖 Generated with [Claude Code](https://claude.com/claude-code)