### PR TITLE
ci: MCP 评测场景以离线 fixture 模式接入 P0 门禁

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
           BOSS_SMOKE_DRY_RUN: "1"
         run: uv run python scripts/smoke_p0.py
 
+      - name: MCP eval scenarios (offline fixtures)
+        run: uv run python evals/run_eval.py --mode fixture --results-dir "${RUNNER_TEMP}/evals"
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -303,6 +303,7 @@ def test_ci_workflow_runs_p0_quality_gate():
 		"uv sync --all-extras",
 		"uv run python scripts/quality_baseline.py",
 		"uv run python scripts/smoke_p0.py",
+		'uv run python evals/run_eval.py --mode fixture --results-dir "${RUNNER_TEMP}/evals"',
 	]
 	assert "scripts/quality_baseline.py" in raw_workflow
 	assert "BOSS_SMOKE_DRY_RUN" in raw_workflow


### PR DESCRIPTION
## 背景

`evals/run_eval.py` 是 MCP-vs-baseline 的对比评测骨架，`--mode fixture` 完全离线、确定性、瞬时完成。但**没有任何 workflow 跑它**——和之前的 `smoke_p0.py` 一样，只靠人肉记得。

场景定义在 `evals/scenarios.json`，一旦它和 `SCHEMA_DATA` 或工具契约漂移，目前没有任何信号。

## 变更

`p0_quality_gate` 增加一步：

```yaml
- name: MCP eval scenarios (offline fixtures)
  run: uv run python evals/run_eval.py --mode fixture --results-dir "${RUNNER_TEMP}/evals"
```

两点刻意设计：

- **锁定 `--mode fixture`**：`external` 模式需要 `--runner-cmd` 且会真实触网，绝不进 CI
- **产物写 `${RUNNER_TEMP}`**：`run_eval.py` 每次跑都会生成一个时间戳结果文件，而 `evals/results/` 是**入库目录**。不重定向的话 CI 每次都会在工作树里留下未跟踪文件。本地实测确认重定向后 `git status evals/` 干净

## 验证

- 本地按 CI 同一条命令执行：`4/4 passed`，exit 0，产物落在 `/tmp/ci-sim/evals/`，工作树未被污染
- 同步更新了 `tests/test_open_source_docs.py` 中逐字钉住 `p0_quality_gate` 命令序列的断言（该测试用精确列表比对，不改必红）
- `uv run python scripts/quality_baseline.py` → ruff / 1687 passed / mypy 全过