### PR TITLE
fix: 尊重系统 SOCKS 代理，依赖改为 httpx[socks]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,16 @@
   本次不暴露任何 CLI 选项、不新增任何错误码。新增 22 条结构门禁锁定上述性质。
 
 ### Fixed
+- **修复设了 SOCKS 系统代理时每一条 httpx 命令都失败**（#412）。全仓四处 `httpx.Client`
+  都用默认 `trust_env=True`，即刻意尊重用户的系统代理；但 httpx 只有装了 `socksio` 才支持
+  `socks5://` scheme，否则在**构造 client 时**就抛 `ImportError`。于是设了
+  `ALL_PROXY=socks5://...` 的用户，`boss status` / `detail` / `favorites` 等每一条只读命令
+  都会失败——而��个 ImportError 被 `display.handle_auth_errors` 的兜底转成
+  `NETWORK_ERROR` + `recovery_action="重试"`，错误码与恢复动作双错，且这是个永远不会
+  因重试而改变的本地环境问题。依赖改为 `httpx[socks]`（拉 `socksio`，35KB、纯 Python、
+  零传递依赖），让代理**能用**而不是失败得好看。
+  CI runner 环境干净、没有代理变量，这条路径在门禁上永远是绿的，故补
+  `tests/test_system_proxy.py` 显式注入代理环境变量把它变成可观测的。
 - `boss ai config` 查看与写入现在都回显 `resolved_base_url`（解析后真正生效的端点）。此前查看模式
   直出 `load_config()`，用户只设 `--provider` 时 `ai_base_url` 为空，实际地址来自
   `PROVIDER_BASE_URLS` 查表却从不显示；而 `--provider` 没有 `click.Choice` 校验（自由字符串），

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,13 @@ classifiers = [
 ]
 dependencies = [
 	"click>=8.0",
-	"httpx>=0.27",
+	# [socks] 拉的是 socksio（35KB、纯 Python、零传递依赖）。四处 httpx.Client 都用
+	# 默认 trust_env=True，即刻意尊重用户的系统代理——对这个项目的目标用户群来说，
+	# 常开代理是常态。但 httpx 只有装了 socksio 才支持 socks5:// scheme，否则在
+	# **构造 client 时**就抛 ImportError，于是 `ALL_PROXY=socks5://...` 的用户每一条
+	# 走 httpx 的命令都失败。CI runner 环境干净、没有代理变量，这条路径在门禁上
+	# 永远是绿的（同 fresh_install job 守的那道缝）。
+	"httpx[socks]>=0.27",
 	"cryptography>=42.0",
 	"patchright>=1.58.2",
 	"browser-cookie3>=0.16.2",

--- a/tests/test_system_proxy.py
+++ b/tests/test_system_proxy.py
@@ -1,0 +1,73 @@
+"""系统代理（`ALL_PROXY` / `HTTPS_PROXY`）下的 httpx 通道回归测试。
+
+背景（issue #412）：全仓四处 `httpx.Client` 构造都用默认 `trust_env=True`，
+即刻意尊重用户的系统代理——对这个项目的目标用户群来说常开代理是常态。
+但 httpx 只有装了 `socksio` 才支持 `socks5://` scheme，否则在**构造 client 时**
+就抛 `ImportError`，于是设了 `ALL_PROXY=socks5://...` 的用户，每一条走 httpx 的
+命令都会失败；而那个 ImportError 会被 `display.handle_auth_errors` 的兜底
+`except Exception` 转成 `NETWORK_ERROR` + `recovery_action="重试"`——错误码与恢复
+动作双错，且这是个永远不会因重试而改变的本地环境问题。
+
+CI runner 环境���净、没有代理变量，所以这条路径在门禁上永远是绿的。下面的测试
+显式注入代理环境变量，把它变成可观测的。
+"""
+
+import httpx
+import pytest
+
+_SOCKS_ENVS = ("ALL_PROXY", "all_proxy")
+_PROXY_ENVS = (*_SOCKS_ENVS, "HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy")
+
+
+@pytest.fixture
+def _clean_proxy_env(monkeypatch):
+	"""开发机上可能本来就设了代理，先清干净再逐条注入，避免测试受环境影响。"""
+	for name in _PROXY_ENVS:
+		monkeypatch.delenv(name, raising=False)
+	return monkeypatch
+
+
+def test_socks_proxy_support_is_installed():
+	"""`socksio` 必须随 `httpx[socks]` 一起装上。
+
+	删掉 pyproject 里的 `[socks]` extra 这条会红——否则那个删除会静默通过，
+	而 CI 环境永远没有代理变量、发现不了。
+	"""
+	pytest.importorskip("socksio", reason="httpx[socks] 未生效：socksio 没装上")
+
+
+@pytest.mark.parametrize("scheme", ["socks5", "socks5h", "http"])
+def test_httpx_client_constructs_under_a_system_proxy(_clean_proxy_env, scheme):
+	"""设了系统代理时 `httpx.Client` 必须能构造出来，不得抛 ImportError。
+
+	`socks5` 是真正的回归点：没有 socksio 时这一条会
+	`ImportError: Using SOCKS proxy, but the 'socksio' package is not installed.`
+	`http` 是对照组——它从来不需要 socksio，用来证明失败确实来自 scheme 而非
+	「设了代理」这件事本身。
+	"""
+	_clean_proxy_env.setenv("ALL_PROXY", f"{scheme}://127.0.0.1:7890")
+
+	# 只构造、不发请求：ImportError 发生在构造期，无需真的连出去。
+	client = httpx.Client(base_url="https://www.zhipin.com", timeout=1)
+	client.close()
+
+
+def test_base_http_client_constructs_under_a_socks_proxy(_clean_proxy_env, monkeypatch):
+	"""仓库自己的 httpx 通道在 SOCKS 代理下也必须能起来。
+
+	直接测 `_BaseHttpClient._get_client()` 而不只是裸 `httpx.Client`：真正会被
+	用户命中的是这条路径，而它额外带了 base_url / cookies / headers。
+	"""
+	from boss_agent_cli.api.client import BossClient
+
+	_clean_proxy_env.setenv("ALL_PROXY", "socks5://127.0.0.1:7890")
+
+	class _StubAuth:
+		def get_token(self):
+			return {"cookies": {"wt2": "x"}, "user_agent": "ua"}
+
+	client = BossClient(_StubAuth())
+	try:
+		assert isinstance(client._get_client(), httpx.Client)
+	finally:
+		client.close()

--- a/uv.lock
+++ b/uv.lock
@@ -261,7 +261,7 @@ dependencies = [
     { name = "browser-cookie3" },
     { name = "click" },
     { name = "cryptography" },
-    { name = "httpx" },
+    { name = "httpx", extra = ["socks"] },
     { name = "patchright" },
     { name = "prompt-toolkit" },
     { name = "pyyaml" },
@@ -303,7 +303,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.0" },
     { name = "cryptography", specifier = ">=42.0" },
     { name = "drissionpage", marker = "extra == 'crawl'", specifier = ">=4.1.1.1,<4.2" },
-    { name = "httpx", specifier = ">=0.27" },
+    { name = "httpx", extras = ["socks"], specifier = ">=0.27" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=2.1.0,<3.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.20" },
     { name = "openpyxl", marker = "extra == 'crawl'", specifier = ">=3.1" },
@@ -1086,6 +1086,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[package.optional-dependencies]
+socks = [
+    { name = "socksio" },
 ]
 
 [[package]]
@@ -2680,6 +2685,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/12/44/c00420a3b7bcdf830529b933392b566c876a4944a24f31e126eb6fd28647/shadowcopy-0.0.4.tar.gz", hash = "sha256:ed89817dda065f893607a04c0b7d6b3b34c3507a4711f441111a4bcb1b1826c0", size = 4138, upload-time = "2023-07-08T00:01:35.266Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ad/32/fdea8e7f7b2b8bae13ee6ab7df1a10d28a24dbeb03a62ff033563f95d77c/shadowcopy-0.0.4-py3-none-any.whl", hash = "sha256:fc51e59a639dc6a5a3a7a9b4e3ecadc71989e339f2d995d90aaa491acd4ba4eb", size = 4212, upload-time = "2023-07-08T00:01:34.042Z" },
+]
+
+[[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 关联 Issue / Related Issue

Closes #412

## 问题

全仓四处 `httpx.Client` 都用默认 `trust_env=True`（`api/_base_client.py:87`、`api/zhilian_client.py:110`、`auth/qr_login.py:27`、`crawler/transport.py:358`），即**刻意尊重用户的系统代理**——对这个项目的目标用户群来说，常开代理是常态。

但 httpx 只有装了 `socksio` 才支持 `socks5://` scheme，否则在**构造 client 时**就抛 `ImportError`。于是设了 `ALL_PROXY=socks5://...` 的用户，`boss status` / `detail` / `favorites` 等**每一条走 httpx 的命令都失败**。

### 失败形态比崩溃本身更糟

那个 `ImportError` 被 `display.handle_auth_errors` 的兜底 `except Exception`（`display.py:594-599`）接住，发出：

```json
{"code": "NETWORK_ERROR", "recoverable": true, "recovery_action": "重试"}
```

**错误码与恢复动作双错。** 这是本地环境问题不是网络抖动，而且永远不会因重试而改变——Agent 会照着 `recovery_action` 重试到底，真人也拿不到任何 `operator_actions`。

### 为什么门禁看不见

CI runner 环境干净、没有代理变量，所以这条路径在门禁上**永远是绿的**。与 #397 的 `fresh_install` job 守的是同一道缝：**门禁看到的与用户拿到的不是一个东西**。

## 变更：让它能用，而不是让它失败得好看

依赖 `httpx>=0.27` → `httpx[socks]>=0.27`。`[socks]` 拉的是 `socksio`：**35 KB、14 个文件、纯 Python、零传递依赖**（实测）。

### 我改了自己在 issue 里的建议

#412 里我给了三条方案并倾向「①把 `ImportError` 分类成专用错误码 + ③四处显式声明 `trust_env`」，把「②加依赖」列为次选，理由是「加依赖不解决错误码语义反了这一层」。

实际做时改了主意，两条理由：

1. **让代理能用优于让它失败得好看。** 用户设 `ALL_PROXY` 是因为**需要**走代理，给一个漂亮的错误信封仍然是不能用。
2. **打包 `socksio` 之后那个 `ImportError` 不会再发生**，再为它新增一个错误码，就是加一个永远发不出来的死契约——正是本仓库刚在 #413 / #415 里反复守住的原则。

用 `httpx[socks]` 而不是裸 `socksio`，是因为前者把「我们要 SOCKS 支持」这个意图写在了依赖声明里。`pyproject.toml` 里补了注释说明 `trust_env` 是有意保留默认值。

## 测试

新增 `tests/test_system_proxy.py`（5 条）：

| 用例 | 守的是 |
|---|---|
| `test_socks_proxy_support_is_installed` | 删掉 `[socks]` extra 会红——否则那个删除静默通过，而 CI 环境永远没有代理变量、发现不了 |
| `test_httpx_client_constructs_under_a_system_proxy[socks5]` / `[socks5h]` | 真正的回归点 |
| `…[http]` | **对照组**，证明失败来自 scheme 而非「设了代理」本身 |
| `test_base_http_client_constructs_under_a_socks_proxy` | 直接测 `_BaseHttpClient._get_client()`——真正会被用户命中的是这条路径 |

fixture 先清空全部代理环境变量再逐条注入，避免开发机自身的代理影响结果。

### 红灯验证

不是只看绿灯就交。卸掉 `socksio` 后：

```
FAILED tests/test_system_proxy.py::test_httpx_client_constructs_under_a_system_proxy[socks5]
FAILED tests/test_system_proxy.py::test_httpx_client_constructs_under_a_system_proxy[socks5h]
FAILED tests/test_system_proxy.py::test_base_http_client_constructs_under_a_socks_proxy
3 failed, 1 passed, 1 skipped
```

`http` 对照组仍绿，装回去 5 条全绿。

- [x] `uv run python scripts/quality_baseline.py` → ruff ok · pytest **1905 passed** · mypy 150 files 零错误
- [x] `uv run ruff check src/ tests/ scripts/ mcp-server/`（CI 的完整范围）→ All checks passed

## Breaking Change

- [x] 本 PR **不包含** 破坏性变更

新增一个 35KB 的纯 Python 传递依赖，无行为变更；不设代理的用户完全无感知。

## 残留（不在本 PR 范围）

「任何 `httpx.Client` 构造失败都会变成 `NETWORK_ERROR` + `重试`」这个**一般性**问题仍然存在。但目前已知的具体失败模式只有 SOCKS 这一个，且已被本 PR 消除；为一个假设中的失败模式预先新增错误码不符合本仓库的既有原则。日后再出现具体实例时另开 issue。