### PR TITLE
fix: 修正 MCP 工具 schema 契约缺陷并加守卫

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - 容器化落地：仓库自带的 `Dockerfile` 重写为多阶段 uv 构建（`uv sync --frozen` 严格按 `uv.lock` 安装，依赖不再漂移）+ 非 root 运行 + `.dockerignore` + `docker-compose.yml` + [Docker 接入文档](docs/integrations/docker.md)，并在 CI 新增 `docker` job 每次构建并验证 CLI 信封、MCP stdio 握手与非 root 身份。镜像定位刻意收窄为**只跑 MCP server 与只读 / 本地命令**：不含浏览器内核，`boss login` 仍在宿主机完成后挂载 `~/.boss-agent`（容器内 `HOME=/data`，故默认数据目录解析为 `/data/.boss-agent`）。不发布 registry 镜像。
 
 ### Fixed
+- 修正 MCP 工具 `boss_favorites_list` 的 `page` 参数 schema：类型写成了 JSON Schema 不存在的 `"int"`（其余 105 个参数均为合法值），严格校验 schema 的 MCP 宿主可能因此拒掉该工具。同时给 `boss_crawl_status` / `boss_crawl_results` / `boss_crawl_shortlist` 的 9 个参数补上缺失的 `description`——Agent 依赖它判断该传什么值。新增三条契约测试守住这一整类问题（type 合法性、参数必须有 description、顶层结构与 required/items 完整性）。
 - `RecruiterPlatform` 抽象基类补齐两个已被命令层实际调用、却从未写进契约的方法：`send_message_by_friend`（`hr reply` 在用）与 `job_detail`（`hr jobs detail` 在用）。此前它们只存在于 `BossRecruiterPlatform` 实现里，任何新写的招聘者平台按 ABC 实现完都能通过类型检查，却会在这两条命令上运行时抛 `AttributeError`。
 - MCP 的 HTTP streaming 传输改用 `@asynccontextmanager` 声明 lifespan：此前是裸 async generator，会走 Starlette 的弃用路径并触发 `DeprecationWarning`。
 - MCP `_run_boss` 现在只接受 JSON 对象形式的 CLI 信封：解析结果非 dict 时（契约违例）返回 `CLI_ERROR` 信封，而不是把非 dict 结果透传给调用方。

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -791,7 +791,13 @@ SCHEMA_DATA = {
 				{
 					"name": "boss_crawl_status",
 					"description": "读取 crawl 页游标、职位数、详情进度和风险状态。",
-					"inputSchema": {"type": "object", "properties": {"run_id": {"type": "string"}}, "required": ["run_id"]},
+					"inputSchema": {
+						"type": "object",
+						"properties": {
+							"run_id": {"type": "string", "description": "crawl run 标识，由 boss crawl start 返回"},
+						},
+						"required": ["run_id"],
+					},
 				},
 				{
 					"name": "boss_crawl_results",
@@ -799,9 +805,13 @@ SCHEMA_DATA = {
 					"inputSchema": {
 						"type": "object",
 						"properties": {
-							"run_id": {"type": "string"},
-							"page": {"type": "integer"},
-							"detail_status": {"type": "string", "enum": ["completed", "pending"]},
+							"run_id": {"type": "string", "description": "crawl run 标识，由 boss crawl start 返回"},
+							"page": {"type": "integer", "description": "只返回该 crawl 页的结果，省略则返回全部"},
+							"detail_status": {
+								"type": "string",
+								"enum": ["completed", "pending"],
+								"description": "按职位详情抓取状态筛选：completed 已补全详情，pending 仅有列表信息",
+							},
 						},
 						"required": ["run_id"],
 					},
@@ -812,11 +822,19 @@ SCHEMA_DATA = {
 					"inputSchema": {
 						"type": "object",
 						"properties": {
-							"run_id": {"type": "string"},
-							"selectors": {"type": "array", "items": {"type": "string"}},
-							"all": {"type": "boolean", "default": False},
-							"tags": {"type": "string"},
-							"note": {"type": "string"},
+							"run_id": {"type": "string", "description": "crawl run 标识，由 boss crawl start 返回"},
+							"selectors": {
+								"type": "array",
+								"items": {"type": "string"},
+								"description": "要导入的职位 selector 列表，取自 boss_crawl_results 的返回；与 all 二选一",
+							},
+							"all": {
+								"type": "boolean",
+								"default": False,
+								"description": "导入该 run 的全部可关联职位；与 selectors 二选一",
+							},
+							"tags": {"type": "string", "description": "写入候选池的本地标签，逗号分隔"},
+							"note": {"type": "string", "description": "写入候选池的本地备注"},
 						},
 						"required": ["run_id"],
 					},

--- a/src/boss_agent_cli/mcp_server.py
+++ b/src/boss_agent_cli/mcp_server.py
@@ -729,7 +729,7 @@ TOOLS = [
 		inputSchema={
 			"type": "object",
 			"properties": {
-				"page": {"type": "int", "description": "页码"},
+				"page": {"type": "integer", "description": "页码"},
 			},
 			"required": [],
 		},

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -90,6 +90,54 @@ def test_all_tools_have_name_and_description():
 		assert tool.description, f"{tool.name} 缺少描述"
 
 
+# JSON Schema 规范定义的全部合法 type 值。注意没有 "int"——那是 Python 的写法，
+# 严格的 MCP 宿主会拒绝或误处理这样的参数 schema。
+_JSON_SCHEMA_TYPES = frozenset({"null", "boolean", "object", "array", "number", "string", "integer"})
+
+
+def test_all_tool_parameter_types_are_valid_json_schema():
+	"""参数 type 必须是 JSON Schema 合法值。
+
+	曾出现 `boss_favorites_list.page` 写成 `"int"`（其余 105 个参数都写对了）。
+	这类笔误不会让任何现有测试变红，却会让严格校验 schema 的 MCP 宿主拒掉该工具。
+	"""
+	invalid = []
+	for tool in TOOLS:
+		for name, spec in (tool.inputSchema or {}).get("properties", {}).items():
+			declared = spec.get("type")
+			if declared is not None and declared not in _JSON_SCHEMA_TYPES:
+				invalid.append(f"{tool.name}.{name} = {declared!r}")
+	assert not invalid, "非法的 JSON Schema type：\n" + "\n".join(invalid)
+
+
+def test_all_tool_parameters_are_described_for_agents():
+	"""每个参数都要有 description——Agent 靠它决定传什么值。"""
+	missing = [
+		f"{tool.name}.{name}"
+		for tool in TOOLS
+		for name, spec in (tool.inputSchema or {}).get("properties", {}).items()
+		if not spec.get("description")
+	]
+	assert not missing, "参数缺少 description：\n" + "\n".join(missing)
+
+
+def test_all_tool_schemas_are_well_formed_objects():
+	"""顶层必须是 object、required 只能引用已声明的属性、array 必须带 items。"""
+	problems = []
+	for tool in TOOLS:
+		schema = tool.inputSchema or {}
+		properties = schema.get("properties", {})
+		if schema.get("type") != "object":
+			problems.append(f"{tool.name}: 顶层 type 应为 object，实际 {schema.get('type')!r}")
+		for name in schema.get("required", []):
+			if name not in properties:
+				problems.append(f"{tool.name}: required 引用了未声明的属性 {name!r}")
+		for name, spec in properties.items():
+			if spec.get("type") == "array" and "items" not in spec:
+				problems.append(f"{tool.name}.{name}: array 缺少 items")
+	assert not problems, "工具 schema 结构问题：\n" + "\n".join(problems)
+
+
 def test_candidate_tool_description_includes_availability():
 	search = next(t for t in TOOLS if t.name == "boss_search")
 	assert "可用性:" in search.description


### PR DESCRIPTION
## 背景

对全部 50 个 MCP 工具、105 个参数做了一次 schema 体检，查出两类缺陷。都在 Agent 直接消费的契约面上，且**现有测试一条都拦不住**。

## 缺陷一：非法的 JSON Schema type

`boss_favorites_list` 的 `page` 参数写成 `{"type": "int"}`。JSON Schema 规范没有 `int` 这个类型——那是 Python 的写法，规范里是 `integer`。

全量扫描确认这是唯一一处：

```
出现过的 type 值: {string: 86, integer: 10, boolean: 5, array: 3, int: 1}
非法 type: [(boss_favorites_list, page, int)]
```

严格校验 schema 的 MCP 宿主可能因此拒掉或误处理该工具。

## 缺陷二：9 个参数没有 description

`boss_crawl_status` / `boss_crawl_results` / `boss_crawl_shortlist` 的全部参数都缺 `description`（源头在 `commands/schema.py` 的 `mcp_tools` 定义，随 #339 引入）。

Agent 靠参数描述判断该传什么值。缺了之后，`selectors` 该从哪来、`all` 和 `selectors` 是互斥的、`detail_status` 两个枚举值分别什么含义——Agent 全得靠猜。已逐个补上，并写清互斥关系与取值来源。

## 加守卫：让这一整类问题不能再回来

新增三条契约测试：

| 测试 | 守住什么 |
|---|---|
| `test_all_tool_parameter_types_are_valid_json_schema` | type 必须是 JSON Schema 七个合法值之一 |
| `test_all_tool_parameters_are_described_for_agents` | 每个参数必须有 description |
| `test_all_tool_schemas_are_well_formed_objects` | 顶层必须是 object、`required` 只能引用已声明属性、`array` 必须带 `items` |

后两类目前全仓干净，属预防性守卫（体检时顺带验过：`required` 无悬空引用、无 array 缺 items、无顶层非 object）。

**守卫经变异验证**：把 `integer` 改回 `int` 后，`test_all_tool_parameter_types_are_valid_json_schema` 精确报红且不误伤其余 119 条；还原后恢复绿色。

## 验证

- `uv run python scripts/quality_baseline.py` → ruff / **1687 passed** / mypy 全过
- `tests/test_mcp_server.py` → 120 passed
- 文档一致性 + MCP 工具契约测试 → 40 passed
- `git diff --check` 干净

## 与 #367 的关系

社区 PR #367 同样发现了 `int` → `integer` 这处笔误。本 PR 覆盖它，并额外修掉 9 处缺失的参数描述、补上三条防回归守卫。#367 的处置由维护者决定。