### PR TITLE
docs: parse_error 契约目录注明通道类错误码不经此方法

### DIFF
--- a/src/boss_agent_cli/platforms/base.py
+++ b/src/boss_agent_cli/platforms/base.py
@@ -131,6 +131,12 @@ class Platform(ABC):
 
 		统一错误码对齐 CLAUDE.md 错误码枚举：
 		AUTH_EXPIRED / RATE_LIMITED / TOKEN_REFRESH_FAILED / ACCOUNT_RISK / UNKNOWN。
+
+		这里只枚举**从平台响应体解析出来**的码。通道 / 来源类失败
+		（``CDP_UNAVAILABLE``、``BROWSER_SESSION_NOT_FOUND`` 等）由 CLI 自身的
+		浏览器或传输状态产生，走「模块层抛 typed exception →
+		``display.handle_auth_errors`` 转信封」这条路径，根本不经过本方法，
+		所以它们出现在 ``SCHEMA_DATA["error_codes"]`` 里但不应加进这个列表。
 		"""
 
 	@abstractmethod


### PR DESCRIPTION
## 关联 Issue / Related Issue

#387（seam 第 2 片回复里承诺的 docstring 补注）

## 变更说明 / Summary

`Platform.parse_error` 的 docstring 枚举的是从平台响应体解析出来的错误码。通道 / 来源类错误码（`CDP_UNAVAILABLE`、`BROWSER_SESSION_NOT_FOUND`）由 CLI 自身状态产生、走 typed exception → `display.handle_auth_errors` 路径，根本不经过 `parse_error`。补一段说明，省掉此后每个新通道码一处错误的同步义务。

只加说明行，不动枚举行——#403 要在同一枚举里加 `ENVIRONMENT_RISK`，避免制造冲突。

## 变更类型 / Type

- [x] docs: 文档

## Breaking Change

- [x] 本 PR **不包含** 破坏性变更

## 测试 / Test Plan

- [x] `uv run pytest tests/test_platform_base.py tests/test_agent_docs.py -q` 通过
- [x] ruff 通过；纯 docstring 改动

## 安全与规范 / Safety & Convention

- [x] commit message 格式: `type: 中文描述`
- [x] 无 `Co-authored-by` 尾注或 AI 署名行