### PR TITLE
ci: 修正两处会让门禁自己随机变红的缺陷

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,19 +154,39 @@ jobs:
       # 只断言 initialize 是不够的：v1.18.0 就是带着一个未注册的 tools/list 发出去的
       # （issue #377），握手照样成功，MCP host 一列工具才拿到 -32601。所以这里必须在
       # 同一个 stdio 会话里把 tools/list 也真的问一遍。
+      #
+      # 两处刻意的写法，都是为了不让这道门禁自己变成 flaky：
+      # 1. printf 之后 sleep：写完三行就关 stdin 的话，服务器可能在回 tools/list 之前
+      #    就因 EOF 退出，读端拿到空串——实测在 CI 上真的发生过。
+      # 2. 按 JSON-RPC id 认响应，不靠行序：任何多余输出或顺序变化都不会误判。
       - name: Verify the MCP server handshake and tool listing over stdio
         run: |
-          printf '%s\n' \
+          { printf '%s\n' \
             '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"ci","version":"1.0"}}}' \
             '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
-            '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+            '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'; sleep 10; } \
             | docker run --rm -i boss-agent-cli:ci \
             | python3 -c "
           import sys, json
-          initialized = json.loads(sys.stdin.readline())
+          initialized = listed = None
+          for line in sys.stdin:
+              line = line.strip()
+              if not line:
+                  continue
+              try:
+                  message = json.loads(line)
+              except json.JSONDecodeError:
+                  continue
+              if message.get('id') == 1:
+                  initialized = message
+              elif message.get('id') == 2:
+                  listed = message
+              if initialized and listed:
+                  break
+          assert initialized, 'initialize 没有收到响应'
           assert initialized['result']['serverInfo']['name'] == 'boss-agent-cli', initialized
           print('MCP initialize ok')
-          listed = json.loads(sys.stdin.readline())
+          assert listed, 'tools/list 没有收到响应'
           assert 'error' not in listed, listed
           names = [tool['name'] for tool in listed['result']['tools']]
           assert names, listed

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,13 @@ jobs:
       - name: Check whitespace
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+            # 刻意不加 --depth=1：浅克隆只取到 base 的 tip，落后于 base 的 PR 分支
+            # 算不出 merge base，`git diff --check A...B` 会直接以
+            # `fatal: origin/<base>...HEAD: no merge base` 退出 128——看起来像空白字符
+            # 违规，实际是这一步崩了。#382 / #383 / #390 三个 PR 都因此吃到假红，
+            # 而恰好是等得最久、落后最多的贡献者最容易撞上。
+            # checkout 已用 fetch-depth: 0，这里只是补一个 origin/<base> 引用，不会多下多少。
+            git fetch --no-tags origin "${{ github.base_ref }}"
             git diff --check "origin/${{ github.base_ref }}...HEAD"
           elif git rev-parse --verify HEAD^ >/dev/null 2>&1; then
             git diff --check HEAD^...HEAD

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,15 +36,18 @@ jobs:
       - name: Run docs checks
         run: uv run pytest tests/test_agent_docs.py tests/test_open_source_docs.py -q
 
+      # 这里刻意不加 --depth=1：浅克隆只取到 base 的 tip，落后于 base 的 PR 分支
+      # 算不出 merge base，`git diff --check A...B` 会直接以
+      # `fatal: origin/<base>...HEAD: no merge base` 退出 128——看起来像空白字符违规，
+      # 实际是这一步崩了。#382 / #383 / #390 三个 PR 都因此吃到假红，而恰好是等得最久、
+      # 落后最多的贡献者最容易撞上。checkout 已用 fetch-depth: 0，这一步只是补一个
+      # origin/<base> 引用，不会多下多少。
+      #
+      # 注释必须留在 run 块外面：tests/test_open_source_docs.py 逐字锁定 step["run"]，
+      # 那条断言守的是「别把 --depth=1 加回来」，不该被注释改动打断。
       - name: Check whitespace
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            # 刻意不加 --depth=1：浅克隆只取到 base 的 tip，落后于 base 的 PR 分支
-            # 算不出 merge base，`git diff --check A...B` 会直接以
-            # `fatal: origin/<base>...HEAD: no merge base` 退出 128——看起来像空白字符
-            # 违规，实际是这一步崩了。#382 / #383 / #390 三个 PR 都因此吃到假红，
-            # 而恰好是等得最久、落后最多的贡献者最容易撞上。
-            # checkout 已用 fetch-depth: 0，这里只是补一个 origin/<base> 引用，不会多下多少。
             git fetch --no-tags origin "${{ github.base_ref }}"
             git diff --check "origin/${{ github.base_ref }}...HEAD"
           elif git rev-parse --verify HEAD^ >/dev/null 2>&1; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 ## [Unreleased]
 
 ### Fixed
+- 修正 Docs 工作流的 `Check whitespace` 对**落后于 master 的 PR 一律假红**：
+  `git fetch --no-tags --depth=1 origin <base>` 只取到 base 的 tip 并留下浅克隆边界，
+  落后的 PR 分支算不出 merge base，`git diff --check A...B` 直接以
+  `fatal: origin/master...HEAD: no merge base` 退出 128——报出来像空白字符违规，
+  实际是这一步崩了。#382 / #383 / #390 三个外部 PR 的 `docs` 红灯都是这个原因，
+  且恰好是等得最久、落后最多的贡献者最容易撞上，还会被当成他们自己的问题。
+  去掉 `--depth=1` 即可（checkout 已用 `fetch-depth: 0`，这里只是补 `origin/<base>` 引用）。
 - **修复 MCP `tools/list` 从未注册：v1.18.0 的 MCP 入口对任何 host 都不可用。**
   `mcp_server.list_tools` 缺失 `@server.list_tools()` 装饰器，`initialize` 握手正常，但 client
   第一次列工具即 `-32601 Method not found`——73 个工具一个都拿不到。回归由 1.18.0 的

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ## [Unreleased]
 
 ### Fixed
+- 修正 CI docker job 的 `tools/list` 断言存在竞态：`printf` 写完三行就关闭 stdin，
+  MCP 服务器可能在回 `tools/list` 之前就因 EOF 退出，读端拿到空串报 `JSONDecodeError`
+  （已在 CI 上真实发生）。改为写完后保持 stdin 一段时间，并按 JSON-RPC `id` 认响应而非
+  依赖行序；`tools/list` 无响应时给出明确断言而不是解析错误。**一道会随机变红的门禁
+  等于没有门禁**——它会挡住无关的合并，正如同批修掉的 PTY 用例那样。
 - 修正 Docs 工作流的 `Check whitespace` 对**落后于 master 的 PR 一律假红**：
   `git fetch --no-tags --depth=1 origin <base>` 只取到 base 的 tip 并留下浅克隆边界，
   落后的 PR 分支算不出 merge base，`git diff --check A...B` 直接以

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -342,7 +342,9 @@ def test_docs_workflow_runs_open_source_doc_checks():
 		"uv run pytest tests/test_agent_docs.py tests/test_open_source_docs.py -q",
 		(
 			"if [ \"${{ github.event_name }}\" = \"pull_request\" ]; then\n"
-			"  git fetch --no-tags --depth=1 origin \"${{ github.base_ref }}\"\n"
+			# 刻意不带 --depth=1：浅克隆取不到 merge base，落后于 base 的 PR 会以
+			# `fatal: no merge base` 退出 128（假红）。这条断言守的就是别把它加回来。
+			"  git fetch --no-tags origin \"${{ github.base_ref }}\"\n"
 			"  git diff --check \"origin/${{ github.base_ref }}...HEAD\"\n"
 			"elif git rev-parse --verify HEAD^ >/dev/null 2>&1; then\n"
 			"  git diff --check HEAD^...HEAD\n"


### PR DESCRIPTION
## 变更说明 / Summary

Docs 工作流的 `Check whitespace` 对**任何落后于 master 的 PR 一律假红**。

```
fatal: origin/master...HEAD: no merge base
##[error]Process completed with exit code 128.
```

`git fetch --no-tags --depth=1 origin <base>` 只取到 base 的 tip 并留下浅克隆边界，
落后的 PR 分支因此算不出 merge base，`git diff --check A...B` 直接崩掉退出 128 ——
**报出来像空白字符违规，实际是这一步自己挂了**。

## 影响面

`#382` / `#383` / `#390` 三个外部 PR 的 `docs` 红灯全是这个原因，不是贡献者的问题：

| PR | 落后 master | CI 十个 job | `docs` | 完整 clone 里跑同一条命令 |
|---|---|---|---|---|
| #382 | 12 天 | 全过 | ❌ | `exit 0`（干净） |
| #383 | 12 天 | 全过 | ❌ | `exit 0`（干净） |
| #390 | 5 天 | 全过 | ❌ | `exit 0`（干净） |
| #380 | 刚更新分支 | 全过 | ✅ | — |
| #394 | 刚 rebase | 全过 | ✅ | — |

落后多少决定撞不撞上——**恰好是等得最久的贡献者最容易吃到，还会被当成他们自己的错**。

## 改动

去掉 `--depth=1`。`actions/checkout` 已用 `fetch-depth: 0`，这一步只是补一个
`origin/<base>` 引用，不会多下多少。

## 测试 / Test Plan

干净克隆里的 A/B（每次都从全新 clone 开始，避免上一次的 `.git/shallow` 污染结果）：

| | 旧写法 `--depth=1` | 新写法 |
|---|---|---|
| 落后 3 个提交的分支 | `fatal: no merge base` / **exit 128** | **exit 0** |
| `.git/shallow` | 生成 | 不生成 |
| 真的尾随空格 | 测不到（已经崩了） | `probe.py:1: trailing whitespace.` **正常抓到** |

- [x] 修完仍能抓出真的空白问题（没有把门禁改松）
- [x] 非 PR 路径（push / 首个提交）分支未改动

## 变更类型 / Type

- [x] ci: CI 工作流

## Breaking Change

- [x] 本 PR **不包含** 破坏性变更（`src/` 零改动）

## 文档与契约 / Docs & Contracts

- [x] 已更新 `CHANGELOG.md` 的 `[Unreleased]`
- [x] 无新增命令 / MCP 工具 / 错误码 / 依赖

## 安全与规范 / Safety & Convention

- [x] commit message 格式 `type: 中文描述`
- [x] 无 `Co-authored-by` 或 AI 署名行

---

## 追加：docker job 的 `tools/list` 断言存在竞态

本 PR 开出后，`docker` job 自己挂了一次 —— 挂在 #394 刚加的那个 `tools/list` 步骤上，
而同一段代码在 #394 上是过的：

```
MCP initialize ok
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

`printf` 写完三行就关闭 stdin，MCP 服务器可能在回 `tools/list` 之前就因 EOF 退出，
读端 `readline()` 拿到空串。

修法：写完后保持 stdin 一段时间给服务器留回包窗口；按 JSON-RPC `id` 认响应而不依赖行序；
`tools/list` 无响应时给出明确断言而非解析错误。

本地连跑 5 次稳定通过（`73 tools`）；删掉 `tools/list` 请求后报
`AssertionError: tools/list 没有收到响应`，失败可诊断。

代价是每次 CI 多约 10 秒纯等待。**一道会随机变红的门禁等于没有门禁** —— 它会挡住无关的
合并，今天 PTY 用例已经这样挡过 #380 一次，不该由我再引入第二个。
