### PR TITLE
feat: 补齐候选者侧命令组的终端渲染

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build/
 .codex/
 .worktrees/
 .claude/
+.pi/
 docs/superpowers/
 my-boss-profile.md
 CLAUDE.md

--- a/src/boss_agent_cli/commands/agent.py
+++ b/src/boss_agent_cli/commands/agent.py
@@ -26,7 +26,13 @@ from boss_agent_cli.commands.ai_cmd import _build_fit_prompt, _create_ai_service
 from boss_agent_cli.commands.crawl import _require_crawl_capabilities, _settings_from_context, _transport_factory
 from boss_agent_cli.crawler.operations import crawl_status, import_crawl_shortlist
 from boss_agent_cli.crawler.service import CrawlService
-from boss_agent_cli.display import handle_error_output, handle_output
+from boss_agent_cli.display import (
+	handle_error_output,
+	handle_output,
+	render_action_result,
+	render_list_result,
+	render_record_result,
+)
 from boss_agent_cli.resume.models import resume_to_text
 from boss_agent_cli.resume.store import ResumeStore
 
@@ -48,7 +54,13 @@ def agent_group() -> None:
 def run_cmd(ctx: click.Context, dry_run: bool, limit: int | None) -> None:
 	"""运行一轮招聘自动化。"""
 	report = _run_agent(ctx, dry_run=dry_run, limit=limit, force_mode=None)
-	handle_output(ctx, "agent.run", _report_payload(report), hints=_agent_hints(ctx))
+	handle_output(
+		ctx,
+		"agent.run",
+		_report_payload(report),
+		render=lambda d: render_record_result(d, title="agent run", next_steps=["boss agent stats"]),
+		hints=_agent_hints(ctx),
+	)
 
 
 @agent_group.command("crawl")
@@ -164,6 +176,7 @@ def crawl_cmd(
 				"missing": missing,
 				"summary": {"analyzed": 0, "missing_details": len(missing)},
 			},
+			render=lambda d: render_record_result(d, title="agent crawl", next_steps=["boss shortlist list"]),
 			hints={"next_actions": [f"boss crawl resume {run_id} --with-detail"]},
 		)
 		return
@@ -206,6 +219,7 @@ def crawl_cmd(
 			"missing": missing,
 			"summary": {"analyzed": len(jobs), "missing_details": len(missing), "returned": len(results)},
 		},
+		render=lambda d: render_record_result(d, title="agent crawl", next_steps=["boss shortlist list"]),
 		hints={
 			"next_actions": [
 				f"boss crawl results {run_id}",
@@ -232,7 +246,13 @@ def train_cmd(ctx: click.Context, dry_run: bool, limit: int | None) -> None:
 		limit=limit,
 		force_mode=AutomationMode.TRAINING,
 	)
-	handle_output(ctx, "agent.train", _report_payload(report), hints=_agent_hints(ctx))
+	handle_output(
+		ctx,
+		"agent.train",
+		_report_payload(report),
+		render=lambda d: render_record_result(d, title="agent train", next_steps=["boss agent review list"]),
+		hints=_agent_hints(ctx),
+	)
 
 
 @agent_group.group("review")
@@ -248,6 +268,12 @@ def review_list_cmd(ctx: click.Context) -> None:
 		ctx,
 		"agent.review.list",
 		{"items": [asdict(item) for item in store.read_reviews()]},
+		render=lambda d: render_list_result(
+			d.get("items", []),
+			"reviews",
+			[("ID", "review_id", "bold cyan"), ("动作", "action", "green"), ("分数", "score", "yellow")],
+			next_steps=["boss agent review approve <id>", "boss agent review reject <id>"],
+		),
 		hints=_agent_hints(ctx),
 	)
 
@@ -265,6 +291,7 @@ def review_approve_cmd(ctx: click.Context, review_id: str) -> None:
 		ctx,
 		"agent.review.approve",
 		{"pending": asdict(pending)},
+		render=lambda d: render_record_result(d, title="agent review approve", next_steps=["boss agent pending list"]),
 		hints=_agent_hints(ctx),
 	)
 
@@ -292,6 +319,7 @@ def review_reject_cmd(ctx: click.Context, review_id: str, reason: str) -> None:
 		ctx,
 		"agent.review.reject",
 		{"review": asdict(rejected), "event": asdict(event)},
+		render=lambda d: render_record_result(d, title="agent review reject", next_steps=["boss agent review list"]),
 		hints=_agent_hints(ctx),
 	)
 
@@ -309,6 +337,12 @@ def pending_list_cmd(ctx: click.Context) -> None:
 		ctx,
 		"agent.pending.list",
 		{"items": [asdict(item) for item in store.read_pending()]},
+		render=lambda d: render_list_result(
+			d.get("items", []),
+			"pending",
+			[("ID", "review_id", "bold cyan"), ("动作", "action", "green"), ("状态", "status", "yellow")],
+			next_steps=["boss agent stats"],
+		),
 		hints=_agent_hints(ctx),
 	)
 
@@ -318,7 +352,13 @@ def pending_list_cmd(ctx: click.Context) -> None:
 def agent_stats_cmd(ctx: click.Context) -> None:
 	"""查看招聘自动化统计。"""
 	store = AutomationStore(ctx.obj["data_dir"])
-	handle_output(ctx, "agent.stats", store.stats(), hints=_agent_hints(ctx))
+	handle_output(
+		ctx,
+		"agent.stats",
+		store.stats(),
+		render=lambda d: render_record_result(d, title="agent stats", next_steps=["boss agent pending list"]),
+		hints=_agent_hints(ctx),
+	)
 
 
 @agent_group.command("control")
@@ -341,6 +381,7 @@ def control_cmd(ctx: click.Context) -> None:
 				"boss agent pending list",
 			],
 		},
+		render=lambda d: render_record_result(d, title="agent control", next_steps=["boss agent stats"]),
 		hints=_agent_hints(ctx),
 	)
 
@@ -361,6 +402,7 @@ def stop_cmd(ctx: click.Context, reason: str) -> None:
 		ctx,
 		"agent.stop",
 		{"status": "CIRCUIT_BREAKER_OPEN", "reason": reason},
+		render=lambda d: render_action_result(d, title="agent stop", next_steps=["boss agent stats"]),
 		hints=_agent_hints(ctx),
 	)
 

--- a/src/boss_agent_cli/commands/ai_cmd.py
+++ b/src/boss_agent_cli/commands/ai_cmd.py
@@ -24,7 +24,12 @@ from boss_agent_cli.ai.prompts import (
 )
 from boss_agent_cli.ai.service import AIService, AIServiceError
 from boss_agent_cli.cache.store import CacheStore
-from boss_agent_cli.display import handle_error_output, handle_output
+from boss_agent_cli.display import (
+	handle_error_output,
+	handle_output,
+	render_action_result,
+	render_ai_result,
+)
 from boss_agent_cli.resume.models import resume_to_text
 from boss_agent_cli.resume.store import ResumeStore
 
@@ -188,6 +193,9 @@ def ai_config_cmd(ctx: click.Context, provider: str | None, model: str | None, a
 		config.pop("ai_api_key", None)
 		handle_output(
 			ctx, "ai-config", config,
+			render=lambda d: render_action_result(
+				d, title="ai config", next_steps=["boss ai local status", "boss ai analyze-jd <security_id>"]
+			),
 			hints={"next_actions": [
 				"boss ai config --provider openai --model gpt-4o --api-key <key>",
 				"boss ai local configure --runtime ollama --model qwen3:14b",
@@ -215,6 +223,7 @@ def ai_config_cmd(ctx: click.Context, provider: str | None, model: str | None, a
 	handle_output(
 		ctx, "ai-config",
 		{"action": "update", "updated_fields": list(updates.keys()) + (["api_key"] if api_key else [])},
+		render=lambda d: render_action_result(d, title="ai config", next_steps=["boss ai config"]),
 		hints={"next_actions": ["boss ai config", "boss ai local status", "boss ai analyze-jd <security_id> --resume <name>"]},
 	)
 
@@ -252,6 +261,7 @@ def ai_analyze_jd_cmd(ctx: click.Context, jd_text: str, resume_name: str) -> Non
 
 	handle_output(
 		ctx, "ai-analyze-jd", result,
+		render=lambda d: render_ai_result(d, title="ai-analyze-jd"),
 		hints={"next_actions": [
 			f"boss ai optimize {resume_name} --jd <jd_text>",
 			f"boss ai suggest {resume_name} --jd <jd_text>",
@@ -279,6 +289,7 @@ def ai_polish_cmd(ctx: click.Context, resume_name: str) -> None:
 
 	handle_output(
 		ctx, "ai-polish", result,
+		render=lambda d: render_ai_result(d, title="ai-polish"),
 		hints={"next_actions": [f"boss resume show {resume_name}"]},
 	)
 
@@ -312,6 +323,7 @@ def ai_optimize_cmd(ctx: click.Context, resume_name: str, jd_text: str) -> None:
 
 	handle_output(
 		ctx, "ai-optimize", result,
+		render=lambda d: render_ai_result(d, title="ai-optimize"),
 		hints={"next_actions": [
 			f"boss resume show {resume_name}",
 			f"boss resume export {resume_name} --format pdf",
@@ -348,6 +360,7 @@ def ai_suggest_cmd(ctx: click.Context, resume_name: str, jd_text: str) -> None:
 
 	handle_output(
 		ctx, "ai-suggest", result,
+		render=lambda d: render_ai_result(d, title="ai-suggest"),
 		hints={"next_actions": [
 			f"boss ai optimize {resume_name} --jd <jd_text>",
 			f"boss resume show {resume_name}",
@@ -394,6 +407,7 @@ def ai_fit_cmd(ctx: click.Context, resume_name: str, limit: int) -> None:
 			ctx,
 			"ai-fit",
 			{"results": [], "missing": [], "summary": {"analyzed": 0, "missing_details": 0}},
+			render=lambda d: render_ai_result(d, title="ai-fit"),
 			hints={"next_actions": ["boss shortlist add <security_id> <job_id>"]},
 		)
 		return
@@ -403,6 +417,7 @@ def ai_fit_cmd(ctx: click.Context, resume_name: str, limit: int) -> None:
 			ctx,
 			"ai-fit",
 			{"results": [], "missing": missing, "summary": {"analyzed": 0, "missing_details": len(missing)}},
+			render=lambda d: render_ai_result(d, title="ai-fit"),
 			hints={"next_actions": ["先对候选池职位执行 boss detail <security_id> 缓存详情后重试"]},
 		)
 		return
@@ -421,6 +436,7 @@ def ai_fit_cmd(ctx: click.Context, resume_name: str, limit: int) -> None:
 		ctx,
 		"ai-fit",
 		result,
+		render=lambda d: render_ai_result(d, title="ai-fit"),
 		hints={"next_actions": [f"boss ai optimize {resume_name} --jd <jd_text>"]},
 	)
 
@@ -471,6 +487,7 @@ def ai_reply_cmd(ctx: click.Context, recruiter_message: str, context: str, resum
 
 	handle_output(
 		ctx, "ai-reply", result,
+		render=lambda d: render_ai_result(d, title="ai-reply"),
 		hints={"next_actions": [
 			"复制草稿到 BOSS 聊天框发送",
 			"boss chatmsg <security_id> 查看完整聊天历史",
@@ -518,6 +535,7 @@ def ai_interview_prep_cmd(ctx: click.Context, jd_text: str, resume_name: str | N
 
 	handle_output(
 		ctx, "ai-interview-prep", result,
+		render=lambda d: render_ai_result(d, title="ai-interview-prep"),
 		hints={"next_actions": [
 			"对照 questions 逐题准备答案",
 			"boss ai chat-coach <chat_text> 用于沟通准备",
@@ -565,6 +583,7 @@ def ai_chat_coach_cmd(ctx: click.Context, chat_text: str, resume_name: str | Non
 
 	handle_output(
 		ctx, "ai-chat-coach", result,
+		render=lambda d: render_ai_result(d, title="ai-chat-coach"),
 		hints={"next_actions": [
 			"按 next_action_recommendation 的建议行动",
 			"message_templates 可直接复制发送",
@@ -589,6 +608,7 @@ def ai_suggest_keywords_cmd(ctx: click.Context, limit: int) -> None:
 			ctx,
 			"ai-suggest-keywords",
 			{"keyword_groups": [], "patterns": [], "search_suggestions": []},
+			render=lambda d: render_ai_result(d, title="ai-suggest-keywords"),
 			hints={"next_actions": ["boss shortlist add <security_id> <job_id>"]},
 		)
 		return
@@ -616,6 +636,7 @@ def ai_suggest_keywords_cmd(ctx: click.Context, limit: int) -> None:
 		ctx,
 		"ai-suggest-keywords",
 		result,
+		render=lambda d: render_ai_result(d, title="ai-suggest-keywords"),
 		hints={"next_actions": [
 			"boss search <推荐关键词>",
 			"boss preset add <name> --query <关键词>",
@@ -674,6 +695,7 @@ def ai_resume_optimize_cmd(ctx: click.Context, resume_name: str, jd_text: str | 
 
 	handle_output(
 		ctx, "ai-resume-optimize", result,
+		render=lambda d: render_ai_result(d, title="ai-resume-optimize"),
 		hints={"next_actions": [
 			f"boss resume edit {resume_name}",
 			f"boss ai optimize {resume_name} --jd <jd_text>",
@@ -742,6 +764,7 @@ def ai_cover_letter_cmd(
 	result.setdefault("highlights", [])
 	handle_output(
 		ctx, "ai-cover-letter", result,
+		render=lambda d: render_ai_result(d, title="ai-cover-letter"),
 		hints={
 			"note": "仅为 AI 生成的草稿，请自行核对真实性后再使用；本命令不发送任何消息",
 			"next_actions": [

--- a/src/boss_agent_cli/commands/ai_local.py
+++ b/src/boss_agent_cli/commands/ai_local.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import subprocess
 from dataclasses import asdict
+from typing import Any
 from pathlib import Path
 
 import click
@@ -17,7 +18,46 @@ from boss_agent_cli.ai.local_models import (
 	recommended_model_rows,
 )
 from boss_agent_cli.ai.service import AIService, AIServiceError
-from boss_agent_cli.display import handle_error_output, handle_output
+from rich.table import Table
+
+from boss_agent_cli import display
+from boss_agent_cli.display import handle_error_output, handle_output, render_action_result, render_next_steps
+
+
+def _render_local_status(data: dict[str, Any]) -> None:
+	"""本地模型配置 + 推荐清单（TTY 路径）。"""
+	state = "[green]已配置[/green]" if data.get("configured") else "[yellow]未配置[/yellow]"
+	display.console.print(f"本地模型：{state}")
+	if data.get("configured"):
+		display.console.print(f"  runtime: {data.get('provider') or '-'}    model: {data.get('model') or '-'}")
+		display.console.print(f"  base_url: {data.get('base_url') or '-'}")
+
+	rows = data.get("recommended_models") or []
+	if rows:
+		table = Table(title="推荐模型")
+		table.add_column("模型", style="bold cyan")
+		table.add_column("runtime", style="green")
+		table.add_column("最低内存", justify="right", style="yellow")
+		table.add_column("说明", style="dim", max_width=40)
+		for row in rows:
+			mark = " ★" if row.get("recommended") else ""
+			table.add_row(
+				f"{row.get('name', '-')}{mark}",
+				str(row.get("runtime", "-")),
+				f"{row.get('min_memory_gb', '-')} GB",
+				str(row.get("description", "")),
+			)
+		display.console.print(table)
+
+	imported = data.get("imported_models") or []
+	if imported:
+		display.console.print(f"  已导入 {len(imported)} 个本地模型")
+
+	render_next_steps(
+		["boss ai local smoke"]
+		if data.get("configured")
+		else ["boss ai local configure --runtime ollama --model qwen3:14b"]
+	)
 
 
 @click.group("local")
@@ -43,6 +83,7 @@ def local_status_cmd(ctx: click.Context) -> None:
 			"recommended_models": recommended_model_rows(),
 			"imported_models": [asdict(item) for item in read_imported_models(ctx.obj["data_dir"])],
 		},
+		render=_render_local_status,
 		hints={"next_actions": ["boss ai local configure --runtime ollama --model qwen3:14b"]},
 	)
 
@@ -67,6 +108,9 @@ def local_configure_cmd(ctx: click.Context, runtime: str, model: str, base_url: 
 		ctx,
 		"ai.local.configure",
 		{"runtime": runtime, "model": model, "base_url": store.get_base_url()},
+		render=lambda d: render_action_result(
+			d, title="ai local configure", next_steps=["boss ai local status", "boss ai local smoke"]
+		),
 		hints={"next_actions": ["boss ai local smoke", "boss ai local status"]},
 	)
 
@@ -101,7 +145,12 @@ def local_pull_cmd(ctx: click.Context, model: str, confirm_download: bool) -> No
 			recoverable=True,
 			recovery_action="确认 Ollama 已安装并可访问网络后重试",
 		)
-	handle_output(ctx, "ai.local.pull", {"status": "installed", "model": model})
+	handle_output(
+		ctx,
+		"ai.local.pull",
+		{"status": "installed", "model": model},
+		render=lambda d: render_action_result(d, title="ai local pull", next_steps=["boss ai local smoke"]),
+	)
 
 
 @ai_local_group.command("import")
@@ -124,7 +173,12 @@ def local_import_cmd(ctx: click.Context, source_path: Path, model: str) -> None:
 	store = AIConfigStore(ctx.obj["data_dir"])
 	store.save_config(ai_provider="custom", ai_model=model, ai_base_url=None)
 	store.save_api_key("local")
-	handle_output(ctx, "ai.local.import", asdict(imported))
+	handle_output(
+		ctx,
+		"ai.local.import",
+		asdict(imported),
+		render=lambda d: render_action_result(d, title="ai local import", next_steps=["boss ai local status"]),
+	)
 
 
 @ai_local_group.command("smoke")
@@ -167,4 +221,9 @@ def local_smoke_cmd(ctx: click.Context) -> None:
 			recoverable=True,
 			recovery_action="确认本地模型服务已启动后重试",
 		)
-	handle_output(ctx, "ai.local.smoke", {"status": "ok", "model": str(model), "reply": reply[:200]})
+	handle_output(
+		ctx,
+		"ai.local.smoke",
+		{"status": "ok", "model": str(model), "reply": reply[:200]},
+		render=lambda d: render_action_result(d, title="ai local smoke", next_steps=["boss ai analyze-jd <security_id>"]),
+	)

--- a/src/boss_agent_cli/commands/clean.py
+++ b/src/boss_agent_cli/commands/clean.py
@@ -6,10 +6,14 @@ import shutil
 import sqlite3
 import time
 from pathlib import Path
+from typing import Any
 
 import click
 
-from boss_agent_cli.display import handle_output
+from rich.table import Table
+
+from boss_agent_cli import display
+from boss_agent_cli.display import handle_output, render_next_steps
 
 
 @click.command("clean")
@@ -85,7 +89,41 @@ def clean_cmd(ctx: click.Context, dry_run: bool, clean_all: bool, privacy: bool,
 	else:
 		hints["next_actions"].append("boss doctor — 检查清理后环境状态")
 
-	handle_output(ctx, "clean", data, hints=hints)
+	handle_output(
+		ctx,
+		"clean",
+		data,
+		render=lambda d: _render_clean(d, hints["next_actions"]),
+		hints=hints,
+	)
+
+
+def _render_clean(data: dict[str, Any], next_steps: list[str]) -> None:
+	"""清理结果表格（TTY 路径）。dry-run 时明确标注未真正删除。"""
+	title = "clean（预演，未实际删除）" if data.get("dry_run") else "clean"
+	table = Table(title=title)
+	table.add_column("目标", style="bold cyan")
+	table.add_column("条数", justify="right", style="green")
+	table.add_column("释放", justify="right", style="yellow")
+	for row in data.get("results", []):
+		table.add_row(
+			str(row.get("target", "-")),
+			str(row.get("cleaned", 0)),
+			_human_bytes(row.get("bytes_freed", 0)),
+		)
+	display.console.print(table)
+	display.console.print(f"  合计释放 [bold]{data.get('total_bytes_freed_display', '0 B')}[/bold]")
+	render_next_steps(next_steps)
+
+
+def _human_bytes(value: int) -> str:
+	"""字节数转人类可读；与信封里的 total_bytes_freed_display 口径一致。"""
+	size = float(value)
+	for unit in ("B", "KB", "MB", "GB"):
+		if size < 1024 or unit == "GB":
+			return f"{int(size)} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+		size /= 1024
+	return f"{size:.1f} GB"
 
 
 def _clean_search_cache(data_dir: Path, *, dry_run: bool, clean_all: bool) -> tuple[int, int]:

--- a/src/boss_agent_cli/commands/crawl.py
+++ b/src/boss_agent_cli/commands/crawl.py
@@ -19,7 +19,12 @@ from boss_agent_cli.config import DEFAULTS
 from boss_agent_cli.crawler.operations import crawl_results, crawl_status, import_crawl_shortlist
 from boss_agent_cli.crawler.service import CrawlService, CrawlSettings
 from boss_agent_cli.crawler.transport import DrissionCrawlerSession
-from boss_agent_cli.display import handle_error_output, handle_output
+from boss_agent_cli.display import (
+	handle_error_output,
+	handle_output,
+	render_action_result,
+	render_record_result,
+)
 
 _HOOK_CHOICES = ("screenshot-full", "none")
 
@@ -200,7 +205,13 @@ def _run_service(ctx: click.Context, service_call: Any) -> None:
 		if outcome.status != "completed"
 		else {"next_actions": ["查看 output_paths 中的 JSON、CSV 或 XLSX 结果文件"]}
 	)
-	handle_output(ctx, "crawl", outcome.as_dict(), hints=hints)
+	handle_output(
+		ctx,
+		"crawl",
+		outcome.as_dict(),
+		render=lambda d: render_record_result(d, title="crawl", next_steps=hints.get("next_actions", [])),
+		hints=hints,
+	)
 
 
 def _launch_background_resume(
@@ -266,7 +277,12 @@ def configure_cmd(
 		"max_retries": max_retries,
 	}
 	configured = _save_crawl_config(Path(ctx.obj["data_dir"]), updates)
-	handle_output(ctx, "crawl.configure", {"crawl": configured})
+	handle_output(
+		ctx,
+		"crawl.configure",
+		{"crawl": configured},
+		render=lambda d: render_record_result(d, title="crawl configure", next_steps=["boss crawl run <关键词> --city <城市>"]),
+	)
 
 
 @crawl_group.command("run")
@@ -389,6 +405,9 @@ def start_cmd(
 			"background": True,
 			"checkpoint": {"resume_command": f"boss crawl resume {run_id}"},
 		},
+		render=lambda d: render_record_result(
+			d, title="crawl start", next_steps=[f"boss crawl status {run_id}", f"boss crawl stop {run_id}"]
+		),
 		hints={"next_actions": [f"boss crawl status {run_id}", f"boss crawl results {run_id}"]},
 	)
 
@@ -444,6 +463,7 @@ def resume_cmd(
 			ctx,
 			"crawl.resume",
 			{"run_id": run_id, "status": status if status in {"queued", "running"} else "queued", "background": True},
+			render=lambda d: render_action_result(d, title="crawl resume", next_steps=[f"boss crawl status {run_id}"]),
 			hints={"next_actions": [f"boss crawl status {run_id}"]},
 		)
 		return
@@ -470,7 +490,14 @@ def status_cmd(ctx: click.Context, run_id: str) -> None:
 	except KeyError:
 		handle_error_output(ctx, "crawl.status", code="JOB_NOT_FOUND", message=f"未找到 crawl run: {run_id}")
 		return
-	handle_output(ctx, "crawl.status", payload)
+	handle_output(
+		ctx,
+		"crawl.status",
+		payload,
+		render=lambda d: render_record_result(
+			d, title="crawl status", next_steps=[f"boss crawl results {run_id}", f"boss crawl stop {run_id}"]
+		),
+	)
 
 
 @crawl_group.command("stop")
@@ -482,7 +509,12 @@ def stop_cmd(ctx: click.Context, run_id: str) -> None:
 		if not cache.request_crawl_stop(run_id):
 			handle_error_output(ctx, "crawl.stop", code="JOB_NOT_FOUND", message=f"未找到 crawl run: {run_id}")
 			return
-	handle_output(ctx, "crawl.stop", {"run_id": run_id, "status": "stop_requested"})
+	handle_output(
+		ctx,
+		"crawl.stop",
+		{"run_id": run_id, "status": "stop_requested"},
+		render=lambda d: render_action_result(d, title="crawl stop", next_steps=[f"boss crawl status {run_id}"]),
+	)
 
 
 @crawl_group.command("results")
@@ -498,7 +530,12 @@ def results_cmd(ctx: click.Context, run_id: str, page: int | None, detail_status
 	except KeyError:
 		handle_error_output(ctx, "crawl.results", code="JOB_NOT_FOUND", message=f"未找到 crawl run: {run_id}")
 		return
-	handle_output(ctx, "crawl.results", payload)
+	handle_output(
+		ctx,
+		"crawl.results",
+		payload,
+		render=lambda d: render_record_result(d, title="crawl results", next_steps=[f"boss crawl shortlist {run_id}"]),
+	)
 
 
 @crawl_group.command("shortlist")
@@ -547,6 +584,7 @@ def shortlist_cmd(
 		ctx,
 		"crawl.shortlist",
 		payload,
+		render=lambda d: render_record_result(d, title="crawl shortlist", next_steps=["boss shortlist list"]),
 		hints={
 			"next_actions": [
 				"boss shortlist list",

--- a/src/boss_agent_cli/commands/preset.py
+++ b/src/boss_agent_cli/commands/preset.py
@@ -8,7 +8,7 @@ from boss_agent_cli.api.endpoints import (
 	STAGE_CODES,
 )
 from boss_agent_cli.cache.store import CacheStore
-from boss_agent_cli.display import handle_error_output, handle_output
+from boss_agent_cli.display import handle_error_output, handle_output, render_action_result, render_list_result
 from boss_agent_cli.search_filters import build_search_params
 
 
@@ -70,6 +70,9 @@ def preset_add_cmd(
 		ctx,
 		"preset",
 		{"action": "add", "name": name, "params": params},
+		render=lambda d: render_action_result(
+			d, title="preset", next_steps=[f"boss search --preset {name}", "boss preset list"]
+		),
 		hints={"next_actions": [f"boss search --preset {name}", "boss preset list"]},
 	)
 
@@ -83,6 +86,15 @@ def preset_list_cmd(ctx: click.Context) -> None:
 		ctx,
 		"preset",
 		items,
+		render=lambda d: render_list_result(
+			d,
+			"presets",
+			[("名称", "name", "bold cyan"), ("条件", "params", "green"), ("创建时间", "created_at", "dim")],
+			next_steps=["boss preset add <name> --query <关键词>"] if not d else [
+				"boss search --preset <name>",
+				"boss preset remove <name>",
+			],
+		),
 		hints={"next_actions": ["boss search --preset <name>", "boss preset remove <name>"]},
 	)
 
@@ -93,4 +105,9 @@ def preset_list_cmd(ctx: click.Context) -> None:
 def preset_remove_cmd(ctx: click.Context, name: str) -> None:
 	with CacheStore(ctx.obj["data_dir"] / "cache" / "boss_agent.db") as cache:
 		removed = cache.delete_saved_search(name)
-	handle_output(ctx, "preset", {"action": "remove", "name": name, "removed": removed})
+	handle_output(
+		ctx,
+		"preset",
+		{"action": "remove", "name": name, "removed": removed},
+		render=lambda d: render_action_result(d, title="preset", next_steps=["boss preset list"]),
+	)

--- a/src/boss_agent_cli/commands/resume_cmd.py
+++ b/src/boss_agent_cli/commands/resume_cmd.py
@@ -4,7 +4,13 @@ from typing import Any
 
 import click
 
-from boss_agent_cli.display import handle_error_output, handle_output
+from boss_agent_cli.display import (
+	handle_error_output,
+	handle_output,
+	render_action_result,
+	render_list_result,
+	render_record_result,
+)
 from boss_agent_cli.resume.models import ResumeData, PersonalInfoSection, resume_to_dict
 from boss_agent_cli.resume.store import ResumeStore
 
@@ -91,6 +97,9 @@ def resume_init_cmd(ctx: click.Context, name: str | None, template: str | None) 
 	handle_output(
 		ctx, "resume",
 		{"action": "init", "name": name, "template": template},
+		render=lambda d: render_action_result(
+			d, title="resume init", next_steps=[f"boss resume show {name}", f"boss resume edit {name} --field title --value <新标题>"]
+		),
 		hints={"next_actions": [
 			f"boss resume show {name}",
 			f"boss resume edit {name} --field title --value <新标题>",
@@ -107,6 +116,14 @@ def resume_list_cmd(ctx: click.Context) -> None:
 	items = store.list_all()
 	handle_output(
 		ctx, "resume", items,
+		render=lambda d: render_list_result(
+			d,
+			"resumes",
+			[("名称", "name", "bold cyan"), ("标题", "title", "green"), ("更新时间", "updated_at", "dim")],
+			next_steps=["boss resume init --template default"]
+			if not d
+			else ["boss resume show <name>", "boss resume init --template default"],
+		),
 		hints={"next_actions": ["boss resume show <name>", "boss resume init --template default"]},
 	)
 
@@ -124,6 +141,11 @@ def resume_show_cmd(ctx: click.Context, name: str) -> None:
 		return
 	handle_output(
 		ctx, "resume", resume_to_dict(resume),
+		render=lambda d: render_record_result(
+			d,
+			title="resume",
+			next_steps=[f"boss resume edit {name} --field title --value <新标题>", f"boss resume export {name} --format json"],
+		),
 		hints={"next_actions": [
 			f"boss resume edit {name} --field title --value <新标题>",
 			f"boss resume export {name} --format json",
@@ -161,6 +183,7 @@ def resume_edit_cmd(ctx: click.Context, name: str, field: str, value: str) -> No
 	handle_output(
 		ctx, "resume",
 		{"action": "edit", "name": name, "field": field, "value": value},
+		render=lambda d: render_action_result(d, title="resume edit", next_steps=[f"boss resume show {name}"]),
 		hints={"next_actions": [f"boss resume show {name}"]},
 	)
 
@@ -179,6 +202,7 @@ def resume_delete_cmd(ctx: click.Context, name: str) -> None:
 	handle_output(
 		ctx, "resume",
 		{"action": "delete", "name": name, "deleted": True},
+		render=lambda d: render_action_result(d, title="resume delete", next_steps=["boss resume list"]),
 		hints={"next_actions": ["boss resume list"]},
 	)
 
@@ -223,6 +247,7 @@ def resume_export_cmd(ctx: click.Context, name: str, fmt: str, output_path: Path
 		handle_output(
 			ctx, "resume",
 			{"action": "export", "name": name, "format": fmt, "path": str(out.resolve())},
+			render=lambda d: render_action_result(d, title="resume export", next_steps=[f"open {out.resolve()}"]),
 			hints={"next_actions": [f"boss resume show {name}"]},
 		)
 		return
@@ -232,6 +257,9 @@ def resume_export_cmd(ctx: click.Context, name: str, fmt: str, output_path: Path
 		Path(output_path).write_text(json_str, encoding="utf-8")
 	handle_output(
 		ctx, "resume", export_data,
+		render=lambda d: render_record_result(
+			d, title="resume export", next_steps=[f"boss resume show {name}"]
+		),
 		hints={"next_actions": [f"boss resume show {name}"]},
 	)
 
@@ -264,6 +292,7 @@ def resume_import_cmd(ctx: click.Context, file_path: Path) -> None:
 	handle_output(
 		ctx, "resume",
 		{"action": "import", "name": resume.name, "title": resume.title},
+		render=lambda d: render_action_result(d, title="resume import", next_steps=[f"boss resume show {resume.name}"]),
 		hints={"next_actions": [f"boss resume show {resume.name}"]},
 	)
 
@@ -292,6 +321,9 @@ def resume_clone_cmd(ctx: click.Context, name: str, new_name: str) -> None:
 	handle_output(
 		ctx, "resume",
 		{"action": "clone", "name": resume.name, "source": name},
+		render=lambda d: render_action_result(
+			d, title="resume clone", next_steps=[f"boss resume show {new_name}", f"boss resume diff {name} {new_name}"]
+		),
 		hints={"next_actions": [f"boss resume show {new_name}", f"boss resume diff {name} {new_name}"]},
 	)
 
@@ -319,6 +351,12 @@ def resume_diff_cmd(ctx: click.Context, name1: str, name2: str) -> None:
 	handle_output(
 		ctx, "resume",
 		{"name1": name1, "name2": name2, "diffs": diffs},
+		render=lambda d: render_list_result(
+			d.get("diffs", []),
+			f"diff: {name1} ↔ {name2}",
+			[("字段", "field", "bold cyan"), (name1, "left", "green"), (name2, "right", "yellow")],
+			next_steps=[f"boss resume show {name1}", f"boss resume show {name2}"],
+		),
 		hints={"next_actions": [f"boss resume show {name1}", f"boss resume show {name2}"]},
 	)
 
@@ -344,6 +382,9 @@ def resume_link_cmd(ctx: click.Context, name: str, security_id: str, job_id: str
 	handle_output(
 		ctx, "resume",
 		{"action": "link", "name": name, "security_id": security_id, "job_id": job_id},
+		render=lambda d: render_action_result(
+			d, title="resume link", next_steps=[f"boss resume applications {name}", f"boss apply {security_id} {job_id}"]
+		),
 		hints={"next_actions": [f"boss resume applications {name}", f"boss apply {security_id} {job_id}"]},
 	)
 
@@ -365,5 +406,11 @@ def resume_applications_cmd(ctx: click.Context, name: str) -> None:
 	handle_output(
 		ctx, "resume",
 		items,
+		render=lambda d: render_list_result(
+			d,
+			f"{name} 关联职位",
+			[("职位", "job_title", "bold cyan"), ("公司", "company", "green"), ("状态", "status", "yellow"), ("更新", "updated_at", "dim")],
+			next_steps=[f"boss resume link {name} <security_id> <job_id>"] if not d else [f"boss resume show {name}"],
+		),
 		hints={"next_actions": [f"boss resume show {name}"]},
 	)

--- a/src/boss_agent_cli/commands/stats.py
+++ b/src/boss_agent_cli/commands/stats.py
@@ -14,7 +14,9 @@ from pathlib import Path
 from typing import Any
 
 import click
+from rich.table import Table
 
+from boss_agent_cli import display
 from boss_agent_cli.display import handle_output
 
 
@@ -291,6 +293,48 @@ footer a {{ color: var(--accent); text-decoration: none; }}
 """
 
 
+def _render_stats(data: dict[str, Any]) -> None:
+	"""把漏斗统计渲染成终端表格（TTY 路径）。
+
+	兼容 ``_collect_stats`` 的两种形状：有缓存时含 ``window`` 段；
+	无缓存时 ``watch_hits`` 落在 ``funnel`` 内并带 ``note``。
+	"""
+	days = data.get("window_days", 30)
+	funnel = data.get("funnel", {})
+	window = data.get("window", {})
+	conversion = data.get("conversion", {})
+
+	table = Table(title=f"求职漏斗 · 最近 {days} 天")
+	table.add_column("阶段", style="bold cyan")
+	table.add_column("总计", justify="right", style="green")
+	table.add_column(f"近 {days} 天", justify="right", style="yellow")
+
+	for label, key in (("打招呼", "greeted"), ("投递", "applied"), ("候选池", "shortlist"), ("监控命中", "watch_hits")):
+		total = funnel.get(key)
+		recent = window.get(key)
+		table.add_row(label, "-" if total is None else str(total), "-" if recent is None else str(recent))
+	display.console.print(table)
+
+	display.console.print(f"  [dim]打招呼 → 投递[/dim]    {_percent(conversion.get('apply_rate'))}")
+	display.console.print(f"  [dim]打招呼 → 候选池[/dim]  {_percent(conversion.get('shortlist_rate'))}")
+
+	if note := data.get("note"):
+		display.console.print(f"\n  [yellow]{note}[/yellow]")
+
+	if hints := _build_hints(data):
+		display.console.print("\n  [bold]下一步：[/bold]")
+		for hint in hints:
+			display.console.print(f"    [dim]{hint}[/dim]")
+
+
+def _percent(value: Any) -> str:
+	"""把 0~1 的比率渲染成百分比；非数值返回占位符。"""
+	try:
+		return f"{round(float(value) * 100, 1)}%"
+	except (TypeError, ValueError):
+		return "-"
+
+
 @click.command("stats")
 @click.option("--days", default=30, type=int, help="统计窗口天数（默认 30 天）")
 @click.option(
@@ -328,4 +372,4 @@ def stats_cmd(ctx: click.Context, days: int, output_format: str, output_path: Pa
 			sys.stdout.flush()
 		return
 
-	handle_output(ctx, "stats", data, hints={"next_actions": _build_hints(data)})
+	handle_output(ctx, "stats", data, render=_render_stats, hints={"next_actions": _build_hints(data)})

--- a/src/boss_agent_cli/commands/stats.py
+++ b/src/boss_agent_cli/commands/stats.py
@@ -17,7 +17,7 @@ import click
 from rich.table import Table
 
 from boss_agent_cli import display
-from boss_agent_cli.display import handle_output
+from boss_agent_cli.display import handle_output, render_action_result
 
 
 def _safe_count(conn: sqlite3.Connection, table: str) -> int:
@@ -364,6 +364,7 @@ def stats_cmd(ctx: click.Context, days: int, output_format: str, output_path: Pa
 			handle_output(
 				ctx, "stats",
 				{"format": "html", "path": str(output_path), "bytes": len(html_text)},
+				render=lambda d: render_action_result(d, title="stats（HTML 报表）", next_steps=[f"open {output_path}"]),
 				hints={"next_actions": [f"open {output_path}"]},
 			)
 		else:

--- a/src/boss_agent_cli/commands/watch.py
+++ b/src/boss_agent_cli/commands/watch.py
@@ -12,7 +12,14 @@ from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.cache.store import CacheStore
 from boss_agent_cli.compliance import require_compliance_allowed
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import handle_auth_errors, handle_error_output, handle_output
+from boss_agent_cli.display import (
+	handle_auth_errors,
+	handle_error_output,
+	handle_output,
+	render_action_result,
+	render_list_result,
+	render_message_panel,
+)
 from boss_agent_cli.search_filters import SearchFilterCriteria, SearchPipelinePlatformError, build_search_params, resolve_welfare_keywords, run_search_pipeline
 
 
@@ -78,6 +85,9 @@ def watch_add_cmd(
 	handle_output(
 		ctx, "watch",
 		{"action": "add", "name": name, "params": params},
+		render=lambda d: render_action_result(
+			d, title="watch", next_steps=[f"boss watch run {name}", "boss watch list"]
+		),
 		hints={"next_actions": [f"boss watch run {name}", "boss watch list"]},
 	)
 
@@ -87,7 +97,20 @@ def watch_add_cmd(
 def watch_list_cmd(ctx: click.Context) -> None:
 	with CacheStore(ctx.obj["data_dir"] / "cache" / "boss_agent.db") as cache:
 		items = cache.list_saved_searches()
-	handle_output(ctx, "watch", items, hints={"next_actions": ["boss watch run <name>", "boss watch remove <name>"]})
+	handle_output(
+		ctx,
+		"watch",
+		items,
+		render=lambda d: render_list_result(
+			d,
+			"watches",
+			[("名称", "name", "bold cyan"), ("条件", "params", "green"), ("创建时间", "created_at", "dim")],
+			next_steps=["boss watch add <name> --query <关键词>"]
+			if not d
+			else ["boss watch run <name>", "boss watch remove <name>"],
+		),
+		hints={"next_actions": ["boss watch run <name>", "boss watch remove <name>"]},
+	)
 
 
 @watch_group.command("remove")
@@ -96,7 +119,12 @@ def watch_list_cmd(ctx: click.Context) -> None:
 def watch_remove_cmd(ctx: click.Context, name: str) -> None:
 	with CacheStore(ctx.obj["data_dir"] / "cache" / "boss_agent.db") as cache:
 		removed = cache.delete_saved_search(name)
-	handle_output(ctx, "watch", {"action": "remove", "name": name, "removed": removed})
+	handle_output(
+		ctx,
+		"watch",
+		{"action": "remove", "name": name, "removed": removed},
+		render=lambda d: render_action_result(d, title="watch", next_steps=["boss watch list"]),
+	)
 
 
 def _execute_single_watch(ctx: click.Context, cache: Any, name: str) -> dict[str, Any] | None:
@@ -178,6 +206,9 @@ def watch_run_cmd(ctx: click.Context, name: str | None, run_all: bool) -> None:
 			handle_output(
 				ctx, "watch",
 				{"mode": "all", "watches": watches, "total": len(watches)},
+				render=lambda d: render_message_panel(
+					{"模式": "全部", "监控数": d.get("total", 0)}, title="watch run"
+				),
 				hints={"next_actions": ["boss watch list", "boss detail <security_id>"]},
 			)
 			return
@@ -208,5 +239,6 @@ def watch_run_cmd(ctx: click.Context, name: str | None, run_all: bool) -> None:
 
 		handle_output(
 			ctx, "watch", summary,
+			render=lambda d: render_message_panel(d, title="watch run"),
 			hints={"next_actions": ["boss detail <security_id>", "boss watch list"]},
 		)

--- a/src/boss_agent_cli/display.py
+++ b/src/boss_agent_cli/display.py
@@ -409,6 +409,17 @@ def render_list_result(
 	render_next_steps(next_steps)
 
 
+def render_record_result(
+	data: dict[str, Any],
+	*,
+	title: str,
+	next_steps: "Sequence[str] | None" = None,
+) -> None:
+	"""多段记录类命令（resume show / export）的统一渲染：分段面板 + 下一步。"""
+	render_sectioned_record(data, title=title)
+	render_next_steps(next_steps)
+
+
 # ── Auth error decorator ─────────────────────────────────────────────
 
 

--- a/src/boss_agent_cli/display.py
+++ b/src/boss_agent_cli/display.py
@@ -6,6 +6,7 @@ Pipe mode (Agent): JSON envelope to stdout.
 """
 
 import sys
+from collections.abc import Sequence
 from typing import Any, Callable
 
 from rich.console import Console
@@ -363,6 +364,49 @@ def render_export_summary(data: dict[str, Any]) -> None:
 		console.print(f"[green]exported[/green] {count} jobs to [bold]{path}[/bold] ({fmt})")
 	else:
 		console.print(f"[green]exported[/green] {count} jobs ({fmt})")
+
+
+def render_next_steps(actions: "Sequence[str] | None") -> None:
+	"""把「下一步可以敲什么」渲染给真人。
+
+	与 ``render_operator_actions`` 的分工：后者渲染 ``hints.operator_actions``
+	（需要离开终端才能完成的动作，如扫码），由 ``handle_output`` 自动调用；
+	本函数由各命令自己的 renderer 主动调用，把该命令的后继命令提示出来。
+
+	这样既满足「空数据态要给可执行下一步」，又不改变 hints 双通道语义
+	——``next_actions`` 仍然只是 Agent 通道，不会被自动渲染到 TTY。
+	"""
+	if not actions:
+		return
+	console.print("\n  [bold]下一步：[/bold]")
+	for action in actions:
+		console.print(f"    [dim]{action}[/dim]")
+
+
+def render_action_result(
+	data: dict[str, Any],
+	*,
+	title: str,
+	next_steps: "Sequence[str] | None" = None,
+) -> None:
+	"""动作类命令（add / remove / init / export ...）的统一确认渲染。
+
+	替代直接回显 JSON：结果字段走面板，后继命令走 next_steps。
+	"""
+	render_message_panel(data, title=title)
+	render_next_steps(next_steps)
+
+
+def render_list_result(
+	items: list[dict[str, Any]],
+	title: str,
+	columns: list[tuple[str, str, str]],
+	*,
+	next_steps: "Sequence[str] | None" = None,
+) -> None:
+	"""列表类命令的统一渲染：表格 + 下一步；空列表也会给出下一步（AC4）。"""
+	render_simple_list(items, title, columns)
+	render_next_steps(next_steps)
 
 
 # ── Auth error decorator ─────────────────────────────────────────────

--- a/src/boss_agent_cli/display.py
+++ b/src/boss_agent_cli/display.py
@@ -10,6 +10,7 @@ from collections.abc import Sequence
 from typing import Any, Callable
 
 from rich.console import Console
+from rich.markup import escape
 from rich.panel import Panel
 from rich.table import Table
 
@@ -417,6 +418,43 @@ def render_record_result(
 ) -> None:
 	"""多段记录类命令（resume show / export）的统一渲染：分段面板 + 下一步。"""
 	render_sectioned_record(data, title=title)
+	render_next_steps(next_steps)
+
+
+def _ai_value_lines(value: Any) -> list[str]:
+	"""把单个 AI 返回值摊成可打印的行；全部转义，不截断。"""
+	if isinstance(value, list):
+		lines = []
+		for item in value:
+			if isinstance(item, dict):
+				inline = "  ".join(f"{k}={v}" for k, v in item.items())
+				lines.append(f"  · {escape(str(inline))}")
+			else:
+				lines.append(f"  · {escape(str(item))}")
+		return lines
+	if isinstance(value, dict):
+		return [f"  [bold]{escape(str(k))}:[/bold] {escape(str(v))}" for k, v in value.items()]
+	return [f"  {escape(str(value))}"]
+
+
+def render_ai_result(
+	data: dict[str, Any],
+	*,
+	title: str,
+	next_steps: "Sequence[str] | None" = None,
+) -> None:
+	"""AI 命令结果的渲染：键名作小标题，长文本整段展示。
+
+	AI 返回结构由 prompt 决定、跨命令不一致，因此不假设任何具体键名，
+	只按值类型决定呈现方式。所有值经 ``escape`` 处理——AI 输出里的方括号
+	不能被当成 Rich 标记解析。
+	"""
+	body: list[str] = []
+	for key, value in data.items():
+		body.append(f"[bold cyan]{escape(str(key))}[/bold cyan]")
+		body.extend(_ai_value_lines(value))
+		body.append("")
+	console.print(Panel("\n".join(body).rstrip() or "[dim]empty[/dim]", title=title, border_style="magenta"))
 	render_next_steps(next_steps)
 
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -752,3 +752,51 @@ class TestRenderListWithSteps:
 		out = stream.getvalue()
 
 		assert "简历A" in out and "简历B" in out
+
+
+class TestRenderAiResult:
+	def test_renders_scalar_and_list_values(self, monkeypatch):
+		from boss_agent_cli.display import render_ai_result
+
+		stream = _capture_display_console(monkeypatch)
+		render_ai_result(
+			{"匹配度": "85分", "优势": ["Go 经验充足", "分布式背景"], "建议": {"简历": "补充量化指标"}},
+			title="ai fit",
+		)
+		out = stream.getvalue()
+
+		assert "85分" in out
+		assert "Go 经验充足" in out
+		assert "分布式背景" in out
+		assert "补充量化指标" in out
+
+	def test_does_not_truncate_long_text(self, monkeypatch):
+		"""AI 长文本（润色后的简历等）不得被截断。"""
+		from boss_agent_cli.display import render_ai_result
+
+		unit = "补充项目量化指标。"
+		long_text = "优化建议：" + unit * 40
+		stream = _capture_display_console(monkeypatch)
+		render_ai_result({"内容": long_text}, title="ai polish")
+		# Panel 会给每行加 │ 边框并按宽度换行，比对前先去掉边框与空白
+		out = stream.getvalue().replace("│", "").replace("\n", "").replace(" ", "")
+
+		assert out.count(unit) == 40, f"长文本被截断，仅剩 {out.count(unit)} 段"
+
+	def test_escapes_rich_markup_from_ai_output(self, monkeypatch):
+		"""AI 输出里的方括号不得被当成 Rich 标记解析。"""
+		from boss_agent_cli.display import render_ai_result
+
+		stream = _capture_display_console(monkeypatch)
+		render_ai_result({"建议": "把 [bold]重点[/bold] 写在前面"}, title="ai suggest")
+		out = stream.getvalue()
+
+		assert "[bold]" in out, "方括号应原样显示而不是被解析成样式"
+
+	def test_renders_next_steps(self, monkeypatch):
+		from boss_agent_cli.display import render_ai_result
+
+		stream = _capture_display_console(monkeypatch)
+		render_ai_result({"x": "y"}, title="ai", next_steps=["boss ai optimize <name>"])
+
+		assert "boss ai optimize" in stream.getvalue()

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -666,3 +666,89 @@ class TestRenderOperatorActions:
 		output = stream.getvalue()
 		assert "确认二维码已完成扫码" in output
 		assert "boss login --timeout 180" not in output
+
+
+# ── 真人链路：下一步提示与动作确认渲染 ──────────────────────────
+
+
+class TestRenderNextSteps:
+	def test_renders_each_action(self, monkeypatch):
+		from boss_agent_cli.display import render_next_steps
+
+		stream = _capture_display_console(monkeypatch)
+		render_next_steps(["boss resume show x", "boss resume list"])
+		out = stream.getvalue()
+
+		assert "boss resume show x" in out
+		assert "boss resume list" in out
+		assert "下一步" in out
+
+	def test_empty_actions_render_nothing(self, monkeypatch):
+		from boss_agent_cli.display import render_next_steps
+
+		stream = _capture_display_console(monkeypatch)
+		render_next_steps([])
+
+		assert stream.getvalue() == ""
+
+	def test_none_renders_nothing(self, monkeypatch):
+		from boss_agent_cli.display import render_next_steps
+
+		stream = _capture_display_console(monkeypatch)
+		render_next_steps(None)
+
+		assert stream.getvalue() == ""
+
+
+class TestRenderActionResult:
+	def test_shows_fields_and_next_steps(self, monkeypatch):
+		from boss_agent_cli.display import render_action_result
+
+		stream = _capture_display_console(monkeypatch)
+		render_action_result(
+			{"action": "init", "name": "我的简历", "template": "default"},
+			title="resume",
+			next_steps=["boss resume show 我的简历"],
+		)
+		out = stream.getvalue()
+
+		assert "init" in out
+		assert "我的简历" in out
+		assert "boss resume show" in out
+		assert "{" not in out, "不应回显 JSON"
+
+	def test_works_without_next_steps(self, monkeypatch):
+		from boss_agent_cli.display import render_action_result
+
+		stream = _capture_display_console(monkeypatch)
+		render_action_result({"action": "remove", "name": "x", "removed": True}, title="preset")
+		out = stream.getvalue()
+
+		assert "remove" in out
+		assert "下一步" not in out
+
+
+class TestRenderListWithSteps:
+	def test_empty_list_still_gives_next_step(self, monkeypatch):
+		"""空列表必须给出可执行的下一步，而不是只说 no xxx（AC4）。"""
+		from boss_agent_cli.display import render_list_result
+
+		stream = _capture_display_console(monkeypatch)
+		render_list_result([], "resumes", [("name", "name", "cyan")], next_steps=["boss resume init"])
+		out = stream.getvalue()
+
+		assert "boss resume init" in out
+
+	def test_non_empty_list_renders_rows(self, monkeypatch):
+		from boss_agent_cli.display import render_list_result
+
+		stream = _capture_display_console(monkeypatch)
+		render_list_result(
+			[{"name": "简历A"}, {"name": "简历B"}],
+			"resumes",
+			[("name", "name", "cyan")],
+			next_steps=[],
+		)
+		out = stream.getvalue()
+
+		assert "简历A" in out and "简历B" in out

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -209,3 +209,91 @@ def test_stats_html_format_invalid_raises(tmp_path):
 	"""非法 --format 值应被 Click 拦截。"""
 	result = _invoke(tmp_path, "--format", "xml")
 	assert result.exit_code != 0
+
+
+# ── TTY 渲染（真人链路）────────────────────────────────────────────
+
+
+def _capture_console(monkeypatch):
+	"""替换 display.console 为可捕获的非终端 Console，返回缓冲区。"""
+	import io
+
+	from rich.console import Console
+
+	stream = io.StringIO()
+	monkeypatch.setattr("boss_agent_cli.display.console", Console(file=stream, force_terminal=False, width=100))
+	return stream
+
+
+def test_render_stats_shows_funnel_counts(monkeypatch):
+	"""渲染应展示漏斗各阶段计数，而不是 JSON。"""
+	from boss_agent_cli.commands.stats import _render_stats
+
+	stream = _capture_console(monkeypatch)
+	_render_stats({
+		"window_days": 30,
+		"funnel": {"greeted": 12, "applied": 3, "shortlist": 8},
+		"window": {"greeted": 5, "applied": 1, "shortlist": 2, "watch_hits": 4},
+		"conversion": {"apply_rate": 0.25, "shortlist_rate": 0.6667, "apply_rate_window": 0.2},
+	})
+	out = stream.getvalue()
+
+	assert "12" in out and "3" in out and "8" in out
+	assert "打招呼" in out
+	assert "{" not in out, "TTY 渲染不应出现 JSON"
+
+
+def test_render_stats_shows_conversion_rate_as_percent(monkeypatch):
+	"""转化率应渲染为百分比，而不是裸小数。"""
+	from boss_agent_cli.commands.stats import _render_stats
+
+	stream = _capture_console(monkeypatch)
+	_render_stats({
+		"window_days": 30,
+		"funnel": {"greeted": 12, "applied": 3, "shortlist": 8},
+		"window": {"greeted": 5, "applied": 1, "shortlist": 2, "watch_hits": 4},
+		"conversion": {"apply_rate": 0.25, "shortlist_rate": 0.6667, "apply_rate_window": 0.2},
+	})
+	out = stream.getvalue()
+
+	assert "25.0%" in out
+	assert "0.25" not in out
+
+
+def test_render_stats_empty_state_gives_next_step(monkeypatch):
+	"""空数据态必须给出可执行的下一步，而不是空表骨架（AC4）。"""
+	from boss_agent_cli.commands.stats import _render_stats
+
+	stream = _capture_console(monkeypatch)
+	_render_stats({
+		"funnel": {"greeted": 0, "applied": 0, "shortlist": 0, "watch_hits": 0},
+		"conversion": {"apply_rate": 0.0, "shortlist_rate": 0.0},
+		"window_days": 30,
+		"note": "缓存尚未建立，先跑一次 search/greet/apply 再查看",
+	})
+	out = stream.getvalue()
+
+	assert "boss search" in out, "空态应提示下一步命令"
+	assert "{" not in out
+
+
+def test_stats_tty_path_writes_nothing_to_stdout(tmp_path, monkeypatch):
+	"""TTY 下 render 生效时 stdout 必须干净（AC2）。"""
+	_capture_console(monkeypatch)
+	monkeypatch.setattr("boss_agent_cli.display.is_json_mode", lambda ctx: False)
+
+	result = CliRunner().invoke(cli, ["--data-dir", str(tmp_path), "stats"])
+
+	assert result.exit_code == 0
+	assert result.stdout.strip() == "", f"TTY 下 stdout 应为空，实际: {result.stdout!r}"
+
+
+def test_stats_json_path_unchanged(tmp_path):
+	"""管道 / --json 路径必须仍是单行 JSON 信封（AC3）。"""
+	result = _invoke(tmp_path)
+
+	assert result.exit_code == 0
+	payload = json.loads(result.stdout)
+	assert payload["ok"] is True
+	assert payload["command"] == "stats"
+	assert "funnel" in payload["data"]


### PR DESCRIPTION
## 背景

TTY 下仍有一批命令直接把 JSON 信封吐给真人看。`stats` / `preset` / `watch` / `clean` /
`ai-local` / `resume` / `ai` / `crawl` / `agent` 这 9 个文件共 63 处 `handle_output`
没有渲染分支，真人跑 `boss stats` 只能自己读信封字段。

## 改动

按命令组拆 5 个提交逐步接线，每步自带测试：

| 提交 | 范围 |
| --- | --- |
| `ce39365` | `stats`：求职漏斗表格 + 转化率 + 下一步引导 |
| `76c5f5e` | `preset` / `watch` / `clean` / `ai-local` |
| `8c43ec0` | `resume` 12 个子命令：列表走表格、show/export 走分段面板、diff 走差异表、动作类走确认面板 |
| `e7e4585` | `ai` 16 处输出 |
| `94c82c0` | `crawl` 8 处、`agent` 11 处，并补上 `stats` HTML 导出回执遗漏的渲染 |

`display.py` 新增几个通用渲染件供后续命令复用：

- `render_next_steps` / `render_action_result`：动作类命令渲染确认面板
- `render_list_result`：列表类命令空态也给出可执行的下一步
- `render_record_result`：记录详情走分段面板
- `render_ai_result`：AI 返回结构随 prompt 变化，故不假设键名、只按值类型呈现；长文本不截断；所有值经 `escape` 处理，避免 AI 输出里的方括号被 Rich 当成标记解析

顺带把 `.pi/` 补进 `.gitignore`——Trellis 为 Pi 平台生成的本地 agent 配置目录，
与已忽略的 `.claude/` `.codex/` `.trellis/` 同类，此前漏了一行。

## 不变量

- stdout 仍只有单行 JSON 信封，渲染全部走 stderr
- 管道 / `--json` 路径逐字未动
- 不改 `hints` 双通道语义：`next_actions` 仍只是 Agent 通道，由各 renderer 自行决定给真人看什么
- 无命令表变更（`register.py` / `schema.py` 未动），命令数与 MCP 工具数计数不受影响

## 验证

`uv run python scripts/quality_baseline.py`

- [x] ruff：`All checks passed!`
- [x] pytest：`1820 passed`（新增 `tests/test_display.py`、`tests/test_stats.py` 用例）
- [x] mypy：`Success: no issues found in 149 source files`
