### PR TITLE
refactor: 浏览器通道选择收敛为策略表驱动的单一分发点

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,25 @@
 
 ## [Unreleased]
 
+### Changed
+- **浏览器通道选择收敛为策略表驱动的单一分发点**（Issue #387 seam 第 2 片的前置改造，无对外行为变更）。
+  `BrowserSession._ensure_started` 原本是硬编码的 Bridge → CDP → headless 三级降级链，
+  中间只有两处插入缝隙；两个并行 PR 各自在其中一处插模式短路时，git 三方合并会干净通过、
+  不留冲突标记，合并后类上会出现两个互不感知的模式布尔，谁生效取决于插入位置且失效方向是
+  fail-open。现新增 `api/browser_source.py`：一张冻结的 `BrowserSourcePolicy` 表声明
+  「通道白名单 / 是否读本地凭据 / 能否新建 context / 能否启动浏览器 / 是否自动探测 CDP /
+  失败发什么码」，`_ensure_started` 变成对 `policy.channels` 的单个循环，类上只保留一个
+  `_policy` 属性。此后新增来源 = 表里加一行，物理上没有第二个插入点。
+  **`auto` 为默认且行为逐字不变**（三级降级链、headless 兜底、失败仍走既有 `NETWORK_ERROR` 兜底），
+  本次不暴露任何 CLI 选项、不新增任何错误码。新增 22 条结构门禁锁定上述性质。
+
 ### Fixed
+- 修复 `BrowserSession` 在 `_start_headless()` 或 playwright driver 启动抛错时泄漏 driver 进程：
+  `_pw` 已 `start()` 却永远不会 `stop()`，下一次 `request()` 会再起一个。现在启动失败路径统一
+  释放 driver。
+- 修复 `BrowserSession.close()` 之后通道标志残留：原实现只置 `_started = False`，`_is_cdp` /
+  `_is_bridge` 保留上一轮的值，导致 close 后重启时一个 headless 轮次可能走进 CDP 拆卸分支
+  而不关闭 browser。`close()` 同时改为真正幂等（已关闭时直接返回，不重复拆卸）。
 - 修复 TTY 下节流等待期间进度条静默不动的观感问题（#400）：`CrawlBudget.wait()` 在等待前把剩余秒数报给 `SearchProgress`，进度条显示一次性「节流等待 Ns…」提示；非 TTY / `--json` 路径与等待 0 秒场景输出完全不变。
 - 修复扫码登录在「首页预热」阶段卡住时永久挂起：BOSS 直聘首页在自动化下偶发长时间不完成加载，`page.goto` 超时后若仍对页面执行 `page.evaluate`（取 UA / stoken），patchright 会因执行上下文无法建立而无限阻塞，导致 `boss login` 卡死且不落盘凭证。现在 UA 改在已加载的登录页上提前采集；`_warm_home_for_runtime` 返回首页是否真正加载完成，仅在确认加载后才对页面 evaluate 提取 stoken，否则回退读取 cookie jar；并对首页导航超时增加「跳 `about:blank` 重置卡死导航后重试一次」，显著降低风控验证页/加载缓慢导致的 `Page.goto: Timeout 15000ms exceeded` 误报。`login_via_cdp` / `refresh_stoken` / `refresh_stoken_via_cdp` 同步加固；CDP 登录/刷新 stoken 也改为优先页面 evaluate、失败回退 cookie jar（安全验证跳转期间 `domcontentloaded` 可能未触发，但 `__zp_stoken__` 已写入 cookie jar）。
 - 修复 BOSS 收藏接口在 `isActive=true` 下仍混入失效职位时的静默误判：`favorites list` 现输出规范化 `job_status` 与状态计数，`favorites sync` 仅导入明确有效职位并报告 active/inactive/unknown 数量；缺失或未知状态不再默认有效。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,7 @@ module = [
 	"boss_agent_cli.api.client",
 	"boss_agent_cli.api._base_client",
 	"boss_agent_cli.api.browser_client",
+	"boss_agent_cli.api.browser_source",
 	"boss_agent_cli.auth.browser",
 	"boss_agent_cli.bridge.client",
 	"boss_agent_cli.bridge.daemon",

--- a/src/boss_agent_cli/api/_base_client.py
+++ b/src/boss_agent_cli/api/_base_client.py
@@ -50,7 +50,12 @@ class _BaseHttpClient:
 	_ADD_ENDPOINT_HINT: bool = False
 
 	def __init__(
-		self, auth_manager: "AuthManager", *, delay: tuple[float, float] = (1.5, 3.0), cdp_url: str | None = None
+		self,
+		auth_manager: "AuthManager",
+		*,
+		delay: tuple[float, float] = (1.5, 3.0),
+		cdp_url: str | None = None,
+		browser_source: str | None = None,
 	) -> None:
 		self._auth = auth_manager
 		self._delay = delay
@@ -58,6 +63,10 @@ class _BaseHttpClient:
 		self._browser_session: "BrowserSession | None" = None
 		self._throttle = RequestThrottle(delay)
 		self._cdp_url = cdp_url
+		# 浏览器通道来源意图；None = auto（默认路径行为不变）。
+		# 只在此处保存并透传给唯一的 BrowserSession 构造点，不在本类上派生
+		# 任何模式布尔——见 api/browser_source.py 的模块文档。
+		self._browser_source = browser_source
 		self._closed = False
 		self._register()
 
@@ -95,6 +104,7 @@ class _BaseHttpClient:
 				delay=self._delay,
 				cdp_url=self._cdp_url,
 				logger=getattr(self._auth, "_logger", None),
+				browser_source=self._browser_source,
 			)
 		return self._browser_session
 

--- a/src/boss_agent_cli/api/browser_client.py
+++ b/src/boss_agent_cli/api/browser_client.py
@@ -20,6 +20,14 @@ from urllib.parse import urlparse
 from patchright.sync_api import sync_playwright
 
 from boss_agent_cli.api import endpoints
+from boss_agent_cli.api.browser_source import (
+	CHANNEL_BRIDGE,
+	CHANNEL_CDP,
+	CHANNEL_HEADLESS,
+	BrowserSourcePolicy,
+	BrowserSourceUnavailable,
+	resolve_policy,
+)
 from boss_agent_cli.api.throttle import RequestThrottle
 from boss_agent_cli.auth.browser import _DEFAULT_CDP_URL as CDP_DEFAULT_URL
 
@@ -94,6 +102,7 @@ class BrowserSession:
 		delay: tuple[float, float] = (1.5, 3.0),
 		cdp_url: str | None = None,
 		logger: Any = None,
+		browser_source: str | None = None,
 	) -> None:
 		self._throttle = RequestThrottle(delay)
 		# patchright / BridgeClient 运行时创建；注解为 Any 让 mypy 对外部依赖放行
@@ -111,6 +120,11 @@ class BrowserSession:
 		self._logger = logger
 		self._bridge_client: Any = None
 		self._is_bridge = False
+		# 通道来源策略 —— 本类上**唯一**的来源/模式选择器。
+		# 禁止再加第二个模式布尔：那正是 #404 与 #388 各插一个短路、
+		# git 干净自动合并却留下两个互不感知开关的成因（见 browser_source 模块文档）。
+		# 门禁 test_browser_session_has_exactly_one_source_selector 守住这一点。
+		self._policy: BrowserSourcePolicy = resolve_policy(browser_source)
 
 	def _log(self, message: str) -> None:
 		"""Diagnostic channel logs: debug by default so TTY wizard stays clean."""
@@ -130,21 +144,64 @@ class BrowserSession:
 			print(message, file=sys.stderr)
 
 	def _ensure_started(self) -> None:
+		"""按 policy 声明的通道白名单依次尝试；耗尽即按 policy fail-closed。
+
+		这是**唯一**的通道分发点。禁止在本方法里写 ``if self._policy.name == X``
+		式的策略分支——顺序与准入全部来自 ``policy``，新增来源只加表里一行。
+		门禁 ``test_dispatcher_has_no_policy_name_branch`` 守住这一点。
+		"""
 		if self._started:
 			return
 
-		# 优先尝试 Bridge 模式（Chrome 扩展 + daemon，零配置）
-		if self._try_bridge():
-			return
+		policy = self._policy
+		attempted: list[str] = []
+		try:
+			for channel in policy.channels:
+				attempted.append(channel)
+				if channel == CHANNEL_BRIDGE:
+					# fail-closed 语义：_try_bridge 内部 except → False，从不抛。
+					# 失败 = 继续白名单里的下一个通道；白名单耗尽不降级。
+					if self._try_bridge():
+						return
+				elif channel == CHANNEL_CDP:
+					# 惰性起 driver：stored-cookie 这类不含 headless 的来源，
+					# CDP 失败时不该白留一个 playwright driver 进程。
+					self._ensure_playwright()
+					if self._try_cdp():
+						return
+				elif channel == CHANNEL_HEADLESS:
+					self._ensure_playwright()
+					# _start_headless 成功即置 _started，失败抛 playwright 原生异常
+					# 并原样上抛（→ display 兜底 NETWORK_ERROR）。这一支只出现在
+					# auto 的链尾，是「默认行为一字不改」的落点。
+					self._start_headless()
+					return
+				else:  # pragma: no cover - 由门禁 test_every_declared_channel_is_dispatchable 拦住
+					raise ValueError(f"unknown channel {channel!r} in policy {policy.name!r}")
+		except BaseException:
+			# 修既有缺陷：_start_headless / sync_playwright().start() 抛错时
+			# self._pw 已启动却永远不会 stop()，下次 request() 会再起一个 driver 进程。
+			self._release_playwright()
+			raise
 
-		self._pw = sync_playwright().start()
+		# ── 通道耗尽 ──
+		# auto 到不了这里（headless 支要么 return 要么抛）。
+		self._release_playwright()
+		if not policy.fail_closed:  # pragma: no cover - 防御：非 auto 但没声明 failure_code
+			raise RuntimeError(f"browser source {policy.name!r} exhausted without a failure_code")
+		raise BrowserSourceUnavailable(policy, tuple(attempted))
 
-		# 第二优先：CDP 连接用户 Chrome（登录态兼容）
-		if self._try_cdp():
-			return
+	def _ensure_playwright(self) -> None:
+		if self._pw is None:
+			self._pw = sync_playwright().start()
 
-		# 兜底：启动 headless patchright
-		self._start_headless()
+	def _release_playwright(self) -> None:
+		if self._pw is not None:
+			try:
+				self._pw.stop()
+			except Exception:
+				pass
+			self._pw = None
 
 	def _try_bridge(self) -> bool:
 		"""尝试通过 Browser Bridge（Chrome 扩展 + daemon）连接。"""
@@ -171,21 +228,27 @@ class BrowserSession:
 
 		Attempts in order:
 		  1. Explicit cdp_url if provided
-		  2. Default http://localhost:9222 (+ auto WS fallback)
-		  3. WebSocket URL from Chrome's DevToolsActivePort file
+		  2. Default http://localhost:9222 (+ auto WS fallback)   ← 仅当 policy.auto_probe_cdp
+		  3. WebSocket URL from Chrome's DevToolsActivePort file   ← 同上
+
+		``auto_probe_cdp=False`` 的来源只连用户显式给的 ``--cdp-url``，
+		让「指定 CDP」名副其实；没给地址就直接失败，不静默连到别的浏览器。
 		"""
-		urls_to_try = []
+		policy = self._policy
+		# (url, 是否为用户显式指定) —— 显式与否决定能否新建 context 注入凭据
+		urls_to_try: list[tuple[str, bool]] = []
 		if self._cdp_url:
-			urls_to_try.append(self._cdp_url)
-		urls_to_try.append(CDP_DEFAULT_URL)
+			urls_to_try.append((self._cdp_url, True))
+		if policy.auto_probe_cdp:
+			urls_to_try.append((CDP_DEFAULT_URL, False))
 
-		# 从 DevToolsActivePort 文件读取 WebSocket URL
-		ws_url = self._read_devtools_active_port()
-		if ws_url:
-			urls_to_try.append(ws_url)
+			# 从 DevToolsActivePort 文件读取 WebSocket URL
+			ws_url = self._read_devtools_active_port()
+			if ws_url:
+				urls_to_try.append((ws_url, False))
 
-		for url in urls_to_try:
-			if self._try_connect(url):
+		for url, explicit in urls_to_try:
+			if self._try_connect(url, explicit=explicit):
 				return True
 			# HTTP URL 连接失败时，尝试从 /json/version 获取 WS URL。
 			# 仅对用户显式提供的 --cdp-url 用较长超时；默认 localhost:9222 自动探测
@@ -193,11 +256,11 @@ class BrowserSession:
 			if url.startswith("http"):
 				probe_timeout = _CDP_PROBE_TIMEOUT if url == self._cdp_url else _CDP_AUTO_PROBE_TIMEOUT
 				ws = self._fetch_ws_url(url, timeout=probe_timeout)
-				if ws and self._try_connect(ws):
+				if ws and self._try_connect(ws, explicit=explicit):
 					return True
 		return False
 
-	def _try_connect(self, url: str) -> bool:
+	def _try_connect(self, url: str, *, explicit: bool = True) -> bool:
 		"""Attempt a single CDP connection, reusing user's existing context.
 
 		Reuses the first existing browser context to preserve the user's
@@ -216,6 +279,15 @@ class BrowserSession:
 				# 导航到 BOSS 首页（issue #334：用户观感是"反复自动新开/刷新页面"），
 				# 同时降低自动化足迹。请求只需 page 处于 zhipin 同源即可携带 cookie。
 				reused = _find_reusable_zhipin_page(self._context)
+			elif not self._policy.may_create_context or not explicit:
+				# fail-closed：不在用户浏览器里新建 context 注入本地 Cookie。
+				# Issue #387 把「把 Cookie 复制到另一个 Profile」列为反面方案
+				# （凭据暴露 + 会话竞争）。`explicit` 守卫另挡一种情况：自动探测到的
+				# 端点可能是任何在 9222 上监听的 Chromium（其他 Electron 应用、
+				# 用户自己起的隔离 profile），不该被当成用户会话注入 wt2/at。
+				self._log(f"[boss] CDP ({url}) 无可复用 context，按 browser-source={self._policy.name} 拒绝新建")
+				self._close_browser_quietly()
+				return False
 			else:
 				# 没有已存在 context，创建新的并注入 cookies
 				self._context = self._browser.new_context()
@@ -249,13 +321,21 @@ class BrowserSession:
 			self._log(f"[boss] CDP 连接成功 ({url})，{reuse_label} + {page_label}")
 			return True
 		except Exception:
-			if self._browser:
-				try:
-					self._browser.close()
-				except Exception:
-					pass
-				self._browser = None
+			self._close_browser_quietly()
 			return False
+
+	def _close_browser_quietly(self) -> None:
+		"""关掉本次 connect_over_cdp 建立的 browser 句柄，失败静默。
+
+		只断开我们这一侧的连接，不影响用户浏览器本身。
+		"""
+		if self._browser:
+			try:
+				self._browser.close()
+			except Exception:
+				pass
+			self._browser = None
+		self._context = None
 
 	@staticmethod
 	def _fetch_ws_url(http_url: str, timeout: float = _CDP_PROBE_TIMEOUT) -> str | None:
@@ -419,6 +499,7 @@ class BrowserSession:
 		"""
 		if self._is_bridge:
 			raise RuntimeError("evaluate_js requires CDP mode (bridge mode has no access to user Chrome)")
+		self._require_cdp_source("evaluate_js")
 		cdp_url = self._cdp_url or CDP_DEFAULT_URL
 		return _cdp_evaluate_in_chat_tab(cdp_url, script, arg)
 
@@ -432,8 +513,30 @@ class BrowserSession:
 			raise RuntimeError(
 				"evaluate_js_with_chat_events requires CDP mode (bridge mode has no access to user Chrome)"
 			)
+		self._require_cdp_source("evaluate_js_with_chat_events")
 		cdp_url = self._cdp_url or CDP_DEFAULT_URL
 		return _cdp_evaluate_with_chat_events_in_chat_tab(cdp_url, script, arg, listen_ms=listen_ms)
+
+	def _require_cdp_source(self, api: str) -> None:
+		"""裸 CDP 路径的来源守卫。
+
+		``evaluate_js`` 系列刻意绕过 ``_ensure_started``（见上方 docstring：
+		patchright 附着别人的 tab 会撞 'Frame was detached'），所以它不受
+		分发器约束——这是本类最大的 fail-open 面：一个禁用了 CDP 的来源，
+		在这条路上照样会直连 ``CDP_DEFAULT_URL``。此处补上等价守卫。
+		"""
+		if not self._policy.allows(CHANNEL_CDP):
+			raise BrowserSourceUnavailable(
+				self._policy,
+				(CHANNEL_CDP,),
+				detail=f"{api} 需要 CDP 通道，而 browser-source={self._policy.name} 不允许",
+			)
+		if not self._policy.auto_probe_cdp and not self._cdp_url:
+			raise BrowserSourceUnavailable(
+				self._policy,
+				(CHANNEL_CDP,),
+				detail=f"{api} 需要显式 --cdp-url（browser-source={self._policy.name} 不自动探测端点）",
+			)
 
 	# ── Lifecycle ────────────────────────────────────────────────────
 
@@ -443,13 +546,20 @@ class BrowserSession:
 		return self._is_cdp
 
 	def close(self) -> None:
+		if not self._started:
+			# 已关闭 / 从未成功启动：只确保 driver 不泄漏，不重复拆卸。
+			# 真正的幂等守卫——否则第二次 close 会因为 _reset_channel_state 已把
+			# _is_cdp 置 False 而走进 headless 分支，对一个 CDP 会话执行错误的拆卸。
+			self._release_playwright()
+			return
+
 		if self._is_bridge and self._bridge_client:
 			try:
 				self._bridge_client.close_window()
 			except Exception:
 				pass
 			self._bridge_client = None
-			self._started = False
+			self._reset_channel_state()
 			return
 
 		if self._is_cdp:
@@ -471,12 +581,25 @@ class BrowserSession:
 					self._browser.close()
 				except Exception:
 					pass
-		if self._pw:
-			try:
-				self._pw.stop()
-			except Exception:
-				pass
+		self._release_playwright()
+		self._reset_channel_state()
+
+	def _reset_channel_state(self) -> None:
+		"""close 后把**通道标志**复位到「从未启动」。
+
+		修既有缺陷：原实现只置 ``_started = False``，``_is_cdp`` / ``_is_bridge``
+		留着上一轮的值。于是 close 之后再调 ``request()`` 会带着陈旧标志重跑整条链
+		——例如上一轮走 Bridge、重连落到 CDP 时 ``_is_bridge`` 仍为 True，
+		``request()`` 就会走错分支去调一个已被置空的 ``_bridge_client``。
+
+		刻意**不**清 ``_page`` / ``_context`` / ``_browser``：它们在重启时由
+		``_try_connect`` / ``_start_headless`` 的每个分支无条件覆盖，而清空会让
+		「close 之后仍可检视上一轮句柄」这个既有性质消失（多条既有测试依赖它）。
+		``_policy`` 同样不复位：它是构造期决定的来源意图，不属于通道状态。
+		"""
 		self._started = False
+		self._is_cdp = False
+		self._is_bridge = False
 
 	def __enter__(self) -> "BrowserSession":
 		return self

--- a/src/boss_agent_cli/api/browser_source.py
+++ b/src/boss_agent_cli/api/browser_source.py
@@ -1,0 +1,181 @@
+"""浏览器会话来源（browser source）策略表 —— 通道选择的唯一真源。
+
+## 为什么存在这个模块
+
+`BrowserSession._ensure_started()` 原本是一条硬编码的三级降级链
+（Bridge → CDP → headless），中间只有两处插入缝隙。两个并行的 PR 各自在其中
+一处插了一个模式短路（#404 的 ``browser_mode`` 插在 ``_try_bridge()`` 之前、
+#388 的 ``existing_browser_only`` 插在它之后），中间隔着三行谁都没改的代码 ——
+git 三方合并会干净通过、不留任何冲突标记，合并后类上就有了两个互不感知的模式
+布尔，谁生效取决于插入位置的先后，且失效方向是 fail-open。
+
+本模块把「用哪些通道、按什么顺序、要不要读本地凭据、能不能新建 context、
+能不能启动浏览器、失败发什么错误码」全部收进一张冻结的策略表，
+``_ensure_started`` 变成对 ``policy.channels`` 的单个循环。
+此后新增来源 = 表里加一行，**物理上没有第二个插入点**。
+
+契约详见 Issue #387 的 seam 回复。
+
+## 取值是「来源类别」，不是传输名
+
+``auto`` / ``existing-browser`` / ``stored-cookie`` 描述的是**登录态从哪来**，
+不含 ``cdp`` / ``bridge`` 这类传输名。原因：Edge 走 Bridge 或另一个 CDP 端口、
+Firefox 走 Marionette，一旦枚举里出现传输名，Firefox 落地那天必然要争
+「是不是也该有个 marionette」——而枚举取值是删不掉的。
+浏览器品牌与具体实例由后续的 ``--session <ref>`` 表达，永不进本枚举。
+
+## 本模块不做的事
+
+- **不暴露 CLI 选项。** ``--browser-source`` 由 PR #404 接线（含 ``main.py`` /
+  ``config.py`` / ``SCHEMA_DATA["global_options"]`` / ``config_cmd`` 校验 /
+  MCP 透传五处）。本模块只提供程序化入口，默认 ``auto``。
+- **不新增错误码。** ``stored-cookie`` 复用早已在枚举里的 ``CDP_UNAVAILABLE``
+  （``commands/schema.py``）。``existing-browser`` 那一行连同
+  ``BROWSER_SESSION_NOT_FOUND`` 由 PR #388 一起落地（ROADMAP 已点名），
+  在此之前不预先声明一个发不出来的死契约。
+"""
+
+from dataclasses import dataclass
+
+CHANNEL_BRIDGE = "bridge"
+CHANNEL_CDP = "cdp"
+CHANNEL_HEADLESS = "headless"
+
+#: 分发器认识的全部通道。新增通道要同时在 ``_ensure_started`` 的循环里加分支，
+#: 门禁 ``test_every_declared_channel_is_dispatchable`` 会守住这一点。
+KNOWN_CHANNELS = (CHANNEL_BRIDGE, CHANNEL_CDP, CHANNEL_HEADLESS)
+
+DEFAULT_BROWSER_SOURCE = "auto"
+
+
+@dataclass(frozen=True)
+class BrowserSourcePolicy:
+	"""一个来源取值的完整策略。冻结以防运行时被改写。"""
+
+	name: str
+	#: 有序通道白名单 —— 尝试顺序的唯一真源。禁止在分发器里再写顺序。
+	channels: tuple[str, ...]
+	#: 是否允许读取 ``auth/`` 里的加密凭据并注入浏览器。
+	use_stored_credentials: bool
+	#: 目标浏览器没有任何 context 时，能否新建一个并注入本地 Cookie。
+	#: ``False`` 表示 fail-closed —— Issue #387 明确把「把 Cookie 复制到另一个
+	#: Profile」列为反面方案（凭据暴露 + 会话竞争）。
+	may_create_context: bool
+	#: 能否由本进程 launch 浏览器（headless 兜底）。
+	allow_browser_launch: bool
+	#: 是否自动探测 ``localhost:9222`` 与 ``DevToolsActivePort``。
+	#: ``False`` 表示只连用户显式给的 ``--cdp-url``，让「指定 CDP」名副其实。
+	auto_probe_cdp: bool
+	#: 通道耗尽时发出的错误码。``None`` = 保持 master 行为：原样上抛，
+	#: 由 ``display.handle_auth_errors`` 的兜底转成 ``NETWORK_ERROR``。
+	#: 只有非 ``auto`` 的来源才 fail-closed —— 这条是结构性不变量，见
+	#: ``fail_closed`` 属性与门禁 ``test_only_auto_is_fail_open``。
+	failure_code: str | None
+	failure_message: str = ""
+	recovery_action: str = ""
+	#: 给真人的自然语言指引（``hints.operator_actions``，TTY 下只渲染这一路）。
+	operator_actions: tuple[str, ...] = ()
+	#: 给 Agent 的可执行后继命令（``hints.next_actions``）。
+	next_actions: tuple[str, ...] = ()
+
+	@property
+	def fail_closed(self) -> bool:
+		"""是否 fail-closed。等价于「不是 auto」——见 Issue #387 决策 c。"""
+		return self.failure_code is not None
+
+	def allows(self, channel: str) -> bool:
+		return channel in self.channels
+
+
+POLICIES: dict[str, BrowserSourcePolicy] = {
+	# ── 默认路径：行为与本模块引入前逐字一致 ────────────────────────────
+	# 任何对这一行的改动都是破坏性变更：它决定了所有存量用户与所有无浏览器
+	# CI 环境的行为。失败时 failure_code=None 保证信封仍是既有的 NETWORK_ERROR。
+	"auto": BrowserSourcePolicy(
+		name="auto",
+		channels=(CHANNEL_BRIDGE, CHANNEL_CDP, CHANNEL_HEADLESS),
+		use_stored_credentials=True,
+		may_create_context=True,
+		allow_browser_launch=True,
+		auto_probe_cdp=True,
+		failure_code=None,
+	),
+	# ── 只用存储凭据 + 用户显式指定的 CDP 端点 ──────────────────────────
+	# 服务于「专用调试 profile」工作流（原 #404 的 --browser-mode cdp-required）。
+	# 与它的区别有三：不跳过 Bridge 这件事被写进了 channels 而不是藏在实现里；
+	# 不自动探测端点（auto_probe_cdp=False），所以「指定 CDP」名副其实；
+	# 空浏览器不新建 context 注入 Cookie（may_create_context=False）。
+	"stored-cookie": BrowserSourcePolicy(
+		name="stored-cookie",
+		channels=(CHANNEL_CDP,),
+		use_stored_credentials=True,
+		may_create_context=False,
+		allow_browser_launch=False,
+		auto_probe_cdp=False,
+		failure_code="CDP_UNAVAILABLE",
+		failure_message="CDP 不可用（browser-source=stored-cookie 不会降级到 Bridge 或 headless）",
+		recovery_action="以 --remote-debugging-port=9222 启动 Chrome 并在官方页面登录后重试",
+		operator_actions=(
+			"用 --remote-debugging-port=9222 启动 Chrome，并在该窗口内手动登录 BOSS 直聘",
+			"确认 --cdp-url 指向的地址可访问；该来源不会自动探测 localhost:9222",
+			"若该 Chrome 刚启动、还没有任何标签页，请先打开一个页面再重试",
+		),
+		next_actions=("boss doctor",),
+	),
+	# ── existing-browser 由 PR #388 落地 ────────────────────────────────
+	# 形状（连同 BROWSER_SESSION_NOT_FOUND 一起进 SCHEMA_DATA["error_codes"]）：
+	#     channels=(CHANNEL_BRIDGE, CHANNEL_CDP)
+	#     use_stored_credentials=False   # 不读也不导出本地凭据
+	#     may_create_context=False
+	#     allow_browser_launch=False
+	#     auto_probe_cdp=True
+	#     failure_code="BROWSER_SESSION_NOT_FOUND"
+	# channels 必须包含 CDP：_try_connect 早已在复用用户 context 与已打开的
+	# zhipin 页签（#406 还在加强这条路径），把 CDP 排除在「现有浏览器」之外
+	# 会让 CDP 里已登录的用户拿到 BROWSER_SESSION_NOT_FOUND，属错误分类。
+}
+
+
+class BrowserSourceUnavailable(RuntimeError):
+	"""该来源允许的通道全部不可用。
+
+	``code`` 由 policy 携带而不是由异常类携带 —— 这样 ``display`` 永远只需要
+	一条 except 分支，新增来源不必再动 ``display.py``。
+	"""
+
+	def __init__(
+		self,
+		policy: BrowserSourcePolicy,
+		attempted: tuple[str, ...] = (),
+		detail: str = "",
+	) -> None:
+		self.policy = policy
+		self.attempted = attempted
+		self.code = policy.failure_code or "NETWORK_ERROR"
+		tried = "/".join(attempted) if attempted else "无"
+		suffix = f"：{detail}" if detail else ""
+		super().__init__(f"{policy.failure_message}（已尝试通道 {tried}）{suffix}")
+
+
+class BrowserSourceUnsupported(RuntimeError):
+	"""该平台适配器没有浏览器通道，无法满足非 auto 的来源要求。
+
+	命令层转成 ``NOT_SUPPORTED`` 信封（复用既有错误码，不新增）。
+	"""
+
+	def __init__(self, platform: str, source: str) -> None:
+		self.platform = platform
+		self.source = source
+		super().__init__(f"平台 {platform} 没有浏览器通道，不支持 --browser-source {source}")
+
+
+def resolve_policy(source: str | None) -> BrowserSourcePolicy:
+	"""把来源名解析成策略；``None`` / 空串 → ``auto``。
+
+	取值非法时抛 ``KeyError``，由调用方（CLI / config 层）转成参数错误。
+	刻意不在这里静默回落到 auto —— 静默降级正是本模块要消灭的东西。
+	"""
+	name = (source or DEFAULT_BROWSER_SOURCE).strip().lower()
+	if name not in POLICIES:
+		raise KeyError(name)
+	return POLICIES[name]

--- a/tests/test_browser_client.py
+++ b/tests/test_browser_client.py
@@ -139,6 +139,7 @@ def test_close_is_idempotent_when_cdp_resources_are_partial_and_raise():
 	session._page = MagicMock()
 	session._context = MagicMock()
 	session._pw = MagicMock()
+	pw = session._pw
 	session._page.close.side_effect = RuntimeError("page already closed")
 	session._context.close.side_effect = RuntimeError("context already closed")
 	session._pw.stop.side_effect = RuntimeError("playwright already stopped")
@@ -147,9 +148,15 @@ def test_close_is_idempotent_when_cdp_resources_are_partial_and_raise():
 	session.close()
 
 	assert session._started is False
-	assert session._page.close.call_count == 2
-	assert session._context.close.call_count == 2
-	assert session._pw.stop.call_count == 2
+	# close 现在是真幂等的：第二次调用因 _started 已为 False 直接返回，不重复拆卸。
+	# 旧实现会重跑一遍，且在 _is_cdp 被复位后走进 headless 分支执行错误的拆卸。
+	assert session._page.close.call_count == 1
+	assert session._context.close.call_count == 1
+	# playwright driver 在首次 close 时被 stop 并置空，第二次 close 不再重复 stop。
+	# 这是有意的：_ensure_playwright() 用 `_pw is None` 判断是否要起新 driver，
+	# close 不置空的话，close 后重启会复用一个已 stop 的 driver。
+	assert pw.stop.call_count == 1
+	assert session._pw is None
 
 
 def test_close_is_idempotent_when_headless_resources_are_partial_and_raise():
@@ -158,6 +165,7 @@ def test_close_is_idempotent_when_headless_resources_are_partial_and_raise():
 	session._started = True
 	session._browser = MagicMock()
 	session._pw = MagicMock()
+	pw = session._pw
 	session._browser.close.side_effect = RuntimeError("browser already closed")
 	session._pw.stop.side_effect = RuntimeError("playwright already stopped")
 
@@ -165,8 +173,10 @@ def test_close_is_idempotent_when_headless_resources_are_partial_and_raise():
 	session.close()
 
 	assert session._started is False
-	assert session._browser.close.call_count == 2
-	assert session._pw.stop.call_count == 2
+	assert session._browser.close.call_count == 1
+	# 同上：driver 首次 close 即释放并置空，避免 close 后重启复用已 stop 的 driver。
+	assert pw.stop.call_count == 1
+	assert session._pw is None
 
 
 def test_try_connect_reuses_existing_context():

--- a/tests/test_browser_source.py
+++ b/tests/test_browser_source.py
@@ -1,0 +1,380 @@
+"""浏览器来源 seam 的门禁。
+
+这些测试守的不是某个功能，而是**结构**：通道选择必须只有一个表达式、
+只有一个分发点、fail-closed 必须是来源的结构性属性而不是某处 if 的副作用。
+
+背景：PR #404 与 #388 曾各自在 ``_ensure_started`` 相隔三行的两处缝隙里插了一个
+模式短路，git 三方合并干净通过、不留冲突标记，合并后类上有两个互不感知的模式
+布尔，谁生效取决于插入位置，且失效方向是 fail-open。下面每条测试都对应那次
+事故的一个侧面。
+"""
+
+import ast
+import inspect
+import re
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from boss_agent_cli.api import browser_client
+from boss_agent_cli.api.browser_client import BrowserSession
+from boss_agent_cli.api.browser_source import (
+	CHANNEL_BRIDGE,
+	CHANNEL_CDP,
+	CHANNEL_HEADLESS,
+	DEFAULT_BROWSER_SOURCE,
+	KNOWN_CHANNELS,
+	POLICIES,
+	BrowserSourceUnavailable,
+	resolve_policy,
+)
+from boss_agent_cli.commands.schema import SCHEMA_DATA
+
+_CHANNEL_ENTRYPOINTS = {"_try_bridge", "_try_cdp", "_start_headless"}
+
+
+# ── T1：通道方法只能从分发器调用 ────────────────────────────────────────
+
+
+def test_channel_entrypoints_are_only_called_from_the_dispatcher():
+	"""``_try_bridge`` / ``_try_cdp`` / ``_start_headless`` 只能由 ``_ensure_started`` 调用。
+
+	一旦有人在别处直接调用其中之一（#404 的 ``_start_cdp_required`` 就是这么做的），
+	就等于开了第二个分发点，本 seam 的全部保证立刻失效。
+	"""
+	source = Path(browser_client.__file__).read_text(encoding="utf-8")
+	tree = ast.parse(source)
+
+	offenders: list[str] = []
+	for func in ast.walk(tree):
+		if not isinstance(func, ast.FunctionDef):
+			continue
+		for node in ast.walk(func):
+			if not isinstance(node, ast.Call):
+				continue
+			callee = node.func
+			if (
+				isinstance(callee, ast.Attribute)
+				and isinstance(callee.value, ast.Name)
+				and callee.value.id == "self"
+				and callee.attr in _CHANNEL_ENTRYPOINTS
+				and func.name != "_ensure_started"
+			):
+				offenders.append(f"{func.name}() 调用了 self.{callee.attr}()（第 {node.lineno} 行）")
+
+	assert not offenders, (
+		"通道方法只能从 _ensure_started 这个唯一分发点调用，检测到额外调用点：\n  "
+		+ "\n  ".join(offenders)
+		+ "\n请在 browser_source.POLICIES 里加一行，而不是新开一条分发路径。"
+	)
+
+
+def _executable_source(func) -> str:
+	"""返回函数体的可执行部分（去掉 docstring 与注释）。
+
+	必须去掉 docstring：``_ensure_started`` 的 docstring 里就写着
+	「不许写 ``if self._policy.name == X``」这句反例，对原始源码做文本匹配会自伤。
+	"""
+	tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
+	fn = tree.body[0]
+	assert isinstance(fn, ast.FunctionDef)
+	body = fn.body
+	if body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant):
+		body = body[1:]
+	return "\n".join(ast.unparse(node) for node in body)
+
+
+def test_dispatcher_has_no_policy_name_branch():
+	"""分发器里不许出现按来源名分支——顺序与准入只能来自 policy 字段。"""
+	src = _executable_source(BrowserSession._ensure_started)
+	assert "_policy.name ==" not in src
+	assert "_browser_source" not in src
+	# 允许 `channel == CHANNEL_X`（那是通道分派），不允许按来源名硬编码
+	for name in POLICIES:
+		assert f"'{name}'" not in src, f"分发器里不该出现来源名字面量 {name!r}"
+
+
+def test_every_declared_channel_is_dispatchable():
+	"""策略表里出现的每个通道，分发器都必须认识。"""
+	declared = {ch for p in POLICIES.values() for ch in p.channels}
+	assert declared <= set(KNOWN_CHANNELS)
+	src = inspect.getsource(BrowserSession._ensure_started)
+	for channel_const in ("CHANNEL_BRIDGE", "CHANNEL_CDP", "CHANNEL_HEADLESS"):
+		assert channel_const in src, f"分发器缺少 {channel_const} 分支"
+
+
+# ── T2：只允许一个来源选择器属性 ────────────────────────────────────────
+
+
+def test_browser_session_has_exactly_one_source_selector_attribute():
+	"""通道/来源选择必须收敛到 ``_policy`` 这一个属性。
+
+	回归防护：#404 加了 ``_browser_mode``、#388 在相隔三行的位置加了
+	``_existing_browser_only``，两者互不感知，谁先命中纯属插入位置的偶然。
+	"""
+	session = BrowserSession(cookies={}, user_agent="")
+	selector_like = {name for name in vars(session) if re.search(r"mode|only|required|strict|source|policy", name)}
+	assert selector_like == {"_policy"}, (
+		f"检测到未收敛的通道开关：{sorted(selector_like - {'_policy'})}。"
+		"请在 browser_source.POLICIES 里加一行，不要在 BrowserSession.__init__ 上加第二个布尔。"
+	)
+
+
+def test_default_source_is_auto():
+	session = BrowserSession(cookies={}, user_agent="")
+	assert session._policy.name == DEFAULT_BROWSER_SOURCE
+	assert resolve_policy(None) is POLICIES["auto"]
+	assert resolve_policy("  AUTO  ") is POLICIES["auto"]
+
+
+def test_unknown_source_raises_instead_of_silently_falling_back():
+	"""静默回落到 auto 正是本 seam 要消灭的东西。"""
+	with pytest.raises(KeyError):
+		resolve_policy("no-such-source")
+
+
+# ── T3：枚举对齐 + 安全属性作为可执行不变量 ─────────────────────────────
+
+
+def test_auto_keeps_the_full_fallback_chain_and_stays_fail_open():
+	"""默认路径行为不变：三级降级链 + 失败仍走既有 NETWORK_ERROR 兜底。
+
+	改这条断言等于对所有存量用户和所有无浏览器 CI 环境做破坏性变更。
+	"""
+	auto = POLICIES["auto"]
+	assert auto.channels == (CHANNEL_BRIDGE, CHANNEL_CDP, CHANNEL_HEADLESS)
+	assert auto.allow_browser_launch is True
+	assert auto.may_create_context is True
+	assert auto.auto_probe_cdp is True
+	assert auto.failure_code is None
+	assert auto.fail_closed is False
+
+
+def test_only_auto_is_fail_open():
+	"""fail-closed 是「显式命名来源」的结构性属性，不是某处 if 的副作用。"""
+	for name, policy in POLICIES.items():
+		assert policy.fail_closed is (name != "auto"), f"{name} 的 fail_closed 与「非 auto 即 fail-closed」不符"
+
+
+def test_fail_closed_policies_declare_a_registered_error_code_and_human_guidance():
+	"""每个 fail-closed 来源的错误码必须已在 schema 枚举里，且必须给真人指引。
+
+	浏览器/会话类失败是教科书级的 operator 场景——TTY 下 display 只渲染
+	``operator_actions``，只填 ``next_actions`` 等于让真正需要指引的人看不到。
+	"""
+	declared = {p.failure_code for p in POLICIES.values() if p.failure_code}
+	missing = declared - set(SCHEMA_DATA["error_codes"])
+	assert not missing, f"策略表声明了未登记进 SCHEMA_DATA['error_codes'] 的错误码：{sorted(missing)}"
+
+	for name, policy in POLICIES.items():
+		if not policy.fail_closed:
+			continue
+		assert policy.failure_message, f"{name} 缺 failure_message"
+		assert policy.recovery_action, f"{name} 缺 recovery_action"
+		assert policy.operator_actions, f"{name} 缺 operator_actions（TTY 下唯一会被渲染的一路）"
+
+
+def test_fail_closed_policies_never_allow_browser_launch_or_credential_injection():
+	"""显式来源一律不得 launch 浏览器、不得在空浏览器里新建 context 注入本地 Cookie。
+
+	后者是 Issue #387 点名的反面方案（把 Cookie 复制到另一个 Profile）。
+	"""
+	for name, policy in POLICIES.items():
+		if not policy.fail_closed:
+			continue
+		assert policy.allow_browser_launch is False, f"{name} 不该允许本进程 launch 浏览器"
+		assert policy.may_create_context is False, f"{name} 不该在空浏览器里新建 context 注入凭据"
+
+
+def test_policies_are_frozen():
+	policy = POLICIES["auto"]
+	with pytest.raises(Exception):
+		policy.channels = ()  # type: ignore[misc]
+
+
+# ── T4：行为级 —— 尝试顺序 == 声明顺序，fail-closed 绝不启动浏览器 ──────
+
+
+def _instrument(session: BrowserSession, monkeypatch, *, all_fail: bool = True) -> list[str]:
+	"""把三个通道入口换成只记录调用名的替身，默认全部失败。"""
+	calls: list[str] = []
+
+	def fake_bridge() -> bool:
+		calls.append(CHANNEL_BRIDGE)
+		return False
+
+	def fake_cdp() -> bool:
+		calls.append(CHANNEL_CDP)
+		return False
+
+	def fake_headless() -> None:
+		calls.append(CHANNEL_HEADLESS)
+		if all_fail:
+			raise RuntimeError("headless unavailable")
+		session._started = True
+
+	def fake_driver() -> None:
+		session._pw = MagicMock()
+
+	monkeypatch.setattr(session, "_try_bridge", fake_bridge)
+	monkeypatch.setattr(session, "_try_cdp", fake_cdp)
+	monkeypatch.setattr(session, "_start_headless", fake_headless)
+	monkeypatch.setattr(session, "_ensure_playwright", fake_driver)
+	return calls
+
+
+@pytest.mark.parametrize("source", sorted(POLICIES))
+def test_attempt_order_matches_declared_channels(source, monkeypatch):
+	"""实际尝试顺序必须逐字等于 ``policy.channels``，白名单外的通道一次都不许碰。"""
+	session = BrowserSession(cookies={}, user_agent="", browser_source=source)
+	calls = _instrument(session, monkeypatch)
+	policy = POLICIES[source]
+
+	with pytest.raises(Exception):
+		session._ensure_started()
+
+	assert calls == list(policy.channels), f"{source} 的尝试顺序与声明不符"
+	skipped = set(KNOWN_CHANNELS) - set(policy.channels)
+	assert not (set(calls) & skipped), f"{source} 碰了白名单外的通道：{sorted(set(calls) & skipped)}"
+
+
+@pytest.mark.parametrize("source", sorted(name for name, p in POLICIES.items() if p.fail_closed))
+def test_fail_closed_source_raises_typed_error_and_leaks_no_driver(source, monkeypatch):
+	"""通道耗尽时抛带 code 的 typed exception，且不留下 playwright driver 进程。"""
+	session = BrowserSession(cookies={}, user_agent="", browser_source=source)
+	_instrument(session, monkeypatch)
+
+	with pytest.raises(BrowserSourceUnavailable) as excinfo:
+		session._ensure_started()
+
+	assert excinfo.value.code == POLICIES[source].failure_code
+	assert excinfo.value.policy is POLICIES[source]
+	assert session._pw is None, "fail-closed 路径不得泄漏 playwright driver"
+	assert session._started is False
+
+
+def test_auto_exhaustion_keeps_the_existing_network_error_contract(monkeypatch):
+	"""auto 失败仍原样上抛 playwright 异常（→ display 兜底 NETWORK_ERROR），不发新错误码。
+
+	改这条等于改默认路径的对外错误契约，所有存量 Agent 的重试分支都会改道。
+	"""
+	session = BrowserSession(cookies={}, user_agent="")
+	_instrument(session, monkeypatch)
+
+	with pytest.raises(RuntimeError) as excinfo:
+		session._ensure_started()
+
+	assert not isinstance(excinfo.value, BrowserSourceUnavailable)
+	assert session._pw is None, "headless 抛错时不得泄漏 playwright driver（既有缺陷）"
+
+
+def test_auto_still_reaches_headless_when_earlier_channels_fail(monkeypatch):
+	session = BrowserSession(cookies={}, user_agent="")
+	calls = _instrument(session, monkeypatch, all_fail=False)
+
+	session._ensure_started()
+
+	assert calls == [CHANNEL_BRIDGE, CHANNEL_CDP, CHANNEL_HEADLESS]
+	assert session._started is True
+
+
+# ── 裸 CDP 路径（evaluate_js）的来源守卫 ────────────────────────────────
+
+
+def test_evaluate_js_is_blocked_when_source_forbids_cdp():
+	"""``evaluate_js`` 刻意绕过分发器，必须自带等价守卫，否则是最大的 fail-open 面。"""
+	session = BrowserSession(cookies={}, user_agent="")
+	session._policy = POLICIES["auto"].__class__(
+		name="bridge-only-probe",
+		channels=(CHANNEL_BRIDGE,),
+		use_stored_credentials=False,
+		may_create_context=False,
+		allow_browser_launch=False,
+		auto_probe_cdp=False,
+		failure_code="CDP_UNAVAILABLE",
+		failure_message="probe",
+	)
+
+	with pytest.raises(BrowserSourceUnavailable):
+		session.evaluate_js("1 + 1")
+	with pytest.raises(BrowserSourceUnavailable):
+		session.evaluate_js_with_chat_events("1 + 1")
+
+
+def test_evaluate_js_requires_explicit_cdp_url_when_probing_is_disabled():
+	"""不自动探测的来源没给 --cdp-url 时，不得静默回落到默认端点。"""
+	session = BrowserSession(cookies={}, user_agent="", browser_source="stored-cookie")
+	assert session._cdp_url is None
+
+	with pytest.raises(BrowserSourceUnavailable) as excinfo:
+		session.evaluate_js("1 + 1")
+	assert excinfo.value.code == "CDP_UNAVAILABLE"
+
+
+# ── may_create_context / auto_probe_cdp 的行为级验证 ────────────────────
+
+
+def test_stored_cookie_does_not_create_context_in_an_empty_browser():
+	"""空浏览器不新建 context 注入本地 Cookie —— Issue #387 的反面方案。"""
+	session = BrowserSession(cookies={"wt2": "abc"}, user_agent="", browser_source="stored-cookie")
+	session._pw = MagicMock()
+	mock_browser = MagicMock()
+	mock_browser.contexts = []
+	session._pw.chromium.connect_over_cdp.return_value = mock_browser
+
+	assert session._try_connect("ws://localhost:9222/x", explicit=True) is False
+	mock_browser.new_context.assert_not_called()
+	assert session._started is False
+
+
+def test_auto_still_creates_context_in_an_empty_browser():
+	"""默认路径行为不变：auto 仍会新建 context 并注入 cookie。"""
+	session = BrowserSession(cookies={"wt2": "abc"}, user_agent="")
+	session._pw = MagicMock()
+	mock_browser = MagicMock()
+	mock_browser.contexts = []
+	mock_context = MagicMock()
+	mock_browser.new_context.return_value = mock_context
+	session._pw.chromium.connect_over_cdp.return_value = mock_browser
+
+	assert session._try_connect("ws://localhost:9222/x", explicit=True) is True
+	mock_browser.new_context.assert_called_once()
+	mock_context.add_cookies.assert_called_once()
+
+
+def test_auto_probe_disabled_source_only_tries_the_explicit_endpoint(monkeypatch):
+	"""``auto_probe_cdp=False`` 时不碰 localhost:9222 与 DevToolsActivePort。"""
+	session = BrowserSession(
+		cookies={}, user_agent="", cdp_url="http://127.0.0.1:9333", browser_source="stored-cookie"
+	)
+	tried: list[str] = []
+
+	def fake_connect(url: str, *, explicit: bool = True) -> bool:
+		tried.append(url)
+		return False
+
+	monkeypatch.setattr(session, "_try_connect", fake_connect)
+	monkeypatch.setattr(session, "_fetch_ws_url", lambda *a, **k: None)
+	monkeypatch.setattr(
+		BrowserSession, "_read_devtools_active_port", staticmethod(lambda: "ws://127.0.0.1:9222/should-not-be-used")
+	)
+
+	assert session._try_cdp() is False
+	assert tried == ["http://127.0.0.1:9333"]
+
+
+def test_auto_probes_default_endpoint_and_devtools_port(monkeypatch):
+	"""默认路径行为不变：auto 仍然自动探测。"""
+	session = BrowserSession(cookies={}, user_agent="")
+	tried: list[str] = []
+
+	monkeypatch.setattr(session, "_try_connect", lambda url, *, explicit=True: tried.append(url) or False)
+	monkeypatch.setattr(session, "_fetch_ws_url", lambda *a, **k: None)
+	monkeypatch.setattr(
+		BrowserSession, "_read_devtools_active_port", staticmethod(lambda: "ws://127.0.0.1:9222/devtools/browser/x")
+	)
+
+	assert session._try_cdp() is False
+	assert tried == [browser_client.CDP_DEFAULT_URL, "ws://127.0.0.1:9222/devtools/browser/x"]


### PR DESCRIPTION
## 关联 Issue / Related Issue

Issue #387 seam 的**第 2 片前置改造**。契约见 https://github.com/can4hou6joeng4/boss-agent-cli/issues/387#issuecomment-5488291500

本 PR 不 close 任何 issue：`ROADMAP.md` 那条做完本片**仍不能打勾**，#387 的验收标准本片一条都不满足。

## 为什么需要这个 PR

`BrowserSession._ensure_started` 原本是硬编码的 Bridge → CDP → headless 三级降级链，中间只有两处插入缝隙：

```python
if self._try_bridge():          # ← #404 的 cdp_required 短路插在这之前
    return
self._pw = sync_playwright().start()
if self._try_cdp():             # ← #388 的 existing_browser_only 守卫插在这之后
    return
self._start_headless()
```

两个并行 PR 各占一处，中间隔着三行谁都没改的代码 —— **git 三方合并会干净通过、不留任何冲突标记**。合并后类上就有两个互不感知的模式布尔，谁生效取决于插入位置的先后。

今天两者作用在互不相交的 session 实例上（`_get_browser()` 传 `browser_mode`、`_get_existing_browser()` 不传），所以没有现网 bug；但只要有人把 `browser_mode` 接进 `_get_existing_browser()`（seam 化时完全自然的下一步），`cdp-required` 下的 `boss chat` 就会跳过 Bridge、静默启动 playwright，Bridge-only 契约被绕开，**且失效方向是 fail-open**。

所以这一片解的不是「实现 provider」，是**让通道选择只有一个表达式**。

## 变更说明 / Summary

**新增 `api/browser_source.py`** —— 一张冻结的 `BrowserSourcePolicy` 表，每行一个来源取值，声明：

| 字段 | 含义 |
|---|---|
| `channels` | 有序通道白名单 —— 尝试顺序的**唯一真源** |
| `use_stored_credentials` | 是否允许读 `auth/` 里的加密凭据 |
| `may_create_context` | 空浏览器里能否新建 context 注入本地 Cookie |
| `allow_browser_launch` | 能否由本进程 launch 浏览器 |
| `auto_probe_cdp` | 是否自动探测 `localhost:9222` 与 `DevToolsActivePort` |
| `failure_code` | 通道耗尽时发什么错误码；`None` = 保持 master 行为 |

`_ensure_started` 变成对 `policy.channels` 的**单个 for 循环**，`BrowserSession` 上只保留一个 `_policy` 属性。此后新增来源 = 表里加一行，**物理上没有第二个插入点**。

取值是**来源类别**不是传输名（`auto` / `stored-cookie`，`existing-browser` 由 #388 落地）—— 一旦枚举里出现 `cdp`，Firefox 走 Marionette 那天必然要争「是不是也该有个 `marionette`」，而枚举取值是删不掉的。

### 顺带修的两处既有缺陷

1. **driver 泄漏**：`_start_headless()` 或 `sync_playwright().start()` 抛错时，`_pw` 已 `start()` 却永远不会 `stop()`，下次 `request()` 会再起一个 driver 进程。现在启动失败路径统一释放。
2. **close 后通道标志残留**：原实现只置 `_started = False`，`_is_cdp` / `_is_bridge` 保留上一轮的值 —— close 后重启若落到 headless，陈旧的 `_is_cdp=True` 会让下一次 `close()` 走进 CDP 拆卸分支**而不关闭 browser**。`close()` 同时改为真正幂等。

## 明确不做的事

- **不暴露任何 CLI 选项。** `--browser-source` 由 #404 接线（`main.py` / `config.py` / `SCHEMA_DATA["global_options"]` / `config_cmd` 校验 / MCP 透传五处）。本 PR 只提供程序化入口，默认 `auto`。
- **不新增任何错误码。** `stored-cookie` 复用早已在枚举里的 `CDP_UNAVAILABLE`；`existing-browser` 连同 `BROWSER_SESSION_NOT_FOUND` 由 #388 一起落地（ROADMAP 已点名）—— 不预先声明一个发不出来的死契约。
- **不引入 Protocol。** `discover` / `verify` / `SessionDescriptor` 留给第 3 片。分发循环已经是「按优先级遍历候选、逐个尝试、耗尽即 fail-closed」，届时把元素从通道名换成候选对象即可，循环体不动。

## Breaking Change

- [x] 本 PR **不包含** 破坏性变更

`auto` 是默认且行为**逐字不变**：三级降级链、headless 兜底、`may_create_context`、`auto_probe_cdp`、失败仍原样上抛走既有 `NETWORK_ERROR` 兜底。有专门的门禁锁定这一点（`test_auto_keeps_the_full_fallback_chain_and_stays_fail_open` / `test_auto_exhaustion_keeps_the_existing_network_error_contract` / `test_auto_still_creates_context_in_an_empty_browser` / `test_auto_probes_default_endpoint_and_devtools_port`）。

唯一可观察的差异在 **double-close 路径**：`close()` 现在真正幂等，第二次调用直接返回而不重复拆卸，playwright driver 也只 `stop()` 一次。这是上面第 2 条修复的必然结果 —— 不置空 `_pw` 的话，`close()` 之后重启会复用一个已 `stop()` 的 driver。两条既有幂等测试的期望值已相应更新并注明理由。

## 新增门禁（22 条）

| 门禁 | 守的是 |
|---|---|
| `test_channel_entrypoints_are_only_called_from_the_dispatcher` | AST 扫描：三个通道方法只能被 `_ensure_started` 调用。#404 的 `_start_cdp_required` 就是第二个分发点 |
| `test_browser_session_has_exactly_one_source_selector_attribute` | 运行时属性扫描：选择器必须收敛到 `_policy` 一个 |
| `test_dispatcher_has_no_policy_name_branch` | 分发器里不许按来源名分支（对 AST 去 docstring 后匹配） |
| `test_only_auto_is_fail_open` | fail-closed 是「非 auto」的**结构性属性**，不是某处 if 的副作用 |
| `test_attempt_order_matches_declared_channels` | 行为级：实际尝试顺序逐字等于 `policy.channels`，白名单外通道一次都不许碰 |
| `test_fail_closed_source_raises_typed_error_and_leaks_no_driver` | fail-closed 抛带 `code` 的 typed exception 且不留 driver |
| `test_fail_closed_policies_declare_a_registered_error_code_and_human_guidance` | 声明的错误码必须已在 `SCHEMA_DATA` 里，且必须有 `operator_actions`（TTY 下唯一会渲染的一路） |
| `test_evaluate_js_is_blocked_when_source_forbids_cdp` | 裸 CDP 路径（刻意绕过分发器、承载招聘者写操作）自带等价守卫 |

## 测试 / Test Plan

- [x] `uv run python scripts/quality_baseline.py` → ruff ok · **pytest 1891 passed** · mypy **150 source files** 零错误
- [x] 既有 `tests/test_browser_client.py` 27 条全绿（除 double-close 两条按上述理由更新期望）
- [x] `tests/test_agent_docs.py` + `tests/test_open_source_docs.py` 38 条全绿

## 后续

合并后 #404 只需做机械改名接线（约 120 行），#388 只需在表里加一行 + 错误码。
