### PR TITLE
feat: 向导统一为单交互窗口并修正终端呈现缺陷

### DIFF
--- a/src/boss_agent_cli/commands/search.py
+++ b/src/boss_agent_cli/commands/search.py
@@ -9,7 +9,15 @@ from boss_agent_cli.api.endpoints import (
 from boss_agent_cli.auth.manager import AuthManager
 from boss_agent_cli.cache.store import CacheStore
 from boss_agent_cli.commands._platform import get_platform_instance
-from boss_agent_cli.display import boss_command_for_ctx, handle_auth_errors, handle_error_output, handle_output, render_job_table
+from boss_agent_cli.display import (
+	SearchProgress,
+	boss_command_for_ctx,
+	handle_auth_errors,
+	handle_error_output,
+	handle_output,
+	is_json_mode,
+	render_job_table,
+)
 from boss_agent_cli.index_cache import try_save_index
 from boss_agent_cli.match_score import score_job_dict
 from boss_agent_cli.search_filters import (
@@ -31,6 +39,16 @@ def _sort_search_items(items: list[dict[str, Any]], sort: str) -> list[dict[str,
 	if sort == "score":
 		return sorted(items, key=lambda item: item.get("match_score", 0), reverse=True)
 	return items
+
+
+def _progress_title(criteria: SearchFilterCriteria, welfare_conditions: Any) -> str:
+	"""进度头部：把本次搜索条件浓缩成一行，让真人知道正在跑什么。"""
+	parts = [f"搜索 {criteria.query}"]
+	if criteria.city:
+		parts.append(str(criteria.city))
+	if welfare_conditions:
+		parts.append(",".join(label for label, _ in welfare_conditions))
+	return " · ".join(parts)
 
 
 @click.command("search")
@@ -172,11 +190,18 @@ def search_cmd(
 		auth = AuthManager(data_dir, logger=logger, platform=ctx.obj.get("platform", "zhipin"))
 		with get_platform_instance(ctx, auth) as platform:
 			max_pages = 5 if welfare_conditions else 1
+			# TTY 下把管线日志接到 Rich 进度；管道 / --json 仍用原 logger，行为不变。
+			progress = None
+			pipeline_logger: Any = logger
+			if not is_json_mode(ctx):
+				progress = SearchProgress(_progress_title(criteria, welfare_conditions), max_pages=max_pages)
+				progress.start()
+				pipeline_logger = progress
 			try:
 				pipeline_result = execute_candidate_search(
 					platform,
 					cache,
-					logger,
+					pipeline_logger,
 					{
 						"query": criteria.query,
 						"city": criteria.city,
@@ -203,6 +228,9 @@ def search_cmd(
 					details=exc.details,
 				)
 				return
+			finally:
+				if progress is not None:
+					progress.finish()
 			items = pipeline_result.items
 			if with_score:
 				items = [score_job_dict(item, criteria=criteria, expect_data=None) for item in items]

--- a/src/boss_agent_cli/commands/wizard.py
+++ b/src/boss_agent_cli/commands/wizard.py
@@ -30,6 +30,7 @@ from boss_agent_cli.wizard.renderer import (
 	render_error,
 	render_event,
 	render_run,
+	wizard_screen,
 )
 from boss_agent_cli.wizard.runner import WorkflowActionError, WorkflowRunner
 from boss_agent_cli.wizard.store import WorkflowStore
@@ -578,12 +579,16 @@ def run_wizard_command(
 
 		# 纯 TTY 无 flag：多轮主菜单循环；flag / headless 仍是单次执行。
 		if interactive and not selectors:
-			_run_interactive_session(
-				ctx,
-				store,
-				timeout_seconds=timeout_seconds,
-				max_retries=max_retries,
-			)
+			# 整个多轮会话独占一块备用屏：退出后终端恢复原样，不留残框。
+			# 单次 flag 路径（--status/--resume/--stop）刻意不进——一进一出会把
+			# 刚渲染的内容直接抹掉，用户什么都看不到。
+			with wizard_screen():
+				_run_interactive_session(
+					ctx,
+					store,
+					timeout_seconds=timeout_seconds,
+					max_retries=max_retries,
+				)
 			return
 
 		try:

--- a/src/boss_agent_cli/commands/wizard.py
+++ b/src/boss_agent_cli/commands/wizard.py
@@ -161,7 +161,8 @@ def _run_plan(
 	):
 		list_run = run
 		if has_result_follow_up(list_run):
-			render_run(list_run)
+			# 摘要由 collect_result_follow_up 在每页菜单前重绘；这里再画一次会因为
+			# clear_wizard_screen 只清可视屏、不清 scrollback 而留下一个残框。
 			return _browse_list_results(
 				ctx,
 				store,

--- a/src/boss_agent_cli/display.py
+++ b/src/boss_agent_cli/display.py
@@ -6,6 +6,7 @@ Pipe mode (Agent): JSON envelope to stdout.
 """
 
 import sys
+import threading
 from collections.abc import Sequence
 from typing import Any, Callable
 
@@ -456,6 +457,77 @@ def render_ai_result(
 		body.append("")
 	console.print(Panel("\n".join(body).rstrip() or "[dim]empty[/dim]", title=title, border_style="magenta"))
 	render_next_steps(next_steps)
+
+
+class SearchProgress:
+	"""``search`` 长任务的 TTY 进度（鸭子类型兼容 ``output.Logger``）。
+
+	只在 TTY 下注入；管道 / ``--json`` 路径仍传原 Logger，行为与改造前完全一致。
+
+	为什么走 logger 注入而不是降低全局日志级别：``output.Logger`` 用裸
+	``print(file=sys.stderr)``，与 Rich 抢同一个流；而详情补抓跑在
+	``ThreadPoolExecutor`` 里，无锁裸 print 会交错。这里统一走 Rich Console
+	（内部有锁）并自带计数锁。
+
+	消息分类依赖 ``search_filters`` 的进度文案标记，该耦合由
+	``test_search_pipeline_progress_markers_contract`` 锁定。
+	"""
+
+	_PAGE_PREFIX = "正在搜索第"
+	_MATCH_MARK = "✅"
+	_EXCLUDE_MARKS = ("❌", "预筛排除")
+
+	def __init__(self, title: str, *, max_pages: int = 1) -> None:
+		self._title = title
+		self._max_pages = max(1, max_pages)
+		self._lock = threading.Lock()
+		self.pages = 0
+		self.matched = 0
+		self.excluded = 0
+
+	# ── Logger 接口 ────────────────────────────────────────
+
+	def info(self, message: str) -> None:
+		text = message.strip()
+		if text.startswith(self._PAGE_PREFIX):
+			with self._lock:
+				self.pages += 1
+			return
+		if text.startswith(self._MATCH_MARK):
+			with self._lock:
+				self.matched += 1
+			console.print(f"  [green]✓[/green] {escape(text.lstrip(self._MATCH_MARK).strip())}")
+			return
+		if any(text.startswith(mark) for mark in self._EXCLUDE_MARKS):
+			# 逐条排除只计数不打印——刷屏会把真正有用的匹配结果冲掉
+			with self._lock:
+				self.excluded += 1
+			return
+
+	def debug(self, message: str) -> None:
+		"""调试细节不进 TTY 进度。"""
+
+	def warning(self, message: str) -> None:
+		console.print(f"  [yellow]{escape(message.strip())}[/yellow]")
+
+	def error(self, message: str) -> None:
+		console.print(f"  [red]{escape(message.strip())}[/red]")
+
+	# ── 状态行 ─────────────────────────────────────────────
+
+	def status_text(self) -> str:
+		with self._lock:
+			parts = [f"第 {self.pages}/{self._max_pages} 页" if self.pages else "准备中"]
+			parts.append(f"匹配 {self.matched}")
+			if self.excluded:
+				parts.append(f"排除 {self.excluded}")
+		return " · ".join(parts)
+
+	def start(self) -> None:
+		console.print(f"[bold]{escape(self._title)}[/bold]")
+
+	def finish(self) -> None:
+		console.print(f"  [dim]{escape(self.status_text())}[/dim]")
 
 
 # ── Auth error decorator ─────────────────────────────────────────────

--- a/src/boss_agent_cli/output.py
+++ b/src/boss_agent_cli/output.py
@@ -23,6 +23,11 @@ _SENSITIVE_KEY_PARTS = (
 _PUBLIC_METADATA_KEYS = {
 	"private_fields",
 }
+# 凭据必然是字符串或容器。数值 / 布尔 / None 命中关键词一律是子串误报——
+# 例如 ai_max_tokens（AI 生成长度上限）、token_expires_in（过期秒数）都含
+# 子串 "token"，脱敏后用户永远看不到自己配的值，None 更会被说成藏着秘密。
+# 已扫描全仓：不存在数值型真凭据，因此放宽不会漏脱敏。
+_NON_CREDENTIAL_TYPES = (bool, int, float, type(None))
 _SENSITIVE_TEXT_PATTERNS = tuple(
 	re.compile(pattern, re.IGNORECASE)
 	for pattern in (
@@ -53,7 +58,7 @@ def redact_sensitive(value: Any) -> Any:
 			key_text = str(key).lower()
 			if _is_error_code_metadata(item) or key_text in _PUBLIC_METADATA_KEYS:
 				redacted[key] = redact_sensitive(item)
-			elif any(part in key_text for part in _SENSITIVE_KEY_PARTS) and not isinstance(item, bool):
+			elif any(part in key_text for part in _SENSITIVE_KEY_PARTS) and not isinstance(item, _NON_CREDENTIAL_TYPES):
 				redacted[key] = _REDACTED
 			else:
 				redacted[key] = redact_sensitive(item)

--- a/src/boss_agent_cli/wizard/prompts.py
+++ b/src/boss_agent_cli/wizard/prompts.py
@@ -1245,7 +1245,7 @@ def _render_list_header(run: Mapping[str, Any]) -> None:
 	from boss_agent_cli.wizard import renderer
 
 	renderer.clear_wizard_screen()
-	renderer.render_run(run)
+	renderer.render_run(run, with_preview=False)
 
 
 def collect_result_follow_up(

--- a/src/boss_agent_cli/wizard/prompts.py
+++ b/src/boss_agent_cli/wizard/prompts.py
@@ -254,6 +254,66 @@ def _advanced_terminal_available() -> bool:
 	return True
 
 
+def _menu_content_lines(
+	items: Sequence[MenuOption],
+	*,
+	selected: int,
+	title: str,
+) -> list[tuple[str, str]]:
+	# Same-line description, left-aligned as a column after padded labels:
+	#   ○  浏览职位列表          ·  选择职位查看详情或打招呼
+	#   ○  返回主菜单            ·  稍后再处理
+	content_label_w, nav_label_w = _menu_label_widths(items)
+	lines: list[tuple[str, str]] = [
+		("class:hint", "↑↓ 选择  ·  Enter 确认  ·  ←/Esc 返回\n\n"),
+	]
+	saw_nav = False
+	for index, item in enumerate(items):
+		is_nav = _is_nav_option(item)
+		if is_nav and not saw_nav:
+			# Separate content choices from paging / exit controls.
+			lines.append(("class:sep", "  ────────────────────────\n"))
+			saw_nav = True
+		active = index == selected
+		desc = _format_menu_description(item.description)
+		if is_nav:
+			marker = "▸" if active else " "
+			style = "class:nav-selected" if active else "class:nav"
+			label = _pad_label(item.label, nav_label_w) if desc else item.label
+			# Indent nav under content; explanations share one left edge.
+			lines.append((style, f"    {marker} {label}"))
+			if desc:
+				lines.append(("class:nav-desc", f"  ·  {desc}"))
+			lines.append(("", "\n"))
+		else:
+			marker = "●" if active else "○"
+			style = "class:selected" if active else "class:item"
+			prefix = "▌ " if active else "  "
+			label = _pad_label(item.label, content_label_w) if desc else item.label
+			# Only pad when any peer has a description; still left-align the "·" column.
+			if not desc and any(
+				(getattr(peer, "description", None) and not _is_nav_option(peer)) for peer in items
+			):
+				label = _pad_label(item.label, content_label_w)
+			lines.append((style, f"{prefix}{marker}  {label}"))
+			if desc:
+				lines.append(("class:description", f"  ·  {desc}"))
+			lines.append(("", "\n"))
+	return lines
+
+
+def _build_menu_container(title: str, control: Any) -> Any:
+	"""把菜单内容包进带标题的边框（D1：标题用当前步骤）。
+
+	抽成模块级函数是为了可测：_advanced_terminal_available() 在 pytest 下恒 False，
+	select() 整条 prompt_toolkit 分支跑不到，只能直接断言这里返回的结构。
+	"""
+	from prompt_toolkit.layout.containers import HSplit, Window
+	from prompt_toolkit.widgets import Frame
+
+	return Frame(HSplit([Window(control)]), title=title, style="class:frame")
+
+
 class PromptToolkitMenu:
 	"""Arrow-key menu whose input and rendering are bound to stderr."""
 
@@ -268,12 +328,10 @@ class PromptToolkitMenu:
 		clear_before: bool = True,
 	) -> str:
 		from prompt_toolkit.application import Application
-		from prompt_toolkit.formatted_text import HTML
 		from prompt_toolkit.input.defaults import create_input
 		from prompt_toolkit.key_binding import KeyBindings
 		from prompt_toolkit.layout import Layout
 		from prompt_toolkit.layout.controls import FormattedTextControl
-		from prompt_toolkit.layout.containers import HSplit, Window
 		from prompt_toolkit.output.defaults import create_output
 		from prompt_toolkit.styles import Style
 
@@ -286,46 +344,7 @@ class PromptToolkitMenu:
 		content_label_w, nav_label_w = _menu_label_widths(items)
 
 		def content() -> list[tuple[str, str]]:
-			# Same-line description, left-aligned as a column after padded labels:
-			#   ○  浏览职位列表          ·  选择职位查看详情或打招呼
-			#   ○  返回主菜单            ·  稍后再处理
-			lines: list[tuple[str, str]] = [
-				("class:title", f"{title}\n"),
-				("class:hint", "↑↓ 选择  ·  Enter 确认  ·  ←/Esc 返回\n\n"),
-			]
-			saw_nav = False
-			for index, item in enumerate(items):
-				is_nav = _is_nav_option(item)
-				if is_nav and not saw_nav:
-					# Separate content choices from paging / exit controls.
-					lines.append(("class:sep", "  ────────────────────────\n"))
-					saw_nav = True
-				active = index == selected
-				desc = _format_menu_description(item.description)
-				if is_nav:
-					marker = "▸" if active else " "
-					style = "class:nav-selected" if active else "class:nav"
-					label = _pad_label(item.label, nav_label_w) if desc else item.label
-					# Indent nav under content; explanations share one left edge.
-					lines.append((style, f"    {marker} {label}"))
-					if desc:
-						lines.append(("class:nav-desc", f"  ·  {desc}"))
-					lines.append(("", "\n"))
-				else:
-					marker = "●" if active else "○"
-					style = "class:selected" if active else "class:item"
-					prefix = "▌ " if active else "  "
-					label = _pad_label(item.label, content_label_w) if desc else item.label
-					# Only pad when any peer has a description; still left-align the "·" column.
-					if not desc and any(
-						(getattr(peer, "description", None) and not _is_nav_option(peer)) for peer in items
-					):
-						label = _pad_label(item.label, content_label_w)
-					lines.append((style, f"{prefix}{marker}  {label}"))
-					if desc:
-						lines.append(("class:description", f"  ·  {desc}"))
-					lines.append(("", "\n"))
-			return lines
+			return _menu_content_lines(items, selected=selected, title=title)
 
 		control = FormattedTextControl(cast(Any, content), focusable=True)
 		bindings = KeyBindings()
@@ -359,19 +378,12 @@ class PromptToolkitMenu:
 			event.app.exit(result=_EXIT)
 
 		application: Application[str] = Application(
-			layout=Layout(
-				HSplit(
-					[
-						Window(FormattedTextControl(HTML("<b>BOSS 求职助手</b>")), height=1),
-						Window(height=1),
-						Window(control),
-					]
-				)
-			),
+			layout=Layout(_build_menu_container(title, control)),
 			key_bindings=bindings,
 			style=Style.from_dict(
 				{
 					"title": "bold #00a6a6",
+					"frame": "#00a6a6",
 					"hint": "#6b7280",
 					"selected": "bold reverse #00a6a6",
 					"item": "",

--- a/src/boss_agent_cli/wizard/prompts.py
+++ b/src/boss_agent_cli/wizard/prompts.py
@@ -1235,6 +1235,19 @@ def has_result_follow_up(run: Mapping[str, Any]) -> bool:
 	return resolved is not None and bool(resolved[0])
 
 
+def _render_list_header(run: Mapping[str, Any]) -> None:
+	"""在结果列表菜单上方重绘任务摘要。
+
+	与「重新进入任务状态」走同一套三段式（清屏 → 摘要 → 菜单不再清屏），
+	让两个入口看到同一个框。放在翻页循环内是必需的：只靠一次渲染 + 常驻
+	不清屏会让菜单层层堆叠，翻一页就丢摘要。
+	"""
+	from boss_agent_cli.wizard import renderer
+
+	renderer.clear_wizard_screen()
+	renderer.render_run(run)
+
+
 def collect_result_follow_up(
 	run: Mapping[str, Any],
 	*,
@@ -1269,11 +1282,13 @@ def collect_result_follow_up(
 				options.append(MenuOption(_RESULT_MORE, f"› 下一页 · 还有 {remaining} 条", kind="nav"))
 			options.append(MenuOption(_RESULT_DONE, "结束浏览", "返回上一级", kind="nav"))
 			end = start + len(chunk)
+			_render_list_header(run)
 			selected = driver.select(
 				f"请选择职位（第 {start + 1}–{end} / 共 {len(items)} 条）",
 				options,
 				default=str(start) if chunk else _RESULT_DONE,
 				allow_back=True,
+				clear_before=False,
 			)
 			if selected == _RESULT_DONE:
 				return None

--- a/src/boss_agent_cli/wizard/renderer.py
+++ b/src/boss_agent_cli/wizard/renderer.py
@@ -379,8 +379,12 @@ def render_result_preview(items: list[Mapping[str, Any]], *, kind: str) -> None:
 	display.console.print(Panel(table, title=f"共 {min(len(items), 20)} 条", border_style="cyan"))
 
 
-def render_run(run: Mapping[str, Any]) -> None:
-	"""Single, human-first summary: content card or one error panel — not a debug dump."""
+def render_run(run: Mapping[str, Any], *, with_preview: bool = True) -> None:
+	"""Single, human-first summary: content card or one error panel — not a debug dump.
+
+	``with_preview=False`` 用于结果列表上方：那里下方已有可选职位菜单，
+	框里再列一遍职位既冗余、页码也跟菜单对不上。
+	"""
 	status = str(run.get("status") or "")
 	if status == "failed":
 		error = run.get("error") or {}
@@ -393,7 +397,7 @@ def render_run(run: Mapping[str, Any]) -> None:
 
 	# Stale waiting_input after a later successful crawl: show results, not a yellow wait card.
 	if status == "waiting_input" and run.get("effective_completed"):
-		if _render_crawl_summary(run):
+		if _render_crawl_summary(run, with_preview=with_preview):
 			return
 
 	if status == "waiting_input":
@@ -403,7 +407,7 @@ def render_run(run: Mapping[str, Any]) -> None:
 		live = str(data.get("live_crawl_status") or data.get("status") or "")
 		jobs_seen = data.get("jobs_seen")
 		if live == "completed" and int(jobs_seen or 0) > 0:
-			if _render_crawl_summary(run):
+			if _render_crawl_summary(run, with_preview=with_preview):
 				return
 		reason = str(data.get("error") or last.get("next_action") or "需要补充信息或人工处理后才能继续")
 		inner = data.get("run_id")
@@ -447,7 +451,7 @@ def render_run(run: Mapping[str, Any]) -> None:
 		return
 
 	# Crawl goals own a dedicated summary (metadata + sample titles + paths).
-	if _render_crawl_summary(run):
+	if _render_crawl_summary(run, with_preview=with_preview):
 		return
 
 	# Management / digest / AI / empty-list friendly summaries.
@@ -1034,7 +1038,7 @@ def _render_job_preview_table(
 	return table
 
 
-def _render_crawl_summary(run: Mapping[str, Any]) -> bool:
+def _render_crawl_summary(run: Mapping[str, Any], *, with_preview: bool = True) -> bool:
 	"""Rich summary for crawl_start/resume/status results. Returns True if rendered."""
 	from rich.console import Group
 	from rich.rule import Rule
@@ -1152,7 +1156,7 @@ def _render_crawl_summary(run: Mapping[str, Any]) -> bool:
 			row("下一步", f"[bold]{next_action}[/bold]")
 
 	# ── Preview under meta: Markdown-style pipe table ───────────────
-	preview_rows = _preview_jobs_from_data(data, limit=5)
+	preview_rows = _preview_jobs_from_data(data, limit=5) if with_preview else []
 	parts: list[Any] = [headline, Text(""), meta]
 
 	if preview_rows:

--- a/src/boss_agent_cli/wizard/renderer.py
+++ b/src/boss_agent_cli/wizard/renderer.py
@@ -146,17 +146,47 @@ def render_event(kind: str, step: str, data: Mapping[str, Any] | None) -> None:
 		display.console.print(f"[yellow]正在重试[/yellow] {label}（第 {attempt} 次）")
 
 
-def clear_wizard_screen() -> None:
-	"""Clear the terminal so only the current wizard page remains visible."""
-	if (
+def _screen_control_unavailable() -> bool:
+	"""True 时一切屏幕控制都退化为 no-op：测试 / 非 TTY / dumb terminal。"""
+	return bool(
 		os.environ.get("PYTEST_CURRENT_TEST")
 		or not sys.stderr.isatty()
 		or os.environ.get("TERM", "").lower() in {"", "dumb", "unknown"}
-	):
+	)
+
+
+def clear_wizard_screen() -> None:
+	"""Clear the terminal so only the current wizard page remains visible."""
+	if _screen_control_unavailable():
 		return
 	# Home + clear scrollback-friendly clear for most terminals.
 	sys.stderr.write("\033[H\033[2J")
 	sys.stderr.flush()
+
+
+@contextmanager
+def wizard_screen() -> Iterator[None]:
+	"""让整个交互会话独占一块备用屏缓冲。
+
+	进入切 alternate screen、退出还原：向导期间终端像一个独立窗口，
+	退出后原有内容完好，全程不往 scrollback 里留残框——clear_wizard_screen
+	的 \033[2J 只清可视屏，清不掉历史，这是真人反馈里「上滚看到两个框」的根因。
+
+	必须是 context manager：commands/wizard.py 有 59 处 return，
+	外加内部会 raise SystemExit，逐点还原必然漏掉某条路径。
+
+	非 TTY / dumb terminal / 测试下是 no-op，Agent 与管道路径完全不受影响。
+	"""
+	if _screen_control_unavailable():
+		yield
+		return
+	sys.stderr.write("\033[?1049h")
+	sys.stderr.flush()
+	try:
+		yield
+	finally:
+		sys.stderr.write("\033[?1049l")
+		sys.stderr.flush()
 
 
 @contextmanager

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -800,3 +800,86 @@ class TestRenderAiResult:
 		render_ai_result({"x": "y"}, title="ai", next_steps=["boss ai optimize <name>"])
 
 		assert "boss ai optimize" in stream.getvalue()
+
+
+class TestSearchProgress:
+	def _progress(self, monkeypatch, **kw):
+		from boss_agent_cli.display import SearchProgress
+
+		stream = _capture_display_console(monkeypatch)
+		return SearchProgress("搜索 Golang", max_pages=3, **kw), stream
+
+	def test_duck_types_logger_interface(self, monkeypatch):
+		progress, _ = self._progress(monkeypatch)
+		for method in ("info", "debug", "warning", "error"):
+			assert callable(getattr(progress, method))
+
+	def test_counts_pages_and_matches(self, monkeypatch):
+		progress, _ = self._progress(monkeypatch)
+		progress.info("正在搜索第 1 页...")
+		progress.info("  ✅ 字节跳动 - Golang 后端（详情匹配）")
+		progress.info("  ✅ 腾讯 - 后端开发（标签匹配）")
+		progress.info("  ❌ 某某科技 - Go 工程师")
+		progress.info("  预筛排除: 前端开发 (岗位类型不符)")
+
+		assert progress.pages == 1
+		assert progress.matched == 2
+		assert progress.excluded == 2
+
+	def test_prints_matched_lines_but_not_excluded_spam(self, monkeypatch):
+		progress, stream = self._progress(monkeypatch)
+		progress.info("  ✅ 字节跳动 - Golang 后端（详情匹配）")
+		progress.info("  ❌ 某某科技 - Go 工程师")
+		out = stream.getvalue()
+
+		assert "字节跳动" in out, "匹配结果应逐条可见"
+		assert "某某科技" not in out, "逐条排除不应刷屏"
+
+	def test_status_line_reports_counters(self, monkeypatch):
+		progress, _ = self._progress(monkeypatch)
+		progress.info("正在搜索第 1 页...")
+		progress.info("  ✅ A - B（详情匹配）")
+
+		status = progress.status_text()
+		assert "1/3" in status
+		assert "匹配 1" in status
+
+	def test_thread_safe_counting(self, monkeypatch):
+		import threading
+
+		progress, _ = self._progress(monkeypatch)
+
+		def worker():
+			for _ in range(50):
+				progress.info("  ✅ A - B（详情匹配）")
+
+		threads = [threading.Thread(target=worker) for _ in range(4)]
+		for t in threads:
+			t.start()
+		for t in threads:
+			t.join()
+
+		assert progress.matched == 200
+
+	def test_debug_is_not_rendered(self, monkeypatch):
+		progress, stream = self._progress(monkeypatch)
+		progress.debug("搜索命中缓存")
+
+		assert stream.getvalue() == ""
+
+
+def test_search_pipeline_progress_markers_contract():
+	"""契约锁定：SearchProgress 依赖管线里的这些标记来分类进度消息。
+
+	改动 search_filters.py 的进度文案会让 TTY 进度静默退化，
+	因此在这里显式锁定——格式变了就让这条测试大声失败。
+	"""
+	from pathlib import Path
+
+	source = Path(__file__).resolve().parents[1] / "src/boss_agent_cli/search_filters.py"
+	content = source.read_text(encoding="utf-8")
+
+	assert '"正在搜索第 {current_page} 页..."' in content.replace("f\"", "\"")
+	assert "✅ {company} - {title}（详情匹配）" in content
+	assert "❌ {company} - {title}" in content
+	assert "预筛排除:" in content

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -245,3 +245,80 @@ def test_step_result_operator_actions_defaults_empty():
 	from boss_agent_cli.wizard.models import StepResult
 
 	assert StepResult({}).to_dict()["operator_actions"] == []
+
+
+# ── 脱敏精度：数值 / None 不可能是凭据 ──────────────────────────
+
+
+def test_numeric_values_are_not_credentials_even_with_sensitive_key():
+	"""凭据必然是字符串或容器；数值命中关键词属误报。
+
+	`ai_max_tokens` / `max_tokens` 是 AI 生成长度上限（进 OpenAI 兼容请求体的
+	`max_tokens` 字段），`token_expires_in` 是过期秒数——都不是凭据，
+	却因为键名含子串 `token` 被脱敏，用户永远看不到自己配的值。
+	"""
+	from boss_agent_cli.output import redact_sensitive
+
+	result = redact_sensitive({
+		"ai_max_tokens": 4096,
+		"max_tokens": 512,
+		"token_expires_in": 3600,
+		"session_timeout": 30.5,
+	})
+
+	assert result["ai_max_tokens"] == 4096
+	assert result["max_tokens"] == 512
+	assert result["token_expires_in"] == 3600
+	assert result["session_timeout"] == 30.5
+
+
+def test_none_values_are_not_redacted():
+	"""None 里没有秘密可泄漏；把它说成 [REDACTED] 是误导。"""
+	from boss_agent_cli.output import redact_sensitive
+
+	result = redact_sensitive({"token_expires_in": None, "api_key": None, "stoken": None})
+
+	assert result["token_expires_in"] is None
+	assert result["api_key"] is None
+	assert result["stoken"] is None
+
+
+def test_real_string_credentials_still_redacted():
+	"""回归护栏：放宽数值不得放过真凭据。"""
+	from boss_agent_cli.output import redact_sensitive
+
+	result = redact_sensitive({
+		"stoken": "real-stoken-value",
+		"api_key": "sk-live-xxxx",
+		"access_token": "at-xxxx",
+		"refresh_token": "rt-xxxx",
+		"zp_token": "zp-xxxx",
+		"cookies": {"wt2": "cookie-value"},
+		"authorization": "Bearer abc",
+		"password": "hunter2",
+		"session_id": "sess-xxxx",
+	})
+
+	for key in result:
+		assert result[key] == "[REDACTED]", f"{key} 是真凭据，必须仍被脱敏"
+
+
+def test_bool_exemption_still_holds():
+	"""既有的 bool 豁免不受影响。"""
+	from boss_agent_cli.output import redact_sensitive
+
+	result = redact_sensitive({"api_key_set": False, "token_present": True})
+
+	assert result["api_key_set"] is False
+	assert result["token_present"] is True
+
+
+def test_status_envelope_exposes_token_expiry():
+	"""端到端：boss status 的过期时间必须能被用户看到。"""
+	import json
+
+	from boss_agent_cli.output import envelope_success
+
+	payload = json.loads(envelope_success("status", {"logged_in": True, "token_expires_in": 7200}))
+
+	assert payload["data"]["token_expires_in"] == 7200

--- a/tests/test_search_pipeline.py
+++ b/tests/test_search_pipeline.py
@@ -417,3 +417,59 @@ def test_pipeline_cache_hit_skips_job_card_request():
 	assert len(result.items) == 1
 	assert client.detail_calls == []  # 命中缓存，零取详情请求
 	assert cache.put_calls == []  # 命中无需写回
+
+
+# ── SearchProgress 端到端接线（真人链路）────────────────────────
+
+
+def test_real_pipeline_drives_search_progress_counters(monkeypatch):
+	"""用真实管线驱动 SearchProgress，证明进度接线端到端有效。
+
+	这是无平台账号条件下能做到的最强验证：管线是真的，只有 client/cache 是 fake。
+	"""
+	import io
+
+	from rich.console import Console
+
+	from boss_agent_cli.display import SearchProgress
+
+	stream = io.StringIO()
+	monkeypatch.setattr(
+		"boss_agent_cli.display.console",
+		Console(file=stream, force_terminal=False, width=120),
+	)
+
+	client = FakeClient(
+		pages=[{
+			"zpData": {
+				"hasMore": False,
+				"jobList": [
+					_make_job_raw(security_id="sec-a", job_id="job-a"),
+					_make_job_raw(security_id="sec-b", job_id="job-b"),
+				],
+			},
+		}],
+		descriptions={"sec-a": "福利：双休 五险一金", "sec-b": "单休，无补贴"},
+	)
+	progress = SearchProgress("搜索 Golang", max_pages=1)
+
+	result = run_search_pipeline(
+		client,
+		FakeCache(),
+		progress,
+		criteria=SearchFilterCriteria(query="Golang"),
+		welfare_conditions=_welfare_conditions(),
+	)
+
+	# 管线真的产出了一个匹配项
+	assert [item["job_id"] for item in result.items] == ["job-a"]
+
+	# 进度对象如实反映了管线过程
+	assert progress.pages == 1, "翻页应被计数"
+	assert progress.matched == 1, "匹配项应被计数"
+	assert progress.excluded >= 1, "不匹配项应被计数"
+
+	out = stream.getvalue()
+	assert "Company-job-a" in out, "匹配项应逐条打印到终端"
+	assert "Company-job-b" not in out, "排除项不应刷屏"
+	assert "1/1" in progress.status_text()

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -1990,7 +1990,9 @@ def test_prompt_toolkit_pty_uses_stderr_and_arrow_keys(tmp_path):
 			if not chunk:
 				break
 			output.extend(chunk)
-			if "BOSS 求职助手" in output.decode("utf-8", errors="ignore"):
+			# 提示行恒在内容区，用作「菜单已渲染」的同步信号；
+			# 标题现在画在框上（D1），不再是内容区的第一行。
+			if "↑↓ 选择" in output.decode("utf-8", errors="ignore"):
 				break
 		for _ in range(5):
 			os.write(stderr_master_fd, b"\x1b[B")
@@ -2042,7 +2044,11 @@ def test_prompt_toolkit_pty_uses_stderr_and_arrow_keys(tmp_path):
 	stderr_text = output.decode("utf-8", errors="replace")
 	assert process.returncode == 0
 	assert stdout_output == b""
-	assert "BOSS 求职助手" in stderr_text
+	# 该场景首屏是登录门菜单，框标题即它的 title（D1：标题=当前步骤）
+	assert "需要先登录才能继续" in stderr_text, "框标题应为当前步骤（D1）"
+	assert "\x1b[?1049h" in stderr_text, "交互会话应进入备用屏（R1）"
+	assert stderr_text.rstrip().endswith("\x1b[?1049l"), "退出应还原备用屏（AC6）"
+	assert "BOSS 求职助手" not in stderr_text, "常驻应用名行已移除（D1）"
 	assert "退出向导" in stderr_text
 	assert "已退出向导" in stderr_text
 
@@ -2581,7 +2587,10 @@ def test_menu_hint_advertises_left_arrow_back():
 
 	source = inspect.getsource(PromptToolkitMenu.select)
 	assert 'bindings.add("left")' in source
-	assert "←/Esc 返回" in source
+	# 提示行随内容区一起抽到了 _menu_content_lines（框标题化重构）
+	from boss_agent_cli.wizard.prompts import _menu_content_lines
+
+	assert "←/Esc 返回" in inspect.getsource(_menu_content_lines)
 
 
 # ── 采集完成后的列表：摘要必须留在菜单上方（与「查看任务状态」一致）──
@@ -2713,3 +2722,161 @@ def test_list_header_disables_preview(monkeypatch):
 	collect_result_follow_up(_crawl_completed_run(), menu=_ScriptedMenu(["0", "job_detail"]))
 
 	assert captured == [False], f"列表上方摘要应关闭预览，实际 {captured}"
+
+
+# ── 整个交互会话独占一块备用屏缓冲 ────────────────────────────
+
+
+_ALT_ENTER = "\033[?1049h"
+_ALT_EXIT = "\033[?1049l"
+
+
+def _force_screen_control(monkeypatch):
+	"""解除 pytest / 非 TTY 的 no-op 守卫，让转义序列真的写出来。"""
+	import io
+
+	stream = io.StringIO()
+	monkeypatch.setattr("boss_agent_cli.wizard.renderer._screen_control_unavailable", lambda: False)
+	monkeypatch.setattr("boss_agent_cli.wizard.renderer.sys", type("S", (), {"stderr": stream})())
+	return stream
+
+
+def test_wizard_screen_enters_and_restores_alternate_buffer(monkeypatch):
+	from boss_agent_cli.wizard.renderer import wizard_screen
+
+	stream = _force_screen_control(monkeypatch)
+	with wizard_screen():
+		assert stream.getvalue() == _ALT_ENTER, "进入时应切到备用屏"
+	assert stream.getvalue() == _ALT_ENTER + _ALT_EXIT, "退出时应还原"
+
+
+def test_wizard_screen_restores_on_exception(monkeypatch):
+	"""异常路径必须还原，否则用户终端卡在备用屏里（AC6）。"""
+	from boss_agent_cli.wizard.renderer import wizard_screen
+
+	stream = _force_screen_control(monkeypatch)
+	with pytest.raises(ValueError):
+		with wizard_screen():
+			raise ValueError("boom")
+	assert stream.getvalue().endswith(_ALT_EXIT)
+
+
+def test_wizard_screen_restores_on_system_exit(monkeypatch):
+	"""向导内部会 raise SystemExit(1)，同样必须还原。"""
+	from boss_agent_cli.wizard.renderer import wizard_screen
+
+	stream = _force_screen_control(monkeypatch)
+	with pytest.raises(SystemExit):
+		with wizard_screen():
+			raise SystemExit(1)
+	assert stream.getvalue().endswith(_ALT_EXIT)
+
+
+def test_wizard_screen_restores_on_keyboard_interrupt(monkeypatch):
+	"""Ctrl-C 也要还原（AC6）。"""
+	from boss_agent_cli.wizard.renderer import wizard_screen
+
+	stream = _force_screen_control(monkeypatch)
+	with pytest.raises(KeyboardInterrupt):
+		with wizard_screen():
+			raise KeyboardInterrupt
+	assert stream.getvalue().endswith(_ALT_EXIT)
+
+
+def test_wizard_screen_is_noop_without_tty(monkeypatch):
+	"""Agent / 管道 / dumb terminal 路径行为完全不变。"""
+	import io
+
+	from boss_agent_cli.wizard.renderer import wizard_screen
+
+	stream = io.StringIO()
+	monkeypatch.setattr("boss_agent_cli.wizard.renderer._screen_control_unavailable", lambda: True)
+	monkeypatch.setattr("boss_agent_cli.wizard.renderer.sys", type("S", (), {"stderr": stream})())
+	with wizard_screen():
+		pass
+	assert stream.getvalue() == ""
+
+
+def test_interactive_session_runs_inside_alternate_screen(monkeypatch, tmp_path):
+	"""多轮向导必须被备用屏包裹；单次 flag 路径不得进（AC7）。"""
+	from boss_agent_cli.commands import wizard as wizard_mod
+
+	order: list[str] = []
+
+	class _FakeScreen:
+		def __enter__(self):
+			order.append("enter")
+			return self
+
+		def __exit__(self, *exc):
+			order.append("exit")
+			return False
+
+	monkeypatch.setattr(wizard_mod, "wizard_screen", lambda: _FakeScreen())
+	monkeypatch.setattr(wizard_mod, "_is_interactive", lambda ctx: True)
+	monkeypatch.setattr(
+		wizard_mod,
+		"_run_interactive_session",
+		lambda *a, **k: order.append("session"),
+	)
+
+	CliRunner().invoke(cli, ["--data-dir", str(tmp_path), "wizard"])
+
+	assert order == ["enter", "session", "exit"]
+
+
+# ── 菜单包进带标题的边框 ──────────────────────────────────────
+
+
+def test_menu_container_is_framed_with_step_title():
+	"""框标题用当前步骤（D1），与采集摘要 Panel 同构。"""
+	from prompt_toolkit.layout.controls import FormattedTextControl
+	from prompt_toolkit.widgets import Frame
+
+	from boss_agent_cli.wizard.prompts import _build_menu_container
+
+	container = _build_menu_container("请选择职位（第 1-12 / 共 75 条）", FormattedTextControl(""))
+
+	assert isinstance(container, Frame)
+	assert container.title == "请选择职位（第 1-12 / 共 75 条）"
+
+
+def test_menu_container_holds_the_content_control():
+	"""框里装的必须是传入的菜单内容，不能丢。"""
+	from prompt_toolkit.layout.controls import FormattedTextControl
+	from prompt_toolkit.layout.containers import Window
+
+	from boss_agent_cli.wizard.prompts import _build_menu_container
+
+	control = FormattedTextControl("菜单内容")
+	container = _build_menu_container("标题", control)
+
+	found = []
+
+	def walk(node):
+		if isinstance(node, Window) and getattr(node, "content", None) is control:
+			found.append(node)
+		for child in getattr(node, "children", []) or []:
+			walk(child)
+		body = getattr(node, "body", None)
+		if body is not None:
+			walk(body)
+
+	walk(container)
+	assert found, "菜单内容控件应在框内"
+
+
+def test_menu_content_does_not_repeat_title_inside_frame(monkeypatch):
+	"""标题上了框，框内就不该再打印一遍（D1：去掉常驻应用名行）。"""
+	from boss_agent_cli.wizard.prompts import _menu_content_lines, MenuOption
+
+	lines = _menu_content_lines(
+		[MenuOption("a", "选项A"), MenuOption("b", "选项B")],
+		selected=0,
+		title="请选择职位",
+	)
+	text = "".join(part[1] for part in lines)
+
+	assert "请选择职位" not in text, "标题已在框上，内容区不应重复"
+	assert "BOSS 求职助手" not in text, "常驻应用名行应移除"
+	assert "选项A" in text and "选项B" in text

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -2619,7 +2619,7 @@ def test_result_list_keeps_summary_visible_above_menu(monkeypatch):
 	rendered: list[str] = []
 	monkeypatch.setattr(
 		"boss_agent_cli.wizard.renderer.render_run",
-		lambda run: rendered.append(str(run.get("run_id"))),
+		lambda run, *, with_preview=True: rendered.append(str(run.get("run_id"))),
 	)
 	monkeypatch.setattr("boss_agent_cli.wizard.renderer.clear_wizard_screen", lambda: None)
 
@@ -2638,7 +2638,7 @@ def test_result_list_redraws_summary_on_every_page(monkeypatch):
 	rendered: list[str] = []
 	monkeypatch.setattr(
 		"boss_agent_cli.wizard.renderer.render_run",
-		lambda run: rendered.append(str(run.get("run_id"))),
+		lambda run, *, with_preview=True: rendered.append(str(run.get("run_id"))),
 	)
 	monkeypatch.setattr("boss_agent_cli.wizard.renderer.clear_wizard_screen", lambda: None)
 
@@ -2653,7 +2653,7 @@ def test_result_list_menu_still_returns_selection(monkeypatch):
 	"""回归护栏：加重绘不得改变选择结果。"""
 	from boss_agent_cli.wizard.prompts import collect_result_follow_up
 
-	monkeypatch.setattr("boss_agent_cli.wizard.renderer.render_run", lambda run: None)
+	monkeypatch.setattr("boss_agent_cli.wizard.renderer.render_run", lambda run, *, with_preview=True: None)
 	monkeypatch.setattr("boss_agent_cli.wizard.renderer.clear_wizard_screen", lambda: None)
 
 	menu = _ScriptedMenu(["1", "job_detail"])
@@ -2661,3 +2661,55 @@ def test_result_list_menu_still_returns_selection(monkeypatch):
 
 	assert isinstance(follow, WizardInput)
 	assert follow.inputs["security_id"] == "sec-1"
+
+
+# ── 浏览列表时摘要框不再重复展示职位预览 ──────────────────────
+
+
+def _capture_wizard_console(monkeypatch):
+	import io
+
+	from rich.console import Console
+
+	stream = io.StringIO()
+	monkeypatch.setattr("boss_agent_cli.display.console", Console(file=stream, force_terminal=False, width=120))
+	return stream
+
+
+def test_crawl_summary_includes_preview_by_default(monkeypatch):
+	"""状态视图（不进列表）仍需要职位预览——那时没有可选菜单。"""
+	from boss_agent_cli.wizard.renderer import render_run
+
+	stream = _capture_wizard_console(monkeypatch)
+	render_run(_crawl_completed_run(job_count=8))
+
+	assert "职位预览" in stream.getvalue()
+
+
+def test_crawl_summary_omits_preview_when_browsing(monkeypatch):
+	"""浏览列表时下方已有可选菜单，框里再列一遍职位是冗余且页码对不上。"""
+	from boss_agent_cli.wizard.renderer import render_run
+
+	stream = _capture_wizard_console(monkeypatch)
+	render_run(_crawl_completed_run(job_count=8), with_preview=False)
+	out = stream.getvalue()
+
+	assert "职位预览" not in out
+	assert "采集已完成" in out, "摘要本身仍要在"
+	assert "75" in out or "8" in out, "职位总数仍要显示"
+
+
+def test_list_header_disables_preview(monkeypatch):
+	"""结果列表上方的摘要必须关掉预览。"""
+	from boss_agent_cli.wizard.prompts import collect_result_follow_up
+
+	captured: list[bool] = []
+	monkeypatch.setattr(
+		"boss_agent_cli.wizard.renderer.render_run",
+		lambda run, *, with_preview=True: captured.append(with_preview),
+	)
+	monkeypatch.setattr("boss_agent_cli.wizard.renderer.clear_wizard_screen", lambda: None)
+
+	collect_result_follow_up(_crawl_completed_run(), menu=_ScriptedMenu(["0", "job_detail"]))
+
+	assert captured == [False], f"列表上方摘要应关闭预览，实际 {captured}"

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -45,6 +45,7 @@ class _ScriptedMenu:
 		self.texts = iter(texts)
 		self.menus = []
 		self.last_kwargs = {}
+		self.kwargs_log = []
 
 	def select(self, title, options, *, default=None, allow_back=True, allow_exit=True, clear_before=True):
 		self.last_kwargs = {
@@ -52,6 +53,7 @@ class _ScriptedMenu:
 			"allow_exit": allow_exit,
 			"clear_before": clear_before,
 		}
+		self.kwargs_log.append(dict(self.last_kwargs))
 		self.menus.append((title, list(options)))
 		value = next(self.selections)
 		if value == "返回":
@@ -1817,7 +1819,9 @@ def test_interactive_wizard_loops_follow_up_from_original_list_results(tmp_path,
 	assert result.exit_code == 0
 	assert executed_goals == ["job_search", "job_detail"]
 	assert result.stdout == ""
-	assert "共 2 条结果" in result.stderr
+	# 列表摘要的渲染职责已移入 collect_result_follow_up（它才知道当前翻到第几页，
+	# 需要逐页重绘）。本用例把该函数整个 mock 掉了，因此观察不到摘要——
+	# 真实路径的渲染由 test_result_list_keeps_summary_visible_above_menu 覆盖。
 	assert "职位详情" in result.stderr
 	assert "Python 工程师" in result.stderr
 
@@ -2578,3 +2582,82 @@ def test_menu_hint_advertises_left_arrow_back():
 	source = inspect.getsource(PromptToolkitMenu.select)
 	assert 'bindings.add("left")' in source
 	assert "←/Esc 返回" in source
+
+
+# ── 采集完成后的列表：摘要必须留在菜单上方（与「查看任务状态」一致）──
+
+
+def _crawl_completed_run(job_count: int = 3) -> dict:
+	jobs = [
+		{
+			"title": f"职位{i}",
+			"company": f"公司{i}",
+			"security_id": f"sec-{i}",
+			"job_id": f"job-{i}",
+			"source": "crawl",
+		}
+		for i in range(job_count)
+	]
+	return {
+		"role": "candidate",
+		"platform": "zhipin",
+		"goal": "crawl_status",
+		"status": "completed",
+		"run_id": "wrn_demo",
+		"last_result": {"data": {"jobs": jobs, "jobs_seen": len(jobs), "status": "completed"}},
+	}
+
+
+def test_result_list_keeps_summary_visible_above_menu(monkeypatch):
+	"""采集完成后的列表必须与「重新进入任务状态」看到同一个摘要框。
+
+	此前 MenuDriver.select 的 clear_before 默认 True，会把 _run_plan 刚渲染的
+	摘要 Panel 清掉，只剩一个光秃秃的选择列表——两个入口观感不一致。
+	"""
+	from boss_agent_cli.wizard.prompts import collect_result_follow_up
+
+	rendered: list[str] = []
+	monkeypatch.setattr(
+		"boss_agent_cli.wizard.renderer.render_run",
+		lambda run: rendered.append(str(run.get("run_id"))),
+	)
+	monkeypatch.setattr("boss_agent_cli.wizard.renderer.clear_wizard_screen", lambda: None)
+
+	menu = _ScriptedMenu(["0", "job_detail"])
+	collect_result_follow_up(_crawl_completed_run(), menu=menu)
+
+	# kwargs_log[0] 是列表菜单本身；后续是选中职位后的动作菜单
+	assert menu.kwargs_log[0]["clear_before"] is False, "列表菜单不得清屏，否则摘要被抹掉"
+	assert rendered == ["wrn_demo"], "选择菜单前应重绘任务摘要"
+
+
+def test_result_list_redraws_summary_on_every_page(monkeypatch):
+	"""翻页时摘要也要跟着重绘，否则翻一页就丢。"""
+	from boss_agent_cli.wizard.prompts import RESULT_PAGE_SIZE, collect_result_follow_up
+
+	rendered: list[str] = []
+	monkeypatch.setattr(
+		"boss_agent_cli.wizard.renderer.render_run",
+		lambda run: rendered.append(str(run.get("run_id"))),
+	)
+	monkeypatch.setattr("boss_agent_cli.wizard.renderer.clear_wizard_screen", lambda: None)
+
+	run = _crawl_completed_run(job_count=RESULT_PAGE_SIZE + 3)
+	menu = _ScriptedMenu(["__result_more__", str(RESULT_PAGE_SIZE), "job_detail"])
+	collect_result_follow_up(run, menu=menu)
+
+	assert len(rendered) == 2, f"两页应各重绘一次摘要，实际 {len(rendered)} 次"
+
+
+def test_result_list_menu_still_returns_selection(monkeypatch):
+	"""回归护栏：加重绘不得改变选择结果。"""
+	from boss_agent_cli.wizard.prompts import collect_result_follow_up
+
+	monkeypatch.setattr("boss_agent_cli.wizard.renderer.render_run", lambda run: None)
+	monkeypatch.setattr("boss_agent_cli.wizard.renderer.clear_wizard_screen", lambda: None)
+
+	menu = _ScriptedMenu(["1", "job_detail"])
+	follow = collect_result_follow_up(_crawl_completed_run(), menu=menu)
+
+	assert isinstance(follow, WizardInput)
+	assert follow.inputs["security_id"] == "sec-1"


### PR DESCRIPTION
## 背景

真人反馈：向导「上滚能看到两个框」、采集完成后摘要框被清掉、职位列表出现两份、
`boss config show` 里 `ai_max_tokens` 显示成 `[REDACTED]`、长时间 `search` 期间终端毫无反馈。

本 PR 原先栈在 #391 上，#391 已合入 master，现已 rebase 到 master、base 切回 master。

## 改动

| 提交 | 问题 | 处理 |
| --- | --- | --- |
| `9d3fb58` | TTY 下 `search` 长任务无进度 | 新增 `SearchProgress`，鸭子类型兼容 `Logger`，仅 TTY 注入管线 |
| `788b277` | 脱敏误伤数值与空值 | 把 bool 豁免补完整为 `(bool, int, float, None)` |
| `ef201ce` | 结果列表清掉了任务摘要框 | 摘要改由 `collect_result_follow_up` 每页重绘 |
| `526abff` | 浏览列表时职位被列两遍 | `render_run` 加 `with_preview` 开关 |
| `0c87c82` | 向导在 scrollback 留残框 | 整个交互会话跑在 alternate screen；菜单包进 Frame |

几处值得单独说的判断：

- **备用屏而非清屏**：`clear_wizard_screen` 的 `\033[2J` 只清可视屏、清不掉 scrollback，
  这正是「上滚看到两个框」的根因。改为进入向导时切 alternate screen、退出还原，
  终端原有内容完好。用 context manager 保证还原——`commands/wizard.py` 有 59 处 `return`
  且内部会 `raise SystemExit`，逐点还原必然漏。单次 flag 路径刻意不进备用屏，
  否则渲染完立刻被抹掉。
- **进度不走「降低全局日志级别」**：`output.Logger` 用裸 `print` 抢 stderr，
  而详情补抓跑在 `ThreadPoolExecutor` 里会交错。改走 Rich Console 并自带计数锁；
  消息分类对管线文案的耦合由 `test_search_pipeline_progress_markers_contract` 锁定。
- **脱敏放宽的安全边界**：`_SENSITIVE_KEY_PARTS` 是子串匹配，`ai_max_tokens` /
  `max_tokens` / `token_expires_in` 都因含 `token` 被替换。凭据必然是字符串或容器，
  已扫描全仓确认不存在数值型真凭据；新增护栏测试锁定 `stoken` / `api_key` /
  `access_token` / `cookies` 等仍被脱敏。
- **`with_preview` 的取舍**：摘要框里的「职位预览」恒为前 5 条且不可选，
  翻到第 13-24 页时与下方可选菜单页码互相矛盾。结果列表上方传 `False`，
  职位由下方菜单唯一承担；状态视图不进列表时仍保留预览，那里没有可选菜单。

菜单容器与内容构造抽成 `_build_menu_container` / `_menu_content_lines`
两个模块级函数以便单测；PTY 用例扩展为覆盖框标题、备用屏进出与 stdout 洁净。

## 不变量

- stdout 仍只有单行 JSON 信封；管道 / `--json` 路径行为不变（进度仍传原 logger）
- 无命令表变更，命令数与 MCP 工具数计数不受影响

## 验证

`uv run python scripts/quality_baseline.py`

- [x] ruff：`All checks passed!`
- [x] pytest：`1848 passed`
- [x] mypy：`Success: no issues found in 149 source files`
