### PR TITLE
fix(search): 节流等待期间在进度条提示等待秒数

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased]
 
 ### Fixed
+- 修复 TTY 下节流等待期间进度条静默不动的观感问题（#400）：`CrawlBudget.wait()` 在等待前把剩余秒数报给 `SearchProgress`，进度条显示一次性「节流等待 Ns…」提示；非 TTY / `--json` 路径与等待 0 秒场景输出完全不变。
 - 修复扫码登录在「首页预热」阶段卡住时永久挂起：BOSS 直聘首页在自动化下偶发长时间不完成加载，`page.goto` 超时后若仍对页面执行 `page.evaluate`（取 UA / stoken），patchright 会因执行上下文无法建立而无限阻塞，导致 `boss login` 卡死且不落盘凭证。现在 UA 改在已加载的登录页上提前采集；`_warm_home_for_runtime` 返回首页是否真正加载完成，仅在确认加载后才对页面 evaluate 提取 stoken，否则回退读取 cookie jar；并对首页导航超时增加「跳 `about:blank` 重置卡死导航后重试一次」，显著降低风控验证页/加载缓慢导致的 `Page.goto: Timeout 15000ms exceeded` 误报。`login_via_cdp` / `refresh_stoken` / `refresh_stoken_via_cdp` 同步加固；CDP 登录/刷新 stoken 也改为优先页面 evaluate、失败回退 cookie jar（安全验证跳转期间 `domcontentloaded` 可能未触发，但 `__zp_stoken__` 已写入 cookie jar）。
 - 修复 BOSS 收藏接口在 `isActive=true` 下仍混入失效职位时的静默误判：`favorites list` 现输出规范化 `job_status` 与状态计数，`favorites sync` 仅导入明确有效职位并报告 active/inactive/unknown 数量；缺失或未知状态不再默认有效。
 

--- a/src/boss_agent_cli/commands/search.py
+++ b/src/boss_agent_cli/commands/search.py
@@ -199,6 +199,7 @@ def search_cmd(
 				progress = SearchProgress(_progress_title(criteria, welfare_conditions), max_pages=max_pages)
 				progress.start()
 				pipeline_logger = progress
+			# 仅 TTY 下把节流等待秒数喂给进度条；管道 / --json 保持 wait("list") 逐字不变。
 			try:
 				pipeline_result = execute_candidate_search(
 					platform,
@@ -219,7 +220,11 @@ def search_cmd(
 						"max_pages": max_pages,
 						"welfare_conditions": welfare_conditions,
 						"before_list_request": (
-							(lambda: request_budget.wait("list")) if request_budget is not None else None
+							(lambda: request_budget.wait("list", on_wait=progress.waiting))
+							if request_budget is not None and progress is not None
+							else (lambda: request_budget.wait("list"))
+							if request_budget is not None
+							else None
 						),
 					},
 					pipeline=run_search_pipeline,

--- a/src/boss_agent_cli/crawler/service.py
+++ b/src/boss_agent_cli/crawler/service.py
@@ -131,12 +131,14 @@ class CrawlBudget:
 		self._clock = clock
 		self._random_delay = random_delay
 
-	def wait(self, kind: str) -> None:
+	def wait(self, kind: str, on_wait: Callable[[float], None] | None = None) -> None:
 		low, high = (5.0, 10.0) if kind == "list" else (3.0, 6.0)
 		interval = self._random_delay(low, high)
 		now = self._clock()
 		remaining = self._cache.reserve_crawl_budget(f"zhipin:{kind}", now=now, interval=interval)
 		if remaining > 0:
+			if on_wait is not None:
+				on_wait(remaining)
 			self._sleeper(remaining)
 
 

--- a/src/boss_agent_cli/display.py
+++ b/src/boss_agent_cli/display.py
@@ -529,6 +529,10 @@ class SearchProgress:
 	def finish(self) -> None:
 		console.print(f"  [dim]{escape(self.status_text())}[/dim]")
 
+	def waiting(self, seconds: float) -> None:
+		"""节流等待前的一次性提示（取整秒，不做倒计时刷屏）。"""
+		console.print(f"  [dim]节流等待 {seconds:.0f}s…[/dim]")
+
 
 # ── Auth error decorator ─────────────────────────────────────────────
 

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -96,6 +96,45 @@ def test_crawl_budget_coordinates_separate_cache_connections(tmp_path: Path) -> 
 	second_cache.close()
 
 
+def test_crawl_budget_reports_wait_before_sleeping(tmp_path: Path) -> None:
+	cache = CacheStore(tmp_path / "budget.db")
+	now = [100.0]
+	sleeps: list[float] = []
+	reported: list[float] = []
+	events: list[str] = []
+	budget = CrawlBudget(
+		cache,
+		clock=lambda: now[0],
+		sleeper=lambda s: (events.append("sleep"), sleeps.append(s)),
+		random_delay=lambda low, high: 5.0,
+	)
+
+	budget.wait("list")  # 首次无历史，remaining == 0，不触发 on_wait
+	now[0] = 101.0
+	budget.wait("list", on_wait=lambda s: (events.append("report"), reported.append(s)))
+
+	assert reported == [4.0]
+	assert sleeps == [4.0]
+	assert events == ["report", "sleep"], "on_wait 必须在 sleep 之前触发，进度条才能先亮出等待"
+	cache.close()
+
+
+def test_crawl_budget_skips_on_wait_when_no_wait_needed(tmp_path: Path) -> None:
+	cache = CacheStore(tmp_path / "budget.db")
+	reported: list[float] = []
+	budget = CrawlBudget(
+		cache,
+		clock=lambda: 100.0,
+		sleeper=lambda s: None,
+		random_delay=lambda low, high: 5.0,
+	)
+
+	budget.wait("list", on_wait=reported.append)  # 无历史 → remaining == 0
+
+	assert reported == [], "等待 0 秒时不应触发 on_wait（避免噪音）"
+	cache.close()
+
+
 class _FakeTransport:
 	def __init__(
 		self,

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -867,6 +867,15 @@ class TestSearchProgress:
 
 		assert stream.getvalue() == ""
 
+	def test_waiting_renders_one_shot_throttle_hint(self, monkeypatch):
+		progress, stream = self._progress(monkeypatch)
+
+		progress.waiting(4.0)
+
+		lines = stream.getvalue().strip().splitlines()
+		assert len(lines) == 1, "节流提示应一次性渲染，不做倒计时刷屏"
+		assert "4" in lines[0]
+
 
 def test_search_pipeline_progress_markers_contract():
 	"""契约锁定：SearchProgress 依赖管线里的这些标记来分类进度消息。


### PR DESCRIPTION
## 关联 Issue / Related Issue

Closes #400

## 变更说明 / Summary

解决 #400：TTY 下 `CrawlBudget.wait()`（#383 引入的跨进程节流）是静默 sleep，导致 `SearchProgress` 进度条挂住不动 5–10 秒，观感上与卡死难以区分。

实现与 issue 建议方案一致，改动很小：

- `CrawlBudget.wait(kind, on_wait=None)`：`remaining > 0` 时**先**把剩余秒数交给回调再 sleep；等待 0 秒不触发回调（无历史记录的空闲搜索零噪音）。
- `SearchProgress.waiting(seconds)`：一次性 dim 提示「节流等待 Ns…」，取整秒，明确不做倒计时刷屏。
- `search_cmd` 仅在 TTY（`progress` 非 None）时把 `progress.waiting` 接为 `on_wait`；管道 / `--json` 路径保持 `wait("list")` 逐字不变，回调默认 `None` 完全向后兼容。

满足 issue 中「别做成噪音」的三条约束：非 TTY 无新增输出；等待 0 秒不打任何东西；不做逐秒倒计时。

## 变更类型 / Type

- [x] fix: Bug 修复

## Breaking Change

- [x] 本 PR **不包含** 破坏性变更

## 截图 / Screenshot

不涉及（TTY 进度条新增一行 dim 提示，无结构变化）。

## 测试 / Test Plan

- [x] `uv run pytest tests/ -q` 全部通过（1869 passed）
- [x] `uv run ruff check src/ tests/` 无报错
- [x] `uv run mypy src/boss_agent_cli` 无报错
- [x] `uv run boss --help` 可加载
- [x] `uv run boss schema --format native` 返回合法 JSON 信封
- [x] 新增/修改的功能已有对应测试覆盖（on_wait 先于 sleep 且携带剩余秒数、0 秒不触发、一次性渲染不刷屏）
- [ ] 本地跑过涉及命令（如有可粘贴已脱敏输出）

**验证全部为离线 mock；未执行任何真实 BOSS 搜索、登录或账号操作。**

## 文档与契约 / Docs & Contracts

- [ ] 如新增命令：已更新 `src/boss_agent_cli/commands/schema.py`（不涉及）
- [ ] 如变更 CLI 行为：已更新 `README.md` 和 `docs/capability-matrix.md`（仅 TTY 进度条反馈，非契约变更）
- [ ] 如新增 MCP 工具：已更新 `mcp-server/server.py` 和 `mcp-server/README.md`（不涉及）
- [ ] 如新增错误码：已添加到 `schema.py` 的 `error_codes`（不涉及）
- [x] 已更新 `CHANGELOG.md` 的 `[Unreleased]` 段落
- [ ] 如变更 Agent 主卖点或安装路径：已同步更新 README / landing 的 MCP 接入说明、PyPI 版本与 GitHub Release 说明（不涉及）

## 安全与规范 / Safety & Convention

- [x] commit message 格式: `type: 中文描述`
- [x] 无 `Co-authored-by` 尾注或 AI 署名行
- [x] 无敏感信息（Token / 密码 / Cookie / security_id / 手机号 / 微信 / 真实账号）
- [x] 如涉及 Cookie、CDP、patchright、请求频率或真实账号，已阅读 `docs/platform-risk.md`（本 PR 只改 TTY 反馈，不改变节流本身）
- [ ] 如涉及发布流程，已阅读 `docs/maintainer/release-checklist.md`（不涉及发布）
- [x] 无新增外部 CDN / script 依赖（HTML 报表类特别注意）
