### PR TITLE
test: 补齐渲染层断言并验证 rich 15 兼容性

### DIFF
--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -268,8 +268,10 @@ class TestRenderers:
 
 		assert "no results" in stream.getvalue()
 
-	def test_render_job_table_with_items(self):
+	def test_render_job_table_with_items(self, monkeypatch):
 		from boss_agent_cli.display import render_job_table
+		stream = _capture_display_console(monkeypatch)
+
 		render_job_table(
 			[
 				{"title": "Go", "company": "X", "salary": "20K", "experience": "3-5年", "education": "本科", "city": "北京"},
@@ -279,6 +281,14 @@ class TestRenderers:
 			page=1,
 			hint_next="next hint",
 		)
+
+		output = stream.getvalue()
+		assert "jobs (2 results)" in output
+		# 第二行走的是 jobName/brandName/salaryDesc 这套平台原始键的回退分支
+		assert "Go" in output and "Python" in output
+		assert "20K" in output and "30K" in output
+		assert "boss show" in output
+		assert "next hint" in output
 
 	def test_render_job_table_shows_internship_type(self, monkeypatch):
 		from boss_agent_cli.display import render_job_table
@@ -301,28 +311,77 @@ class TestRenderers:
 		output = stream.getvalue()
 		assert "实习" in output
 
-	def test_render_job_detail_minimal(self):
+	def test_render_job_detail_minimal(self, monkeypatch):
 		from boss_agent_cli.display import render_job_detail
+		stream = _capture_display_console(monkeypatch)
+
 		render_job_detail({"title": "Go", "salary": "20K"})
 
-	def test_render_job_detail_with_long_description_truncated(self):
+		output = stream.getvalue()
+		assert "job detail" in output
+		assert "Go" in output
+		assert "20K" in output
+		# 缺失字段回退成 "-"，而不是抛错或渲染出 None
+		assert "None" not in output
+
+	def test_render_job_detail_without_ids_omits_next_hint(self, monkeypatch):
 		from boss_agent_cli.display import render_job_detail
-		long_desc = "a" * 800
+		stream = _capture_display_console(monkeypatch)
+
+		render_job_detail({"title": "Go", "salary": "20K"})
+
+		assert "next:" not in stream.getvalue()
+
+	def test_render_job_detail_hands_sensitive_action_back_to_the_platform(self, monkeypatch):
+		"""有 security_id + job_id 时给出的默认引导必须是「回官网手动完成」。"""
+		from boss_agent_cli.display import render_job_detail
+		stream = _capture_display_console(monkeypatch)
+
+		render_job_detail({"title": "Go", "salary": "20K", "security_id": "sec1", "job_id": "job1"})
+
+		output = stream.getvalue()
+		assert "next:" in output
+		assert "回到平台官网" in output
+
+	def test_render_job_detail_truncates_long_description_at_500_chars(self, monkeypatch):
+		from boss_agent_cli.display import render_job_detail
+		stream = _capture_display_console(monkeypatch)
+
+		# 用 z 作填充符：面板里其余文案（job detail / exp / edu / skills / company /
+		# boss / description）都不含小写 z，所以计数就等于描述被保留的长度。
 		render_job_detail({
 			"title": "Go", "salary": "20K",
 			"company": "X", "boss_name": "Z", "boss_title": "HR",
 			"skills": ["Go", "Kafka"],
-			"description": long_desc,
+			"description": "z" * 800,
 			"security_id": "sec1", "job_id": "job1",
 		})
 
-	def test_render_status_logged_in(self):
+		output = stream.getvalue()
+		assert output.count("z") == 500, "描述应被截断到 500 字符"
+		assert "..." in output
+		assert "description:" in output
+
+	def test_render_status_logged_in(self, monkeypatch):
 		from boss_agent_cli.display import render_status
+		stream = _capture_display_console(monkeypatch)
+
 		render_status({"logged_in": True, "user_name": "张三"})
 
-	def test_render_status_not_logged_in(self):
+		output = stream.getvalue()
+		assert "logged in" in output
+		assert "张三" in output
+		assert "not logged in" not in output
+
+	def test_render_status_not_logged_in(self, monkeypatch):
 		from boss_agent_cli.display import render_status
+		stream = _capture_display_console(monkeypatch)
+
 		render_status({"logged_in": False})
+
+		output = stream.getvalue()
+		assert "not logged in" in output
+		assert "boss login" in output
 
 	def test_render_status_not_logged_in_with_custom_login_action(self, monkeypatch):
 		from boss_agent_cli.display import render_status
@@ -334,32 +393,78 @@ class TestRenderers:
 		assert "not logged in" in output
 		assert "boss --platform zhilian login" in output
 
-	def test_render_simple_list_empty(self):
+	def test_render_simple_list_empty(self, monkeypatch):
 		from boss_agent_cli.display import render_simple_list
+		stream = _capture_display_console(monkeypatch)
+
 		render_simple_list([], title="items", columns=[("name", "name", "cyan")])
 
-	def test_render_simple_list_with_items(self):
+		assert "no items" in stream.getvalue()
+
+	def test_render_simple_list_with_items(self, monkeypatch):
 		from boss_agent_cli.display import render_simple_list
+		stream = _capture_display_console(monkeypatch)
+
 		render_simple_list(
 			[{"name": "A", "stage": "s1"}, {"name": "B", "stage": "s2"}],
 			title="items",
 			columns=[("Name", "name", "cyan"), ("Stage", "stage", "green")],
 		)
 
-	def test_render_message_panel(self):
+		output = stream.getvalue()
+		assert "items (2)" in output
+		assert "Name" in output and "Stage" in output
+		assert "s1" in output and "s2" in output
+
+	def test_render_simple_list_falls_back_for_missing_keys(self, monkeypatch):
+		from boss_agent_cli.display import render_simple_list
+		stream = _capture_display_console(monkeypatch)
+
+		render_simple_list(
+			[{"name": "A"}],
+			title="items",
+			columns=[("Name", "name", "cyan"), ("Stage", "stage", "green")],
+		)
+
+		output = stream.getvalue()
+		assert "-" in output
+		assert "None" not in output, "缺字段应渲染为 -，不能把 None 显示给用户"
+
+	def test_render_message_panel(self, monkeypatch):
 		from boss_agent_cli.display import render_message_panel
+		stream = _capture_display_console(monkeypatch)
+
 		render_message_panel({"a": 1, "b": "x"}, title="result")
 
-	def test_render_batch_operation_summary_dry_run_with_candidates(self):
+		output = stream.getvalue()
+		assert "result" in output
+		assert "a:" in output and "b:" in output
+		assert "1" in output and "x" in output
+
+	def test_render_batch_operation_summary_dry_run_with_candidates(self, monkeypatch):
 		from boss_agent_cli.display import render_batch_operation_summary
+		stream = _capture_display_console(monkeypatch)
+
 		render_batch_operation_summary({
 			"dry_run": True,
 			"candidates": [{"title": "Go", "company": "X", "salary": "20K", "experience": "3年", "education": "本科", "city": "北京"}],
 		})
 
-	def test_render_batch_operation_summary_dry_run_empty(self):
+		output = stream.getvalue()
+		assert "dry run" in output
+		assert "1 candidates" in output
+		assert "Go" in output
+		assert "success:" not in output, "dry run 不得出现执行结果计数"
+
+	def test_render_batch_operation_summary_dry_run_empty(self, monkeypatch):
 		from boss_agent_cli.display import render_batch_operation_summary
+		stream = _capture_display_console(monkeypatch)
+
 		render_batch_operation_summary({"dry_run": True, "candidates": []})
+
+		output = stream.getvalue()
+		assert "dry run" in output
+		assert "0 candidates" in output
 
 	def test_render_batch_operation_summary_success(self, monkeypatch):
 		from boss_agent_cli.display import render_batch_operation_summary
@@ -377,21 +482,48 @@ class TestRenderers:
 		assert "failed: 1" in output
 		assert "rate limited" in output
 
-	def test_render_sectioned_record_mixed(self):
+	def test_render_sectioned_record_mixed(self, monkeypatch):
 		from boss_agent_cli.display import render_sectioned_record
+		stream = _capture_display_console(monkeypatch)
+
 		render_sectioned_record({
 			"info": {"name": "张三", "phone": "13800000000", "tags": ["A", "B"], "meta": {"k": "v"}},
 			"expect": {},
 			"note": "一句话说明",
 		})
 
-	def test_render_string_grid_empty(self):
+		output = stream.getvalue()
+		assert "info" in output and "张三" in output
+		assert "empty" in output, "空 section 应显式渲染 empty 而不是留白"
+		assert "一句话说明" in output, "非 dict 的 section 走裸行渲染"
+
+	def test_render_sectioned_record_truncates_nested_values(self, monkeypatch):
+		from boss_agent_cli.display import render_sectioned_record
+		stream = _capture_display_console(monkeypatch)
+
+		render_sectioned_record({"info": {"blob": ["z" * 400]}})
+
+		# 嵌套 list/dict 被 str() 后截到 200 字符，避免一条记录刷屏
+		assert stream.getvalue().count("z") == 198
+
+	def test_render_string_grid_empty(self, monkeypatch):
 		from boss_agent_cli.display import render_string_grid
+		stream = _capture_display_console(monkeypatch)
+
 		render_string_grid([], title="cities")
 
-	def test_render_string_grid_with_items(self):
+		assert "no cities" in stream.getvalue()
+
+	def test_render_string_grid_with_items(self, monkeypatch):
 		from boss_agent_cli.display import render_string_grid
+		stream = _capture_display_console(monkeypatch)
+
 		render_string_grid(["北京", "上海", "广州", "深圳", "杭州"], title="cities", columns=4)
+
+		output = stream.getvalue()
+		assert "cities (5)" in output
+		for city in ("北京", "上海", "广州", "深圳", "杭州"):
+			assert city in output, f"{city} 应出现在网格里"
 
 	def test_render_export_summary_with_path(self, monkeypatch):
 		from boss_agent_cli.display import render_export_summary
@@ -404,6 +536,13 @@ class TestRenderers:
 		assert "/tmp/x.csv" in output
 		assert "csv" in output
 
-	def test_render_export_summary_without_path(self):
+	def test_render_export_summary_without_path(self, monkeypatch):
 		from boss_agent_cli.display import render_export_summary
+		stream = _capture_display_console(monkeypatch)
+
 		render_export_summary({"count": 5, "format": "json"})
+
+		output = stream.getvalue()
+		assert "exported 5 jobs" in output
+		assert "json" in output
+		assert " to " not in output, "无 path 时不应出现 'to <路径>' 片段"


### PR DESCRIPTION
## 背景

`display.py` 覆盖率 **99%**，看起来 TTY 渲染层守得很好。但用 AST 逐个统计 `TestRenderers` 里的断言后，真相是：**19 个渲染器测试里有 14 个一个断言都没有**，只调用函数、不检查输出。

最能说明问题的一个：

```python
def test_render_job_detail_with_long_description_truncated(self):
    long_desc = "a" * 800
    render_job_detail({..., "description": long_desc, ...})
    # ← 到此结束，没有断言
```

它**名字里写着 truncated**、专门构造 800 字符描述，却从不验证截断发生。把 `display.py` 里的截断逻辑整个删掉，它照样绿。

这就是覆盖率表演：行被执行了，行为没被验证。

## 变更

给 14 个零断言用例补上真实的输出断言（复用已有的 `_capture_display_console`），并新增 5 个用例覆盖此前完全没测的分支：

- `test_render_job_detail_truncates_long_description_at_500_chars` —— 改用 `z` 填充（面板其余文案不含小写 z），直接断言 `output.count("z") == 500`，精确锁死截断长度
- `test_render_sectioned_record_truncates_nested_values` —— 锁死嵌套 list/dict 被 `str()` 后截到 200 字符的行为
- `test_render_job_detail_hands_sensitive_action_back_to_the_platform` —— 断言默认引导文案是「回到平台官网」，这是合规边界在 TTY 侧的体现，此前无人守
- `test_render_job_detail_without_ids_omits_next_hint` —— 缺 id 时不应出现 next 提示
- `test_render_simple_list_falls_back_for_missing_keys` —— 缺字段渲染成 `-` 而非把 `None` 显示给用户

补强的断言还顺带锁住了几处易漂移的口径：`dry run` 分支不得出现 `success:` 计数、无 path 的导出摘要不得出现 `to <路径>` 片段、平台原始键（`jobName`/`brandName`/`salaryDesc`）的回退分支确实生效。

## 断言有效性经变异测试验证

不是"写了断言就算数"——两处计数型断言都做了变异验证：

| 变异 | 结果 |
|---|---|
| 截断长度 `500` → `700` | ✅ 仅 `..._truncates_long_description_at_500_chars` 失败 |
| 嵌套值截断 `str(v)[:200]` → `str(v)` | ✅ 仅 `..._truncates_nested_values` 失败 |

两次都精确命中对应用例、不误伤其余 44 个，改完即还原（`git diff` 确认 `display.py` 零改动）。

## 顺带回答了一个悬着的风险

依赖里 `rich v14.3.3 → v15.0.0` 是**大版本跨越**，而 `display.py` 是全仓唯一使用 rich 的模块。此前"测试全绿"不足以说明兼容，因为大部分渲染测试根本不看输出。

现在断言是真的了，重新实测：

```
rich 14.3.3 → 45 passed
rich 15.0.0 → 45 passed（渲染层）
rich 15.0.0 → 1684 passed（全量）
```

**结论：rich 15 对本项目无破坏性影响**，dependabot 提该升级时可放心合并。升级本身不在本 PR 范围内。

## 验证

`uv run python scripts/quality_baseline.py` → ruff / 1684 passed / mypy 全过；`git diff --check` 干净。本 PR 只动 `tests/test_display.py`，无生产代码改动。