### PR TITLE
feat: 信封 hints 拆分双受众通道并前移向导登录门

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -192,7 +192,10 @@ CLI (Click)
             └─ output.py → JSON envelope → stdout
 ```
 
-**Invariants**: stdout is JSON-only · stderr holds logs · `exit 0/1` · errors carry `code/recoverable/recovery_action` · `boss schema` is the authoritative capability source. **Stack**: Python ≥ 3.10 · Click · httpx · patchright / CDP / Bridge (login, export, and declared browser adapters) · cryptography · sqlite3 (WAL) · pytest (1600+).
+**Invariants**: stdout is JSON-only · stderr holds logs · `exit 0/1` · errors carry `code/recoverable/recovery_action` · `boss schema` is the authoritative capability source.
+**Two audiences, one envelope**: `hints.next_actions` holds follow-up commands for the Agent to run; `hints.operator_actions` holds natural-language guidance for the human operator (scan a QR code, adjust filters in the browser — anything done away from the terminal). TTY renders only the latter, to stderr; an Agent should relay it to the operator.
+**Command or wizard**: single-shot, stateless capability calls go through top-level commands; anything needing cross-step state, resumability, or handing guidance to a human goes through `boss wizard` (goals listed under `wizard_catalog` in `boss schema`).
+**Stack**: Python ≥ 3.10 · Click · httpx · patchright / CDP / Bridge (login, export, and declared browser adapters) · cryptography · sqlite3 (WAL) · pytest (1600+).
 
 ## 🔌 Local Storage
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ CLI (Click)
 `QianchengPlatform (51job 占位适配器，统一返回 NOT_SUPPORTED)`：仅用于平台注册与 schema 可见性，接真实接口前需满足只读研究门槛。
 
 **不变量**：stdout 仅 JSON 信封 · stderr 仅日志 · `exit 0/1` · 错误含 `code/recoverable/recovery_action` · `boss schema` 为能力真源。
+**双受众提示**：`hints.next_actions` 是给 Agent 执行的后继命令，`hints.operator_actions` 是给真人操作者的自然语言指引（扫码、在浏览器里调整条件等需要离开终端完成的动作）；TTY 下只渲染后者到 stderr，Agent 应把它转述给操作者。
+**命令还是 wizard**：单次、无状态的能力调用走顶层命令；需要跨步骤状态、可恢复、或中途要把指引递给真人的走 `boss wizard`（goal 取值见 `boss schema` 的 `wizard_catalog`）。
 **选型**：Python ≥ 3.10 · Click · httpx · patchright / CDP / Bridge（登录、导出与声明的浏览器 adapter）· cryptography（Fernet）· sqlite3（WAL）· pytest（1600+ 项）。
 
 ## 🔌 本地存储

--- a/docs/commands.en.md
+++ b/docs/commands.en.md
@@ -17,6 +17,22 @@ subcommands under `hr`, grouped below by workflow stage.
 
 Compatibility setting: `boss config set operating_mode assisted|research`. Both modes can call every implemented capability; schema still reports risk/data classifications, and missing platform implementations return `NOT_SUPPORTED`.
 
+## Command or wizard
+
+Top-level commands and `boss wizard` are two parallel capability surfaces. The split is declared in `conventions.command_vs_wizard` from `boss schema`:
+
+- **Single-shot, stateless capability calls** → top-level commands (`boss search`, `boss detail`, `boss greet`, …)
+- **Cross-step state, resumability, or handing guidance to a human mid-flow** → `boss wizard` (goals listed under `wizard_catalog`)
+
+Envelope `hints` splits by audience the same way (`conventions.hints`):
+
+| Field | Audience | Form |
+|-------|----------|------|
+| `hints.next_actions` | AI Agent | `boss xxx` commands the agent runs directly |
+| `hints.operator_actions` | Human operator | Natural language, usually done away from the terminal (scan a QR code, adjust filters in the browser, clear a risk-control check) |
+
+In a TTY only `operator_actions` is rendered, to stderr; `next_actions` stays an agent-only channel and is not rendered. An agent receiving `operator_actions` should relay it verbatim rather than inventing its own wording.
+
 ## Basics
 
 | Command | Description |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -13,6 +13,22 @@ boss <命令> --help                      # 查看单个命令选项
 
 兼容配置：`boss config set operating_mode assisted|research`。两种模式均可调用全部已实现能力；schema 仍提供风险和数据分类，平台缺失能力返回 `NOT_SUPPORTED`。
 
+## 命令还是 wizard
+
+顶层命令和 `boss wizard` 是两套并行的能力面，分工写在 `boss schema` 的 `conventions.command_vs_wizard`：
+
+- **单次、无状态的能力调用** → 顶层命令（`boss search` / `boss detail` / `boss greet` …）
+- **需要跨步骤状态、可恢复、或中途要把指引递给真人** → `boss wizard`（goal 取值见 `wizard_catalog`）
+
+信封的 `hints` 同样按受众分成两条通道（`conventions.hints`）：
+
+| 字段 | 受众 | 形式 |
+|------|------|------|
+| `hints.next_actions` | AI Agent | `boss xxx` 命令，Agent 直接执行 |
+| `hints.operator_actions` | 真人操作者 | 自然语言，通常需要离开终端完成（扫码、在浏览器里调整筛选、处理风控验证） |
+
+TTY 下只把 `operator_actions` 渲染到 stderr；`next_actions` 是纯 Agent 通道，不渲染。Agent 拿到 `operator_actions` 时应转述给操作者，而不是自己编措辞。
+
 ## 基础操作
 
 | 命令 | 说明 |

--- a/src/boss_agent_cli/commands/login.py
+++ b/src/boss_agent_cli/commands/login.py
@@ -10,30 +10,45 @@ def _classify_login_error(exc: Exception, ctx: click.Context) -> dict[str, objec
 
 	The login flow intentionally remains unchanged; this helper only turns broad
 	Cookie/CDP/QR/browser failures into actionable CLI diagnostics.
+
+	hints 分两条受众通道（见 schema conventions.hints）：
+	  next_actions     — 面向 Agent 的可执行命令
+	  operator_actions — 面向真人操作者的自然语言指引（多半要离开终端完成）
 	"""
 	raw_message = str(exc) or exc.__class__.__name__
 	message = raw_message.lower()
 	recovery_action = login_action_for_ctx(ctx)
+	login_cmd = login_action_for_ctx(ctx)
+	status_cmd = boss_command_for_ctx(ctx, "status")
+	doctor_cmd = boss_command_for_ctx(ctx, "doctor")
 
 	def payload(
-		code: str, user_message: str, next_actions: list[str], recovery: str | None = None
+		code: str,
+		user_message: str,
+		next_actions: list[str],
+		operator_actions: list[str],
+		recovery: str | None = None,
 	) -> dict[str, object]:
 		return {
 			"code": code,
 			"message": user_message,
 			"recoverable": True,
 			"recovery_action": recovery or recovery_action,
-			"hints": {"next_actions": next_actions},
+			"hints": {
+				"next_actions": next_actions,
+				"operator_actions": operator_actions,
+			},
 		}
 
 	if isinstance(exc, TimeoutError) or "timeout" in message or "超时" in raw_message:
 		return payload(
 			"LOGIN_TIMEOUT",
 			f"登录等待超时: {raw_message}",
+			[f"{login_cmd} --timeout 180", "boss-chrome"],
 			[
 				"确认二维码已完成扫码并在网页端授权登录",
-				"网络较慢时可追加 --timeout 180 或更长时间",
-				"如已打开本机 Chrome，可先运行 boss-chrome 后再重试登录",
+				"网络较慢时可延长超时时间后重试",
+				"如已打开本机 Chrome，可先启动带调试端口的 Chrome 再重试登录",
 			],
 		)
 
@@ -41,11 +56,8 @@ def _classify_login_error(exc: Exception, ctx: click.Context) -> dict[str, objec
 		return payload(
 			"BROWSER_KERNEL_MISSING",
 			f"patchright 浏览器内核缺失或与所需修订版不匹配: {raw_message}",
-			[
-				"运行 patchright install chromium 安装当前 patchright 所需的浏览器内核",
-				"安装完成后重新执行登录",
-				"可先运行 boss doctor 预检浏览器内核状态",
-			],
+			["patchright install chromium", doctor_cmd, login_cmd],
+			["浏览器内核安装完成后重新执行登录"],
 			recovery="patchright install chromium",
 		)
 
@@ -53,9 +65,9 @@ def _classify_login_error(exc: Exception, ctx: click.Context) -> dict[str, objec
 		return payload(
 			"CDP_UNAVAILABLE",
 			f"Chrome 调试连接不可用: {raw_message}",
+			["boss-chrome", login_cmd],
 			[
-				"运行 boss-chrome 启动带调试端口的 Chrome",
-				"或去掉 --cdp，让命令自动尝试 Cookie / QR 登录降级链路",
+				"启动带调试端口的 Chrome 后重试，或去掉 --cdp 让命令自动降级到 Cookie / 扫码链路",
 				"确认 --cdp-url 指向可访问的 Chrome DevTools 地址",
 			],
 		)
@@ -64,6 +76,7 @@ def _classify_login_error(exc: Exception, ctx: click.Context) -> dict[str, objec
 		return payload(
 			"LOGIN_RISK_CONTROL",
 			f"登录请求可能触发平台风控: {raw_message}",
+			[],
 			[
 				"暂停自动化重试，改用浏览器手动确认账号状态",
 				"降低请求频率，避免短时间重复登录或刷新",
@@ -75,10 +88,10 @@ def _classify_login_error(exc: Exception, ctx: click.Context) -> dict[str, objec
 		return payload(
 			"LOGIN_EXPIRED",
 			f"登录态已失效或授权不足: {raw_message}",
+			[login_cmd, status_cmd],
 			[
-				"重新执行登录并完成网页端授权",
+				"重新登录并在网页端完成授权",
 				"如使用 Cookie 提取，确认浏览器内目标平台仍处于登录状态",
-				"登录后运行 status 验证本地登录态",
 			],
 		)
 
@@ -86,20 +99,21 @@ def _classify_login_error(exc: Exception, ctx: click.Context) -> dict[str, objec
 		return payload(
 			"LOGIN_CREDENTIAL_EXTRACTION_FAILED",
 			f"登录成功后提取凭证失败: {raw_message}",
+			[f"{login_cmd} --cookie-source chrome", "boss-chrome"],
 			[
 				"确认浏览器已完成登录并进入平台首页",
-				"若 Cookie 提取失败，可指定 --cookie-source chrome/firefox/edge",
-				"若仍失败，可运行 boss-chrome 后使用 --cdp 重试",
+				"若 Cookie 提取失败，可改用 --cookie-source 指定 chrome/firefox/edge",
 			],
 		)
 
 	return payload(
 		"NETWORK_ERROR",
 		f"登录失败: {raw_message}",
+		[doctor_cmd, login_cmd],
 		[
 			"检查网络连通性后重试",
-			"如浏览器内已登录，可尝试指定 --cookie-source chrome/firefox/edge",
-			"若问题持续，请运行 boss doctor 并附带诊断输出反馈",
+			"如浏览器内已登录，可尝试用 --cookie-source 指定 chrome/firefox/edge",
+			"若问题持续，请附带 doctor 诊断输出反馈",
 		],
 	)
 

--- a/src/boss_agent_cli/commands/schema.py
+++ b/src/boss_agent_cli/commands/schema.py
@@ -1347,6 +1347,13 @@ SCHEMA_DATA = {
 			"0": "命令成功 (ok=true)",
 			"1": "命令失败 (ok=false)",
 		},
+		"hints": {
+			"next_actions": "面向 AI Agent 的后继命令（boss xxx 形式），由 Agent 直接执行",
+			"operator_actions": "面向真人操作者的自然语言指引，通常需要离开终端完成"
+			"（扫码、在浏览器里调整条件、处理风控验证等）；Agent 应转述给操作者，TTY 下渲染到 stderr",
+		},
+		"command_vs_wizard": "单次、无状态的能力调用走顶层命令；需要跨步骤状态、可恢复、"
+		"或中途需要把指引递给真人操作者的走 boss wizard（goal 取值见 wizard_catalog）",
 	},
 }
 

--- a/src/boss_agent_cli/commands/wizard.py
+++ b/src/boss_agent_cli/commands/wizard.py
@@ -151,8 +151,8 @@ def _run_plan(
 			return run
 		if run.get("status") != "completed":
 			return run
-		render_run(run)
-		return run
+		# completed：不提前 return——落入下方 completed 处理器渲染摘要并可浏览结果。
+		# 提前 return 会让外层立刻回主菜单清屏，采集摘要一闪即逝（真实使用反馈）。
 
 	# TTY：列表结果可连续选择；职位详情后提供打招呼等操作；失败交给 _emit_run。
 	if interactive and (
@@ -297,6 +297,15 @@ def _run_interactive_session(
 	max_retries: int,
 ) -> None:
 	"""TTY multi-turn loop: main menu → execute → follow-ups → continue/exit."""
+	# 登录门：在任何目标选择之前解决登录态。已登录时零输出直接放行。
+	from boss_agent_cli.wizard.preflight import GATE_EXIT, GATE_LOCAL_ONLY, ensure_login
+
+	gate = ensure_login(ctx)
+	if gate == GATE_EXIT:
+		render_cancelled()
+		return
+	local_only = gate == GATE_LOCAL_ONLY
+
 	while True:
 		try:
 			selection = collect_wizard_input(
@@ -304,6 +313,7 @@ def _run_interactive_session(
 				default_platform=ctx.obj.get("platform") or "zhipin",
 				available_runs=store.list_recent(),
 				data_dir=ctx.obj.get("data_dir"),
+				local_only=local_only,
 			)
 		except WizardCancelled:
 			render_cancelled()

--- a/src/boss_agent_cli/display.py
+++ b/src/boss_agent_cli/display.py
@@ -57,6 +57,25 @@ def is_json_mode(ctx: Any) -> bool:
 	return force_json or not sys.stdout.isatty()
 
 
+def render_operator_actions(hints: dict[str, Any] | None) -> None:
+	"""把「人该做什么」渲染到 stderr。
+
+	只渲染 hints.operator_actions（面向真人操作者的自然语言指引）。
+	hints.next_actions 是面向 Agent 的命令通道，TTY 下刻意不渲染——避免给
+	每条命令的输出加噪音。无 operator_actions 时零输出，因此对既有命令的
+	TTY 行为没有影响。
+	"""
+	if not hints:
+		return
+	actions = hints.get("operator_actions")
+	if not actions or not isinstance(actions, (list, tuple)):
+		return
+	console.print()
+	for index, action in enumerate(actions):
+		prefix = "↓ 你需要：" if index == 0 else "　　　　　"
+		console.print(f"[yellow]{prefix}[/yellow]{action}")
+
+
 def handle_output(
 	ctx: Any,
 	command: str,
@@ -71,6 +90,7 @@ def handle_output(
 		emit_success(command, data, pagination=pagination, hints=hints)
 	elif render:
 		render(data)
+		render_operator_actions(hints)
 	else:
 		# Fallback: no render function, emit JSON even in TTY
 		emit_success(command, data, pagination=pagination, hints=hints)
@@ -101,6 +121,7 @@ def handle_error_output(
 		console.print(f"[red]error[/red] [{code}] {message}")
 		if recovery_action:
 			console.print(f"  [dim]recovery: {recovery_action}[/dim]")
+		render_operator_actions(hints)
 		raise SystemExit(1)
 
 

--- a/src/boss_agent_cli/wizard/actions.py
+++ b/src/boss_agent_cli/wizard/actions.py
@@ -326,11 +326,20 @@ def _auth_status(context: ActionContext, inputs: Mapping[str, Any], prior: Mappi
 			_unwrap(platform, platform.user_info(), "当前平台不支持登录态检查")
 	token = context.auth().check_status()
 	if token is None:
-		raise WorkflowActionError(
-			"AUTH_REQUIRED",
-			"未登录",
-			recoverable=True,
-			recovery_action=f"boss --platform {context.platform} login",
+		# 未登录不是失败，是「在等人」。返回 WAITING_INPUT 让 run 挂起可恢复，
+		# 而不是把整个 workflow 打成 failed 逼用户从头重走向导。
+		# 刻意不阻塞轮询等待扫码——Agent 与真人都不该被卡在这里。
+		login_command = f"boss --platform {context.platform} login"
+		control = context.workflow_control
+		resume_command = f"boss wizard --resume {control.run_id}" if control else "boss wizard"
+		return StepResult(
+			{"authenticated": False, "platform": context.platform, "role": context.role},
+			status=WorkflowStatus.WAITING_INPUT,
+			next_action=resume_command,
+			operator_actions=(
+				f"运行 {login_command} 并在弹出的浏览器里扫码登录",
+				f"登录完成后回到终端，执行 {resume_command} 继续",
+			),
 		)
 	return StepResult({"authenticated": True, "platform": context.platform, "role": context.role})
 
@@ -707,19 +716,35 @@ def _crawl_outcome_result(outcome: Any, cache: CacheStore | None = None) -> Step
 		)
 	if outcome.status in {"risk_stopped", "budget_stopped"}:
 		# 风控停止时 service 会 keep Chrome；把标记写入结果供向导文案使用。
+		browser_kept_open = outcome.status == "risk_stopped"
 		if isinstance(data, dict):
 			browser_raw = data.get("browser")
 			browser = browser_raw if isinstance(browser_raw, dict) else {}
 			data = {
 				**data,
-				"browser_kept_open": outcome.status == "risk_stopped",
+				"browser_kept_open": browser_kept_open,
 				"cdp_port": browser.get("cdp_port") or data.get("cdp_port"),
 			}
+		resume_command = f"boss crawl resume {outcome.run_id}"
+		operator_actions: tuple[str, ...]
+		if browser_kept_open:
+			operator_actions = (
+				"这通常不是账号退出登录——采集用的是独立浏览器，首次启动常被平台环境校验拦下",
+				"采集用 Chrome 已保持打开：若窗口里已是正常职位列表，直接选「继续采集」即可（会换用页面内请求重试）",
+				"若窗口提示环境异常，先在该窗口手动刷新职位搜索页，再选「继续采集」",
+				f"命令行恢复：{resume_command}",
+			)
+		else:
+			operator_actions = (
+				"本轮采集因预算上限停止，不是账号异常",
+				f"确认要继续时选「继续采集」，或在终端执行 {resume_command}",
+			)
 		return StepResult(
 			data,
 			status=WorkflowStatus.WAITING_INPUT,
-			next_action=f"boss crawl resume {outcome.run_id}",
+			next_action=resume_command,
 			artifacts=tuple(outcome.output_paths.values()),
+			operator_actions=operator_actions,
 		)
 	if outcome.status != "completed":
 		raise WorkflowActionError(

--- a/src/boss_agent_cli/wizard/models.py
+++ b/src/boss_agent_cli/wizard/models.py
@@ -72,6 +72,9 @@ class StepResult:
 	status: WorkflowStatus = WorkflowStatus.COMPLETED
 	next_action: str | None = None
 	artifacts: tuple[str, ...] = ()
+	# 面向真人操作者的自然语言指引（需要离开终端完成的动作）。
+	# 与 next_action（面向 Agent 的命令）职责互斥，见 schema conventions.hints。
+	operator_actions: tuple[str, ...] = ()
 
 	def to_dict(self) -> dict[str, Any]:
 		return {
@@ -79,4 +82,5 @@ class StepResult:
 			"status": self.status.value,
 			"next_action": self.next_action,
 			"artifacts": list(self.artifacts),
+			"operator_actions": list(self.operator_actions),
 		}

--- a/src/boss_agent_cli/wizard/preflight.py
+++ b/src/boss_agent_cli/wizard/preflight.py
@@ -1,0 +1,166 @@
+"""向导入口的登录门：在任何目标选择之前解决登录态。
+
+为什么放在这一层：`auth_status` 是每个 goal 的第一个 step，而 step 只在
+`collect_wizard_input` 走完之后才执行——用户要先选身份、平台、目标分类、
+目标并填完参数（共 5 层），才会被告知未登录，之前的选择全部白做。
+
+为什么 TTY 下内联阻塞等扫码是对的：headless / Agent 路径的「不阻塞」原则
+（见 wizard/actions.py 的 _auth_status）是为了避免 Agent 卡在子进程里空等。
+TTY 恰恰相反——人就坐在终端前，他要的就是「给我个二维码我现在扫」。
+两种受众的正确行为相反，不要把 headless 的原则套到这里。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rich.panel import Panel
+
+from boss_agent_cli import display
+from boss_agent_cli.auth.manager import AuthManager
+from boss_agent_cli.wizard.catalog import GOALS
+
+# 登录门的三种出口。
+GATE_READY = "ready"
+GATE_LOCAL_ONLY = "local_only"
+GATE_EXIT = "exit"
+
+_LOGIN_TIMEOUT_SECONDS = 180
+
+
+def local_goal_names(role: str) -> tuple[str, ...]:
+	"""不需要登录态的 goal（步骤里不含 auth_status）。"""
+	return tuple(name for name, goal in GOALS.get(role, {}).items() if "auth_status" not in goal.steps)
+
+
+def _browser_kernel_status() -> tuple[str, str]:
+	"""复用 doctor 的浏览器内核判定，返回 (status, detail)。
+
+	只在真要开浏览器之前调用——已登录用户不该为此付出任何启动开销。
+	"""
+	from boss_agent_cli.commands.doctor_checks import (
+		_evaluate_patchright_chromium,
+		_patchright_browser_cache_dirs,
+		_patchright_chromium_revision,
+	)
+
+	try:
+		return _evaluate_patchright_chromium(
+			_patchright_chromium_revision(),
+			_patchright_browser_cache_dirs(),
+		)
+	except Exception as exc:  # 预检本身不该阻断登录，退化成 warn
+		return "warn", f"无法确认浏览器内核状态：{exc}"
+
+
+def _render_health_card(platform_name: str) -> None:
+	lines = [
+		"[yellow]✗[/yellow] 未登录 —— 大部分能力需要登录后才能使用",
+		f"[dim]平台：{platform_name}[/dim]",
+	]
+	display.console.print(Panel("\n".join(lines), title="登录态检查", border_style="yellow"))
+
+
+def _render_kernel_blocked(detail: str) -> None:
+	display.console.print(
+		Panel(
+			"\n".join(
+				[
+					"[red]无法自动打开浏览器[/red]：缺少 patchright 所需的 Chromium 内核。",
+					"",
+					detail,
+					"",
+					"[bold]安装完成后回到这里重新选择「现在登录」即可。[/bold]",
+				]
+			),
+			title="环境不支持自动扫码",
+			border_style="red",
+		)
+	)
+
+
+def _render_login_failure(ctx: Any, exc: Exception) -> None:
+	"""复用 login 命令的错误分类，把双通道文案渲染给真人。"""
+	from boss_agent_cli.commands.login import _classify_login_error
+
+	payload = _classify_login_error(exc, ctx)
+	raw_hints = payload.get("hints")
+	hints: dict[str, Any] = raw_hints if isinstance(raw_hints, dict) else {}
+	lines = [f"[red]{payload.get('message')}[/red]"]
+	operator_actions = hints.get("operator_actions") or []
+	if operator_actions:
+		lines.append("")
+		lines.extend(f"· {action}" for action in operator_actions)
+	display.console.print(Panel("\n".join(lines), title="登录失败", border_style="red"))
+
+
+def _gate_options(role: str) -> list[Any]:
+	from boss_agent_cli.wizard.prompts import MenuOption
+
+	options = [MenuOption("login", "现在登录", "打开浏览器扫码，登录后继续")]
+	if local_goal_names(role):
+		options.append(MenuOption("local", "仅看本地功能", "简历、候选池、采集任务等无需登录的能力"))
+	options.append(MenuOption("exit", "退出", ""))
+	return options
+
+
+def ensure_login(ctx: Any, *, menu: Any = None, role: str | None = None) -> str:
+	"""向导入口登录门。返回 GATE_READY / GATE_LOCAL_ONLY / GATE_EXIT。
+
+	已登录时零输出、零开销直接返回 GATE_READY——老用户感知不到这一层。
+
+	role 默认从 ctx.obj 派生，避免调用方漏传导致按错误身份判断本地能力。
+	"""
+	from boss_agent_cli.wizard.prompts import WizardCancelled, _menu_driver
+
+	data_dir = ctx.obj["data_dir"]
+	logger = ctx.obj["logger"]
+	platform_name = ctx.obj.get("platform") or "zhipin"
+	active_role = role or ctx.obj.get("role") or "candidate"
+	auth = AuthManager(data_dir, logger=logger, platform=platform_name)
+
+	if auth.check_status() is not None:
+		return GATE_READY
+
+	driver = menu or _menu_driver()
+	_render_health_card(platform_name)
+
+	while True:
+		try:
+			choice = driver.select(
+				"需要先登录才能继续，现在登录吗？",
+				_gate_options(active_role),
+				default="login",
+				allow_back=False,
+			)
+		except WizardCancelled:
+			return GATE_EXIT
+
+		if choice == "exit":
+			return GATE_EXIT
+
+		if choice == "local":
+			if not local_goal_names(active_role):
+				display.console.print(
+					"[yellow]当前身份的所有能力都需要登录，没有可离线使用的功能。[/yellow]"
+				)
+				continue
+			return GATE_LOCAL_ONLY
+
+		# choice == "login"：先确认环境能开浏览器，再真开。
+		status, detail = _browser_kernel_status()
+		if status == "error":
+			_render_kernel_blocked(detail)
+			continue
+
+		try:
+			from boss_agent_cli.wizard.renderer import busy_status
+
+			with busy_status("正在打开浏览器，请在弹出的窗口中扫码登录…"):
+				auth.login(timeout=_LOGIN_TIMEOUT_SECONDS, cdp_url=ctx.obj.get("cdp_url"))
+		except Exception as exc:
+			_render_login_failure(ctx, exc)
+			continue
+
+		display.console.print("[green]✓[/green] 登录成功，继续")
+		return GATE_READY

--- a/src/boss_agent_cli/wizard/prompts.py
+++ b/src/boss_agent_cli/wizard/prompts.py
@@ -11,7 +11,7 @@ from typing import Any, Mapping, Protocol, Sequence, cast
 import click
 
 from boss_agent_cli.wizard.catalog import GOALS, catalog_data
-from boss_agent_cli.wizard.models import WizardInput
+from boss_agent_cli.wizard.models import WizardInput, WorkflowInputError
 
 
 @dataclass(frozen=True)
@@ -291,7 +291,7 @@ class PromptToolkitMenu:
 			#   ○  返回主菜单            ·  稍后再处理
 			lines: list[tuple[str, str]] = [
 				("class:title", f"{title}\n"),
-				("class:hint", "↑↓ 选择  ·  Enter 确认  ·  Esc 返回\n\n"),
+				("class:hint", "↑↓ 选择  ·  Enter 确认  ·  ←/Esc 返回\n\n"),
 			]
 			saw_nav = False
 			for index, item in enumerate(items):
@@ -349,6 +349,7 @@ class PromptToolkitMenu:
 			event.app.exit(result=items[selected].value)
 
 		@bindings.add("escape")
+		@bindings.add("left")
 		def go_back(event: Any) -> None:
 			event.app.exit(result=_BACK if allow_back else _EXIT)
 
@@ -592,12 +593,31 @@ def _collect_control(
 	return WizardControl(action=action, run_id=run_id)
 
 
+def _visible_goal_groups(
+	role: str, *, local_only: bool = False
+) -> tuple[tuple[str, tuple[str, ...]], ...]:
+	"""goal 分组；local_only 时只保留无需登录（步骤不含 auth_status）的目标。"""
+	groups = GOAL_GROUPS.get(role, ())
+	if not local_only:
+		return groups
+	from boss_agent_cli.wizard.preflight import local_goal_names
+
+	allowed = set(local_goal_names(role))
+	filtered = []
+	for name, goals in groups:
+		kept = tuple(goal for goal in goals if goal in allowed)
+		if kept:
+			filtered.append((name, kept))
+	return tuple(filtered)
+
+
 def _collect_new_plan(
 	menu: MenuDriver,
 	*,
 	default_role: str,
 	default_platform: str,
 	data_dir: Path | None = None,
+	local_only: bool = False,
 ) -> WizardInput:
 	role: str | None = None
 	platform: str | None = None
@@ -618,15 +638,18 @@ def _collect_new_plan(
 					[MenuOption(value, PLATFORM_LABELS.get(value, value)) for value in platforms],
 					default=default_platform if default_platform in platforms else platforms[0],
 				)
+			groups = _visible_goal_groups(role, local_only=local_only)
+			if not groups:
+				raise WorkflowInputError(f"{ROLE_LABELS.get(role, role)}的所有能力都需要登录")
 			if group_name is None:
 				group_name = menu.select(
 					"请选择目标分类",
 					[
 						MenuOption(name, name, GOAL_GROUP_HINTS.get(name, ""))
-						for name, _ in GOAL_GROUPS[role]
+						for name, _ in groups
 					],
 				)
-			goal_names = next(goals for name, goals in GOAL_GROUPS[role] if name == group_name)
+			goal_names = next(goals for name, goals in groups if name == group_name)
 			goal = menu.select(
 				"请选择本次要完成的事项",
 				[
@@ -741,6 +764,7 @@ def collect_wizard_input(
 	show_controls: bool = True,
 	available_runs: Sequence[Mapping[str, Any]] = (),
 	data_dir: Path | None = None,
+	local_only: bool = False,
 ) -> WizardInput | WizardControl:
 	"""Collect a plan or run-control action without executing business logic."""
 	driver = menu or _menu_driver()
@@ -760,6 +784,7 @@ def collect_wizard_input(
 				default_role=default_role,
 				default_platform=default_platform,
 				data_dir=data_dir,
+				local_only=local_only,
 			)
 		except WizardBack:
 			if not show_controls:

--- a/src/boss_agent_cli/wizard/renderer.py
+++ b/src/boss_agent_cli/wizard/renderer.py
@@ -416,7 +416,13 @@ def render_run(run: Mapping[str, Any]) -> None:
 			lines.append(f"内部采集编号：{inner}")
 		if int(jobs_seen or 0) > 0:
 			lines.append(f"本地已有职位：{jobs_seen} 条（可在「查看采集进度与产物」中浏览）")
-		if data.get("status") == "risk_stopped" or "非 JSON" in reason or "未登录" in reason or "环境" in reason:
+		operator_actions = last.get("operator_actions") or []
+		if operator_actions:
+			# 数据驱动：step 自己声明「人该做什么」，renderer 不再猜。
+			lines.append("")
+			lines.extend(str(item) for item in operator_actions)
+		elif data.get("status") == "risk_stopped" or "非 JSON" in reason or "未登录" in reason or "环境" in reason:
+			# 兜底：SQLite 里的历史 run 没有 operator_actions 字段，仍走旧的子串启发式。
 			lines.append("")
 			if data.get("browser_kept_open"):
 				lines.extend(

--- a/tests/test_auth_and_login_extended.py
+++ b/tests/test_auth_and_login_extended.py
@@ -420,7 +420,9 @@ def test_login_risk_control_error_is_not_suggested_as_plain_network_retry(mock_a
 	parsed = json.loads(result.output)
 	assert parsed["error"]["code"] == "LOGIN_RISK_CONTROL"
 	assert "风控" in parsed["error"]["message"]
-	assert any("暂停自动化重试" in action for action in parsed["hints"]["next_actions"])
+	# 风控下没有安全的可执行命令可推荐；指引全部走面向真人的通道。
+	assert parsed["hints"]["next_actions"] == []
+	assert any("暂停自动化重试" in action for action in parsed["hints"]["operator_actions"])
 
 
 @patch("boss_agent_cli.commands.login.AuthManager")
@@ -451,3 +453,58 @@ def test_login_generic_error_keeps_network_fallback_with_doctor_hint(mock_auth_c
 	assert parsed["error"]["code"] == "NETWORK_ERROR"
 	assert "登录失败" in parsed["error"]["message"]
 	assert any("boss doctor" in action for action in parsed["hints"]["next_actions"])
+
+
+# ── login 错误 hints 的双受众通道拆分（R5 / A11）─────────────
+
+
+@pytest.mark.parametrize(
+	"side_effect,expected_code",
+	[
+		(TimeoutError("login timeout"), "LOGIN_TIMEOUT"),
+		(RuntimeError("Executable doesn't exist at /x"), "BROWSER_KERNEL_MISSING"),
+		(ConnectionError("cdp refused"), "CDP_UNAVAILABLE"),
+		(RuntimeError("HTTP 403 forbidden risk control"), "LOGIN_RISK_CONTROL"),
+		(RuntimeError("401 unauthorized"), "LOGIN_EXPIRED"),
+		(RuntimeError("cookie stoken extraction failed"), "LOGIN_CREDENTIAL_EXTRACTION_FAILED"),
+		(RuntimeError("boom"), "NETWORK_ERROR"),
+	],
+)
+@patch("boss_agent_cli.commands.login.AuthManager")
+def test_login_error_hints_split_by_audience(mock_auth_cls, side_effect, expected_code):
+	"""next_actions 只放真命令，自然语言指引一律走 operator_actions。"""
+	mock_auth = MagicMock()
+	mock_auth.login.side_effect = side_effect
+	mock_auth_cls.return_value = mock_auth
+
+	result = CliRunner().invoke(cli, ["login"])
+	assert result.exit_code == 1
+	hints = json.loads(result.output)["error"]
+	parsed = json.loads(result.output)
+	assert parsed["error"]["code"] == expected_code
+
+	hints = parsed["hints"]
+	assert set(hints) == {"next_actions", "operator_actions"}
+	# 每个分类都必须给真人留下可读指引。
+	assert hints["operator_actions"], f"{expected_code} 缺少 operator_actions"
+
+	# next_actions 必须是可执行命令，不是叙述句。
+	for action in hints["next_actions"]:
+		assert action.startswith(("boss", "patchright")), (
+			f"{expected_code} 的 next_actions 混入了非命令条目: {action!r}"
+		)
+		assert "，" not in action and "。" not in action
+
+
+@patch("boss_agent_cli.commands.login.AuthManager")
+def test_login_success_hints_stay_agent_only(mock_auth_cls):
+	"""登录成功是终态，不需要人再做什么——不产出 operator_actions。"""
+	mock_auth = MagicMock()
+	mock_auth.login.return_value = {"_method": "cookie", "token": "t"}
+	mock_auth_cls.return_value = mock_auth
+
+	result = CliRunner().invoke(cli, ["login"])
+	assert result.exit_code == 0
+	hints = json.loads(result.output)["hints"]
+	assert "next_actions" in hints
+	assert not hints.get("operator_actions")

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -546,3 +546,123 @@ class TestRenderers:
 		assert "exported 5 jobs" in output
 		assert "json" in output
 		assert " to " not in output, "无 path 时不应出现 'to <路径>' 片段"
+
+
+# ── operator_actions 双受众渲染（TTY 分支）─────────────────
+
+
+class TestRenderOperatorActions:
+	"""render_operator_actions 只渲染面向真人的通道，且只走 stderr。"""
+
+	def _tty_ctx(self):
+		ctx = MagicMock()
+		ctx.obj = {"json_output": False}
+		return ctx
+
+	def test_operator_actions_rendered_in_tty(self, monkeypatch):
+		stream = _capture_display_console(monkeypatch)
+		rendered = []
+		with patch.object(sys, "stdout") as mock_out:
+			mock_out.isatty.return_value = True
+			handle_output(
+				self._tty_ctx(),
+				"wizard",
+				{"ok": True},
+				render=rendered.append,
+				hints={"operator_actions": ["扫码登录后回到终端"]},
+			)
+		assert rendered == [{"ok": True}]
+		assert "你需要" in stream.getvalue()
+		assert "扫码登录后回到终端" in stream.getvalue()
+
+	def test_next_actions_not_rendered_in_tty(self, monkeypatch):
+		"""A4：next_actions 是纯 Agent 通道，TTY 下不渲染。"""
+		stream = _capture_display_console(monkeypatch)
+		with patch.object(sys, "stdout") as mock_out:
+			mock_out.isatty.return_value = True
+			handle_output(
+				self._tty_ctx(),
+				"search",
+				{"items": []},
+				render=lambda _data: None,
+				hints={"next_actions": ["boss show 1", "boss shortlist add x y"]},
+			)
+		assert stream.getvalue() == ""
+
+	def test_no_hints_produces_no_output(self, monkeypatch):
+		"""A5：无 hints 的命令 TTY 输出零变化。"""
+		stream = _capture_display_console(monkeypatch)
+		with patch.object(sys, "stdout") as mock_out:
+			mock_out.isatty.return_value = True
+			handle_output(
+				self._tty_ctx(), "search", {"items": []}, render=lambda _data: None
+			)
+		assert stream.getvalue() == ""
+
+	def test_empty_operator_actions_produces_no_output(self, monkeypatch):
+		stream = _capture_display_console(monkeypatch)
+		with patch.object(sys, "stdout") as mock_out:
+			mock_out.isatty.return_value = True
+			for hints in ({}, {"operator_actions": []}, {"operator_actions": None}):
+				handle_output(
+					self._tty_ctx(),
+					"search",
+					{},
+					render=lambda _data: None,
+					hints=hints,
+				)
+		assert stream.getvalue() == ""
+
+	def test_multiple_actions_align_continuation_lines(self, monkeypatch):
+		stream = _capture_display_console(monkeypatch)
+		with patch.object(sys, "stdout") as mock_out:
+			mock_out.isatty.return_value = True
+			handle_output(
+				self._tty_ctx(),
+				"wizard",
+				{},
+				render=lambda _data: None,
+				hints={"operator_actions": ["第一步动作", "第二步动作"]},
+			)
+		output = stream.getvalue()
+		assert "↓ 你需要：第一步动作" in output
+		assert "第二步动作" in output
+		assert output.count("你需要") == 1
+
+	def test_json_mode_does_not_render(self, monkeypatch):
+		"""JSON 模式走信封，不触发 Rich 渲染。"""
+		stream = _capture_display_console(monkeypatch)
+		ctx = MagicMock()
+		ctx.obj = {"json_output": True}
+		with patch("boss_agent_cli.display.emit_success") as mock_emit:
+			handle_output(
+				ctx,
+				"wizard",
+				{},
+				render=lambda _data: None,
+				hints={"operator_actions": ["扫码登录"]},
+			)
+			mock_emit.assert_called_once()
+		assert stream.getvalue() == ""
+
+	def test_error_output_renders_operator_actions_before_exit(self, monkeypatch):
+		import pytest
+
+		stream = _capture_display_console(monkeypatch)
+		with patch.object(sys, "stdout") as mock_out:
+			mock_out.isatty.return_value = True
+			with pytest.raises(SystemExit):
+				handle_error_output(
+					self._tty_ctx(),
+					"login",
+					code="LOGIN_TIMEOUT",
+					message="登录等待超时",
+					recovery_action="boss login",
+					hints={
+						"next_actions": ["boss login --timeout 180"],
+						"operator_actions": ["确认二维码已完成扫码"],
+					},
+				)
+		output = stream.getvalue()
+		assert "确认二维码已完成扫码" in output
+		assert "boss login --timeout 180" not in output

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -172,3 +172,76 @@ def test_config_from_file(tmp_path):
 	assert cfg["export_dir"] == "/tmp/exports"
 	assert cfg["log_level"] == "debug"
 	assert cfg["request_delay"] == [1.5, 3.0]
+
+
+# --- hints 双受众通道契约（operator_actions） ---
+
+
+def test_envelope_success_preserves_operator_actions():
+	"""operator_actions 是面向真人的通道，不得被脱敏抹掉。"""
+	result = envelope_success(
+		"wizard",
+		{"authenticated": False},
+		hints={
+			"next_actions": ["boss wizard --resume wrn_x9k2"],
+			"operator_actions": ["扫码登录后回到终端"],
+		},
+	)
+	parsed = json.loads(result)
+	assert parsed["hints"]["operator_actions"] == ["扫码登录后回到终端"]
+	assert parsed["hints"]["next_actions"] == ["boss wizard --resume wrn_x9k2"]
+
+
+def test_envelope_error_preserves_operator_actions():
+	result = envelope_error(
+		"login",
+		code="LOGIN_TIMEOUT",
+		message="登录等待超时",
+		recoverable=True,
+		hints={
+			"next_actions": ["boss login --timeout 180"],
+			"operator_actions": ["确认二维码已完成扫码并在网页端授权登录"],
+		},
+	)
+	parsed = json.loads(result)
+	assert parsed["hints"]["operator_actions"] == ["确认二维码已完成扫码并在网页端授权登录"]
+	assert parsed["hints"]["next_actions"] == ["boss login --timeout 180"]
+
+
+def test_operator_actions_key_is_not_sensitive():
+	"""字段名不得命中 _SENSITIVE_KEY_PARTS，否则整个数组会变成 [REDACTED]。"""
+	from boss_agent_cli.output import redact_sensitive
+
+	redacted = redact_sensitive({"operator_actions": ["去浏览器里确认筛选条件"]})
+	assert redacted["operator_actions"] == ["去浏览器里确认筛选条件"]
+
+
+def test_operator_actions_values_still_redact_credentials():
+	"""值仍走 redact_sensitive_text——文案里别写「键：值」形式。"""
+	result = envelope_success(
+		"wizard",
+		{},
+		hints={"operator_actions": ["把 token=abc123 填进去"]},
+	)
+	parsed = json.loads(result)
+	assert parsed["hints"]["operator_actions"] == ["把 token=[REDACTED] 填进去"]
+
+
+def test_step_result_carries_operator_actions():
+	from boss_agent_cli.wizard.models import StepResult, WorkflowStatus
+
+	result = StepResult(
+		{"authenticated": False},
+		status=WorkflowStatus.WAITING_INPUT,
+		next_action="boss wizard --resume wrn_x9k2",
+		operator_actions=("扫码登录后回到终端",),
+	)
+	payload = result.to_dict()
+	assert payload["operator_actions"] == ["扫码登录后回到终端"]
+	assert payload["status"] == "waiting_input"
+
+
+def test_step_result_operator_actions_defaults_empty():
+	from boss_agent_cli.wizard.models import StepResult
+
+	assert StepResult({}).to_dict()["operator_actions"] == []

--- a/tests/test_schema_contract.py
+++ b/tests/test_schema_contract.py
@@ -39,6 +39,24 @@ def test_schema_output_is_json_envelope():
 	assert isinstance(data["error_codes"], dict)
 
 
+# ── 双受众信封契约 ──────────────────────────────────────────────────
+
+
+def test_schema_conventions_declare_hints_audiences():
+	"""conventions 必须声明 next_actions / operator_actions 各自的受众。"""
+	hints = SCHEMA_DATA["conventions"]["hints"]
+	assert set(hints) == {"next_actions", "operator_actions"}
+	assert "Agent" in hints["next_actions"]
+	assert "操作者" in hints["operator_actions"]
+
+
+def test_schema_conventions_declare_command_vs_wizard():
+	"""commands 与 wizard_catalog 是两套并行能力面，必须声明何时用哪个。"""
+	declaration = SCHEMA_DATA["conventions"]["command_vs_wizard"]
+	assert "顶层命令" in declaration
+	assert "wizard" in declaration
+
+
 # ── Schema 命令集 == 注册命令集 ─────────────────────────────────────
 
 

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -597,9 +597,14 @@ def test_runner_normalizes_auth_and_network_failures(tmp_path):
 			_action_context(tmp_path),
 			run_id="auth-required-run",
 		)
-	assert auth_run["error"]["code"] == "AUTH_REQUIRED"
-	assert auth_run["error"]["recoverable"] is True
-	assert "boss --platform zhipin login" == auth_run["error"]["recovery_action"]
+	# 未登录不是失败，是「在等人」：run 挂起可恢复，而不是被打成 failed。
+	assert auth_run["status"] == "waiting_input"
+	assert auth_run["error"] is None
+	last = auth_run["last_result"]
+	assert last["status"] == "waiting_input"
+	assert last["data"]["authenticated"] is False
+	assert last["next_action"] == "boss wizard --resume auth-required-run"
+	assert any("boss --platform zhipin login" in action for action in last["operator_actions"])
 
 	def broken(context, inputs, prior):
 		raise OSError("offline")
@@ -1694,7 +1699,16 @@ def test_error_message_prefers_platform_chinese_text():
 	assert "换一条" in (recovery_message("INVALID_PARAM") or "")
 
 
+def _gate_logged_in(monkeypatch):
+	"""让向导入口的登录门直接放行（模拟已登录用户）。"""
+	monkeypatch.setattr(
+		"boss_agent_cli.auth.manager.AuthManager.check_status",
+		lambda self: {"cookies": {"wt2": "x"}, "stoken": "s"},
+	)
+
+
 def test_interactive_wizard_loops_follow_up_from_original_list_results(tmp_path, monkeypatch):
+	_gate_logged_in(monkeypatch)
 	list_run = {
 		"run_id": "search-run",
 		"role": "candidate",
@@ -1844,6 +1858,7 @@ def test_interactive_wizard_exit_during_entity_follow_up_does_not_traceback(tmp_
 
 
 def test_interactive_wizard_returns_to_main_menu_after_success(tmp_path, monkeypatch):
+	_gate_logged_in(monkeypatch)
 	plans = iter(
 		[
 			WizardInput(role="candidate", platform="zhipin", goal="shortlist", inputs={}, mode="tty"),
@@ -2113,6 +2128,7 @@ def test_root_tty_and_explicit_wizard_share_prompt_collector(tmp_path, monkeypat
 
 
 def test_tty_root_and_explicit_wizard_render_only_to_stderr(tmp_path, monkeypatch):
+	_gate_logged_in(monkeypatch)
 	collected = WizardInput(
 		role="candidate",
 		platform="zhipin",
@@ -2186,3 +2202,379 @@ def test_wizard_status_and_stop_use_explicit_run_id(tmp_path):
 	)
 	assert stop.exit_code == 1
 	assert json.loads(stop.stdout)["error"]["code"] == "JOB_NOT_FOUND"
+
+
+# ── 未登录 = waiting_input（不是 failed，也不阻塞）─────────────
+
+
+def _auth_plan():
+	return WorkflowPlan(
+		role="candidate",
+		platform="zhipin",
+		goal="recommendations",
+		inputs={},
+		requested_steps=("auth_status",),
+		mode="headless",
+	)
+
+
+def test_auth_status_waiting_input_is_resumable_and_reruns_step(tmp_path):
+	"""A6：未登录挂起后，同一 run_id 可 resume，且 auth_status 会重跑而非被跳过。"""
+	run_id = "waiting-login-run"
+	with WorkflowStore(tmp_path) as store:
+		first = WorkflowRunner(store, DEFAULT_ACTIONS).run(
+			_auth_plan(), _action_context(tmp_path), run_id=run_id
+		)
+	assert first["status"] == "waiting_input"
+	assert first["error"] is None
+
+	# 人「登录完」后重跑同一条 run：auth_status 必须重新执行。
+	calls = []
+
+	def logged_in(context, inputs, prior):
+		calls.append(prior)
+		return StepResult({"authenticated": True, "platform": "zhipin", "role": "candidate"})
+
+	with WorkflowStore(tmp_path) as store:
+		resumed = WorkflowRunner(store, {"auth_status": logged_in}).run(
+			_auth_plan(), _action_context(tmp_path), run_id=run_id
+		)
+	assert len(calls) == 1, "waiting_input 步骤 resume 时必须重跑，不能被 prior_results 跳过"
+	assert resumed["status"] == "completed"
+
+
+def test_auth_status_waiting_input_does_not_block(tmp_path):
+	"""A7：未登录路径不得阻塞轮询等待扫码。"""
+	started = time.monotonic()
+	with WorkflowStore(tmp_path) as store:
+		run = WorkflowRunner(store, DEFAULT_ACTIONS).run(
+			_auth_plan(), _action_context(tmp_path), run_id="nonblocking-run"
+		)
+	assert run["status"] == "waiting_input"
+	assert time.monotonic() - started < 2.0
+
+
+def test_auth_status_operator_actions_are_natural_language(tmp_path):
+	"""operator_actions 面向真人；next_action 才是给 Agent 的命令。"""
+	with WorkflowStore(tmp_path) as store:
+		run = WorkflowRunner(store, DEFAULT_ACTIONS).run(
+			_auth_plan(), _action_context(tmp_path), run_id="operator-actions-run"
+		)
+	last = run["last_result"]
+	assert last["next_action"] == "boss wizard --resume operator-actions-run"
+	actions = last["operator_actions"]
+	assert len(actions) == 2
+	assert any("扫码" in action for action in actions)
+
+
+def test_auth_status_without_workflow_control_falls_back(tmp_path):
+	"""直接调 action（无 WorkflowControl）时 resume 命令要有兜底，不能抛 AttributeError。"""
+	result = DEFAULT_ACTIONS["auth_status"](_action_context(tmp_path), {}, {})
+	assert result.status is WorkflowStatus.WAITING_INPUT
+	assert result.next_action == "boss wizard"
+	assert result.operator_actions
+
+
+# ── waiting_input 面板：数据驱动 + 历史 run 兜底（A12）────────
+
+
+def _capture_waiting_panel(monkeypatch, run):
+	from boss_agent_cli.wizard import renderer as renderer_mod
+
+	panels = []
+	monkeypatch.setattr(renderer_mod.display.console, "print", lambda obj, *a, **k: panels.append(obj))
+	renderer_mod.render_run(run)
+	waiting = [p for p in panels if getattr(p, "title", None) == "等待继续"]
+	assert waiting, "waiting_input 应渲染「等待继续」面板"
+	return waiting[0].renderable
+
+
+def test_waiting_panel_prefers_operator_actions(monkeypatch):
+	"""有 operator_actions 时用它，不再靠 reason 子串猜文案。"""
+	body = _capture_waiting_panel(
+		monkeypatch,
+		{
+			"role": "candidate",
+			"goal": "recommendations",
+			"status": "waiting_input",
+			"last_result": {
+				"data": {"authenticated": False},
+				"next_action": "boss wizard --resume r1",
+				"operator_actions": ["运行 boss --platform zhipin login 并扫码", "登录完成后回到终端继续"],
+			},
+		},
+	)
+	assert "运行 boss --platform zhipin login 并扫码" in body
+	assert "登录完成后回到终端继续" in body
+	# 旧启发式文案不应出现
+	assert "继续采集" not in body
+
+
+def test_waiting_panel_falls_back_for_legacy_runs(monkeypatch):
+	"""SQLite 里的历史 run 没有 operator_actions 字段，必须仍走旧启发式。"""
+	body = _capture_waiting_panel(
+		monkeypatch,
+		{
+			"role": "candidate",
+			"goal": "crawl_start",
+			"status": "waiting_input",
+			"last_result": {
+				"data": {
+					"status": "risk_stopped",
+					"browser_kept_open": True,
+					"error": "环境异常",
+				},
+				"next_action": "boss crawl resume c1",
+			},
+		},
+	)
+	assert "采集用 Chrome 已保持打开" in body
+
+
+def test_crawl_risk_stop_emits_browser_operator_actions():
+	"""风控停止的文案改为由 step 声明数据，而不是 renderer 猜。"""
+	from boss_agent_cli.wizard.actions import _crawl_outcome_result
+
+	result = _crawl_outcome_result(_crawl_outcome("crawl-1", "risk_stopped"))
+	assert result.status is WorkflowStatus.WAITING_INPUT
+	assert result.next_action == "boss crawl resume crawl-1"
+	assert any("Chrome 已保持打开" in action for action in result.operator_actions)
+	assert any("boss crawl resume crawl-1" in action for action in result.operator_actions)
+
+
+def test_crawl_budget_stop_does_not_claim_risk():
+	"""预算停止不是账号异常，文案必须区分开。"""
+	from boss_agent_cli.wizard.actions import _crawl_outcome_result
+
+	result = _crawl_outcome_result(_crawl_outcome("crawl-1", "budget_stopped"))
+	assert result.status is WorkflowStatus.WAITING_INPUT
+	assert any("预算上限" in action for action in result.operator_actions)
+	assert not any("Chrome 已保持打开" in action for action in result.operator_actions)
+
+
+# ── 向导入口登录门（R6 / A13–A18）───────────────────────────
+
+
+def _gate_ctx(tmp_path, *, platform="zhipin", role="candidate"):
+	ctx = SimpleNamespace()
+	ctx.obj = {
+		"data_dir": tmp_path,
+		"logger": Logger(),
+		"platform": platform,
+		"role": role,
+		"cdp_url": None,
+	}
+	return ctx
+
+
+def test_gate_is_silent_and_free_when_logged_in(tmp_path, monkeypatch, capsys):
+	"""A13：已登录用户零输出、不预检浏览器内核、不开浏览器。"""
+	from boss_agent_cli.wizard import preflight
+
+	monkeypatch.setattr(
+		"boss_agent_cli.auth.manager.AuthManager.check_status",
+		lambda self: {"cookies": {"wt2": "x"}},
+	)
+	kernel_calls = []
+	monkeypatch.setattr(preflight, "_browser_kernel_status", lambda: kernel_calls.append(1) or ("ok", ""))
+	login_calls = []
+	monkeypatch.setattr(
+		"boss_agent_cli.auth.manager.AuthManager.login",
+		lambda self, **kw: login_calls.append(kw),
+	)
+
+	assert preflight.ensure_login(_gate_ctx(tmp_path)) == preflight.GATE_READY
+	assert kernel_calls == []
+	assert login_calls == []
+	captured = capsys.readouterr()
+	assert captured.out == ""
+	assert captured.err == ""
+
+
+def test_gate_offers_login_before_any_goal_selection(tmp_path, monkeypatch):
+	"""A14/A15：未登录时先给三选菜单；选「现在登录」直接开浏览器。"""
+	from boss_agent_cli.wizard import preflight
+
+	monkeypatch.setattr("boss_agent_cli.auth.manager.AuthManager.check_status", lambda self: None)
+	monkeypatch.setattr(preflight, "_browser_kernel_status", lambda: ("ok", ""))
+	login_calls = []
+	monkeypatch.setattr(
+		"boss_agent_cli.auth.manager.AuthManager.login",
+		lambda self, **kw: login_calls.append(kw) or {"cookies": {"wt2": "x"}},
+	)
+
+	menu = _ScriptedMenu(["login"])
+	assert preflight.ensure_login(_gate_ctx(tmp_path), menu=menu) == preflight.GATE_READY
+	assert len(login_calls) == 1
+	title, options = menu.menus[0]
+	assert "现在登录" in title or "登录" in title
+	assert [option.value for option in options] == ["login", "local", "exit"]
+
+
+def test_gate_blocks_on_missing_browser_kernel_without_opening_browser(tmp_path, monkeypatch):
+	"""A16：内核缺失时给安装指引，绝不尝试开浏览器。"""
+	from boss_agent_cli.wizard import preflight
+
+	monkeypatch.setattr("boss_agent_cli.auth.manager.AuthManager.check_status", lambda self: None)
+	monkeypatch.setattr(
+		preflight,
+		"_browser_kernel_status",
+		lambda: ("error", "patchright 需要 chromium-1234，请运行 patchright install chromium"),
+	)
+	login_calls = []
+	monkeypatch.setattr(
+		"boss_agent_cli.auth.manager.AuthManager.login",
+		lambda self, **kw: login_calls.append(kw),
+	)
+
+	# 第一次选登录 → 被内核拦住回到菜单；第二次选退出。
+	menu = _ScriptedMenu(["login", "exit"])
+	assert preflight.ensure_login(_gate_ctx(tmp_path), menu=menu) == preflight.GATE_EXIT
+	assert login_calls == [], "内核缺失时不得尝试打开浏览器"
+
+
+def test_gate_login_failure_shows_operator_actions_and_retries(tmp_path, monkeypatch, capsys):
+	"""登录失败复用 R5 的双通道文案，且可回菜单重试。"""
+	from boss_agent_cli.wizard import preflight
+
+	monkeypatch.setattr("boss_agent_cli.auth.manager.AuthManager.check_status", lambda self: None)
+	monkeypatch.setattr(preflight, "_browser_kernel_status", lambda: ("ok", ""))
+
+	def _boom(self, **kw):
+		raise TimeoutError("login timeout")
+
+	monkeypatch.setattr("boss_agent_cli.auth.manager.AuthManager.login", _boom)
+
+	menu = _ScriptedMenu(["login", "exit"])
+	assert preflight.ensure_login(_gate_ctx(tmp_path), menu=menu) == preflight.GATE_EXIT
+	assert len(menu.menus) == 2, "登录失败后应回到菜单可重试"
+
+
+def test_gate_local_only_filters_goal_menu(tmp_path, monkeypatch):
+	"""A17：仅本地功能时 goal 菜单只剩不需登录的目标。"""
+	from boss_agent_cli.wizard import preflight
+	from boss_agent_cli.wizard.prompts import _visible_goal_groups
+
+	monkeypatch.setattr("boss_agent_cli.auth.manager.AuthManager.check_status", lambda self: None)
+	menu = _ScriptedMenu(["local"])
+	assert preflight.ensure_login(_gate_ctx(tmp_path), menu=menu) == preflight.GATE_LOCAL_ONLY
+
+	groups = _visible_goal_groups("candidate", local_only=True)
+	visible = {goal for _name, goals in groups for goal in goals}
+	assert visible == set(preflight.local_goal_names("candidate"))
+	assert "job_search" not in visible and "shortlist" in visible
+
+
+def test_gate_recruiter_has_no_local_goals(tmp_path, monkeypatch):
+	"""A17：招聘者全部能力都需登录，菜单不该出现「仅看本地功能」。"""
+	from boss_agent_cli.wizard import preflight
+	from boss_agent_cli.wizard.prompts import _visible_goal_groups
+
+	assert preflight.local_goal_names("recruiter") == ()
+	assert _visible_goal_groups("recruiter", local_only=True) == ()
+
+	monkeypatch.setattr("boss_agent_cli.auth.manager.AuthManager.check_status", lambda self: None)
+	menu = _ScriptedMenu(["exit"])
+	preflight.ensure_login(_gate_ctx(tmp_path, role="recruiter"), menu=menu)
+	_title, options = menu.menus[0]
+	assert [option.value for option in options] == ["login", "exit"]
+
+
+def test_headless_paths_bypass_the_gate(tmp_path):
+	"""A18：headless / --input-json 不经登录门，仍走 R3 的 waiting_input。"""
+	result = CliRunner().invoke(
+		cli,
+		[
+			"--json",
+			"--data-dir",
+			str(tmp_path),
+			"wizard",
+			"--input-json",
+			json.dumps({"role": "candidate", "platform": "zhipin", "goal": "recommendations"}),
+		],
+	)
+	payload = json.loads(result.stdout)
+	assert payload["ok"] is True
+	assert payload["data"]["status"] == "waiting_input"
+	assert payload["data"]["error"] is None
+
+
+# ── 恢复采集完成后必须停留在结果上，而不是闪回主菜单 ─────────
+
+
+def test_recovery_completion_falls_through_to_result_browsing(tmp_path, monkeypatch):
+	"""真实使用反馈：继续采集成功后摘要一闪即逝，要进「查看任务状态」才能看到。
+
+	修复后：recovery 完成 → 落入 completed 处理器（渲染 + 可浏览列表），
+	不再提前 return 让主菜单立刻清屏。
+	"""
+	from boss_agent_cli.commands import wizard as wizard_mod
+
+	waiting_run = {
+		"run_id": "outer-1",
+		"role": "candidate",
+		"platform": "zhipin",
+		"goal": "crawl_start",
+		"status": "waiting_input",
+		"last_result": {"data": {"run_id": "crawl-inner", "status": "risk_stopped"}},
+	}
+	completed_run = {
+		"run_id": "recovery-1",
+		"role": "candidate",
+		"platform": "zhipin",
+		"goal": "crawl_resume",
+		"status": "completed",
+		"last_result": {"data": {"items": [{"title": "Golang 工程师"}]}},
+	}
+
+	class _FakeRunner:
+		def __init__(self, store, actions):
+			self.calls = 0
+
+		def run(self, plan, context, **kwargs):
+			self.calls += 1
+			return waiting_run if self.calls == 1 else completed_run
+
+	monkeypatch.setattr(wizard_mod, "WorkflowRunner", _FakeRunner)
+	monkeypatch.setattr(wizard_mod, "_build_context", lambda ctx, plan: object())
+	monkeypatch.setattr(wizard_mod, "render_run", lambda run: None)
+	monkeypatch.setattr(
+		wizard_mod,
+		"collect_waiting_recovery",
+		lambda run, **kw: WizardInput(
+			role="candidate", platform="zhipin", goal="crawl_resume",
+			inputs={"run_id": "crawl-inner"}, mode="tty",
+		),
+	)
+	browsed = []
+	monkeypatch.setattr(wizard_mod, "has_result_follow_up", lambda run: True)
+	monkeypatch.setattr(
+		wizard_mod,
+		"_browse_list_results",
+		lambda ctx, store, runner, run, **kw: browsed.append(run["run_id"]) or run,
+	)
+
+	ctx = SimpleNamespace()
+	ctx.obj = {"data_dir": tmp_path, "logger": Logger(), "platform": "zhipin",
+	           "role": "candidate", "cdp_url": None, "delay": (0, 0), "config": {}}
+	plan = build_plan(WizardInput(
+		role="candidate", platform="zhipin", goal="crawl_start",
+		inputs={"query": "Golang", "city": "广州"}, mode="tty",
+	))
+	result = wizard_mod._run_plan(
+		ctx, object(), plan,
+		interactive=True, resume_run_id=None, timeout_seconds=None, max_retries=0,
+	)
+	assert browsed == ["recovery-1"], "recovery 完成后应进入结果浏览，而不是直接返回主菜单"
+	assert result["run_id"] == "recovery-1"
+
+
+def test_menu_hint_advertises_left_arrow_back():
+	"""左方向键返回是公开交互承诺，提示行必须写出来。"""
+	import inspect
+
+	from boss_agent_cli.wizard.prompts import PromptToolkitMenu
+
+	source = inspect.getsource(PromptToolkitMenu.select)
+	assert 'bindings.add("left")' in source
+	assert "←/Esc 返回" in source


### PR DESCRIPTION
## 背景

本仓库同时服务两类消费者：AI Agent（`--json` / MCP / 管道）与真人（TTY + Rich）。对照参考项目 [`1xiaoyueryuer/boss-hr-agent-toolkit`](https://github.com/1xiaoyueryuer/boss-hr-agent-toolkit) 后确认，其编排能力已被本仓库 `wizard/runner.py` 覆盖，但**信封受众分离**的设计本仓库没有。真实试用又暴露出向导对 TTY 用户只做了状态建模、没做引导。

## 改动

### 1. `hints` 拆分双受众通道

| 字段 | 受众 | 形式 |
|---|---|---|
| `hints.next_actions` | AI Agent | `boss xxx` 命令，Agent 直接执行 |
| `hints.operator_actions` | 真人操作者 | 自然语言，通常需要离开终端完成 |

判定标准是「是否需要人离开终端」（扫码、在浏览器里调筛选、处理风控验证），不是「是否需要确认」。

`display.render_operator_actions` 在 TTY 下**只渲染 `operator_actions`** 到 stderr；`next_actions` 保持纯 Agent 通道不渲染。此前 `display.py` 的 TTY 分支把 `hints` 整个丢弃，真人从来看不到任何提示。无 `operator_actions` 时零输出，因此 42 个既有命令的 TTY 行为逐字节不变。

`SCHEMA_DATA["conventions"]` 新增 `hints` 与 `command_vs_wizard` 两块，后者声明：单次无状态的能力调用走顶层命令，需要跨步骤状态 / 可恢复 / 中途要把指引递给真人的走 `boss wizard`。

### 2. wizard 未登录不再打成 failed

`auth_status` 未登录时返回 `WAITING_INPUT` 而非抛 `AUTH_REQUIRED`，run 可 `--resume`，之前选的角色、平台、目标全部保留（此前落 `failed`，用户得从头重走向导）。该路径**不阻塞轮询等扫码**。

`renderer.py` 的 `waiting_input` 面板改为读 `operator_actions` 数据，旧的 `"未登录" in reason` 子串启发式仅作历史 run 兜底。

### 3. 新增向导入口登录门 `wizard/preflight.py`

此前 `auth_status` 是 goal 的第一个 step，而 step 在向导收集完角色/平台/目标分类/目标/参数**五层选择之后**才执行——未登录时这些全部白做。

登录门前移到 `collect_wizard_input` 之前：

- **已登录时零输出、零开销**：`check_status()` 是本地文件读，命中即放行，不预检浏览器内核、不开浏览器
- 未登录时给体检卡 + 三选菜单；选「现在登录」**内联打开浏览器扫码**，扫完无缝进向导，不需要用户退出去敲命令
- 浏览器内核缺失时先给 `patchright install chromium` 指引，**不再开完浏览器才失败**（复用 `doctor_checks._evaluate_patchright_chromium`）
- 无需登录的目标（简历、候选池、采集任务）可在未登录时使用；招聘者无离线能力，该选项不出现

> TTY 内联阻塞等扫码是**刻意**的：headless / Agent 的「不阻塞」原则是为了避免 Agent 卡在子进程里空等；TTY 下人就坐在终端前，两种受众的正确行为相反。headless 路径保持 `WAITING_INPUT` 不变。

### 4. `login` 错误 hints 重新分流

`_classify_login_error` 的七个分类此前把自然语言人类指令（「确认二维码已完成扫码并在网页端授权登录」）装在 `next_actions` 里——这正是「没有第二条通道时人类指令只能往 Agent 通道挤」的实例。现按新契约分流。`LOGIN_RISK_CONTROL` 的 `next_actions` **刻意为空**：风控下没有安全的可执行命令可推荐。

### 5. 真实试用修复

- **恢复采集完成后结果不展示**：`_run_plan` 恢复分支渲染后提前 `return`，主菜单下一次清屏把摘要吞掉。改为落入 `completed` 处理器展示结果并可浏览职位
- **风控停止文案误导**：明确说明这不是账号掉登录，而是采集用独立浏览器被平台环境校验拦下
- **菜单支持左方向键返回**：`left` 与 `escape` 共用 `go_back`，提示行同步为 `↑↓ 选择 · Enter 确认 · ←/Esc 返回`

## 验证

- `uv run python scripts/quality_baseline.py` — **1804 passed** · mypy 149 files 零错误 · ruff 全绿
- `uv run pytest tests/test_agent_docs.py tests/test_open_source_docs.py -q` — 38 passed
- `git diff --check` 干净
- 作者已在真实终端完成端到端试用（登录门 → 扫码 → 采集 → 恢复 → 结果浏览）

新增用例覆盖 A1–A18：信封字段不被脱敏、TTY 只渲染 `operator_actions`、无 hints 时零输出、`waiting_input` 可 resume 且步骤重跑、不阻塞、内核缺失时不开浏览器、已登录时零输出、goal 菜单本地过滤、headless 路径不受登录门影响。

## 兼容性

全部为加性变更。唯一行为改变是 wizard 未登录时 run 状态由 `failed` 变 `waiting_input`，影响一个既有用例（已更新）。`login` 的 `next_actions` 内容有调整，属刻意的通道归位。

## 后续

向导 TUI 的「结果一闪即逝」与人为分页（`RESULT_PAGE_SIZE = 12`）共享同一个根因——清屏重画模型。改用 `prompt_toolkit` 的 alt-screen 持久视口可从结构上消除这两类问题，已单独立项，不在本 PR 范围。