### PR TITLE
fix: boss ai config 回显解析后的实际端点

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
   本次不暴露任何 CLI 选项、不新增任何错误码。新增 22 条结构门禁锁定上述性质。
 
 ### Fixed
+- `boss ai config` 查看与写入现在都回显 `resolved_base_url`（解析后真正生效的端点）。此前查看模式
+  直出 `load_config()`，用户只设 `--provider` 时 `ai_base_url` 为空，实际地址来自
+  `PROVIDER_BASE_URLS` 查表却从不显示；而 `--provider` 没有 `click.Choice` 校验（自由字符串），
+  名字相近的 provider 记混或拼错时，API key 与简历全文会被发到另一家而界面上看不出任何差别。
+  该命令此前零测试覆盖，一并补齐 7 条。
 - 修复 `BrowserSession` 在 `_start_headless()` 或 playwright driver 启动抛错时泄漏 driver 进程：
   `_pw` 已 `start()` 却永远不会 `stop()`，下一次 `request()` 会再起一个。现在启动失败路径统一
   释放 driver。

--- a/src/boss_agent_cli/commands/ai_cmd.py
+++ b/src/boss_agent_cli/commands/ai_cmd.py
@@ -191,6 +191,11 @@ def ai_config_cmd(ctx: click.Context, provider: str | None, model: str | None, a
 		config = store.load_config()
 		config["api_key_set"] = store.get_api_key() is not None
 		config.pop("ai_api_key", None)
+		# 回显解析后的实际端点：只设 --provider 时 ai_base_url 是空的，
+		# 真正生效的地址来自 PROVIDER_BASE_URLS 查表，用户此前无从确认。
+		# provider 名相近时（如 openrouter / orcarouter）记混会把 API key 与
+		# 简历全文发到另一家，而界面上看不出任何差别。
+		config["resolved_base_url"] = store.get_base_url()
 		handle_output(
 			ctx, "ai-config", config,
 			render=lambda d: render_action_result(
@@ -222,7 +227,13 @@ def ai_config_cmd(ctx: click.Context, provider: str | None, model: str | None, a
 
 	handle_output(
 		ctx, "ai-config",
-		{"action": "update", "updated_fields": list(updates.keys()) + (["api_key"] if api_key else [])},
+		{
+			"action": "update",
+			"updated_fields": list(updates.keys()) + (["api_key"] if api_key else []),
+			# 写入后立刻回显生效的端点，让「刚配的这个 provider 会把数据发去哪」
+			# 在同一屏内可确认，而不是要再跑一次 boss ai config 才看得到。
+			"resolved_base_url": store.get_base_url(),
+		},
 		render=lambda d: render_action_result(d, title="ai config", next_steps=["boss ai config"]),
 		hints={"next_actions": ["boss ai config", "boss ai local status", "boss ai analyze-jd <security_id> --resume <name>"]},
 	)

--- a/tests/test_ai_config_cmd.py
+++ b/tests/test_ai_config_cmd.py
@@ -1,0 +1,103 @@
+"""`boss ai config` 命令级测试。
+
+这条命令此前零测试覆盖。核心断言是**解析后的实际端点必须回显**：
+只设 `--provider` 时 `ai_base_url` 为空，真正生效的地址来自 `PROVIDER_BASE_URLS`
+查表；不回显的话，provider 名相近（`openrouter` / `orcarouter`）记混会把 API key
+与简历全文发到另一家，而用户在任何界面上都看不出差别。
+"""
+
+import json
+
+from click.testing import CliRunner
+
+from boss_agent_cli.ai.config import PROVIDER_BASE_URLS, AIConfigStore
+from boss_agent_cli.main import cli
+
+
+def _run(tmp_path, *args):
+	result = CliRunner().invoke(cli, ["--json", "--data-dir", str(tmp_path), "ai", "config", *args])
+	assert result.exit_code == 0, result.output
+	return json.loads(result.stdout)
+
+
+def test_view_echoes_resolved_base_url_for_a_named_provider(tmp_path):
+	"""只设 provider（不设 --base-url）时，查看模式必须回显查表得到的端点。"""
+	store = AIConfigStore(tmp_path)
+	store.save_config(ai_provider="openrouter", ai_model="anthropic/claude-sonnet-4.5")
+
+	payload = _run(tmp_path)
+
+	assert payload["ok"] is True
+	data = payload["data"]
+	# 用户从没设过 ai_base_url —— 正是这种情况下端点最不透明
+	assert not data.get("ai_base_url")
+	assert data["resolved_base_url"] == PROVIDER_BASE_URLS["openrouter"]
+
+
+def test_view_resolved_base_url_prefers_explicit_override(tmp_path):
+	"""显式 --base-url 优先于 provider 查表，回显的必须是真正生效的那个。"""
+	store = AIConfigStore(tmp_path)
+	store.save_config(
+		ai_provider="openrouter",
+		ai_model="m",
+		ai_base_url="https://proxy.internal/v1",
+	)
+
+	data = _run(tmp_path)["data"]
+
+	assert data["resolved_base_url"] == "https://proxy.internal/v1"
+
+
+def test_view_resolved_base_url_is_null_when_unconfigured(tmp_path):
+	"""全新 data-dir 下没有可解析的端点，字段仍存在且为 null（不缺键）。"""
+	data = _run(tmp_path)["data"]
+
+	assert "resolved_base_url" in data
+	assert data["resolved_base_url"] is None
+
+
+def test_view_never_leaks_the_api_key(tmp_path):
+	"""回显端点不得顺带把密钥带出来——只暴露布尔。"""
+	store = AIConfigStore(tmp_path)
+	store.save_config(ai_provider="openai", ai_model="gpt-4o")
+	store.save_api_key("sk-super-secret")
+
+	result = CliRunner().invoke(cli, ["--json", "--data-dir", str(tmp_path), "ai", "config"])
+	data = json.loads(result.stdout)["data"]
+
+	assert data["api_key_set"] is True
+	assert "ai_api_key" not in data
+	assert "sk-super-secret" not in result.stdout
+
+
+def test_update_echoes_resolved_base_url_immediately(tmp_path):
+	"""写入后同一屏内就能确认「这个 provider 会把数据发去哪」。"""
+	data = _run(tmp_path, "--provider", "deepseek", "--model", "deepseek-chat")["data"]
+
+	assert data["action"] == "update"
+	assert set(data["updated_fields"]) == {"ai_provider", "ai_model"}
+	assert data["resolved_base_url"] == PROVIDER_BASE_URLS["deepseek"]
+
+
+def test_brand_adjacent_providers_resolve_to_different_endpoints(tmp_path):
+	"""名字相近的 provider 必须解析到不同端点，且该差别在输出里可见。
+
+	`--provider` 没有 click.Choice 校验（自由字符串），所以拼错不会报错；
+	能救用户的只有这条回显。
+	"""
+	adjacent = [name for name in PROVIDER_BASE_URLS if name.endswith("router")]
+	if len(adjacent) < 2:
+		return  # 仓库里目前只有一家 *router 时跳过
+
+	seen = set()
+	for name in adjacent:
+		data = _run(tmp_path, "--provider", name, "--model", "m")["data"]
+		seen.add(data["resolved_base_url"])
+	assert len(seen) == len(adjacent), f"{adjacent} 解析到了相同端点，用户无法区分"
+
+
+def test_unknown_provider_resolves_to_null_rather_than_a_wrong_endpoint(tmp_path):
+	"""拼错的 provider 解析为 null，不会静默落到别家端点。"""
+	data = _run(tmp_path, "--provider", "openrouterr", "--model", "m")["data"]
+
+	assert data["resolved_base_url"] is None


### PR DESCRIPTION
## 关联 / Related

兑现 #409 review 里的承诺（*"That's a repo gap, not yours — I'll make `ai config` echo `get_base_url()`."*）。

## 问题

`boss ai config` 查看模式直出 `load_config()`。用户只设 `--provider` 时 `ai_base_url` 是空的，真正生效的地址来自 `PROVIDER_BASE_URLS` 查表——**从不回显**。

而 `--provider` 没有 `click.Choice` 校验（`ai_cmd.py:177` 是自由字符串），所以拼错或记混不会报错。registry 里已经有 `openrouter`，#409 正在加 `orcarouter`——两个品牌相邻名。记混的后果是 **API key 与简历全文被发到另一家公司的端点，而用户在任何界面上都看不出差别**。

对照 `boss ai local status`（`ai_local.py:81`）与 `ai local configure`（`:110`）——它们本来就带 `store.get_base_url()`，只有 `ai config` 漏了。

## 变更

查看与写入两条路径都加 `resolved_base_url`。写入路径也加是为了让「刚配的这个 provider 会把数据发去哪」在同一屏内可确认，不用再跑一次命令。

用 `resolved_base_url` 而不是 `base_url`，是为了与 payload 里同时存在的 `ai_base_url`（用户显式覆盖值）区分开——前者是「实际生效的」，后者是「你设过的」。

## 测试

这条命令此前**零测试覆盖**，新增 7 条：

| 用例 | 断言 |
|---|---|
| 命名 provider | 未设 `ai_base_url` 时回显查表结果 |
| 显式覆盖 | `--base-url` 优先，回显真正生效的那个 |
| 未配置 | 字段存在且为 `null`，不缺键 |
| 密钥安全 | 只暴露 `api_key_set` 布尔，stdout 不含密钥原文 |
| 写入即回显 | `action=update` 同时带 `resolved_base_url` |
| 品牌相邻名 | 所有 `*router` provider 必须解析到**不同**端点 |
| 拼错 provider | 解析为 `null`，不静默落到别家端点 |

- [x] `uv run python scripts/quality_baseline.py` → ruff ok · pytest **1898 passed** · mypy 150 files 零错误

## Breaking Change

- [x] 本 PR **不包含** 破坏性变更

信封 `data` 新增一个键，属加性变更；既有键与错误契约不变。