### PR TITLE
fix: 收紧 mcp 上界并补齐全新安装门禁

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,71 @@ jobs:
       - name: Run mypy
         run: uv run mypy src/boss_agent_cli
 
+  fresh_install:
+    # 其余所有 job 都走 uv.lock 里钉死的依赖，**用户走的是全新解析**——两者从来没被对齐过。
+    # 后果是真实发生过的：`mcp` 声明为无上界的 `>=1.0.0`，mcp 2.0 重写了 Server API 并删掉
+    # `@server.list_tools()` / `@server.call_tool()`，于是每一个全新安装的用户都只能拿到
+    # `AttributeError: 'Server' object has no attribute 'call_tool'`，boss-mcp 连起都起不来，
+    # 而 CI 因为锁着 1.x 永远全绿。
+    #
+    # 所以这个 job 刻意不用 uv.lock：装构建产物、让依赖按 pyproject 的约束重新解析，
+    # 再真跑一次 MCP 会话。它守的是「门禁看到的」与「用户拿到的」之间那道缝。
+    name: Fresh install resolves to a working MCP server
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Build the wheel
+        run: uv build --wheel
+
+      - name: Install it with fresh dependency resolution
+        run: |
+          uv venv /tmp/freshenv
+          VIRTUAL_ENV=/tmp/freshenv uv pip install "$(ls dist/*.whl)[mcp]"
+          /tmp/freshenv/bin/python -c "import importlib.metadata as m; print('resolved mcp:', m.version('mcp'))"
+
+      - name: Run a real MCP session against it
+        run: |
+          { printf '%s\n' \
+            '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"ci","version":"1.0"}}}' \
+            '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+            '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'; sleep 10; } \
+            | /tmp/freshenv/bin/boss-mcp \
+            | python3 -c "
+          import sys, json
+          initialized = listed = None
+          for line in sys.stdin:
+              line = line.strip()
+              if not line:
+                  continue
+              try:
+                  message = json.loads(line)
+              except json.JSONDecodeError:
+                  continue
+              if message.get('id') == 1:
+                  initialized = message
+              elif message.get('id') == 2:
+                  listed = message
+              if initialized and listed:
+                  break
+          assert initialized, 'initialize 没有收到响应——多半是 boss-mcp 起不来'
+          assert initialized['result']['serverInfo']['name'] == 'boss-agent-cli', initialized
+          print('MCP initialize ok')
+          assert listed, 'tools/list 没有收到响应'
+          assert 'error' not in listed, listed
+          names = [tool['name'] for tool in listed['result']['tools']]
+          assert names and 'boss_status' in names, listed
+          print('MCP tools/list ok:', len(names), 'tools')
+          "
+
   docker:
     # 容器镜像必须每次构建，否则会像此前那个无人引用的 Dockerfile 一样静默腐烂。
     #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 ## [Unreleased]
 
+## [1.19.1] - 2026-08-27
+
+### Fixed
+- **修复全新安装的 `boss-mcp` 完全起不来。** `mcp` 此前声明为无上界的 `mcp>=1.0.0`，
+  而 mcp 2.0 重写了 `Server` API——`@server.list_tools()` / `@server.call_tool()` 全部移除，
+  改为 `add_request_handler`。`mcp_server` 在模块层就用这些装饰器，因此任何解析到 2.x 的
+  全新安装都直接 `AttributeError: 'Server' object has no attribute 'call_tool'`，
+  `boss-mcp` 连启动都做不到。已收紧为 `mcp>=1.0.0,<2.0.0`。
+  这不是 1.19.0 引入的：1.18.0 在 mcp 2.x 下有完全相同的崩溃，只是此前没人从 PyPI
+  全新装一次验过。issue #377 的报告人当时用了 `--with 'mcp<2.0'`，所以他们看到的是
+  `-32601` 而不是崩溃。
+  mcp 2.x 的适配另开 issue 跟踪，放开上界之前不做。
+
+### Added
+- CI 新增 `fresh_install` job：**刻意不走 `uv.lock`**，装构建产物、让依赖按 `pyproject`
+  的约束重新解析，再真跑一次 MCP 会话。此前所有 job 都锁着 1.x 依赖，因此
+  「CI 全绿、用户全崩」可以长期共存——这个 job 守的就是**门禁看到的与用户拿到的**
+  之间那道缝。红灯验证：移除 `mcp` 上界后该 job 以「initialize 没有收到响应」失败。
+
 ## [1.19.0] - 2026-08-27
 
 ### Fixed

--- a/ROADMAP.en.md
+++ b/ROADMAP.en.md
@@ -4,6 +4,7 @@ This document tracks the medium-term and long-term direction of `boss-agent-cli`
 
 ## Released
 
+- ✅ v1.19.1 (2026-08-27): fixed fresh installs resolving to mcp 2.x, which made `boss-mcp` crash on import (dependency now capped at `<2.0.0`), and added a `fresh_install` CI gate that deliberately bypasses `uv.lock`
 - ✅ v1.19.0 (2026-08-27): fixed the never-registered MCP `tools/list` (the MCP entry point was unusable for every host since v1.18.0) and added protocol-level plus CI gates, opened every implemented capability under assisted / research, unified the terminal-only `boss wizard` into a single interactive window, and split envelope `hints` into agent / operator channels
 - ✅ v1.18.0 (2026-07-29): usable Docker / Compose image with CI build gate, MCP schema contract fixes and `mcp_server` split, offline evals in P0, pinned ruff rules, and dependency refresh (rich 15)
 - ✅ v1.17.0 (2026-07-27): `boss favorites list/sync` for syncing saved jobs, the restricted Research Mode resumable crawl workflow, and internship job-type fields plus the internship filter mapping fix

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,6 +4,7 @@
 
 ## 已发布
 
+- ✅ v1.19.1（2026-08-27）：修复全新安装解析到 mcp 2.x 导致 `boss-mcp` 直接崩溃（依赖收紧为 `<2.0.0`），并新增不走 `uv.lock` 的 `fresh_install` CI 门禁
 - ✅ v1.19.0（2026-08-27）：修复 MCP `tools/list` 从未注册（v1.18.0 起 MCP 入口对所有 host 不可用）并补齐协议层与 CI 门禁 + 开放 assisted / research 下全部已实现能力 + 纯终端 `boss wizard` 统一为单交互窗口 + 信封 `hints` 拆分 Agent / 真人双受众通道
 - ✅ v1.18.0（2026-07-29）：可用 Docker / Compose 镜像与 CI 构建门禁 + MCP schema 契约修复与 `mcp_server` 拆分 + 离线 evals 进 P0 + ruff 规则钉死与依赖刷新（rich 15）
 - ✅ v1.17.0（2026-07-27）：`boss favorites list/sync` 职位收藏同步 + 受限 Research Mode 的可恢复 crawl 工作流 + 实习岗位类型字段与筛选映射修复

--- a/docs/marketing/awesome-submissions.md
+++ b/docs/marketing/awesome-submissions.md
@@ -55,8 +55,8 @@
 - [x] README 双语（中文 + 英文）
 - [x] MIT License
 - [x] CI 全绿（pytest / ruff / mypy / CodeQL）
-- [x] 发布到 PyPI（`pip install boss-agent-cli`，当前 latest release v1.19.0）
-- [x] GitHub Release 规范（latest release v1.19.0 已发）
+- [x] 发布到 PyPI（`pip install boss-agent-cli`，当前 latest release v1.19.1）
+- [x] GitHub Release 规范（latest release v1.19.1 已发）
 - [x] CHANGELOG 完整
 - [x] Code of Conduct + Security Policy
 - [x] Issue / PR 模板

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "boss-agent-cli"
-version = "1.19.0"
+version = "1.19.1"
 description = "AI Agent 专用的 BOSS 直聘求职 CLI 工具"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -57,7 +57,14 @@ bridge = [
 	"aiohttp>=3.9",
 ]
 mcp = [
-	"mcp>=1.0.0",
+	# 上界是必须的，不是保守：mcp 2.0 重写了 Server API——装饰器 `@server.list_tools()` /
+	# `@server.call_tool()` 全部移除，改成 `add_request_handler`。`mcp_server` 在模块层
+	# 就用这些装饰器，所以装到 2.x 的用户连 `boss-mcp` 都起不来，直接
+	# `AttributeError: 'Server' object has no attribute 'call_tool'`。
+	# 此前声明是无上界的 `mcp>=1.0.0`，于是所有全新安装都解析到 2.x 并崩溃，而 CI 走
+	# uv.lock 里钉死的 1.x，永远看不到——这正是「门禁看到的和用户拿到的不是一个东西」。
+	# 放开上界之前必须先支持 2.x API（见 mcp 2.x 适配 issue）。
+	"mcp>=1.0.0,<2.0.0",
 ]
 crawl = [
 	"DrissionPage>=4.1.1.1,<4.2",

--- a/src/boss_agent_cli/__init__.py
+++ b/src/boss_agent_cli/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 	)
 	from boss_agent_cli.resume.models import ResumeData, ResumeFile
 
-__version__ = "1.19.0"
+__version__ = "1.19.1"
 
 _LAZY_EXPORT_MODULES = {
 	"AuthManager": "boss_agent_cli.auth.manager",

--- a/tests/test_agent_docs.py
+++ b/tests/test_agent_docs.py
@@ -242,7 +242,10 @@ def test_glama_metadata_exists_and_declares_owner():
 def test_pyproject_exposes_boss_mcp_script():
 	pyproject = _read("pyproject.toml")
 	assert 'boss-mcp = "boss_agent_cli.mcp_server:run"' in pyproject
-	assert '"mcp>=1.0.0"' in pyproject
+	# 上界是硬要求：mcp 2.0 删掉了 `@server.list_tools()` / `@server.call_tool()`，
+	# 而 mcp_server 在模块层就用它们，装到 2.x 的用户连 boss-mcp 都起不来。
+	# 声明无上界时 CI 仍走 uv.lock 里的 1.x，全绿，用户全崩。放开前必须先适配 2.x API。
+	assert '"mcp>=1.0.0,<2.0.0"' in pyproject
 
 
 def test_agent_facing_docs_keep_bounded_runtime_boundary():

--- a/uv.lock
+++ b/uv.lock
@@ -254,7 +254,7 @@ wheels = [
 
 [[package]]
 name = "boss-agent-cli"
-version = "1.19.0"
+version = "1.19.1"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },
@@ -303,7 +303,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=42.0" },
     { name = "drissionpage", marker = "extra == 'crawl'", specifier = ">=4.1.1.1,<4.2" },
     { name = "httpx", specifier = ">=0.27" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0,<2.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.20" },
     { name = "openpyxl", marker = "extra == 'crawl'", specifier = ">=3.1" },
     { name = "patchright", specifier = ">=1.58.2" },


### PR DESCRIPTION
## 变更说明 / Summary

发布 1.19.0 后照 `docs/maintainer/release-checklist.md` §6 从 PyPI 全新装了一次，
发现 **`boss-mcp` 连启动都做不到**：

```
File ".../boss_agent_cli/mcp_server.py", line 125, in <module>
    @server.list_tools()
AttributeError: 'Server' object has no attribute 'list_tools'
```

`mcp` 此前声明为**无上界**的 `mcp>=1.0.0`，而 **mcp 2.0 重写了 `Server` API** ——
`@server.list_tools()` / `@server.call_tool()` 全部移除，改为 `add_request_handler`。
`mcp_server` 在模块层就用这些装饰器，因此任何解析到 2.x 的全新安装都在 import 时崩溃。

## 这不是 1.19.0 引入的

已实测：**1.18.0 在 mcp 2.x 下有完全相同的崩溃**（挂在 `@server.call_tool()`）。
只是此前没人从 PyPI 全新装一次验过。

| 版本 | mcp 1.x（uv.lock / CI） | mcp 2.x（全新安装） |
|---|---|---|
| 1.18.0 | `tools/list` → `-32601` | **import 崩溃** |
| 1.19.0 | 正常，73 tools | **import 崩溃** |
| 本 PR | 正常，73 tools | 正常（依赖被约束到 1.x） |

顺带解开一个当时没追下去的细节：#377 的报告人用的是 `uvx --with 'mcp<2.0'`，
所以他们看到的是 `-32601` 而不是崩溃。那个 `<2.0` 本身就是线索。

## 改动

### 1. `mcp>=1.0.0,<2.0.0`

上界是硬要求，不是保守。放开之前必须先适配 2.x 的 `add_request_handler` API，
另开 issue 跟踪。

### 2. 新增 `fresh_install` CI job —— 补上让它溜过去的那道缝

其余所有 job 都走 `uv.lock` 里钉死的依赖，**用户走的是全新解析**，两者从来没被对齐过。
于是「CI 全绿 + 用户全崩」可以长期共存，而且没有任何信号。

这个 job 刻意**不用 `uv.lock`**：装构建产物、让依赖按 `pyproject` 的约束重新解析，
再真跑一次 MCP 会话（`initialize` + `tools/list`）。

## 测试 / Test Plan

- [x] **红灯验证**（守卫不经红灯验证等于没有守卫）：临时移除 `mcp` 上界 → 全新解析拿到
      **mcp 2.1.1** → 该 job 以 `AssertionError: initialize 没有收到响应——多半是 boss-mcp 起不来` 退出 1
- [x] 加上上界后全新解析拿到 **mcp 1.29.1**，实跑 MCP 会话：`tools/list → 73 tools; boss_status 在列`
- [x] 对照实验：`pip install boss-agent-cli[mcp]==1.18.0` 在 mcp 2.1.1 下同样崩溃，确认非本次回归
- [x] `uv run python scripts/quality_baseline.py`：**1851 passed** · ruff 全绿 · mypy 149 files
- [x] `uv run pytest tests/test_agent_docs.py tests/test_open_source_docs.py -q`：38 passed
- [x] `BOSS_SMOKE_DRY_RUN=1 uv run python scripts/smoke_p0.py`
- [x] `uv run python evals/run_eval.py --mode fixture`：4/4 passed
- [x] `uv run boss schema --format native`：`ok=true`，39 个顶层命令
- [x] `git diff --check` 干净

`test_pyproject_exposes_boss_mcp_script` 的断言同步改为锁**上界** —— 上界现在才是要守的
不变量，不该只锁下界。

## 版本

一并切 **1.19.1**（`CHANGELOG` / `pyproject` / `__init__` / `uv.lock` / `ROADMAP` ×2 /
`awesome-submissions`）。1.19.0 对全新安装的用户是不可用的，不适合停留。

## 变更类型 / Type

- [x] fix: Bug 修复
- [x] ci: CI 工作流
- [x] chore: 发版准备

## Breaking Change

- [x] 本 PR **不包含** 破坏性变更（收紧依赖上界只会阻止一个本就崩溃的组合）

## 安全与规范 / Safety & Convention

- [x] commit message 格式 `type: 中文描述`
- [x] 无 `Co-authored-by` 或 AI 署名行
- [x] 已阅读 `docs/maintainer/release-checklist.md`
