### PR TITLE
chore: 准备 1.20.0 发版

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## [Unreleased]
 
+## [1.20.0] - 2026-09-03
+
+> **升级提示（仅影响 `mcp` extra）**：`mcp` 依赖的**下界**从 `1.0.0` 提到 `2.1.0`
+> （区间 `mcp>=2.1.0,<3.0.0`）。主推的 `uvx --from boss-agent-cli[mcp] boss-mcp`
+> 每次现解析临时环境，不受影响；受影响的只有「把 `boss-agent-cli[mcp]` 装进一个
+> 还钉着 `mcp<2` 的长期共享环境」这种场景——请一并放开该环境里的 `mcp` 约束。
+> **MCP 线格式与工具集合一字未变**，宿主侧无需任何改动。
+
 ### Changed
 - **适配 mcp 2.x Server API（Issue #398），依赖改为 `mcp>=2.1.0,<3.0.0`。** mcp 2.0 移除了
   `@server.list_tools()` / `@server.call_tool()` 装饰器，改为
@@ -38,7 +46,7 @@
   都用默认 `trust_env=True`，即刻意尊重用户的系统代理；但 httpx 只有装了 `socksio` 才支持
   `socks5://` scheme，否则在**构造 client 时**就抛 `ImportError`。于是设了
   `ALL_PROXY=socks5://...` 的用户，`boss status` / `detail` / `favorites` 等每一条只读命令
-  都会失败——而��个 ImportError 被 `display.handle_auth_errors` 的兜底转成
+  都会失败——而那个 ImportError 被 `display.handle_auth_errors` 的兜底转成
   `NETWORK_ERROR` + `recovery_action="重试"`，错误码与恢复动作双错，且这是个永远不会
   因重试而改变的本地环境问题。依赖改为 `httpx[socks]`（拉 `socksio`，35KB、纯 Python、
   零传递依赖），让代理**能用**而不是失败得好看。

--- a/ROADMAP.en.md
+++ b/ROADMAP.en.md
@@ -4,6 +4,7 @@ This document tracks the medium-term and long-term direction of `boss-agent-cli`
 
 ## Released
 
+- ✅ v1.20.0 (2026-09-03): adapted to the mcp 2.x Server API (dependency now `mcp>=2.1.0,<3.0.0`; the MCP wire format is unchanged), fixed every httpx command failing when a SOCKS system proxy is set, collapsed browser-channel selection into a single policy-table-driven dispatch point (prerequisite for the #387 seam), made `boss ai config` echo the resolved endpoint, and wrote down the AI provider admission and removal rules
 - ✅ v1.19.1 (2026-08-27): fixed fresh installs resolving to mcp 2.x, which made `boss-mcp` crash on import (dependency now capped at `<2.0.0`), and added a `fresh_install` CI gate that deliberately bypasses `uv.lock`
 - ✅ v1.19.0 (2026-08-27): fixed the never-registered MCP `tools/list` (the MCP entry point was unusable for every host since v1.18.0) and added protocol-level plus CI gates, opened every implemented capability under assisted / research, unified the terminal-only `boss wizard` into a single interactive window, and split envelope `hints` into agent / operator channels
 - ✅ v1.18.0 (2026-07-29): usable Docker / Compose image with CI build gate, MCP schema contract fixes and `mcp_server` split, offline evals in P0, pinned ruff rules, and dependency refresh (rich 15)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,6 +4,7 @@
 
 ## 已发布
 
+- ✅ v1.20.0（2026-09-03）：适配 mcp 2.x Server API（依赖 `mcp>=2.1.0,<3.0.0`，MCP 线格式未变）+ 修复设了 SOCKS 系统代理时每一条 httpx 命令都失败 + 浏览器通道选择收敛为策略表驱动的单一分发点（#387 seam 前置）+ `boss ai config` 回显解析后的实际端点 + AI provider 准入与移除规则成文
 - ✅ v1.19.1（2026-08-27）：修复全新安装解析到 mcp 2.x 导致 `boss-mcp` 直接崩溃（依赖收紧为 `<2.0.0`），并新增不走 `uv.lock` 的 `fresh_install` CI 门禁
 - ✅ v1.19.0（2026-08-27）：修复 MCP `tools/list` 从未注册（v1.18.0 起 MCP 入口对所有 host 不可用）并补齐协议层与 CI 门禁 + 开放 assisted / research 下全部已实现能力 + 纯终端 `boss wizard` 统一为单交互窗口 + 信封 `hints` 拆分 Agent / 真人双受众通道
 - ✅ v1.18.0（2026-07-29）：可用 Docker / Compose 镜像与 CI 构建门禁 + MCP schema 契约修复与 `mcp_server` 拆分 + 离线 evals 进 P0 + ruff 规则钉死与依赖刷新（rich 15）

--- a/docs/marketing/awesome-submissions.md
+++ b/docs/marketing/awesome-submissions.md
@@ -55,8 +55,8 @@
 - [x] README 双语（中文 + 英文）
 - [x] MIT License
 - [x] CI 全绿（pytest / ruff / mypy / CodeQL）
-- [x] 发布到 PyPI（`pip install boss-agent-cli`，当前 latest release v1.19.1）
-- [x] GitHub Release 规范（latest release v1.19.1 已发）
+- [x] 发布到 PyPI（`pip install boss-agent-cli`，当前 latest release v1.20.0）
+- [x] GitHub Release 规范（latest release v1.20.0 已发）
 - [x] CHANGELOG 完整
 - [x] Code of Conduct + Security Policy
 - [x] Issue / PR 模板

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "boss-agent-cli"
-version = "1.19.1"
+version = "1.20.0"
 description = "AI Agent 专用的 BOSS 直聘求职 CLI 工具"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/boss_agent_cli/__init__.py
+++ b/src/boss_agent_cli/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 	)
 	from boss_agent_cli.resume.models import ResumeData, ResumeFile
 
-__version__ = "1.19.1"
+__version__ = "1.20.0"
 
 _LAZY_EXPORT_MODULES = {
 	"AuthManager": "boss_agent_cli.auth.manager",

--- a/uv.lock
+++ b/uv.lock
@@ -255,7 +255,7 @@ wheels = [
 
 [[package]]
 name = "boss-agent-cli"
-version = "1.19.1"
+version = "1.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },


### PR DESCRIPTION
## 发布主线

**让门禁看不见的那些故障变得可见并修掉。** 这一批里有两条都属于同一个模式——CI 环境永远碰不到，所以在门禁上长期全绿，只有人主动去找才会暴露。

| 变更 | 关联 |
|---|---|
| 适配 mcp 2.x Server API，依赖 `mcp>=2.1.0,<3.0.0` | #398 |
| 修复设了 SOCKS 系统代理时每一条 httpx 命令都失败 | #412 |
| 浏览器通道选择收敛为策略表驱动的单一分发点 | #387 seam 前置 |
| `boss ai config` 回显 `resolved_base_url` | #409 衍生 |
| AI provider 准入与移除规则成文并对齐既有条目 | #409 衍生 |
| 节流等待期间的 TTY 进度提示 | #400 |

## 版本与升级提示

`1.19.1` → **`1.20.0`**（minor）。CLI 的公开契约、JSON 信封、错误码枚举、命令表均无破坏性变更。

唯一需要用户注意的是 **`mcp` extra 的下界从 `1.0.0` 提到 `2.1.0`**，已在 CHANGELOG 该版本段落顶部用引用块显著提示：主推的 `uvx --from boss-agent-cli[mcp] boss-mcp` 每次现解析临时环境、不受影响；受影响的只有「装进一个还钉着 `mcp<2` 的长期共享环境」这种场景。**MCP 线格式与工具集合一字未变，宿主侧无需任何改动。**

## 版本号同步

`pyproject.toml` · `src/boss_agent_cli/__init__.py` · `ROADMAP.md` + `.en.md` 已发布列表 · `docs/marketing/awesome-submissions.md`（2 处）。`CHANGELOG.md` 的 `[Unreleased]` 留空，内容归入 `## [1.20.0] - 2026-09-03`。

## 发布清单逐条

**§2 本地验证** —— 全部通过
```
[ok] ruff   All checks passed!            （另跑 CI 完整范围 src/ tests/ scripts/ mcp-server/）
[ok] pytest 1905 passed
[ok] mypy   Success: no issues found in 150 source files
[ok] boss --help · boss schema --format native
[ok] BOSS_SMOKE_DRY_RUN=1 scripts/smoke_p0.py
[ok] git diff --check
```

**§3 敏感数据** —— diff 内无 cookie / token / 手机号 / API 密钥 / 真实 `security_id`；smoke 输出里 `security_id` 是 `<redacted>` 占位。

**§4 包检查** —— wheel 397 KB、154 个包内文件；抽查确认不含 `.venv` / `.pytest_cache` / `dist` / 测试 / demo 的 mp4·gif / `.trellis`。新模块 `api/browser_source.py` 与改动后的 `mcp_server.py` 均在包内。

**额外：全新安装复验**（不在清单里，但本次风险集中在依赖上，值得单跑）
```
boss-agent-cli 1.20.0 · mcp 2.1.1 · httpx 0.28.1 · socksio 1.0.0
✓ 真实 stdio MCP 会话 initialize + tools/list 成功，73 个工具全部带 inputSchema
✓ ALL_PROXY=socks5://127.0.0.1:7890 下 httpx.Client 构造成功
```

## 合并后

CI 绿即打注解 tag：

```bash
git tag -a v1.20.0 -m "v1.20.0"
git push origin v1.20.0
```

release workflow 会跑测试、构建、建 GitHub Release 并 `uv publish` 到 PyPI。

## Breaking Change

- [x] 本 PR **不包含** 破坏性变更