### PR TITLE
test: 补齐 MCP handler 注册门禁并修正 PTY 用例假红

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,11 +151,28 @@ jobs:
           docker run --rm --entrypoint boss boss-agent-cli:ci --json schema --format native \
             | python3 -c "import sys, json; d = json.load(sys.stdin); assert d['ok'], d; print('schema commands:', len(d['data']['commands']))"
 
-      - name: Verify the MCP server handshake over stdio
+      # 只断言 initialize 是不够的：v1.18.0 就是带着一个未注册的 tools/list 发出去的
+      # （issue #377），握手照样成功，MCP host 一列工具才拿到 -32601。所以这里必须在
+      # 同一个 stdio 会话里把 tools/list 也真的问一遍。
+      - name: Verify the MCP server handshake and tool listing over stdio
         run: |
-          printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"ci","version":"1.0"}}}' \
+          printf '%s\n' \
+            '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"ci","version":"1.0"}}}' \
+            '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+            '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
             | docker run --rm -i boss-agent-cli:ci \
-            | python3 -c "import sys, json; d = json.loads(sys.stdin.readline()); assert d['result']['serverInfo']['name'] == 'boss-agent-cli', d; print('MCP initialize ok')"
+            | python3 -c "
+          import sys, json
+          initialized = json.loads(sys.stdin.readline())
+          assert initialized['result']['serverInfo']['name'] == 'boss-agent-cli', initialized
+          print('MCP initialize ok')
+          listed = json.loads(sys.stdin.readline())
+          assert 'error' not in listed, listed
+          names = [tool['name'] for tool in listed['result']['tools']]
+          assert names, listed
+          assert 'boss_status' in names, names
+          print('MCP tools/list ok:', len(names), 'tools')
+          "
 
       - name: Verify it runs as non-root
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,68 @@
 
 ## [Unreleased]
 
+### Fixed
+- **修复 MCP `tools/list` 从未注册：v1.18.0 的 MCP 入口对任何 host 都不可用。**
+  `mcp_server.list_tools` 缺失 `@server.list_tools()` 装饰器，`initialize` 握手正常，但 client
+  第一次列工具即 `-32601 Method not found`——73 个工具一个都拿不到。回归由 1.18.0 的
+  `mcp_server` 拆分引入，该拆分合并 33 分钟后即发版，没有留下暴露窗口。
+  四道门禁同时失效，故本次连门禁一起补（见下方 Added）：`tests/test_mcp_server.py` 用 mock 模块
+  顶替整个 `mcp` 包，装饰器在不在原理上观测不到；CI 的 stdio 握手只断言 `initialize`；
+  eval 跑离线 fixture 绕开协议层；`__all__` + `mcp-server/server.py` 的 re-export 让这个
+  未注册的孤儿函数在 ruff / mypy 眼里完全正常。感谢 @xie-good 报告、@LiuLin1220 修复。
+- 脱敏放宽：`_SENSITIVE_KEY_PARTS` 是子串匹配，`ai_max_tokens` / `token_expires_in` 只因键名含
+  `token` 就被替换成 `[REDACTED]`。凭据必然是字符串或容器，故把 bool 豁免补完整为
+  `(bool, int, float, None)`，并加护栏测试锁定 `stoken` / `api_key` / `cookies` 等仍被脱敏。
+- 修正三个终端呈现缺陷：结果列表菜单每页重绘任务摘要框（此前被 `clear_before` 清掉）；
+  `render_run` 新增 `with_preview` 开关，浏览列表时职位不再被摘要框与可选菜单列两遍；
+  `search` 长任务在 TTY 下注入 `SearchProgress` 显示实时进度（管道 / `--json` 仍传原 logger）。
+- 修正 `tests/test_wizard.py` 的 PTY 用例假红：启动同步循环 5s 超时后**照样发送按键**，
+  此时 prompt_toolkit 尚未接管输入，按键被丢弃，最终报成「没退出」——把「启动慢」误诊为
+  「交互坏」，且不留任何线索。现在必须确认菜单真渲染出来才发按键，否则以「菜单未渲染」
+  失败并附上已捕获输出；期限放宽到 30s / 20s 并可用环境变量覆盖（命中同步标记即跳出，
+  快机器仍约 1s）。此前它曾在 CI 的 P0 baseline job 上超时并挡住合并，而同一 commit 的
+  五个测试矩阵 job 全过。
+
+### Added
+- MCP handler 注册守卫 `tests/test_mcp_handler_registration.py`：不查装饰器语法，直接问运行时
+  注册表 `server.request_handlers`。「装饰器名 → request 类型」的映射**从 SDK 自身反推**
+  （在全新 `Server` 上应用装饰器后 diff 注册表键），因此 SDK 将来新增 `list_prompts` /
+  `read_resource` 等 handler 时守卫覆盖面自动跟上，不需人工维护。同时断言 `tools/list` 经协议
+  发出的工具集合与 `mcp_tools.TOOLS` **逐名相等**（不引入硬编码计数）。两条测试刻意在子进程里
+  跑：`tests/test_mcp_server.py` 会 `sys.modules.setdefault("mcp", <mock>)`，一旦拿到 mock，
+  `request_handlers` 就是 MagicMock，守卫会静默变成恒真。
+- CI 的 docker job 在同一个 stdio 会话里补做 `tools/list`，断言工具列表非空且含 `boss_status`。
+  只断言 `initialize` 正是让上面那个回归发出去的原因。
+- 开放 assisted / research 下全部已实现能力，移除模式级 `COMPLIANCE_BLOCKED` 执行门
+  （错误码保留作历史协议兼容）；平台未实现的能力仍返回 `NOT_SUPPORTED`。
+- 新增共享 Workflow 持久化与纯终端 `boss wizard`：无子命令时默认进入向导，TTY 向导与
+  `--input-json` / `--resume` / MCP 共用同一个确定性 runner，状态落 SQLite 的
+  `workflow_runs` / `workflow_steps`。`schema` 与 MCP 同步暴露 `wizard` 与 `wizard_catalog`。
+- 增强 crawl 传输：登录态注入、页面内请求与回退，命中风控时保留浏览器便于续跑。
+- 信封 `hints` 拆为双受众通道：`next_actions` 给 Agent 执行的后继命令，`operator_actions` 给真人的
+  自然语言指引（扫码、去浏览器操作等）。判定标准是「是否需要人离开终端」，不是「是否需要确认」。
+  TTY 下 `display.render_operator_actions` **只渲染 `operator_actions`** 到 stderr——此前 TTY 分支
+  把 `hints` 整个丢弃，真人从来看不到任何提示。无 `operator_actions` 时零输出，既有命令的 TTY
+  行为逐字节不变。`SCHEMA_DATA["conventions"]` 新增 `hints` 与 `command_vs_wizard` 两块。
+- 新增向导入口登录门 `wizard/preflight.py`：登录检查从 goal 的第一个 step 前移到收集角色 /
+  平台 / 目标 / 参数之前——此前未登录时这五层选择全部白做。已登录时零输出零开销（本地文件读，
+  不预检浏览器内核）；未登录时可内联扫码登录并无缝进向导；浏览器内核缺失时先给
+  `patchright install chromium` 指引，不再开完浏览器才失败。headless 路径保持 `WAITING_INPUT`
+  不变（TTY 下人就在终端前，阻塞等扫码是刻意的；Agent 不能卡在子进程里空等）。
+- 向导未登录时 run 状态由 `failed` 改为 `WAITING_INPUT`，可 `--resume` 且保留已选的角色 /
+  平台 / 目标，不必从头重走。
+- 补齐候选者侧九个命令组（`stats` / `preset` / `watch` / `clean` / `ai-local` / `resume` / `ai` /
+  `crawl` / `agent`）共 63 处 `handle_output` 的 TTY 渲染分支，真人不再需要自己读 JSON 信封。
+  `display.py` 新增 `render_next_steps` / `render_action_result` / `render_list_result` /
+  `render_record_result` / `render_ai_result` 五个通用件；`render_ai_result` 不假设键名、只按值类型
+  呈现，并对所有值做 escape，避免 AI 输出里的方括号被 Rich 当标记解析。stdout 仍只有单行信封。
+- 向导整个多轮交互会话跑在 alternate screen（`\033[?1049h` / `\033[?1049l`）里：进入切、退出还原，
+  终端原有内容完好，不再往 scrollback 留残框——`clear_wizard_screen` 的 `\033[2J` 只清可视屏、
+  清不掉历史，这是「上滚看到多个框」的根因。用 context manager 保证还原（`commands/wizard.py`
+  有 59 处 `return` 且内部会 `raise SystemExit`，逐点还原必然漏）。单次 flag 路径
+  （`--status` / `--resume` / `--stop`）刻意不进备用屏，否则渲染完立刻被抹掉。菜单包进 `Frame`，
+  框标题为当前步骤；菜单支持 `←` / `Esc` 返回。
+
 ## [1.18.0] - 2026-07-29
 
 ### Added

--- a/tests/test_mcp_handler_registration.py
+++ b/tests/test_mcp_handler_registration.py
@@ -1,0 +1,146 @@
+"""MCP handler 注册守卫。
+
+`mcp_server` 为了保住 `mcp-server/server.py` wrapper 的导入路径，把 handler 写进 `__all__`
+并原样再导出。副作用是：一个**忘记加装饰器**的 handler 在 ruff / mypy 眼里完全正常——
+它被 `__all__` 声明、被 wrapper 引用，静态检查认为它「有人用」。issue #377 里的
+`list_tools` 就是这样带着 v1.18.0 发了出去，MCP host 一列工具就拿到 -32601。
+
+所以这里不查装饰器语法，直接问运行时注册表：`server.request_handlers` 里有没有它。
+
+两条测试都刻意在**子进程**里跑。`tests/test_mcp_server.py` 会在导入时
+`sys.modules.setdefault("mcp", <mock 模块>)`，而 pytest 单进程收集全部测试模块——
+一旦本文件拿到那个 mock，`request_handlers` 就是个 MagicMock，任何断言都恒真，
+守卫会变成装饰用的。子进程保证拿到真实 SDK。
+"""
+
+import json
+import subprocess
+import sys
+from typing import Any
+
+# 不硬编码「装饰器名 → request 类型」映射表：在全新 Server 上应用装饰器，diff
+# request_handlers 的键集合，多出来的那一个就是它负责的类型。SDK 将来新增
+# handler（list_prompts / read_resource / ...）时这张表自己跟着长，守卫的覆盖面
+# 不需要人工维护——这正是 #377 那类问题最需要的性质。
+_REGISTRATION_PROBE = """
+import inspect
+import json
+import warnings
+
+from mcp.server import Server
+
+import boss_agent_cli.mcp_server as mcp_server
+
+
+async def _dummy(*args, **kwargs):
+	return []
+
+
+def _handler_decorators():
+	discovered = {}
+	for name in dir(Server):
+		if name.startswith("_"):
+			continue
+		probe = Server("probe")
+		before = set(probe.request_handlers)
+		with warnings.catch_warnings():
+			warnings.simplefilter("ignore")
+			try:
+				getattr(probe, name)()(_dummy)
+			except Exception:
+				# 不是 handler 装饰器工厂（run / create_initialization_options / ...）
+				continue
+		added = set(probe.request_handlers) - before
+		if len(added) == 1:
+			discovered[name] = added.pop()
+	return discovered
+
+
+decorators = _handler_decorators()
+registered = set(mcp_server.server.request_handlers)
+declared = []
+unregistered = []
+for name in mcp_server.__all__:
+	attr = getattr(mcp_server, name, None)
+	if not inspect.iscoroutinefunction(attr) or name not in decorators:
+		continue
+	declared.append(name)
+	if decorators[name] not in registered:
+		unregistered.append(name)
+
+print(json.dumps({
+	"known_decorators": sorted(decorators),
+	"declared_handlers": sorted(declared),
+	"unregistered_handlers": sorted(unregistered),
+}))
+"""
+
+# 协议层实际发出的工具集合，必须与 mcp_tools.TOOLS 逐名相等。用集合相等而不是数量
+# 断言：既抓「工具漏发」，也抓「协议层发出了目录外的工具」，且不引入 73 这个硬编码
+# 数字——CLAUDE.md 要求计数只有一个真源。
+_CATALOG_PROBE = """
+import asyncio
+import json
+import sys
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from boss_agent_cli.mcp_tools import TOOLS
+
+
+async def main():
+	params = StdioServerParameters(command=sys.executable, args=["-m", "boss_agent_cli.mcp_server"])
+	async with stdio_client(params) as (read_stream, write_stream):
+		async with ClientSession(read_stream, write_stream) as session:
+			await session.initialize()
+			listed = await session.list_tools()
+	print(json.dumps({
+		"over_protocol": sorted(tool.name for tool in listed.tools),
+		"in_catalog": sorted(tool.name for tool in TOOLS),
+	}))
+
+
+asyncio.run(main())
+"""
+
+
+def _run_probe(source: str) -> dict[str, Any]:
+	result = subprocess.run(
+		[sys.executable, "-c", source],
+		capture_output=True,
+		text=True,
+		encoding="utf-8",
+		timeout=60,
+	)
+	assert result.returncode == 0, f"探针进程失败：\n{result.stderr}"
+	parsed: dict[str, Any] = json.loads(result.stdout)
+	return parsed
+
+
+def test_every_declared_mcp_handler_is_registered() -> None:
+	report = _run_probe(_REGISTRATION_PROBE)
+
+	# 探针自身的健全性检查。少了这条，一旦 SDK 改了内部结构导致探针什么都发现不了，
+	# unregistered 会是空列表，守卫就静默变成恒真——比没有守卫更糟。
+	assert report["known_decorators"], "没能从 SDK 反推出任何 handler 装饰器：探针坏了"
+	assert {"call_tool", "list_tools"} <= set(report["declared_handlers"]), (
+		f"__all__ 里少了已知的 MCP handler，实际发现 {report['declared_handlers']}；"
+		"把 handler 从 __all__ 移出去会同时绕开本守卫"
+	)
+
+	assert report["unregistered_handlers"] == [], (
+		f"{report['unregistered_handlers']} 写进了 __all__ 却没出现在 server.request_handlers 里，"
+		"即漏了 @server.<name>() 装饰器。MCP host 调用对应方法会收到 -32601 Method not found。"
+	)
+
+
+def test_tools_over_protocol_match_the_catalog() -> None:
+	report = _run_probe(_CATALOG_PROBE)
+
+	assert report["in_catalog"], "工具目录为空：探针坏了"
+	assert report["over_protocol"] == report["in_catalog"], (
+		"tools/list 发出的工具集合与 mcp_tools.TOOLS 不一致；"
+		f"只在协议层：{sorted(set(report['over_protocol']) - set(report['in_catalog']))}；"
+		f"只在目录里：{sorted(set(report['in_catalog']) - set(report['over_protocol']))}"
+	)

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -38,6 +38,13 @@ from boss_agent_cli.wizard.prompts import (
 	collect_wizard_input,
 )
 
+# PTY 用例要真起一个 CLI 进程并等 prompt_toolkit 渲染完首屏，耗时随机器负载浮动：
+# 本机约 1s，而 CI 的 P0 baseline job 在同一个 job 里串跑 ruff / pytest / mypy，
+# 曾因 5s 硬期限超时假红并挡住 #380 的合并（同一 commit 上五个测试矩阵 job 全过）。
+# 放宽期限不会拖慢快机器——命中同步标记或进程退出就立刻跳出循环。
+_PTY_STARTUP_TIMEOUT = float(os.environ.get("BOSS_TEST_PTY_STARTUP_TIMEOUT", "30"))
+_PTY_EXIT_TIMEOUT = float(os.environ.get("BOSS_TEST_PTY_EXIT_TIMEOUT", "20"))
+
 
 class _ScriptedMenu:
 	def __init__(self, selections, texts=()):
@@ -1978,7 +1985,8 @@ def test_prompt_toolkit_pty_uses_stderr_and_arrow_keys(tmp_path):
 	output = bytearray()
 	stdout_output = bytearray()
 	try:
-		startup_deadline = time.monotonic() + 5
+		menu_rendered = False
+		startup_deadline = time.monotonic() + _PTY_STARTUP_TIMEOUT
 		while time.monotonic() < startup_deadline:
 			ready, _, _ = select.select([stderr_master_fd], [], [], 0.1)
 			if not ready:
@@ -1993,12 +2001,22 @@ def test_prompt_toolkit_pty_uses_stderr_and_arrow_keys(tmp_path):
 			# 提示行恒在内容区，用作「菜单已渲染」的同步信号；
 			# 标题现在画在框上（D1），不再是内容区的第一行。
 			if "↑↓ 选择" in output.decode("utf-8", errors="ignore"):
+				menu_rendered = True
 				break
+		# 必须确认菜单真渲染出来了再发按键。此前超时也照发，prompt_toolkit 尚未接管
+		# 输入，按键被丢掉，最终报成「没退出」——把「启动慢」误诊为「交互坏」，
+		# 而且看不到任何有用线索。
+		if not menu_rendered:
+			process.kill()
+			pytest.fail(
+				f"prompt_toolkit 菜单在 {_PTY_STARTUP_TIMEOUT}s 内未渲染；"
+				f"已捕获输出：{output.decode('utf-8', errors='replace')!r}"
+			)
 		for _ in range(5):
 			os.write(stderr_master_fd, b"\x1b[B")
 			time.sleep(0.05)
 		os.write(stderr_master_fd, b"\r")
-		completion_deadline = time.monotonic() + 5
+		completion_deadline = time.monotonic() + _PTY_EXIT_TIMEOUT
 		while process.poll() is None and time.monotonic() < completion_deadline:
 			ready, _, _ = select.select([stderr_master_fd], [], [], 0.1)
 			if ready:
@@ -2011,7 +2029,10 @@ def test_prompt_toolkit_pty_uses_stderr_and_arrow_keys(tmp_path):
 				output.extend(chunk)
 		if process.poll() is None:
 			process.kill()
-			pytest.fail("prompt_toolkit PTY did not exit after arrow-key selection")
+			pytest.fail(
+				f"prompt_toolkit PTY 在选中后 {_PTY_EXIT_TIMEOUT}s 内未退出；"
+				f"已捕获输出：{output.decode('utf-8', errors='replace')!r}"
+			)
 		process.wait(timeout=2)
 		while True:
 			ready, _, _ = select.select([stderr_master_fd], [], [], 0.05)


### PR DESCRIPTION
## 关联 / Related

依赖 **#380**（`fix: 恢复 MCP 工具列表协议注册`，修 #377）。本 PR 只补门禁，不重复实现修复。

> #380 已于 2026-08-27 合并（`6957569`），本 PR 已 rebase 到其上，守卫全部转绿。

## 变更说明 / Summary

#377 的 `list_tools` 漏装饰器能带着 v1.18.0 发出去，是因为**四道门禁同时失效**：

| 门禁 | 为什么没拦住 |
|---|---|
| `tests/test_mcp_server.py` | `sys.modules.setdefault("mcp", <mock>)` 顶替整个 SDK，`@server.list_tools()` 变成 MagicMock 上的空操作，**装饰器在不在原理上观测不到** |
| CI docker job | stdio 握手只断言 `initialize`；握手成功但工具表为空 |
| eval | 跑离线 fixture，绕开协议层 |
| ruff / mypy | `__all__` 声明 + `mcp-server/server.py` 的 re-export，给未注册的孤儿函数做了完整的活体伪装 |

所以补的是门禁，不是单点断言。

### 1. `tests/test_mcp_handler_registration.py`（新增）

两条守卫，**都在子进程里跑真 SDK**：pytest 单进程收集全部测试模块，
`sys.modules["mcp"]` 是真包还是 mock 取决于收集顺序——一个随收集顺序变化的守卫不是守卫。

**结构守卫**不查装饰器语法，直接问运行时的 `server.request_handlers`。
「装饰器名 → request 类型」的映射**从 SDK 自身反推**（在全新 `Server` 上应用装饰器后
diff 注册表键），自动发现了 11 个 handler 装饰器，因此 SDK 将来新增
`list_prompts` / `read_resource` 时守卫覆盖面自动跟上，不需人工维护。
另加两条探针自检断言，防止映射发现不到东西时守卫静默变成恒真。

**目录守卫**断言 `tools/list` 经协议发出的名字集合与 `mcp_tools.TOOLS` **逐名相等**——
既抓漏发也抓多发，且不引入硬编码计数（计数只有一个真源）。

### 2. CI docker job

在同一个 stdio 会话里补做 `initialize` → `notifications/initialized` → `tools/list`，
断言工具列表非空且含 `boss_status`。已在本地对着**未修复**的入口验证过：
新步骤以 `-32601` 退出 1，而旧步骤照样打印 `MCP initialize ok` 放行。

### 3. `tests/test_wizard.py` PTY 用例假红

启动同步循环 5s 超时后**照样发送按键**，此时 prompt_toolkit 尚未接管输入，
按键被丢弃，最终报成「没退出」——把「启动慢」误诊为「交互坏」，且不留任何线索。

现在必须确认菜单真渲染出来才发按键，否则以「菜单未渲染」失败并附上已捕获输出；
期限放宽到 30s / 20s 并可用环境变量覆盖（命中同步标记即跳出，快机器仍约 1s）。

它曾在 CI 的 P0 baseline job 上超时并**挡住 #380 的合并**，而同一 commit 的
五个测试矩阵 job 全过——典型的假红。

### 4. `CHANGELOG.md`

master 自 v1.18.0 起 8 个提交未记 CHANGELOG，`[Unreleased]` 一直是空的，
而 #385 / #388 / #390 三个外部 PR 全都老实写了这一段——不先补齐，它们会在同一个
空段落上互相文本冲突。已补记 #379 / #381 / `0a2636f` / #392，含 #392 里把脱敏的
bool 豁免补完整为 `(bool, int, float, None)` 这个信封可见的行为变化。

## 变更类型 / Type

- [x] test: 测试
- [x] ci: CI 工作流
- [x] docs: 文档

## Breaking Change

- [x] 本 PR **不包含** 破坏性变更（`src/` 零改动）

## 测试 / Test Plan

- [x] **红灯验证**（守卫不经红灯验证等于没有守卫）：
  - 注掉 `@server.list_tools()` → 结构守卫 + 目录守卫**都失败**
  - 注掉 `@server.call_tool()` → 结构守卫**同样失败**（证明是通用守卫，不是给 `list_tools` 打的补丁）
  - 两者都在 → 全绿
- [x] `uv run python scripts/quality_baseline.py`（rebase 到含 #380 的 master 后）：**1851 passed** · ruff 全绿 · mypy 149 files 零错误
- [x] `uv run pytest tests/test_agent_docs.py tests/test_open_source_docs.py -q`：38 passed
- [x] `BOSS_SMOKE_DRY_RUN=1 uv run python scripts/smoke_p0.py`：4 步 dry-run 正常
- [x] `uv run python evals/run_eval.py --mode fixture`：4/4 passed
- [x] CI 新步骤本地实跑（本地入口替换 `docker run`）：`MCP tools/list ok: 73 tools`
- [x] PTY 用例正常路径仍 ~0.9s；`BOSS_TEST_PTY_STARTUP_TIMEOUT=0.01` 时给出「菜单未渲染」而非误导性失败

## 文档与契约 / Docs & Contracts

- [x] 无新增命令 / MCP 工具 / 错误码 / 外部依赖
- [x] 已更新 `CHANGELOG.md` 的 `[Unreleased]`
- [x] `boss schema` 输出不变（39 命令 / 73 工具 / 47 错误码）

## 安全与规范 / Safety & Convention

- [x] commit message 格式 `type: 中文描述`
- [x] 无 `Co-authored-by` 或 AI 署名行
- [x] 无敏感信息
