### PR TITLE
docs: 明确 AI provider 的准入与移除规则并对齐既有条目

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 ## [Unreleased]
 
 ### Changed
+- `CONTRIBUTING.md` / `.en.md` 新增「新增 AI provider」一节，把 provider 的准入与移除写成明规则：
+  文档只写可用一次 API 调用证伪的陈述（不接受安全姿态、定价承诺、评级与会静默过期的规模数字）；
+  服务商自荐需提供可验证归属（企业域名邮箱或官方公开双向引用，不追溯）；端点连续两个 minor
+  版本不可用即直接移除，不走弃用周期、不算破坏性变更。第三条是前两条能够宽松的前提。
+- 按上述规则对齐既有条目：`docs/integrations/ai-models.md` / `.en.md` 的 Atlas Cloud 段落移除
+  59 个模型的全量清单（会随服务商上下线静默失真且无测试可守）与链接上的 UTM 追踪参数，
+  定性措辞压回与 `openrouter` 同一语域，并补回「可用模型以服务端实际支持为准」。
+  README 的赞助展示位不受影响——那是已披露的赞助关系，与 provider 文档条目是两回事。
 - **浏览器通道选择收敛为策略表驱动的单一分发点**（Issue #387 seam 第 2 片的前置改造，无对外行为变更）。
   `BrowserSession._ensure_started` 原本是硬编码的 Bridge → CDP → headless 三级降级链，
   中间只有两处插入缝隙；两个并行 PR 各自在其中一处插模式短路时，git 三方合并会干净通过、

--- a/CONTRIBUTING.en.md
+++ b/CONTRIBUTING.en.md
@@ -121,6 +121,49 @@ On error, the envelope must contain `error.code`, `error.recoverable`, and `erro
 - **Mock external I/O**: `AuthManager`, `BossClient`, `CacheStore`, and `AIService` are mock boundaries — tests should not hit the real BOSS Zhipin API.
 - **Error-path parity**: for every success path, add at least one error path test (auth expired, rate-limited, invalid param, etc.).
 
+## Adding an AI Provider
+
+`boss ai` keeps a table of OpenAI-compatible providers in `PROVIDER_BASE_URLS` (`src/boss_agent_cli/ai/config.py`). New providers are welcome, **including PRs authored by the provider's own engineers** — that is how `atlas` got here.
+
+But every row transfers a maintenance liability to this project: when a provider changes domains, changes pricing, or retires a model, the docs go stale silently and no test can catch it. Hence the three rules below.
+
+### 1. Docs carry only falsifiable claims
+
+Entries in `docs/integrations/ai-models.md` describe **capability boundaries only** — OpenAI compatibility, the `provider/model` namespace, which models are reachable, and that the authoritative model list is whatever the server actually supports.
+
+Not accepted: security-posture claims ("security gateway", "guardrails", "zero-trust", "tool governance"), pricing promises ("zero-markup", "cheapest"), ratings or rankings, and scale figures that go stale silently ("200+ models"). The test is simple: **can this sentence be falsified with a single API call?** If not, it does not belong in first-party docs.
+
+This applies to **all** entries, including ones already in the table — existing entries are being brought in line, not just new submissions.
+
+### 2. Vendor-authored entries need verifiable attribution
+
+If you work for the provider and are submitting your own company's entry, please include one verifiable link in the PR — either:
+
+- a commit authored from a corporate-domain address (`@yourcompany.com`), **or**
+- a public reference from the provider's own site or GitHub org pointing at this repo / this PR
+
+This is not about trust; it is about maintainability — when the endpoint moves, someone needs to be reachable. There is precedent: for one earlier provider, both the PR and the author's account later disappeared from GitHub, and the orphaned entry was then silently deleted by an unrelated refactor and went unnoticed for a long time.
+
+This rule is not applied retroactively.
+
+### 3. Removal policy
+
+A provider endpoint that is **unavailable across two consecutive minor releases** is removed from `PROVIDER_BASE_URLS` outright — no deprecation cycle, no advance notice, and **not treated as a breaking change**.
+
+This rule is what lets the first two stay permissive: because removal is cheap, admission does not have to be strict.
+
+### Chain updates
+
+Adding a provider touches five places (`boss schema` does not enumerate providers, so it needs no change):
+
+1. `PROVIDER_BASE_URLS` in `src/boss_agent_cli/ai/config.py`
+2. The `--provider` help text in `src/boss_agent_cli/commands/ai_cmd.py` — it is the only documentation of the value domain, because that option has no `click.Choice` validation
+3. `docs/integrations/ai-models.md` and `docs/integrations/ai-models.en.md` (both languages must stay in sync)
+4. `tests/test_ai_config.py`: a base-URL resolution test plus the membership assertion in `test_provider_base_urls_completeness`
+5. The `[Unreleased]` section of `CHANGELOG.md`
+
+> **Watch out for brand-adjacent names.** `--provider` accepts a free string, so a typo raises nothing. `boss ai config` echoes `resolved_base_url`, and `tests/test_ai_config_cmd.py` asserts that all `*router` providers resolve to distinct endpoints — if your provider's name is close to an existing one, confirm that test still passes.
+
 ## Reporting Issues
 
 Pick the matching template under `.github/ISSUE_TEMPLATE/`:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,49 @@ git diff --check
 8. 更新对应模块的 `CLAUDE.md`
 9. 如果命令对 Agent 通过 MCP 调用有用，还需在 `src/boss_agent_cli/mcp_server.py` 的 `TOOLS` 列表加 Tool 定义、在 `_build_args` 函数加分支；工具名与合规命令标识对不上时（如 `boss_hr_*` 系对应 `recruiter-*`）要登记 `_MCP_TOOL_COMPLIANCE_COMMAND_OVERRIDES`，否则低风险过滤不生效；`mcp-server/server.py` 是手工维护的 re-export 清单，新增公开符号需补一行；工具总数变化时同步 `README.en.md` 中的 "MCP server with N tools"（有测试按 `len(TOOLS)` 动态断言）
 
+## 新增 AI provider
+
+`boss ai` 通过 `src/boss_agent_cli/ai/config.py` 的 `PROVIDER_BASE_URLS` 维护一张 OpenAI 兼容服务商表。欢迎补充新的服务商，**包括由服务商自己的工程师提交**——`atlas` 就是这样进来的。
+
+但每加一行，维护责任就落到本项目：服务商改域名、调价、下线模型时，文档会静默失真，而没有任何测试守得住。所以有下面三条。
+
+### 1. 文档只写可验证陈述
+
+`docs/integrations/ai-models.md` 里的条目**只描述能力边界**——OpenAI 兼容性、`provider/model` 命名空间、能触达哪些模型、以及模型名以服务端实际支持为准。
+
+不接受：安全姿态断言（「安全网关」「护栏」「零信任」「工具治理」）、定价承诺（「零加价」「最便宜」）、评级或排名、以及会随时间静默失效的规模数字（「200+ 模型」）。判据很简单：**这句话能不能用一次 API 调用证伪？** 不能的，就不写进第一方文档。
+
+这条对**所有**条目适用，包括已经在表里的——现有条目会逐步对齐，不是只对新提交的执行。
+
+### 2. 服务商自荐需要可验证归属
+
+如果你是该服务商的员工并在提交自家的 provider，请在 PR 里提供一条可验证的关联，二选一：
+
+- 用企业域名邮箱（`@yourcompany.com`）提交 commit，**或**
+- 给出服务商官方站点或 GitHub org 指向本仓库 / 本 PR 的公开引用
+
+这不是信任问题，是可维护性问题：端点搬家时需要有人能对口。此前有过一次先例——那条 provider 的 PR 与作者账号后来双双从 GitHub 消失，留下的条目还被一次无关重构误删，很久没人发现。
+
+本条不追溯适用于已有条目。
+
+### 3. 移除机制
+
+服务商端点**连续两个 minor 版本不可用**即直接从 `PROVIDER_BASE_URLS` 移除，不走弃用周期、不提前公告、**不算破坏性变更**。
+
+这条是前两条能够宽松的前提：因为随时能删，所以准入不必苛刻。
+
+### 连锁更新
+
+新增一个 provider 需要同步五处（`boss schema` 不含 provider 枚举，无需改）：
+
+1. `src/boss_agent_cli/ai/config.py` 的 `PROVIDER_BASE_URLS`
+2. `src/boss_agent_cli/commands/ai_cmd.py` 中 `--provider` 的 help 文案（它是取值域的唯一文档，因为该选项没有 `click.Choice` 校验）
+3. `docs/integrations/ai-models.md` 与 `docs/integrations/ai-models.en.md`（中英必须同步）
+4. `tests/test_ai_config.py`：base-url 解析测试 + `test_provider_base_urls_completeness` 的成员断言
+5. `CHANGELOG.md` 的 `[Unreleased]`
+
+> **注意名字相近的服务商。** `--provider` 接受自由字符串，拼错不会报错。`boss ai config` 会回显 `resolved_base_url`，`tests/test_ai_config_cmd.py` 有一条测试断言所有 `*router` 系服务商必须解析到不同端点——新增时如果与既有条目品牌相近，请确认那条测试仍然通过。
+
 ## 提交 Issue
 
 请在 `.github/ISSUE_TEMPLATE/` 下选择对应模板：

--- a/docs/integrations/ai-models.en.md
+++ b/docs/integrations/ai-models.en.md
@@ -13,7 +13,7 @@ The `boss ai` command group speaks an OpenAI-compatible protocol. This guide sum
 | `qwen` | `https://dashscope.aliyuncs.com/compatible-mode/v1` | Tongyi Qwen3 models |
 | `zhipu` | `https://open.bigmodel.cn/api/paas/v4` | GLM-4.6 and GLM-Z1 |
 | `siliconflow` | `https://api.siliconflow.cn/v1` | SiliconFlow aggregated inference |
-| `atlas` | `https://api.atlascloud.ai/v1` | **Full-modal aggregator** — one OpenAI-compatible API spanning DeepSeek, Qwen, GLM, Kimi, MiniMax, Claude, GPT, and more |
+| `atlas` | `https://api.atlascloud.ai/v1` | Aggregated access — one OpenAI-compatible API spanning DeepSeek, Qwen, GLM, Kimi, MiniMax, Claude, GPT, and more |
 | `custom` | set manually with `--base-url` | LiteLLM, OneAPI, self-hosted proxies, and other compatible gateways |
 
 ## Claude 4.7 / GPT-5 configuration examples
@@ -69,7 +69,7 @@ boss ai config \
 
 ### Atlas Cloud (one key across many model families)
 
-[Atlas Cloud](https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=boss-agent-cli) is a full-modal AI inference platform: a single OpenAI-compatible API gives you DeepSeek, Qwen, GLM, Kimi, MiniMax, Claude, GPT, and more — no per-vendor wiring:
+[Atlas Cloud](https://www.atlascloud.ai/) exposes an OpenAI-compatible API: one key reaches DeepSeek, Qwen, GLM, Kimi, MiniMax, Claude, GPT, and other model families without per-vendor wiring. The authoritative model list is whatever the server actually supports:
 
 ```bash
 boss ai config \
@@ -79,23 +79,6 @@ boss ai config \
 ```
 
 > `deepseek-ai/deepseek-v4-pro` is a reasoning model with chain-of-thought — give it enough `max_tokens` (>= 512), otherwise tokens may be consumed by the reasoning trace and you get an empty `content` with `finish_reason=length`. The `--max-tokens` default in `boss ai config` is already 4096, so no extra tuning is needed.
-
-<details>
-<summary>Full Atlas Cloud LLM model list (59 models, matching the official <code>/zh/models/list/llm</code>)</summary>
-
-- Anthropic (Claude): `anthropic/claude-haiku-4.5-20251001`, `anthropic/claude-opus-4.8`, `anthropic/claude-sonnet-4.6`
-- OpenAI (GPT): `openai/gpt-5.4`, `openai/gpt-5.5`
-- Google (Gemini): `google/gemini-3.1-flash-lite`, `google/gemini-3.1-pro-preview`, `google/gemini-3.5-flash`
-- Alibaba Qwen: `qwen/qwen2.5-7b-instruct`, `Qwen/Qwen3-235B-A22B-Instruct-2507`, `qwen/qwen3-235b-a22b-thinking-2507`, `qwen/qwen3-30b-a3b`, `Qwen/Qwen3-30B-A3B-Instruct-2507`, `qwen/qwen3-30b-a3b-thinking-2507`, `qwen/qwen3-32b`, `qwen/qwen3-8b`, `Qwen/Qwen3-Coder`, `qwen/qwen3-coder-next`, `qwen/qwen3-max-2026-01-23`, `Qwen/Qwen3-Next-80B-A3B-Instruct`, `Qwen/Qwen3-Next-80B-A3B-Thinking`, `Qwen/Qwen3-VL-235B-A22B-Instruct`, `qwen/qwen3-vl-235b-a22b-thinking`, `qwen/qwen3-vl-30b-a3b-instruct`, `qwen/qwen3-vl-30b-a3b-thinking`, `qwen/qwen3-vl-8b-instruct`, `qwen/qwen3.5-122b-a10b`, `qwen/qwen3.5-27b`, `qwen/qwen3.5-35b-a3b`, `qwen/qwen3.5-397b-a17b`, `qwen/qwen3.6-35b-a3b`, `qwen/qwen3.6-plus`
-- DeepSeek: `deepseek-ai/deepseek-ocr`, `deepseek-ai/deepseek-r1-0528`, `deepseek-ai/DeepSeek-V3-0324`, `deepseek-ai/DeepSeek-V3.1`, `deepseek-ai/DeepSeek-V3.1-Terminus`, `deepseek-ai/deepseek-v3.2`, `deepseek-ai/DeepSeek-V3.2-Exp`, `deepseek-ai/deepseek-v4-flash`, `deepseek-ai/deepseek-v4-pro`
-- Moonshot (Kimi): `moonshotai/Kimi-K2-Instruct`, `moonshotai/Kimi-K2-Instruct-0905`, `moonshotai/Kimi-K2-Thinking`, `moonshotai/kimi-k2.5`, `moonshotai/kimi-k2.6`
-- Zhipu GLM: `zai-org/GLM-4.6`, `zai-org/glm-4.7`, `zai-org/glm-5`, `zai-org/glm-5-turbo`, `zai-org/glm-5.1`, `zai-org/glm-5v-turbo`
-- MiniMax: `MiniMaxAI/MiniMax-M2`, `minimaxai/minimax-m2.1`, `minimaxai/minimax-m2.5`, `minimaxai/minimax-m2.7`
-- xAI: `xai/grok-4.3`
-- Kuaishou KAT: `kwaipilot/kat-coder-pro-v2`
-- Other: `owl`
-
-</details>
 
 ### Self-hosted proxy via LiteLLM / OneAPI
 

--- a/docs/integrations/ai-models.md
+++ b/docs/integrations/ai-models.md
@@ -13,7 +13,7 @@
 | `qwen` | `https://dashscope.aliyuncs.com/compatible-mode/v1` | 通义千问 Qwen3 系列 |
 | `zhipu` | `https://open.bigmodel.cn/api/paas/v4` | 智谱 GLM-4.6 / GLM-Z1 |
 | `siliconflow` | `https://api.siliconflow.cn/v1` | 硅基流动聚合推理 |
-| `atlas` | `https://api.atlascloud.ai/v1` | **全模态聚合入口**，一个 OpenAI 兼容 API 覆盖 DeepSeek、Qwen、GLM、Kimi、MiniMax、Claude、GPT 等 |
+| `atlas` | `https://api.atlascloud.ai/v1` | **聚合入口**，一个 OpenAI 兼容 API 覆盖 DeepSeek、Qwen、GLM、Kimi、MiniMax、Claude、GPT 等 |
 | `custom` | 需手动指定 `--base-url` | 自建代理、LiteLLM、OneAPI 等 |
 
 ## Claude 4.7 / GPT-5 配置示例
@@ -69,7 +69,7 @@ boss ai config \
 
 ### Atlas Cloud（一个 key 覆盖多家模型）
 
-[Atlas Cloud](https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=boss-agent-cli) 是一个全模态 AI 推理平台，用一个 OpenAI 兼容 API 就能访问 DeepSeek、Qwen、GLM、Kimi、MiniMax、Claude、GPT 等模型，无需逐家接入：
+[Atlas Cloud](https://www.atlascloud.ai/) 提供 OpenAI 兼容 API，一个 key 即可访问 DeepSeek、Qwen、GLM、Kimi、MiniMax、Claude、GPT 等多家模型，无需逐家接入。可用模型以服务端实际支持为准：
 
 ```bash
 boss ai config \
@@ -79,23 +79,6 @@ boss ai config \
 ```
 
 > `deepseek-ai/deepseek-v4-pro` 是带思维链的推理模型，`max_tokens` 要给足（建议 ≥ 512），否则 token 可能先耗在思维链上，出现 `content` 为空且 `finish_reason=length`。`boss ai config` 的 `--max-tokens` 默认即为 4096，无需额外调整。
-
-<details>
-<summary>Atlas Cloud 全量 LLM 模型清单（59 个，与官网 <code>/zh/models/list/llm</code> 一致）</summary>
-
-- Anthropic (Claude)：`anthropic/claude-haiku-4.5-20251001`、`anthropic/claude-opus-4.8`、`anthropic/claude-sonnet-4.6`
-- OpenAI (GPT)：`openai/gpt-5.4`、`openai/gpt-5.5`
-- Google (Gemini)：`google/gemini-3.1-flash-lite`、`google/gemini-3.1-pro-preview`、`google/gemini-3.5-flash`
-- 阿里 Qwen：`qwen/qwen2.5-7b-instruct`、`Qwen/Qwen3-235B-A22B-Instruct-2507`、`qwen/qwen3-235b-a22b-thinking-2507`、`qwen/qwen3-30b-a3b`、`Qwen/Qwen3-30B-A3B-Instruct-2507`、`qwen/qwen3-30b-a3b-thinking-2507`、`qwen/qwen3-32b`、`qwen/qwen3-8b`、`Qwen/Qwen3-Coder`、`qwen/qwen3-coder-next`、`qwen/qwen3-max-2026-01-23`、`Qwen/Qwen3-Next-80B-A3B-Instruct`、`Qwen/Qwen3-Next-80B-A3B-Thinking`、`Qwen/Qwen3-VL-235B-A22B-Instruct`、`qwen/qwen3-vl-235b-a22b-thinking`、`qwen/qwen3-vl-30b-a3b-instruct`、`qwen/qwen3-vl-30b-a3b-thinking`、`qwen/qwen3-vl-8b-instruct`、`qwen/qwen3.5-122b-a10b`、`qwen/qwen3.5-27b`、`qwen/qwen3.5-35b-a3b`、`qwen/qwen3.5-397b-a17b`、`qwen/qwen3.6-35b-a3b`、`qwen/qwen3.6-plus`
-- DeepSeek：`deepseek-ai/deepseek-ocr`、`deepseek-ai/deepseek-r1-0528`、`deepseek-ai/DeepSeek-V3-0324`、`deepseek-ai/DeepSeek-V3.1`、`deepseek-ai/DeepSeek-V3.1-Terminus`、`deepseek-ai/deepseek-v3.2`、`deepseek-ai/DeepSeek-V3.2-Exp`、`deepseek-ai/deepseek-v4-flash`、`deepseek-ai/deepseek-v4-pro`
-- Moonshot (Kimi)：`moonshotai/Kimi-K2-Instruct`、`moonshotai/Kimi-K2-Instruct-0905`、`moonshotai/Kimi-K2-Thinking`、`moonshotai/kimi-k2.5`、`moonshotai/kimi-k2.6`
-- 智谱 GLM：`zai-org/GLM-4.6`、`zai-org/glm-4.7`、`zai-org/glm-5`、`zai-org/glm-5-turbo`、`zai-org/glm-5.1`、`zai-org/glm-5v-turbo`
-- MiniMax：`MiniMaxAI/MiniMax-M2`、`minimaxai/minimax-m2.1`、`minimaxai/minimax-m2.5`、`minimaxai/minimax-m2.7`
-- xAI：`xai/grok-4.3`
-- 快手 KAT：`kwaipilot/kat-coder-pro-v2`
-- 其他：`owl`
-
-</details>
 
 ### 自建代理（LiteLLM / OneAPI）
 


### PR DESCRIPTION
## 关联 / Related

兑现 #409 review 里的承诺：*"I'm going to write this rule down and apply it to the existing entries too, including trimming the `atlas` section."*

**规则与存量对齐放在同一个提交里**——否则一条只作用于新提交的规则站不住脚，#409 的作者会看到它专门落在自己头上。

## 为什么现在写

`PROVIDER_BASE_URLS` 已有 11 家，此前没有任何成文的准入或移除标准。每加一行，维护责任就落到本项目：服务商改域名、调价、下线模型时文档会静默失真，而没有任何测试守得住。

审 #409 时暴露了三个具体缺口：文档里出现了无法用一次 API 调用证伪的断言（安全姿态、定价、规模数字）；厂商自荐没有任何归属要求；**移除机制根本不存在**——`tests/test_ai_config.py:213` 的 `test_provider_base_urls_completeness` 全是 `in` 断言、没有全集断言，同步删掉 dict 条目和断言不会红（`#323` 正是这样把 `atlas` 删掉而没人发现的）。

## 三条规则

| | 规则 |
|---|---|
| **1** | 文档只写**可用一次 API 调用证伪**的陈述。不接受安全姿态断言、定价承诺、评级排名、会静默过期的规模数字。**对所有条目适用，包括已在表里的。** |
| **2** | 服务商自荐需可验证归属：企业域名邮箱 **或** 官方站点/org 的公开双向引用。定位是**可维护性**而非信任——端点搬家时需要有人能对口。**不追溯。** |
| **3** | 端点**连续两个 minor 版本不可用即直接移除**，不走弃用周期、不算破坏性变更。 |

第 3 条是前两条能够宽松的前提：**因为随时能删，所以准入不必苛刻。** 这条逻辑写进了文档本身，避免三条读起来像互不相干的门槛。

规则 2 里引用了此前那次先例（PR 与作者账号双双从 GitHub 消失、留下的条目被无关重构误删且很久没人发现）但**不点名**——事实说清楚，不让还在用该 provider 的人难堪。

## 存量对齐

`docs/integrations/ai-models.md` + `.en.md` 的 Atlas Cloud 段落：

| 项 | 处理 | 依据 |
|---|---|---|
| **59 个模型全量清单**（含「与官网 `/zh/models/list/llm` 一致」） | **整块删除** | 规则 1 点名的「会静默过期的规模资产」，也是这段里最大的维护负债 |
| 链接上的 UTM 追踪参数 | 去掉，留裸 URL | provider 文档不是导流位 |
| 「全模态 AI 推理平台」 | 压回「提供 OpenAI 兼容 API」 | 与 `openrouter` 同一语域 |
| 表格行 **`全模态聚合入口`** | → **`聚合入口`** | 同上 |
| 「可用模型以服务端实际支持为准」 | **补回** | 这正是该 provider 首版贡献者的原始措辞 |
| `max_tokens ≥ 512` 的 caveat | **保留** | 真技术信息，不在规则禁止范围 |

### 刻意没动的两处

- **README 的赞助展示位**（4 处 UTM）——那是**已披露的赞助关系**，与 provider 文档条目属于不同类别。本规则管的是 `docs/integrations/` 里的条目该写什么。
- **「如何选择」表里的厂商点名行**——规则没有涵盖这一条，而且仓库对 `openrouter` 与 `atlas` 都有同类行。按写下的规则执行，不多做。

## 顺带写进文档的实用信息

- **连锁更新清单五处**，并明确 **`boss schema` 不含 provider 枚举、无需改**（审 #409 时实测确认：`boss schema --format native` 里 `provider` 只有两次命中，都在 `AI_NOT_CONFIGURED` 的占位串里）。省得下一个贡献者去猜。
- **品牌相邻名提醒**：`--provider` 没有 `click.Choice` 校验，拼错不报错；指向 #411 新增的 `tests/test_ai_config_cmd.py` 那条「所有 `*router` 必须解析到不同端点」的断言。

## 测试

- [x] `uv run python scripts/quality_baseline.py` → ruff ok · pytest **1898 passed** · mypy 150 files 零错误
- [x] `tests/test_agent_docs.py` + `tests/test_open_source_docs.py` 中英同步断言全绿

## Breaking Change

- [x] 本 PR **不包含** 破坏性变更

纯文档。用户可见的唯一变化是 `ai-models.md` 里不再列出那 59 个模型名——它本来就随服务商变动而失真，权威来源是服务端。