### PR TITLE
feat: add orcarouter as a first-class AI provider

### DIFF
--- a/docs/integrations/ai-models.en.md
+++ b/docs/integrations/ai-models.en.md
@@ -10,6 +10,7 @@ The `boss ai` command group speaks an OpenAI-compatible protocol. This guide sum
 | `deepseek` | `https://api.deepseek.com/v1` | DeepSeek-V3 and DeepSeek-R1 |
 | `moonshot` | `https://api.moonshot.cn/v1` | Kimi K2 |
 | `openrouter` | `https://openrouter.ai/api/v1` | Aggregated access to Anthropic Claude, OpenAI, Google, Meta, and more |
+| `orcarouter` | `https://api.orcarouter.ai/v1` | OpenAI-compatible gateway; `orcarouter/auto` selects a model server-side per request |
 | `qwen` | `https://dashscope.aliyuncs.com/compatible-mode/v1` | Tongyi Qwen3 models |
 | `zhipu` | `https://open.bigmodel.cn/api/paas/v4` | GLM-4.6 and GLM-Z1 |
 | `siliconflow` | `https://api.siliconflow.cn/v1` | SiliconFlow aggregated inference |
@@ -80,6 +81,19 @@ boss ai config \
 
 > `deepseek-ai/deepseek-v4-pro` is a reasoning model with chain-of-thought — give it enough `max_tokens` (>= 512), otherwise tokens may be consumed by the reasoning trace and you get an empty `content` with `finish_reason=length`. The `--max-tokens` default in `boss ai config` is already 4096, so no extra tuning is needed.
 
+### OrcaRouter (OpenAI-compatible gateway)
+
+[OrcaRouter](https://www.orcarouter.ai) exposes an OpenAI-compatible API and uses a `provider/model` namespace. The special model id `orcarouter/auto` does not map to one fixed model on the endpoint — the server selects a model per request. The authoritative model list is whatever the server actually supports:
+
+```bash
+boss ai config \
+  --provider orcarouter \
+  --model orcarouter/auto \
+  --api-key <ORCAROUTER_KEY>
+```
+
+> Every `boss ai` prompt template ends with "return JSON only". Because `orcarouter/auto` may pick a different model per request, one that is less reliable at emitting structured JSON can cause intermittent `AI_PARSE_ERROR`s. If you hit `AI_PARSE_ERROR`, pin a specific model known to emit structured output reliably rather than relying on `auto`.
+
 ### Self-hosted proxy via LiteLLM / OneAPI
 
 ```bash
@@ -99,6 +113,7 @@ boss ai config \
 | You want mainland-China direct access without an extra proxy | `qwen`, `zhipu`, `deepseek`, or `moonshot` |
 | You want one key that spans many vendors | `openrouter` or `atlas` |
 | You want a full-modal, OpenAI-compatible aggregator | `atlas` + `deepseek-ai/deepseek-v4-pro` |
+| You want the server to pick the model per request | `orcarouter` + `orcarouter/auto` |
 | You already run your own compatible proxy | `custom` + `--base-url` |
 
 ## Validate the configuration

--- a/docs/integrations/ai-models.md
+++ b/docs/integrations/ai-models.md
@@ -10,6 +10,7 @@
 | `deepseek` | `https://api.deepseek.com/v1` | DeepSeek-V3、DeepSeek-R1 |
 | `moonshot` | `https://api.moonshot.cn/v1` | Kimi K2 |
 | `openrouter` | `https://openrouter.ai/api/v1` | **聚合入口**，支持 Anthropic Claude、OpenAI、Google、Meta 等全家桶 |
+| `orcarouter` | `https://api.orcarouter.ai/v1` | OpenAI 兼容网关；`orcarouter/auto` 由服务端按请求选型 |
 | `qwen` | `https://dashscope.aliyuncs.com/compatible-mode/v1` | 通义千问 Qwen3 系列 |
 | `zhipu` | `https://open.bigmodel.cn/api/paas/v4` | 智谱 GLM-4.6 / GLM-Z1 |
 | `siliconflow` | `https://api.siliconflow.cn/v1` | 硅基流动聚合推理 |
@@ -80,6 +81,19 @@ boss ai config \
 
 > `deepseek-ai/deepseek-v4-pro` 是带思维链的推理模型，`max_tokens` 要给足（建议 ≥ 512），否则 token 可能先耗在思维链上，出现 `content` 为空且 `finish_reason=length`。`boss ai config` 的 `--max-tokens` 默认即为 4096，无需额外调整。
 
+### OrcaRouter（OpenAI 兼容网关）
+
+[OrcaRouter](https://www.orcarouter.ai) 提供 OpenAI 兼容 API，采用 `provider/model` 命名空间。特殊模型 id `orcarouter/auto` 不固定对应端点上某个具体模型，而是由服务端按请求选择。可用模型以服务端实际支持为准：
+
+```bash
+boss ai config \
+  --provider orcarouter \
+  --model orcarouter/auto \
+  --api-key <ORCAROUTER_KEY>
+```
+
+> 每条 `boss ai` 提示词模板都以「只返回 JSON，不要包含其他内容」结尾。`orcarouter/auto` 每次请求可能选中不同模型，若选到不擅长稳定输出结构化 JSON 的模型，会间歇性触发 `AI_PARSE_ERROR`。若遇到 `AI_PARSE_ERROR`，请固定一个已知能稳定输出结构化结果的模型，而不是依赖 `auto`。
+
 ### 自建代理（LiteLLM / OneAPI）
 
 ```bash
@@ -99,6 +113,7 @@ boss ai config \
 | 国内直连不走代理 | `qwen` / `zhipu` / `deepseek` / `moonshot` |
 | 需要混用多家模型 | `openrouter` 或 `atlas` 一个 key 全覆盖 |
 | 想要全模态 + OpenAI 兼容聚合入口 | `atlas` + `deepseek-ai/deepseek-v4-pro` |
+| 想要模型由服务端按请求自动选型 | `orcarouter` + `orcarouter/auto` |
 | 已有自建代理 | `custom` + `--base-url` |
 
 ## 配置校验

--- a/src/boss_agent_cli/ai/config.py
+++ b/src/boss_agent_cli/ai/config.py
@@ -21,6 +21,7 @@ PROVIDER_BASE_URLS: dict[str, str | None] = {
 	"deepseek": "https://api.deepseek.com/v1",
 	"moonshot": "https://api.moonshot.cn/v1",
 	"openrouter": "https://openrouter.ai/api/v1",
+	"orcarouter": "https://api.orcarouter.ai/v1",
 	"qwen": "https://dashscope.aliyuncs.com/compatible-mode/v1",
 	"zhipu": "https://open.bigmodel.cn/api/paas/v4",
 	"siliconflow": "https://api.siliconflow.cn/v1",

--- a/src/boss_agent_cli/commands/ai_cmd.py
+++ b/src/boss_agent_cli/commands/ai_cmd.py
@@ -174,7 +174,7 @@ def ai_group() -> None:
 
 
 @ai_group.command("config")
-@click.option("--provider", default=None, help="AI 提供商（openai/deepseek/moonshot/openrouter/qwen/zhipu/siliconflow/atlas/ollama/vllm/custom）")
+@click.option("--provider", default=None, help="AI 提供商（openai/deepseek/moonshot/openrouter/orcarouter/qwen/zhipu/siliconflow/atlas/ollama/vllm/custom）")
 @click.option("--model", default=None, help="模型名称（如 gpt-4o / claude-sonnet-4.5 / deepseek-chat）")
 @click.option("--api-key", default=None, help="API 密钥（将加密存储）")
 @click.option("--base-url", default=None, help="自定义 API 基础地址（provider=custom 或自建代理时使用）")

--- a/tests/test_ai_config.py
+++ b/tests/test_ai_config.py
@@ -10,6 +10,7 @@ _EXPECTED_PROVIDERS = frozenset({
 	"deepseek",
 	"moonshot",
 	"openrouter",
+	"orcarouter",
 	"qwen",
 	"zhipu",
 	"siliconflow",
@@ -146,6 +147,13 @@ def test_base_url_openrouter(tmp_path, monkeypatch):
 	store = _make_store(tmp_path, monkeypatch)
 	store.save_config(ai_provider="openrouter")
 	assert store.get_base_url() == "https://openrouter.ai/api/v1"
+
+
+def test_base_url_orcarouter(tmp_path, monkeypatch):
+	"""OrcaRouter OpenAI 兼容网关入口。"""
+	store = _make_store(tmp_path, monkeypatch)
+	store.save_config(ai_provider="orcarouter")
+	assert store.get_base_url() == "https://api.orcarouter.ai/v1"
 
 
 def test_base_url_qwen(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

`boss-agent-cli` describes itself as *"A recruiting-platform CLI for people and AI agents — terminal wizard · welfare filtering · dual-role workflows · JSON envelopes."* A growing part of that story is `boss ai`: the resume-polishing and interview-coaching command group that speaks an OpenAI-compatible protocol against a provider registry in `AIConfigStore`.

Today the registry already ships `openrouter` as a first-class provider — the `--provider openrouter` line in `boss ai config` resolves its base URL from `PROVIDER_BASE_URLS` instead of asking the user to hand-roll a `--base-url`. This PR adds `orcarouter` as the same kind of named provider, mirroring exactly how `openrouter` and `atlas` are wired in.

OrcaRouter is an OpenAI-compatible gateway that exposes a `provider/model` namespace, including the `orcarouter/auto` router model, which selects a model server-side per request.

After this PR:

```bash
boss ai config --provider orcarouter --model orcarouter/auto --api-key <KEY>
```

## Changes

- `src/boss_agent_cli/ai/config.py`: add `orcarouter` → `https://api.orcarouter.ai/v1` to `PROVIDER_BASE_URLS`
- `src/boss_agent_cli/commands/ai_cmd.py`: list `orcarouter` in the `--provider` help text
- `tests/test_ai_config.py`: base-url resolution test + provider registry membership for `orcarouter`
- `docs/integrations/ai-models.md` / `ai-models.en.md`: provider table row, config example, "How to choose" row, and an `AI_PARSE_ERROR` caveat for `orcarouter/auto`

## Verification

- `uv run pytest tests/ -q` → 1937 passed (environment clean of proxy variables; the earlier "pre-existing failure" in my first draft was an environmental `ALL_PROXY=socks5://…` artifact — `httpx` picks up `trust_env`, and the `socksio` ImportError surfaced as that test failure. With proxy env unset the suite is fully green; the fix is tracked in #416)
- `uv run ruff check src/ tests/` → All checks passed
- `uv run mypy src/boss_agent_cli` → Success, no issues in 150 source files

## Type

- [x] feat: new feature
- [x] docs: documentation

## Notes

No breaking changes. No new dependencies. The commit message follows the repo's `type: 中文描述` convention.

I'm an engineer on the OrcaRouter team.
