### PR TITLE
chore: 准备 1.19.0 发版

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+## [1.19.0] - 2026-08-27
+
 ### Fixed
 - 修正 CI docker job 的 `tools/list` 断言存在竞态：`printf` 写完三行就关闭 stdin，
   MCP 服务器可能在回 `tools/list` 之前就因 EOF 退出，读端拿到空串报 `JSONDecodeError`

--- a/ROADMAP.en.md
+++ b/ROADMAP.en.md
@@ -4,6 +4,7 @@ This document tracks the medium-term and long-term direction of `boss-agent-cli`
 
 ## Released
 
+- ✅ v1.19.0 (2026-08-27): fixed the never-registered MCP `tools/list` (the MCP entry point was unusable for every host since v1.18.0) and added protocol-level plus CI gates, opened every implemented capability under assisted / research, unified the terminal-only `boss wizard` into a single interactive window, and split envelope `hints` into agent / operator channels
 - ✅ v1.18.0 (2026-07-29): usable Docker / Compose image with CI build gate, MCP schema contract fixes and `mcp_server` split, offline evals in P0, pinned ruff rules, and dependency refresh (rich 15)
 - ✅ v1.17.0 (2026-07-27): `boss favorites list/sync` for syncing saved jobs, the restricted Research Mode resumable crawl workflow, and internship job-type fields plus the internship filter mapping fix
 - ✅ v1.16.0 (2026-07-17): explicit `operating_mode` two-mode contract (`assisted` / `research`) and the compliance guardrail rebuilt as an immutable capability policy registry, with CLI, schema, and MCP filtering all derived from one source of truth

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,6 +4,7 @@
 
 ## 已发布
 
+- ✅ v1.19.0（2026-08-27）：修复 MCP `tools/list` 从未注册（v1.18.0 起 MCP 入口对所有 host 不可用）并补齐协议层与 CI 门禁 + 开放 assisted / research 下全部已实现能力 + 纯终端 `boss wizard` 统一为单交互窗口 + 信封 `hints` 拆分 Agent / 真人双受众通道
 - ✅ v1.18.0（2026-07-29）：可用 Docker / Compose 镜像与 CI 构建门禁 + MCP schema 契约修复与 `mcp_server` 拆分 + 离线 evals 进 P0 + ruff 规则钉死与依赖刷新（rich 15）
 - ✅ v1.17.0（2026-07-27）：`boss favorites list/sync` 职位收藏同步 + 受限 Research Mode 的可恢复 crawl 工作流 + 实习岗位类型字段与筛选映射修复
 - ✅ v1.16.0（2026-07-17）：显式 `operating_mode` 双模式契约（`assisted` / `research`）+ 合规护栏升级为不可变能力策略注册表，CLI / schema / MCP 过滤从同一真源派生

--- a/docs/marketing/awesome-submissions.md
+++ b/docs/marketing/awesome-submissions.md
@@ -2,7 +2,7 @@
 
 > **Historical snapshot:** counts and default low-risk positioning below are superseded by the current open-capability wizard design. Use README and `boss schema` before submitting.
 
-本文件记录 boss-agent-cli 向各大 awesome 列表投稿的模板，供维护者提交用。最后更新：master 当前状态 (2026-07-29)。
+本文件记录 boss-agent-cli 向各大 awesome 列表投稿的模板，供维护者提交用。最后更新：master 当前状态 (2026-08-27)。
 
 ## 项目一句话介绍
 
@@ -55,8 +55,8 @@
 - [x] README 双语（中文 + 英文）
 - [x] MIT License
 - [x] CI 全绿（pytest / ruff / mypy / CodeQL）
-- [x] 发布到 PyPI（`pip install boss-agent-cli`，当前 latest release v1.18.0）
-- [x] GitHub Release 规范（latest release v1.18.0 已发）
+- [x] 发布到 PyPI（`pip install boss-agent-cli`，当前 latest release v1.19.0）
+- [x] GitHub Release 规范（latest release v1.19.0 已发）
 - [x] CHANGELOG 完整
 - [x] Code of Conduct + Security Policy
 - [x] Issue / PR 模板

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "boss-agent-cli"
-version = "1.18.0"
+version = "1.19.0"
 description = "AI Agent 专用的 BOSS 直聘求职 CLI 工具"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/boss_agent_cli/__init__.py
+++ b/src/boss_agent_cli/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 	)
 	from boss_agent_cli.resume.models import ResumeData, ResumeFile
 
-__version__ = "1.18.0"
+__version__ = "1.19.0"
 
 _LAZY_EXPORT_MODULES = {
 	"AuthManager": "boss_agent_cli.auth.manager",

--- a/uv.lock
+++ b/uv.lock
@@ -254,7 +254,7 @@ wheels = [
 
 [[package]]
 name = "boss-agent-cli"
-version = "1.18.0"
+version = "1.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },


### PR DESCRIPTION
## 变更说明 / Summary

切 **1.19.0**，不是 1.18.1。

这个仓库只从 master 切版（全部历史版本都是 `chore: 准备 X 发版` + tag），而 master 自
v1.18.0 起已累了三个 feature 级提交（#379 开放能力与纯终端 wizard、#381 hints 双受众通道、
#392 向导单交互窗口）。从这样的 master 切「补丁版」会把 feature 装进 patch 号里，语义上是错的；
要真发 1.18.1 得从 `v1.18.0` 拉分支 cherry-pick，属于这个仓库从未有过的流程负担，不值得。

## 本版核心

**修复 MCP `tools/list` 从未注册** —— `mcp_server.list_tools` 缺 `@server.list_tools()`，
`initialize` 握手正常但 client 第一次列工具即 `-32601`，**73 个工具一个都拿不到**，
自 v1.18.0 起持续近一个月（#377 / #380）。

同批补齐了让它溜出去的门禁（#394），并修掉三处**门禁自己随机变红**的缺陷（#394 / #395）：
PTY 用例、`docs` 的 whitespace 检查、以及新加的 docker `tools/list` 步骤本身。

## 版本号变更位置

| 文件 | 内容 |
|---|---|
| `CHANGELOG.md` | `[Unreleased]` → `[1.19.0] - 2026-08-27`，新开空的 `[Unreleased]` |
| `pyproject.toml` | `version = "1.19.0"` |
| `src/boss_agent_cli/__init__.py` | `__version__ = "1.19.0"` |
| `uv.lock` | 同步 |
| `ROADMAP.md` / `ROADMAP.en.md` | 已发布列表加 v1.19.0 |
| `docs/marketing/awesome-submissions.md` | latest release + 最后更新日期 |

`docs/integrations/docker.md` 不再钉版本号（#379 已改为 "the current ... contract"），无需改。

## 测试 / Test Plan（照 `docs/maintainer/release-checklist.md`）

- [x] `uv sync --all-extras`
- [x] `uv run python scripts/quality_baseline.py`：**1851 passed** · ruff 全绿 · mypy 149 files 零错误
- [x] `uv run pytest tests/test_agent_docs.py tests/test_open_source_docs.py -q`：38 passed
- [x] `uv run boss --version`：`boss, version 1.19.0`
- [x] `uv run boss --help` 可加载
- [x] `uv run boss schema --format native`：`ok=true`，39 个顶层命令
- [x] `BOSS_SMOKE_DRY_RUN=1 uv run python scripts/smoke_p0.py`
- [x] `uv run python evals/run_eval.py --mode fixture`：4/4 passed
- [x] `git diff --check` 干净
- [x] `uv build` → `boss_agent_cli-1.19.0-py3-none-any.whl` + `.tar.gz`
- [x] **解开 wheel 核对产物真的带着修复**：`mcp_server.py:125` 是 `@server.list_tools()`，
      `__version__ = "1.19.0"`。这次事故的教训就是「以为发出去了」，所以产物要亲眼看过。

## 敏感数据检查 / Sensitive data（checklist §3）

- [x] 提交中无 Cookie / Token / 手机号 / 微信 / 真实姓名 / 公司私有数据 / 真实 `security_id`
- [x] Release notes 不含真实命令输出

## 变更类型 / Type

- [x] chore: 发版准备

## Breaking Change

- [x] 本 PR **不包含** 破坏性变更

## 安全与规范 / Safety & Convention

- [x] commit message 格式 `type: 中文描述`
- [x] 无 `Co-authored-by` 或 AI 署名行
- [x] 已阅读 `docs/maintainer/release-checklist.md`
